### PR TITLE
bitnami/dataplatform-bp2 Add Data Platform Metrics Emitter and Prometheus Exporters

### DIFF
--- a/bitnami/dataplatform-bp2/Chart.lock
+++ b/bitnami/dataplatform-bp2/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 14.1.0
+  version: 14.1.1
 - name: spark
   repository: https://charts.bitnami.com/bitnami
   version: 5.7.2
@@ -10,12 +10,12 @@ dependencies:
   version: 17.0.3
 - name: logstash
   repository: https://charts.bitnami.com/bitnami
-  version: 3.6.5
+  version: 3.6.6
 - name: wavefront
   repository: https://charts.bitnami.com/bitnami
   version: 3.1.11
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.9.0
-digest: sha256:e7e8c66b1ddd5ef1f5f93bfe1a54ace250f220b4390a3aff8e3410b915ebaae4
-generated: "2021-09-15T13:51:57.038914+05:30"
+digest: sha256:bb19026f61e735f759f095fe169c51a257d67995cc3f1a4ae135f83551c76484
+generated: "2021-09-22T15:00:44.573024788Z"

--- a/bitnami/dataplatform-bp2/Chart.lock
+++ b/bitnami/dataplatform-bp2/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 5.7.2
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 17.0.2
+  version: 17.0.3
 - name: logstash
   repository: https://charts.bitnami.com/bitnami
   version: 3.6.5
@@ -16,6 +16,6 @@ dependencies:
   version: 3.1.11
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.8.0
-digest: sha256:235a3673c3146ab894e9e3f8f4ddf6140a2155cf82ca305d97f5ebd5ba179e2c
-generated: "2021-09-13T10:00:31.9197+02:00"
+  version: 1.9.0
+digest: sha256:e7e8c66b1ddd5ef1f5f93bfe1a54ace250f220b4390a3aff8e3410b915ebaae4
+generated: "2021-09-15T13:51:57.038914+05:30"

--- a/bitnami/dataplatform-bp2/Chart.yaml
+++ b/bitnami/dataplatform-bp2/Chart.yaml
@@ -58,4 +58,4 @@ sources:
   - https://www.elastic.co/products/logstash
   - https://zookeeper.apache.org/
   - https://github.com/bitnami/bitnami-docker-zookeeper
-version: 7.0.0
+version: 8.0.0

--- a/bitnami/dataplatform-bp2/Chart.yaml
+++ b/bitnami/dataplatform-bp2/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.0.0
+appVersion: 0.0.10
 dependencies:
   - condition: kafka.enabled
     name: kafka

--- a/bitnami/dataplatform-bp2/README.md
+++ b/bitnami/dataplatform-bp2/README.md
@@ -361,6 +361,10 @@ Regular upgrade is compatible from previous versions.
 
 ## Upgrading
 
+### To 8.0.0
+
+This major adds the data platform metrics emitter and Prometheus exporters to the chart which emit health metrics of the data platform.
+
 ### To 7.0.0
 
 This major updates the Elasticsearch subchart to its newest major, 17.0.0, which adds support for X-pack security features such as SSL/TLS encryption and password protection. Check [Elasticsearch Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch#to-1700) for more information.

--- a/bitnami/dataplatform-bp2/README.md
+++ b/bitnami/dataplatform-bp2/README.md
@@ -96,6 +96,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
 
+### Common parameters
+
+| Name                | Description                                | Value |
+| ------------------- | ------------------------------------------ | ----- |
+| `commonLabels`      | Labels to add to all deployed objects      | `{}`  |
+| `commonAnnotations` | Annotations to add to all deployed objects | `{}`  |
+
+
 ### Data Platform Chart parameters
 
 | Name                                                             | Description                                                                                                      | Value                           |
@@ -122,8 +130,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.exporter.readinessProbe.timeoutSeconds`            | Timeout seconds for readinessProbe                                                                               | `15`                            |
 | `dataplatform.exporter.readinessProbe.failureThreshold`          | Failure threshold for readinessProbe                                                                             | `15`                            |
 | `dataplatform.exporter.readinessProbe.successThreshold`          | Success threshold for readinessProbe                                                                             | `15`                            |
-| `dataplatform.exporter.port`                                     | Data Platform Prometheus exporter port                                                                           | `9090`                          |
-| `dataplatform.exporter.threads`                                  | Number of Data Platform exporter threads                                                                         | `7`                             |
+| `dataplatform.exporter.startupProbe.enabled`                     | Enable startupProbe                                                                                              | `false`                         |
+| `dataplatform.exporter.startupProbe.initialDelaySeconds`         | Initial delay seconds for startupProbe                                                                           | `10`                            |
+| `dataplatform.exporter.startupProbe.periodSeconds`               | Period seconds for startupProbe                                                                                  | `5`                             |
+| `dataplatform.exporter.startupProbe.timeoutSeconds`              | Timeout seconds for startupProbe                                                                                 | `15`                            |
+| `dataplatform.exporter.startupProbe.failureThreshold`            | Failure threshold for startupProbe                                                                               | `15`                            |
+| `dataplatform.exporter.startupProbe.successThreshold`            | Success threshold for startupProbe                                                                               | `15`                            |
+| `dataplatform.exporter.containerPorts.http`                      | Data Platform Prometheus exporter port                                                                           | `9090`                          |
+| `dataplatform.exporter.priorityClassName`                        | exporter priorityClassName                                                                                       | `""`                            |
 | `dataplatform.exporter.command`                                  | Override Data Platform Exporter entrypoint string.                                                               | `[]`                            |
 | `dataplatform.exporter.args`                                     | Arguments for the provided command if needed                                                                     | `[]`                            |
 | `dataplatform.exporter.resources.limits`                         | The resources limits for the container                                                                           | `{}`                            |
@@ -143,8 +157,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.exporter.tolerations`                              | Tolerations for exporter pods assignment. Evaluated as a template                                                | `[]`                            |
 | `dataplatform.exporter.podLabels`                                | Additional labels for Metrics exporter pod                                                                       | `{}`                            |
 | `dataplatform.exporter.podAnnotations`                           | Additional annotations for Metrics exporter pod                                                                  | `{}`                            |
-| `dataplatform.exporter.customLivenessProbe`                      | Override default liveness probe%%MAIN_CONTAINER_NAME%%                                                           | `{}`                            |
-| `dataplatform.exporter.customReadinessProbe`                     | Override default readiness probe%%MAIN_CONTAINER_NAME%%                                                          | `{}`                            |
+| `dataplatform.exporter.customLivenessProbe`                      | Override default liveness probe                                                                                  | `{}`                            |
+| `dataplatform.exporter.customReadinessProbe`                     | Override default readiness probe                                                                                 | `{}`                            |
+| `dataplatform.exporter.customStartupProbe`                       | Override default startup probe                                                                                   | `{}`                            |
 | `dataplatform.exporter.updateStrategy.type`                      | Update strategy - only really applicable for deployments with RWO PVs attached                                   | `RollingUpdate`                 |
 | `dataplatform.exporter.updateStrategy.rollingUpdate`             | Deployment rolling update configuration parameters                                                               | `{}`                            |
 | `dataplatform.exporter.extraEnvVars`                             | Additional environment variables to set                                                                          | `[]`                            |
@@ -155,14 +170,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.exporter.initContainers`                           | Add init containers to the %%MAIN_CONTAINER_NAME%% pods                                                          | `[]`                            |
 | `dataplatform.exporter.sidecars`                                 | Add sidecars to the %%MAIN_CONTAINER_NAME%% pods                                                                 | `[]`                            |
 | `dataplatform.exporter.service.type`                             | Service type for default Data Platform Prometheus exporter service                                               | `ClusterIP`                     |
-| `dataplatform.exporter.service.annotations.prometheus.io/scrape` | Enable Data Platform Prometheus exporter                                                                         | `true`                     |
-| `dataplatform.exporter.service.annotations.prometheus.io/port`   | Data Platform Prometheus exporter port                                                                           | `9090`                     |
-| `dataplatform.exporter.service.annotations.prometheus.io/path`   | Data Platform Prometheus exporter metrics path                                                                   | `/metrics`                     |
+| `dataplatform.exporter.service.annotations.prometheus.io/scrape` | Enable Data Platform Prometheus exporter                                                                         | `undefined`                     |
+| `dataplatform.exporter.service.annotations.prometheus.io/port`   | Data Platform Prometheus exporter port                                                                           | `undefined`                     |
+| `dataplatform.exporter.service.annotations.prometheus.io/path`   | Data Platform Prometheus exporter metrics path                                                                   | `undefined`                     |
 | `dataplatform.exporter.service.labels`                           | Additional labels for Data Platform exporter service                                                             | `{}`                            |
-| `dataplatform.exporter.service.port`                             | Kubernetes Service port                                                                                          | `9090`                          |
+| `dataplatform.exporter.service.ports.http`                       | Kubernetes Service port                                                                                          | `9090`                          |
 | `dataplatform.exporter.service.loadBalancerIP`                   | Load balancer IP for the Data Platform Exporter Service (optional, cloud specific)                               | `""`                            |
 | `dataplatform.exporter.service.nodePorts.http`                   | Node ports for the HTTP exporter service                                                                         | `""`                            |
-| `dataplatform.exporter.service.nodePorts.https`                  | Node ports for the HTTPS exporter service                                                                        | `""`                            |
 | `dataplatform.exporter.service.loadBalancerSourceRanges`         | Exporter Load Balancer Source ranges                                                                             | `[]`                            |
 | `dataplatform.exporter.hostAliases`                              | Deployment pod host aliases                                                                                      | `[]`                            |
 | `dataplatform.emitter.enabled`                                   | Start Data Platform metrics emitter                                                                              | `true`                          |
@@ -183,8 +197,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.emitter.readinessProbe.timeoutSeconds`             | Timeout seconds for readinessProbe                                                                               | `15`                            |
 | `dataplatform.emitter.readinessProbe.failureThreshold`           | Failure threshold for readinessProbe                                                                             | `15`                            |
 | `dataplatform.emitter.readinessProbe.successThreshold`           | Success threshold for readinessProbe                                                                             | `15`                            |
-| `dataplatform.emitter.port`                                      | Data Platform emitter port                                                                                       | `8091`                          |
-| `dataplatform.emitter.threads`                                   | Number of Data Platform emitter threads                                                                          | `7`                             |
+| `dataplatform.emitter.startupProbe.enabled`                      | Enable startupProbe                                                                                              | `false`                         |
+| `dataplatform.emitter.startupProbe.initialDelaySeconds`          | Initial delay seconds for startupProbe                                                                           | `10`                            |
+| `dataplatform.emitter.startupProbe.periodSeconds`                | Period seconds for startupProbe                                                                                  | `5`                             |
+| `dataplatform.emitter.startupProbe.timeoutSeconds`               | Timeout seconds for startupProbe                                                                                 | `15`                            |
+| `dataplatform.emitter.startupProbe.failureThreshold`             | Failure threshold for startupProbe                                                                               | `15`                            |
+| `dataplatform.emitter.startupProbe.successThreshold`             | Success threshold for startupProbe                                                                               | `15`                            |
+| `dataplatform.emitter.containerPorts.http`                       | Data Platform emitter port                                                                                       | `8091`                          |
+| `dataplatform.emitter.priorityClassName`                         | exporter priorityClassName                                                                                       | `""`                            |
 | `dataplatform.emitter.command`                                   | Override Data Platform entrypoint string.                                                                        | `[]`                            |
 | `dataplatform.emitter.args`                                      | Arguments for the provided command if needed                                                                     | `[]`                            |
 | `dataplatform.emitter.resources.limits`                          | The resources limits for the container                                                                           | `{}`                            |
@@ -206,6 +226,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.emitter.podAnnotations`                            | Additional annotations for Metrics emitter pod                                                                   | `{}`                            |
 | `dataplatform.emitter.customLivenessProbe`                       | Override default liveness probe%%MAIN_CONTAINER_NAME%%                                                           | `{}`                            |
 | `dataplatform.emitter.customReadinessProbe`                      | Override default readiness probe%%MAIN_CONTAINER_NAME%%                                                          | `{}`                            |
+| `dataplatform.emitter.customStartupProbe`                        | Override default startup probe                                                                                   | `{}`                            |
 | `dataplatform.emitter.updateStrategy.type`                       | Update strategy - only really applicable for deployments with RWO PVs attached                                   | `RollingUpdate`                 |
 | `dataplatform.emitter.updateStrategy.rollingUpdate`              | Deployment rolling update configuration parameters                                                               | `{}`                            |
 | `dataplatform.emitter.extraEnvVars`                              | Additional environment variables to set                                                                          | `[]`                            |
@@ -218,10 +239,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.emitter.service.type`                              | Service type for default Data Platform metrics emitter service                                                   | `ClusterIP`                     |
 | `dataplatform.emitter.service.annotations`                       | annotations for Data Platform emitter service                                                                    | `{}`                            |
 | `dataplatform.emitter.service.labels`                            | Additional labels for Data Platform emitter service                                                              | `{}`                            |
-| `dataplatform.emitter.service.port`                              | Kubernetes Service port                                                                                          | `8091`                          |
+| `dataplatform.emitter.service.ports.http`                        | Kubernetes Service port                                                                                          | `8091`                          |
 | `dataplatform.emitter.service.loadBalancerIP`                    | Load balancer IP for the dataplatform emitter Service (optional, cloud specific)                                 | `""`                            |
 | `dataplatform.emitter.service.nodePorts.http`                    | Node ports for the HTTP emitter service                                                                          | `""`                            |
-| `dataplatform.emitter.service.nodePorts.https`                   | Node ports for the HTTPS emitter service                                                                         | `""`                            |
 | `dataplatform.emitter.service.loadBalancerSourceRanges`          | Data Platform Emitter Load Balancer Source ranges                                                                | `[]`                            |
 | `dataplatform.emitter.hostAliases`                               | Deployment pod host aliases                                                                                      | `[]`                            |
 

--- a/bitnami/dataplatform-bp2/README.md
+++ b/bitnami/dataplatform-bp2/README.md
@@ -9,6 +9,7 @@ This Helm chart enables the fully automated Kubernetes deployment of such multi-
 -   Apache Spark              – In-memory data analytics
 -   Elasticsearch with Kibana – Data persistence and search
 -   Logstash                  - Data Processing Pipeline
+-   Data Platform Prometheus Exporter - Prometheus exporter that emits the health metrics of the data platform
 
 These containerized stateful software stacks are deployed in multi-node cluster configurations, which is defined by the Helm Chart blueprint for this data platform deployment, covering:
 
@@ -41,6 +42,7 @@ The "Small" size data platform in default configuration deploys the following:
 3. Elasticsearch with 3 master nodes, 2 data nodes, 2 coordinating nodes and 1 kibana node
 4. Logstash with 2 nodes
 5. Spark with 1 Master and 2 worker nodes
+6. Data Platform Metrics emitter and Prometheus exporter
 
 The data platform can be optionally deployed with the Tanzu observability framework. In that case, the wavefront collectors will be set up as a DaemonSet to collect the Kubernetes cluster metrics to enable runtime feed into the Tanzu Observability service. It will also be pre-configured to scrape the metrics from the Prometheus endpoint that each application (Kafka/Spark/Elasticsearch/Logstash) emits the metrics to.
 
@@ -92,6 +94,136 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
+
+
+### Data Platform Chart parameters
+
+| Name                                                             | Description                                                                                                      | Value                           |
+| ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `dataplatform.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                             | `true`                          |
+| `dataplatform.serviceAccount.name`                               | The name of the ServiceAccount to create                                                                         | `""`                            |
+| `dataplatform.serviceAccount.automountServiceAccountToken`       | Allows auto mount of ServiceAccountToken on the serviceAccount created                                           | `true`                          |
+| `dataplatform.rbac.create`                                       | Whether to create & use RBAC resources or not                                                                    | `true`                          |
+| `dataplatform.exporter.enabled`                                  | Start a prometheus exporter                                                                                      | `true`                          |
+| `dataplatform.exporter.image.registry`                           | dataplatform exporter image registry                                                                             | `docker.io`                     |
+| `dataplatform.exporter.image.repository`                         | dataplatform exporter image repository                                                                           | `bitnami/dataplatform-exporter` |
+| `dataplatform.exporter.image.tag`                                | dataplatform exporter image tag (immutable tags are recommended)                                                 | `latest`                        |
+| `dataplatform.exporter.image.pullPolicy`                         | dataplatform exporter image pull policy                                                                          | `IfNotPresent`                  |
+| `dataplatform.exporter.image.pullSecrets`                        | Specify docker-registry secret names as an array                                                                 | `[]`                            |
+| `dataplatform.exporter.livenessProbe.enabled`                    | Enable livenessProbe                                                                                             | `true`                          |
+| `dataplatform.exporter.livenessProbe.initialDelaySeconds`        | Initial delay seconds for livenessProbe                                                                          | `10`                            |
+| `dataplatform.exporter.livenessProbe.periodSeconds`              | Period seconds for livenessProbe                                                                                 | `5`                             |
+| `dataplatform.exporter.livenessProbe.timeoutSeconds`             | Timeout seconds for livenessProbe                                                                                | `15`                            |
+| `dataplatform.exporter.livenessProbe.failureThreshold`           | Failure threshold for livenessProbe                                                                              | `15`                            |
+| `dataplatform.exporter.livenessProbe.successThreshold`           | Success threshold for livenessProbe                                                                              | `1`                             |
+| `dataplatform.exporter.readinessProbe.enabled`                   | Enable readinessProbe                                                                                            | `true`                          |
+| `dataplatform.exporter.readinessProbe.initialDelaySeconds`       | Initial delay seconds for readinessProbe                                                                         | `10`                            |
+| `dataplatform.exporter.readinessProbe.periodSeconds`             | Period seconds for readinessProbe                                                                                | `5`                             |
+| `dataplatform.exporter.readinessProbe.timeoutSeconds`            | Timeout seconds for readinessProbe                                                                               | `15`                            |
+| `dataplatform.exporter.readinessProbe.failureThreshold`          | Failure threshold for readinessProbe                                                                             | `15`                            |
+| `dataplatform.exporter.readinessProbe.successThreshold`          | Success threshold for readinessProbe                                                                             | `15`                            |
+| `dataplatform.exporter.port`                                     | Data Platform Prometheus exporter port                                                                           | `9090`                          |
+| `dataplatform.exporter.threads`                                  | Number of Data Platform exporter threads                                                                         | `7`                             |
+| `dataplatform.exporter.command`                                  | Override Data Platform Exporter entrypoint string.                                                               | `[]`                            |
+| `dataplatform.exporter.args`                                     | Arguments for the provided command if needed                                                                     | `[]`                            |
+| `dataplatform.exporter.resources.limits`                         | The resources limits for the container                                                                           | `{}`                            |
+| `dataplatform.exporter.resources.requests`                       | The requested resources for the container                                                                        | `{}`                            |
+| `dataplatform.exporter.containerSecurityContext.enabled`         | Enable Data Platform exporter containers' Security Context                                                       | `true`                          |
+| `dataplatform.exporter.containerSecurityContext.runAsUser`       | User ID for the containers.                                                                                      | `1001`                          |
+| `dataplatform.exporter.containerSecurityContext.runAsNonRoot`    | Enable Data Platform exporter containers' Security Context runAsNonRoot                                          | `true`                          |
+| `dataplatform.exporter.podSecurityContext.enabled`               | Enable Data Platform exporter pods' Security Context                                                             | `true`                          |
+| `dataplatform.exporter.podSecurityContext.fsGroup`               | Group ID for the pods.                                                                                           | `1001`                          |
+| `dataplatform.exporter.podAffinityPreset`                        | Data Platform exporter pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `dataplatform.exporter.podAntiAffinityPreset`                    | Data Platform exporter pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `dataplatform.exporter.nodeAffinityPreset.type`                  | Data Platform exporter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `dataplatform.exporter.nodeAffinityPreset.key`                   | Data Platform exporter node label key to match Ignored if `affinity` is set.                                     | `""`                            |
+| `dataplatform.exporter.nodeAffinityPreset.values`                | Data Platform exporter node label values to match. Ignored if `affinity` is set.                                 | `[]`                            |
+| `dataplatform.exporter.affinity`                                 | Affinity settings for exporter pod assignment. Evaluated as a template                                           | `{}`                            |
+| `dataplatform.exporter.nodeSelector`                             | Node labels for exporter pods assignment. Evaluated as a template                                                | `{}`                            |
+| `dataplatform.exporter.tolerations`                              | Tolerations for exporter pods assignment. Evaluated as a template                                                | `[]`                            |
+| `dataplatform.exporter.podLabels`                                | Additional labels for Metrics exporter pod                                                                       | `{}`                            |
+| `dataplatform.exporter.podAnnotations`                           | Additional annotations for Metrics exporter pod                                                                  | `{}`                            |
+| `dataplatform.exporter.customLivenessProbe`                      | Override default liveness probe%%MAIN_CONTAINER_NAME%%                                                           | `{}`                            |
+| `dataplatform.exporter.customReadinessProbe`                     | Override default readiness probe%%MAIN_CONTAINER_NAME%%                                                          | `{}`                            |
+| `dataplatform.exporter.updateStrategy.type`                      | Update strategy - only really applicable for deployments with RWO PVs attached                                   | `RollingUpdate`                 |
+| `dataplatform.exporter.updateStrategy.rollingUpdate`             | Deployment rolling update configuration parameters                                                               | `{}`                            |
+| `dataplatform.exporter.extraEnvVars`                             | Additional environment variables to set                                                                          | `[]`                            |
+| `dataplatform.exporter.extraEnvVarsCM`                           | ConfigMap with extra environment variables                                                                       | `""`                            |
+| `dataplatform.exporter.extraEnvVarsSecret`                       | Secret with extra environment variables                                                                          | `""`                            |
+| `dataplatform.exporter.extraVolumes`                             | Extra volumes to add to the deployment                                                                           | `[]`                            |
+| `dataplatform.exporter.extraVolumeMounts`                        | Extra volume mounts to add to the container                                                                      | `[]`                            |
+| `dataplatform.exporter.initContainers`                           | Add init containers to the %%MAIN_CONTAINER_NAME%% pods                                                          | `[]`                            |
+| `dataplatform.exporter.sidecars`                                 | Add sidecars to the %%MAIN_CONTAINER_NAME%% pods                                                                 | `[]`                            |
+| `dataplatform.exporter.service.type`                             | Service type for default Data Platform Prometheus exporter service                                               | `ClusterIP`                     |
+| `dataplatform.exporter.service.annotations.prometheus.io/scrape` | Enable Data Platform Prometheus exporter                                                                         | `true`                     |
+| `dataplatform.exporter.service.annotations.prometheus.io/port`   | Data Platform Prometheus exporter port                                                                           | `9090`                     |
+| `dataplatform.exporter.service.annotations.prometheus.io/path`   | Data Platform Prometheus exporter metrics path                                                                   | `/metrics`                     |
+| `dataplatform.exporter.service.labels`                           | Additional labels for Data Platform exporter service                                                             | `{}`                            |
+| `dataplatform.exporter.service.port`                             | Kubernetes Service port                                                                                          | `9090`                          |
+| `dataplatform.exporter.service.loadBalancerIP`                   | Load balancer IP for the Data Platform Exporter Service (optional, cloud specific)                               | `""`                            |
+| `dataplatform.exporter.service.nodePorts.http`                   | Node ports for the HTTP exporter service                                                                         | `""`                            |
+| `dataplatform.exporter.service.nodePorts.https`                  | Node ports for the HTTPS exporter service                                                                        | `""`                            |
+| `dataplatform.exporter.service.loadBalancerSourceRanges`         | Exporter Load Balancer Source ranges                                                                             | `[]`                            |
+| `dataplatform.exporter.hostAliases`                              | Deployment pod host aliases                                                                                      | `[]`                            |
+| `dataplatform.emitter.enabled`                                   | Start Data Platform metrics emitter                                                                              | `true`                          |
+| `dataplatform.emitter.image.registry`                            | Data Platform emitter image registry                                                                             | `docker.io`                     |
+| `dataplatform.emitter.image.repository`                          | Data Platform emitter image repository                                                                           | `bitnami/dataplatform-emitter`  |
+| `dataplatform.emitter.image.tag`                                 | Data Platform emitter image tag (immutable tags are recommended)                                                 | `latest`                        |
+| `dataplatform.emitter.image.pullPolicy`                          | Data Platform emitter image pull policy                                                                          | `IfNotPresent`                  |
+| `dataplatform.emitter.image.pullSecrets`                         | Specify docker-registry secret names as an array                                                                 | `[]`                            |
+| `dataplatform.emitter.livenessProbe.enabled`                     | Enable livenessProbe                                                                                             | `true`                          |
+| `dataplatform.emitter.livenessProbe.initialDelaySeconds`         | Initial delay seconds for livenessProbe                                                                          | `10`                            |
+| `dataplatform.emitter.livenessProbe.periodSeconds`               | Period seconds for livenessProbe                                                                                 | `5`                             |
+| `dataplatform.emitter.livenessProbe.timeoutSeconds`              | Timeout seconds for livenessProbe                                                                                | `15`                            |
+| `dataplatform.emitter.livenessProbe.failureThreshold`            | Failure threshold for livenessProbe                                                                              | `15`                            |
+| `dataplatform.emitter.livenessProbe.successThreshold`            | Success threshold for livenessProbe                                                                              | `1`                             |
+| `dataplatform.emitter.readinessProbe.enabled`                    | Enable readinessProbe                                                                                            | `true`                          |
+| `dataplatform.emitter.readinessProbe.initialDelaySeconds`        | Initial delay seconds for readinessProbe                                                                         | `10`                            |
+| `dataplatform.emitter.readinessProbe.periodSeconds`              | Period seconds for readinessProbe                                                                                | `5`                             |
+| `dataplatform.emitter.readinessProbe.timeoutSeconds`             | Timeout seconds for readinessProbe                                                                               | `15`                            |
+| `dataplatform.emitter.readinessProbe.failureThreshold`           | Failure threshold for readinessProbe                                                                             | `15`                            |
+| `dataplatform.emitter.readinessProbe.successThreshold`           | Success threshold for readinessProbe                                                                             | `15`                            |
+| `dataplatform.emitter.port`                                      | Data Platform emitter port                                                                                       | `8091`                          |
+| `dataplatform.emitter.threads`                                   | Number of Data Platform emitter threads                                                                          | `7`                             |
+| `dataplatform.emitter.command`                                   | Override Data Platform entrypoint string.                                                                        | `[]`                            |
+| `dataplatform.emitter.args`                                      | Arguments for the provided command if needed                                                                     | `[]`                            |
+| `dataplatform.emitter.resources.limits`                          | The resources limits for the container                                                                           | `{}`                            |
+| `dataplatform.emitter.resources.requests`                        | The requested resources for the container                                                                        | `{}`                            |
+| `dataplatform.emitter.containerSecurityContext.enabled`          | Enable Data Platform emitter containers' Security Context                                                        | `true`                          |
+| `dataplatform.emitter.containerSecurityContext.runAsUser`        | User ID for the containers.                                                                                      | `1001`                          |
+| `dataplatform.emitter.containerSecurityContext.runAsNonRoot`     | Enable Data Platform emitter containers' Security Context runAsNonRoot                                           | `true`                          |
+| `dataplatform.emitter.podSecurityContext.enabled`                | Enable Data Platform emitter pods' Security Context                                                              | `true`                          |
+| `dataplatform.emitter.podSecurityContext.fsGroup`                | Group ID for the pods.                                                                                           | `1001`                          |
+| `dataplatform.emitter.podAffinityPreset`                         | Data Platform emitter pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`        | `""`                            |
+| `dataplatform.emitter.podAntiAffinityPreset`                     | Data Platform emitter pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`   | `soft`                          |
+| `dataplatform.emitter.nodeAffinityPreset.type`                   | Data Platform emitter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `""`                            |
+| `dataplatform.emitter.nodeAffinityPreset.key`                    | Data Platform emitter node label key to match Ignored if `affinity` is set.                                      | `""`                            |
+| `dataplatform.emitter.nodeAffinityPreset.values`                 | Data Platform emitter node label values to match. Ignored if `affinity` is set.                                  | `[]`                            |
+| `dataplatform.emitter.affinity`                                  | Affinity settings for emitter pod assignment. Evaluated as a template                                            | `{}`                            |
+| `dataplatform.emitter.nodeSelector`                              | Node labels for emitter pods assignment. Evaluated as a template                                                 | `{}`                            |
+| `dataplatform.emitter.tolerations`                               | Tolerations for emitter pods assignment. Evaluated as a template                                                 | `[]`                            |
+| `dataplatform.emitter.podLabels`                                 | Additional labels for Metrics emitter pod                                                                        | `{}`                            |
+| `dataplatform.emitter.podAnnotations`                            | Additional annotations for Metrics emitter pod                                                                   | `{}`                            |
+| `dataplatform.emitter.customLivenessProbe`                       | Override default liveness probe%%MAIN_CONTAINER_NAME%%                                                           | `{}`                            |
+| `dataplatform.emitter.customReadinessProbe`                      | Override default readiness probe%%MAIN_CONTAINER_NAME%%                                                          | `{}`                            |
+| `dataplatform.emitter.updateStrategy.type`                       | Update strategy - only really applicable for deployments with RWO PVs attached                                   | `RollingUpdate`                 |
+| `dataplatform.emitter.updateStrategy.rollingUpdate`              | Deployment rolling update configuration parameters                                                               | `{}`                            |
+| `dataplatform.emitter.extraEnvVars`                              | Additional environment variables to set                                                                          | `[]`                            |
+| `dataplatform.emitter.extraEnvVarsCM`                            | ConfigMap with extra environment variables                                                                       | `""`                            |
+| `dataplatform.emitter.extraEnvVarsSecret`                        | Secret with extra environment variables                                                                          | `""`                            |
+| `dataplatform.emitter.extraVolumes`                              | Extra volumes to add to the deployment                                                                           | `[]`                            |
+| `dataplatform.emitter.extraVolumeMounts`                         | Extra volume mounts to add to the container                                                                      | `[]`                            |
+| `dataplatform.emitter.initContainers`                            | Add init containers to the %%MAIN_CONTAINER_NAME%% pods                                                          | `[]`                            |
+| `dataplatform.emitter.sidecars`                                  | Add sidecars to the %%MAIN_CONTAINER_NAME%% pods                                                                 | `[]`                            |
+| `dataplatform.emitter.service.type`                              | Service type for default Data Platform metrics emitter service                                                   | `ClusterIP`                     |
+| `dataplatform.emitter.service.annotations`                       | annotations for Data Platform emitter service                                                                    | `{}`                            |
+| `dataplatform.emitter.service.labels`                            | Additional labels for Data Platform emitter service                                                              | `{}`                            |
+| `dataplatform.emitter.service.port`                              | Kubernetes Service port                                                                                          | `8091`                          |
+| `dataplatform.emitter.service.loadBalancerIP`                    | Load balancer IP for the dataplatform emitter Service (optional, cloud specific)                                 | `""`                            |
+| `dataplatform.emitter.service.nodePorts.http`                    | Node ports for the HTTP emitter service                                                                          | `""`                            |
+| `dataplatform.emitter.service.nodePorts.https`                   | Node ports for the HTTPS emitter service                                                                         | `""`                            |
+| `dataplatform.emitter.service.loadBalancerSourceRanges`          | Data Platform Emitter Load Balancer Source ranges                                                                | `[]`                            |
+| `dataplatform.emitter.hostAliases`                               | Deployment pod host aliases                                                                                      | `[]`                            |
 
 
 ### Kafka parameters
@@ -238,6 +370,8 @@ $ helm install my-release -f values.yaml bitnami/dataplatform-bp2
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
 ### Data Platform Deployment with Observability Framework
+
+In the default deployment, the helm chart deploys the data platform with [Metrics Emitter](https://hub.docker.com/r/bitnami/dataplatform-emitter) and [Prometheus Exporter](https://hub.docker.com/r/bitnami/dataplatform-exporter) which emit the health metrics of the data platform which can be integrated with your observability solution.
 
 In case you need to deploy the data platform with Tanzu Observability Framework for all the applications (Kafka/Spark/Elasticsearch/Logstash) in the data platform, you can specify the 'enabled' parameter using the `--set <component>.metrics.enabled=true` argument to `helm install`. For Example,
 

--- a/bitnami/dataplatform-bp2/templates/_helpers.tpl
+++ b/bitnami/dataplatform-bp2/templates/_helpers.tpl
@@ -6,3 +6,65 @@ Usage:
 {{- define "subcomponent.service.name" -}}
 {{- printf "%s-%s" .context.Release.Name .componentName | trunc 63 -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dataplatform.fullname" -}}
+{{- include "common.names.fullname" . -}}
+{{- end -}}
+
+{{/*
+Define the name of the dataplatform exporter
+*/}}
+{{- define "dataplatform.exporter-name" -}}
+{{- printf "%s-%s" (include "dataplatform.fullname" .) "exporter" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Define the name of the dataplatform emitter
+*/}}
+{{- define "dataplatform.emitter-name" -}}
+{{- printf "%s-%s" (include "dataplatform.fullname" .) "emitter" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+ Create the name of the service account to use
+ */}}
+{{- define "dataplatform.serviceAccountName" -}}
+{{- if .Values.dataplatform.serviceAccount.create -}}
+    {{- default (include "dataplatform.fullname" .) .Values.dataplatform.serviceAccount.name -}}
+{{- else -}}
+    {{- default "default" .Values.dataplatform.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper dataplatform-exporter image name
+*/}}
+{{- define "dataplatform.exporter.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.dataplatform.exporter.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "dataplatform.exporter.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.dataplatform.exporter.image ) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Return the proper dataplatform-emitter image name
+*/}}
+{{- define "dataplatform.emitter.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.dataplatform.emitter.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "dataplatform.emitter.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.dataplatform.emitter.image ) "global" .Values.global) -}}
+{{- end -}}

--- a/bitnami/dataplatform-bp2/templates/emitter-deployment.yaml
+++ b/bitnami/dataplatform-bp2/templates/emitter-deployment.yaml
@@ -84,27 +84,61 @@ spec:
               value: {{ .Release.Name }}
             - name: BP_NAMESPACE
               value: {{ .Release.Namespace }}
+          {{- if or .Values.dataplatform.emitter.extraEnvVarsCM .Values.dataplatform.exporter.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.dataplatform.emitter.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.dataplatform.emitter.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: emitter-port
-              containerPort: {{ .Values.dataplatform.emitter.port }}
+              containerPort: {{ .Values.dataplatform.emitter.containerPorts.http }}
           {{- if .Values.dataplatform.emitter.resources }}
           resources: {{- toYaml .Values.dataplatform.emitter.resources | nindent 12 }}
           {{- end }}
           {{- if .Values.dataplatform.emitter.livenessProbe.enabled }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.emitter.livenessProbe "enabled") "context" $) | nindent 12 }}
+          livenessProbe:
             httpGet:
               path: "/v1/health"
-              port: {{ .Values.dataplatform.emitter.port }}
+              port: {{ .Values.dataplatform.emitter.containerPorts.http }}
+            initialDelaySeconds: {{ .Values.dataplatform.emitter.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dataplatform.emitter.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dataplatform.emitter.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.dataplatform.emitter.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.dataplatform.emitter.livenessProbe.successThreshold }}
           {{- else if .Values.dataplatform.emitter.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.dataplatform.emitter.readinessProbe.enabled }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.emitter.readinessProbe "enabled") "context" $) | nindent 12 }}
+          readinessProbe:
             httpGet:
               path: "/v1/health"
-              port: {{ .Values.dataplatform.emitter.port }}
+              port: {{ .Values.dataplatform.emitter.containerPorts.http }}
+            initialDelaySeconds: {{ .Values.dataplatform.emitter.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dataplatform.emitter.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dataplatform.emitter.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.dataplatform.emitter.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.dataplatform.emitter.readinessProbe.successThreshold }}
           {{- else if .Values.dataplatform.emitter.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.emitter.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: "/v1/health"
+              port: {{ .Values.dataplatform.emitter.containerPorts.http }}
+            initialDelaySeconds: {{ .Values.dataplatform.emitter.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dataplatform.emitter.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dataplatform.emitter.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.dataplatform.emitter.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.dataplatform.emitter.startupProbe.successThreshold }}
+          {{- else if .Values.dataplatform.emitter.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
           {{- if .Values.dataplatform.emitter.extraVolumeMounts }}

--- a/bitnami/dataplatform-bp2/templates/emitter-deployment.yaml
+++ b/bitnami/dataplatform-bp2/templates/emitter-deployment.yaml
@@ -1,0 +1,120 @@
+{{- if .Values.dataplatform.emitter.enabled }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: dataplatform-emitter
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ include "dataplatform.emitter-name" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: 1
+  {{- if .Values.dataplatform.emitter.updateStrategy }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.updateStrategy "context" $) | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: dataplatform-emitter
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.dataplatform.emitter.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.commonAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 8 }}
+        {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: dataplatform-emitter
+        {{- if .Values.dataplatform.emitter.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "dataplatform.serviceAccountName" . }}
+      {{- include "dataplatform.emitter.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.dataplatform.emitter.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dataplatform.emitter.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.emitter.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.dataplatform.emitter.podAffinityPreset "component" "dataplatform-emitter" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.dataplatform.emitter.podAntiAffinityPreset "component" "dataplatform-emitter" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.dataplatform.emitter.nodeAffinityPreset.type "key" .Values.dataplatform.emitter.nodeAffinityPreset.key "values" .Values.dataplatform.emitter.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.dataplatform.emitter.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.emitter.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dataplatform.emitter.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dataplatform.emitter.priorityClassName }}
+      priorityClassName: {{ .Values.dataplatform.emitter.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.dataplatform.emitter.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.dataplatform.emitter.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- if .Values.dataplatform.emitter.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: dataplatform-emitter
+          image: {{ include "dataplatform.emitter.image" . }}
+          imagePullPolicy: {{ .Values.dataplatform.emitter.image.pullPolicy | quote }}
+          {{- if .Values.dataplatform.emitter.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.dataplatform.emitter.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.emitter.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.emitter.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: BP_NAME
+              value: {{ include "dataplatform.fullname" . }}
+            - name: BP_RELEASE_NAME
+              value: {{ .Release.Name }}
+            - name: BP_NAMESPACE
+              value: {{ .Release.Namespace }}
+          ports:
+            - name: emitter-port
+              containerPort: {{ .Values.dataplatform.emitter.port }}
+          {{- if .Values.dataplatform.emitter.resources }}
+          resources: {{- toYaml .Values.dataplatform.emitter.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.emitter.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.emitter.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: "/v1/health"
+              port: {{ .Values.dataplatform.emitter.port }}
+          {{- else if .Values.dataplatform.emitter.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.emitter.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.emitter.readinessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: "/v1/health"
+              port: {{ .Values.dataplatform.emitter.port }}
+          {{- else if .Values.dataplatform.emitter.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.dataplatform.emitter.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.dataplatform.emitter.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.emitter.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        {{- if .Values.dataplatform.emitter.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+{{ end }}

--- a/bitnami/dataplatform-bp2/templates/emitter-svc.yaml
+++ b/bitnami/dataplatform-bp2/templates/emitter-svc.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-    {{- if .Values.dataplatform.emitter.service.Labels }}
+    {{- if .Values.dataplatform.emitter.service.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.emitter.service.labels "context" $ ) | nindent 4 }}
     {{- end }}
   name: "{{ include "dataplatform.emitter-name" . }}"
@@ -31,7 +31,7 @@ spec:
   {{- end }}
   ports:
     - name: tcp-client
-      port: {{ .Values.dataplatform.emitter.service.port }}
+      port: {{ .Values.dataplatform.emitter.service.ports.http }}
       protocol: TCP
       targetPort: emitter-port
       {{- if and (or (eq .Values.dataplatform.emitter.service.type "NodePort") (eq .Values.dataplatform.emitter.service.type "LoadBalancer")) (not (empty .Values.dataplatform.emitter.service.nodePorts.http)) }}

--- a/bitnami/dataplatform-bp2/templates/emitter-svc.yaml
+++ b/bitnami/dataplatform-bp2/templates/emitter-svc.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.dataplatform.emitter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: dataplatform-emitter
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.dataplatform.emitter.service.Labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.emitter.service.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: "{{ include "dataplatform.emitter-name" . }}"
+  {{- if or .Values.dataplatform.emitter.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.dataplatform.emitter.service.annotations }}
+    {{ include "common.tplvalues.render" ( dict "value" .Values.dataplatform.emitter.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: {{ .Values.dataplatform.emitter.service.type }}
+  {{ if eq .Values.dataplatform.emitter.service.type "LoadBalancer" }}
+  loadBalancerSourceRanges: {{ .Values.dataplatform.emitter.service.loadBalancerSourceRanges }}
+  {{ end }}
+  {{- if (and (eq .Values.dataplatform.emitter.service.type "LoadBalancer") (not (empty .Values.dataplatform.emitter.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.dataplatform.emitter.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: tcp-client
+      port: {{ .Values.dataplatform.emitter.service.port }}
+      protocol: TCP
+      targetPort: emitter-port
+      {{- if and (or (eq .Values.dataplatform.emitter.service.type "NodePort") (eq .Values.dataplatform.emitter.service.type "LoadBalancer")) (not (empty .Values.dataplatform.emitter.service.nodePorts.http)) }}
+      nodePort: {{ .Values.dataplatform.emitter.service.nodePorts.http }}
+      {{- else if eq .Values.dataplatform.emitter.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: dataplatform-emitter
+{{ end }}

--- a/bitnami/dataplatform-bp2/templates/exporter-deployment.yaml
+++ b/bitnami/dataplatform-bp2/templates/exporter-deployment.yaml
@@ -81,28 +81,62 @@ spec:
             - name: BP_NAME
               value: {{ include "dataplatform.fullname" . }}
             - name: DP_URI
-              value: http://{{ include "dataplatform.emitter-name" . }}:{{ .Values.dataplatform.emitter.service.port }}
+              value: http://{{ include "dataplatform.emitter-name" . }}:{{ .Values.dataplatform.emitter.service.ports.http }}
+          {{- if or .Values.dataplatform.exporter.extraEnvVarsCM .Values.dataplatform.exporter.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.dataplatform.exporter.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.dataplatform.exporter.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: exporter-port
-              containerPort: {{ .Values.dataplatform.exporter.port }}
+              containerPort: {{ .Values.dataplatform.exporter.containerPorts.http }}
           {{- if .Values.dataplatform.exporter.resources }}
           resources: {{- toYaml .Values.dataplatform.exporter.resources | nindent 12 }}
           {{- end }}
           {{- if .Values.dataplatform.exporter.livenessProbe.enabled }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.exporter.livenessProbe "enabled") "context" $) | nindent 12 }}
+          livenessProbe:
             httpGet:
               path: "/metrics"
-              port: {{ .Values.dataplatform.exporter.port }}
+              port: {{ .Values.dataplatform.exporter.containerPorts.http }}
+            initialDelaySeconds: {{ .Values.dataplatform.exporter.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dataplatform.exporter.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dataplatform.exporter.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.dataplatform.exporter.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.dataplatform.exporter.livenessProbe.successThreshold }}
           {{- else if .Values.dataplatform.exporter.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.dataplatform.exporter.readinessProbe.enabled }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.exporter.readinessProbe "enabled") "context" $) | nindent 12 }}
+          readinessProbe:
             httpGet:
               path: "/metrics"
-              port: {{ .Values.dataplatform.exporter.port }}
+              port: {{ .Values.dataplatform.exporter.containerPorts.http }}
+            initialDelaySeconds: {{ .Values.dataplatform.exporter.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dataplatform.exporter.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dataplatform.exporter.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.dataplatform.exporter.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.dataplatform.exporter.readinessProbe.successThreshold }}
           {{- else if .Values.dataplatform.exporter.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.exporter.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: "/v1/health"
+              port: {{ .Values.dataplatform.exporter.containerPorts.http }}
+            initialDelaySeconds: {{ .Values.dataplatform.exporter.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.dataplatform.exporter.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.dataplatform.exporter.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.dataplatform.exporter.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.dataplatform.exporter.startupProbe.successThreshold }}
+          {{- else if .Values.dataplatform.exporter.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
           {{- if .Values.dataplatform.exporter.extraVolumeMounts }}

--- a/bitnami/dataplatform-bp2/templates/exporter-deployment.yaml
+++ b/bitnami/dataplatform-bp2/templates/exporter-deployment.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.dataplatform.exporter.enabled }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: dataplatform-exporter
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ include "dataplatform.exporter-name" . }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  replicas: 1
+  {{- if .Values.dataplatform.exporter.updateStrategy }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.updateStrategy "context" $) | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: dataplatform-exporter
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.dataplatform.exporter.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.commonAnnotations }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 8 }}
+        {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: dataplatform-exporter
+        {{- if .Values.dataplatform.exporter.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "dataplatform.serviceAccountName" . }}
+      {{- include "dataplatform.exporter.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.dataplatform.exporter.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dataplatform.exporter.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.exporter.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.dataplatform.exporter.podAffinityPreset "component" "dataplatform-exporter" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.dataplatform.exporter.podAntiAffinityPreset "component" "dataplatform-exporter" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.dataplatform.exporter.nodeAffinityPreset.type "key" .Values.dataplatform.exporter.nodeAffinityPreset.key "values" .Values.dataplatform.exporter.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.dataplatform.exporter.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.exporter.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dataplatform.exporter.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dataplatform.exporter.priorityClassName }}
+      priorityClassName: {{ .Values.dataplatform.exporter.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.dataplatform.exporter.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.dataplatform.exporter.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- if .Values.dataplatform.exporter.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.initContainers "context" $) | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: dataplatform-exporter
+          image: {{ include "dataplatform.exporter.image" . }}
+          imagePullPolicy: {{ .Values.dataplatform.exporter.image.pullPolicy | quote }}
+          {{- if .Values.dataplatform.exporter.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.dataplatform.exporter.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.exporter.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.exporter.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: BP_NAME
+              value: {{ include "dataplatform.fullname" . }}
+            - name: DP_URI
+              value: http://{{ include "dataplatform.emitter-name" . }}:{{ .Values.dataplatform.emitter.service.port }}
+          ports:
+            - name: exporter-port
+              containerPort: {{ .Values.dataplatform.exporter.port }}
+          {{- if .Values.dataplatform.exporter.resources }}
+          resources: {{- toYaml .Values.dataplatform.exporter.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.exporter.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.exporter.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: "/metrics"
+              port: {{ .Values.dataplatform.exporter.port }}
+          {{- else if .Values.dataplatform.exporter.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.exporter.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.exporter.readinessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: "/metrics"
+              port: {{ .Values.dataplatform.exporter.port }}
+          {{- else if .Values.dataplatform.exporter.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.dataplatform.exporter.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.dataplatform.exporter.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.exporter.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        {{- if .Values.dataplatform.exporter.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+{{ end }}

--- a/bitnami/dataplatform-bp2/templates/exporter-svc.yaml
+++ b/bitnami/dataplatform-bp2/templates/exporter-svc.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.dataplatform.exporter.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: dataplatform-exporter
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.dataplatform.exporter.service.Labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.exporter.service.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: "{{ include "dataplatform.exporter-name" . }}"
+  {{- if or .Values.dataplatform.exporter.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.dataplatform.exporter.service.annotations }}
+    {{ include "common.tplvalues.render" ( dict "value" .Values.dataplatform.exporter.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: {{ .Values.dataplatform.exporter.service.type }}
+  {{ if eq .Values.dataplatform.exporter.service.type "LoadBalancer" }}
+  loadBalancerSourceRanges: {{ .Values.dataplatform.exporter.service.loadBalancerSourceRanges }}
+  {{ end }}
+  {{- if (and (eq .Values.dataplatform.exporter.service.type "LoadBalancer") (not (empty .Values.dataplatform.exporter.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.dataplatform.exporter.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: tcp-client
+      port: {{ .Values.dataplatform.exporter.service.port }}
+      protocol: TCP
+      targetPort: exporter-port
+      {{- if and (or (eq .Values.dataplatform.exporter.service.type "NodePort") (eq .Values.dataplatform.exporter.service.type "LoadBalancer")) (not (empty .Values.dataplatform.exporter.service.nodePorts.http)) }}
+      nodePort: {{ .Values.dataplatform.exporter.service.nodePorts.http }}
+      {{- else if eq .Values.dataplatform.exporter.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: dataplatform-exporter
+{{ end }}

--- a/bitnami/dataplatform-bp2/templates/exporter-svc.yaml
+++ b/bitnami/dataplatform-bp2/templates/exporter-svc.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-    {{- if .Values.dataplatform.exporter.service.Labels }}
+    {{- if .Values.dataplatform.exporter.service.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.exporter.service.labels "context" $ ) | nindent 4 }}
     {{- end }}
   name: "{{ include "dataplatform.exporter-name" . }}"
@@ -31,7 +31,7 @@ spec:
   {{- end }}
   ports:
     - name: tcp-client
-      port: {{ .Values.dataplatform.exporter.service.port }}
+      port: {{ .Values.dataplatform.exporter.service.ports.http }}
       protocol: TCP
       targetPort: exporter-port
       {{- if and (or (eq .Values.dataplatform.exporter.service.type "NodePort") (eq .Values.dataplatform.exporter.service.type "LoadBalancer")) (not (empty .Values.dataplatform.exporter.service.nodePorts.http)) }}

--- a/bitnami/dataplatform-bp2/templates/role.yaml
+++ b/bitnami/dataplatform-bp2/templates/role.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.dataplatform.rbac.create -}}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: Role
+metadata:
+  name: {{ template "dataplatform.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: dataplatform
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - statefulsets
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - ""
+    resources:
+      - namespaces
+      - namespaces/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - apps
+    resources:
+      - controllerrevisions
+      - daemonsets
+      - daemonsets/status
+      - deployments
+      - deployments/scale
+      - deployments/status
+      - replicasets
+      - replicasets/scale
+      - replicasets/status
+      - statefulsets
+      - statefulsets/scale
+      - statefulsets/status
+    verbs:
+      - get
+      - list
+      - watch      
+{{- end -}}

--- a/bitnami/dataplatform-bp2/templates/role.yaml
+++ b/bitnami/dataplatform-bp2/templates/role.yaml
@@ -23,7 +23,7 @@ rules:
       - list
       - watch
   - apiGroups:
-    - ""
+      - ""
     resources:
       - namespaces
       - namespaces/status
@@ -32,7 +32,7 @@ rules:
       - list
       - watch
   - apiGroups:
-    - apps
+      - apps
     resources:
       - controllerrevisions
       - daemonsets
@@ -49,5 +49,5 @@ rules:
     verbs:
       - get
       - list
-      - watch      
+      - watch
 {{- end -}}

--- a/bitnami/dataplatform-bp2/templates/rolebinding.yaml
+++ b/bitnami/dataplatform-bp2/templates/rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.dataplatform.serviceAccount.create .Values.dataplatform.rbac.create }}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: RoleBinding
+metadata:
+  name: {{ template "dataplatform.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: dataplatform
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  kind: Role
+  name: {{ template "dataplatform.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "dataplatform.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/bitnami/dataplatform-bp2/templates/serviceaccount.yaml
+++ b/bitnami/dataplatform-bp2/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.dataplatform.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "dataplatform.serviceAccountName" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: dataplatform
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.dataplatform.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/bitnami/dataplatform-bp2/values.yaml
+++ b/bitnami/dataplatform-bp2/values.yaml
@@ -69,7 +69,7 @@ dataplatform:
       ## pullSecrets:
       ##   - myRegistryKeySecretName
       ##
-      pullSecrets: []    
+      pullSecrets: []
     ## Configure extra options for liveness probe
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
     ## @param dataplatform.exporter.livenessProbe.enabled Enable livenessProbe
@@ -322,7 +322,7 @@ dataplatform:
       ## pullSecrets:
       ##   - myRegistryKeySecretName
       ##
-      pullSecrets: []    
+      pullSecrets: []
     ## Configure extra options for liveness probe
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
     ## @param dataplatform.emitter.livenessProbe.enabled Enable livenessProbe

--- a/bitnami/dataplatform-bp2/values.yaml
+++ b/bitnami/dataplatform-bp2/values.yaml
@@ -16,6 +16,536 @@ global:
   imagePullSecrets: []
   storageClass: ""
 
+## @section Data Platform Exporter deployment parameters
+
+## Configuration for the dataplatform prometheus exporter
+##
+dataplatform:
+  serviceAccount:
+    ## @param dataplatform.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## @param dataplatform.serviceAccount.name The name of the ServiceAccount to create
+    ## If not set and create is true, a name is generated using the fullname template
+    ##
+    name: ""
+    ## @param dataplatform.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+    ##
+    automountServiceAccountToken: true
+  ## Role Based Access
+  ## ref: https://kubernetes.io/docs/admin/authorization/rbac/
+  ##
+  rbac:
+    ## @param dataplatform.rbac.create Whether to create & use RBAC resources or not
+    ## binding dataplatform ServiceAccount to a role
+    ## that allows dataplatform pods querying the K8s API
+    ##
+    create: true
+  exporter:
+    ## @param dataplatform.exporter.enabled Start a prometheus exporter
+    ##
+    enabled: true
+    ## Data Platform BP2 exporter image
+    ## ref: https://hub.docker.com/r/bitnami/dataplatform-exporter/tags/
+    ## @param dataplatform.exporter.image.registry dataplatform exporter image registry
+    ## @param dataplatform.exporter.image.repository dataplatform exporter image repository
+    ## @param dataplatform.exporter.image.tag dataplatform exporter image tag (immutable tags are recommended)
+    ## @param dataplatform.exporter.image.pullPolicy dataplatform exporter image pull policy
+    ## @param dataplatform.exporter.image.pullSecrets Specify docker-registry secret names as an array
+    ##
+    image:
+      registry: harbor-repo.vmware.com
+      repository: octo_data_platforms/dp-exporter
+      tag: latest
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## Example:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []    
+    ## Configure extra options for liveness probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    ## @param dataplatform.exporter.livenessProbe.enabled Enable livenessProbe
+    ## @param dataplatform.exporter.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+    ## @param dataplatform.exporter.livenessProbe.periodSeconds Period seconds for livenessProbe
+    ## @param dataplatform.exporter.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+    ## @param dataplatform.exporter.livenessProbe.failureThreshold Failure threshold for livenessProbe
+    ## @param dataplatform.exporter.livenessProbe.successThreshold Success threshold for livenessProbe
+    ##
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      timeoutSeconds: 15
+      failureThreshold: 15
+      successThreshold: 1
+    ## Configure extra options for readiness probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    ## @param dataplatform.exporter.readinessProbe.enabled Enable readinessProbe
+    ## @param dataplatform.exporter.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+    ## @param dataplatform.exporter.readinessProbe.periodSeconds Period seconds for readinessProbe
+    ## @param dataplatform.exporter.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+    ## @param dataplatform.exporter.readinessProbe.failureThreshold Failure threshold for readinessProbe
+    ## @param dataplatform.exporter.readinessProbe.successThreshold Success threshold for readinessProbe
+    ##
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      timeoutSeconds: 15
+      failureThreshold: 15
+      successThreshold: 15
+    ## @param dataplatform.exporter.port dataplatform exporter port
+    ##
+    port: 9090
+    ## @param dataplatform.exporter.threads Number of dataplatform exporter threads
+    ##
+    threads: 7
+    ## @param dataplatform.exporter.command Override dataplatform entrypoint string.
+    ##
+    command: []
+    ## @param dataplatform.exporter.args Arguments for the provided command if needed
+    ##
+    args: []
+    ## Exporter resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param exporter.resources.limits The resources limits for the container
+    ## @param exporter.resources.requests The requested resources for the container
+    ##
+    resources:
+      ## Example:
+      ## limits:
+      ##    cpu: 200m
+      ##    memory: 256Mi
+      limits: {}
+      ## Examples:
+      ## requests:
+      ##    cpu: 200m
+      ##    memory: 10Mi
+      requests: {}
+    ## dataplatform exporter containers' Security Context
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    ## @param dataplatform.exporter.containerSecurityContext.enabled Enable dataplatform exporter containers' Security Context
+    ## @param dataplatform.exporter.containerSecurityContext.runAsUser User ID for the containers.
+    ## @param dataplatform.exporter.containerSecurityContext.runAsNonRoot Enable dataplatform exporter containers' Security Context runAsNonRoot
+    ##
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1001
+      runAsNonRoot: true
+    ## dataplatform exporter pods' Security Context
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+    ## @param dataplatform.exporter.podSecurityContext.enabled Enable exporter pods' Security Context
+    ## @param dataplatform.exporter.podSecurityContext.fsGroup Group ID for the pods.
+    ##
+    podSecurityContext:
+      enabled: true
+      fsGroup: 1001
+    ## @param dataplatform.exporter.podAffinityPreset exporter pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+    ##
+    podAffinityPreset: ""
+    ## @param dataplatform.exporter.podAntiAffinityPreset exporter pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+    ##
+    podAntiAffinityPreset: soft
+    ## Node affinity preset
+    ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    ##
+    nodeAffinityPreset:
+      ## @param dataplatform.exporter.nodeAffinityPreset.type exporter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+      type: ""
+      ## @param dataplatform.exporter.nodeAffinityPreset.key exporter node label key to match Ignored if `affinity` is set.
+      ## E.g.
+      ## key: "kubernetes.io/e2e-az-name"
+      ##
+      key: ""
+      ## @param dataplatform.exporter.nodeAffinityPreset.values exporter node label values to match. Ignored if `affinity` is set.
+      ## E.g.
+      ## values:
+      ##   - e2e-az1
+      ##   - e2e-az2
+      ##
+      values: []
+    ## @param dataplatform.exporter.affinity Affinity settings for exporter pod assignment. Evaluated as a template
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    affinity: {}
+    ## @param dataplatform.exporter.nodeSelector Node labels for exporter pods assignment. Evaluated as a template
+    ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+    ##
+    nodeSelector: {}
+    ## @param dataplatform.exporter.tolerations Tolerations for exporter pods assignment. Evaluated as a template
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ##
+    tolerations: []
+    ## @param dataplatform.exporter.podLabels Additional labels for Metrics exporter pod
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    ##
+    podLabels: {}
+    ## @param dataplatform.exporter.podAnnotations Additional annotations for Metrics exporter pod
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    podAnnotations: {}
+    ## @param dataplatform.exporter.customLivenessProbe Override default liveness probe%%MAIN_CONTAINER_NAME%%
+    ##
+    customLivenessProbe: {}
+    ## @param dataplatform.exporter.customReadinessProbe Override default readiness probe%%MAIN_CONTAINER_NAME%%
+    ##
+    customReadinessProbe: {}
+    ## Update strategy
+    ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
+    ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
+    ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
+    ## @param dataplatform.exporter.updateStrategy.type Update strategy - only really applicable for deployments with RWO PVs attached
+    ## @param dataplatform.exporter.updateStrategy.rollingUpdate Deployment rolling update configuration parameters
+    ##
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate: {}
+    ## @param dataplatform.exporter.extraEnvVars Additional environment variables to set
+    ## Example:
+    ## extraEnvVars:
+    ##   - name: FOO
+    ##     value: "bar"
+    ##
+    extraEnvVars: []
+    ## @param dataplatform.exporter.extraEnvVarsCM ConfigMap with extra environment variables
+    ##
+    extraEnvVarsCM: ""
+    ## @param dataplatform.exporter.extraEnvVarsSecret Secret with extra environment variables
+    ##
+    extraEnvVarsSecret: ""
+    ## @param dataplatform.exporter.extraVolumes Extra volumes to add to the deployment
+    ##
+    extraVolumes: []
+    ## @param dataplatform.exporter.extraVolumeMounts Extra volume mounts to add to the container
+    ##
+    extraVolumeMounts: []
+    ## @param dataplatform.exporter.initContainers Add init containers to the %%MAIN_CONTAINER_NAME%% pods
+    ## Example:
+    ## initContainers:
+    ##   - name: your-image-name
+    ##     image: your-image
+    ##     imagePullPolicy: Always
+    ##     ports:
+    ##       - name: portname
+    ##         containerPort: 1234
+    ##
+    initContainers: []
+    ## @param dataplatform.exporter.sidecars Add sidecars to the %%MAIN_CONTAINER_NAME%% pods
+    ## Example:
+    ## sidecars:
+    ##   - name: your-image-name
+    ##     image: your-image
+    ##     imagePullPolicy: Always
+    ##     ports:
+    ##       - name: portname
+    ##         containerPort: 1234
+    ##
+    sidecars: []
+    ## Service for the dataplatform exporter deployment
+    ##
+    service:
+      ## @param dataplatform.exporter.service.type Service type for default dataplatform exporter service
+      ##
+      type: ClusterIP
+      ## @param dataplatform.exporter.service.annotations annotations for dataplatform exporter service
+      ##
+      annotations: {}
+      ## @param dataplatform.exporter.service.labels Additional labels for dataplatform exporter service
+      ##
+      labels: {}
+      ## @param dataplatform.exporter.service.port Kubernetes Service port
+      ##
+      port: 9090
+      ## @param dataplatform.exporter.service.loadBalancerIP Load balancer IP for the dataplatform Exporter Service (optional, cloud specific)
+      ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+      ##
+      loadBalancerIP: ""
+      ## @param dataplatform.exporter.service.nodePorts.http Node ports for the HTTP exporter service
+      ## @param dataplatform.exporter.service.nodePorts.https Node ports for the HTTPS exporter service
+      ## nodePorts:
+      ##   http: <to set explicitly, choose port between 30000-32767>
+      ##   https: <to set explicitly, choose port between 30000-32767>
+      nodePorts:
+        http: ""
+        https: ""
+      ## @param dataplatform.exporter.service.loadBalancerSourceRanges Exporter Load Balancer Source ranges
+      ## loadBalancerSourceRanges:
+      ##   - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
+    ## @param dataplatform.exporter.hostAliases Deployment pod host aliases
+    ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+    ##
+    hostAliases: []
+
+  emitter:
+    ## @param dataplatform.emitter.enabled Start dataplatform metrics emitter
+    ##
+    enabled: true
+    ## Data Platform BP2 emitter image
+    ## ref: https://hub.docker.com/r/bitnami/dataplatform-emitter/tags/
+    ## @param dataplatform.emitter.image.registry dataplatform emitter image registry
+    ## @param dataplatform.emitter.image.repository dataplatform emitter image repository
+    ## @param dataplatform.emitter.image.tag dataplatform emitter image tag (immutable tags are recommended)
+    ## @param dataplatform.emitter.image.pullPolicy dataplatform emitter image pull policy
+    ## @param dataplatform.emitter.image.pullSecrets Specify docker-registry secret names as an array
+    ##
+    image:
+      registry: harbor-repo.vmware.com
+      repository: octo_data_platforms/dp-emitter
+      tag: latest
+      ## Specify a imagePullPolicy
+      ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## Example:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []    
+    ## Configure extra options for liveness probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    ## @param dataplatform.emitter.livenessProbe.enabled Enable livenessProbe
+    ## @param dataplatform.emitter.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+    ## @param dataplatform.emitter.livenessProbe.periodSeconds Period seconds for livenessProbe
+    ## @param dataplatform.emitter.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+    ## @param dataplatform.emitter.livenessProbe.failureThreshold Failure threshold for livenessProbe
+    ## @param dataplatform.emitter.livenessProbe.successThreshold Success threshold for livenessProbe
+    ##
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      timeoutSeconds: 15
+      failureThreshold: 15
+      successThreshold: 1
+    ## Configure extra options for readiness probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    ## @param dataplatform.emitter.readinessProbe.enabled Enable readinessProbe
+    ## @param dataplatform.emitter.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+    ## @param dataplatform.emitter.readinessProbe.periodSeconds Period seconds for readinessProbe
+    ## @param dataplatform.emitter.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+    ## @param dataplatform.emitter.readinessProbe.failureThreshold Failure threshold for readinessProbe
+    ## @param dataplatform.emitter.readinessProbe.successThreshold Success threshold for readinessProbe
+    ##
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      timeoutSeconds: 15
+      failureThreshold: 15
+      successThreshold: 15
+    ## @param dataplatform.emitter.port dataplatform emitter port
+    ##
+    port: 8091
+    ## @param dataplatform.emitter.threads Number of dataplatform emitter threads
+    ##
+    threads: 7
+    ## @param dataplatform.emitter.command Override dataplatform entrypoint string.
+    ##
+    command: []
+    ## @param dataplatform.emitter.args Arguments for the provided command if needed
+    ##
+    args: []
+    ## Dataplatform metrics emitter resource requests and limits
+    ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param dataplatform.emitter.resources.limits The resources limits for the container
+    ## @param dataplatform.emitter.resources.requests The requested resources for the container
+    ##
+    resources:
+      ## Example:
+      ## limits:
+      ##    cpu: 200m
+      ##    memory: 256Mi
+      limits: {}
+      ## Examples:
+      ## requests:
+      ##    cpu: 200m
+      ##    memory: 10Mi
+      requests: {}
+    ## dataplatform emitter containers' Security Context
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    ## @param dataplatform.emitter.containerSecurityContext.enabled Enable dataplatform emitter containers' Security Context
+    ## @param dataplatform.emitter.containerSecurityContext.runAsUser User ID for the containers.
+    ## @param dataplatform.emitter.containerSecurityContext.runAsNonRoot Enable dataplatform emitter containers' Security Context runAsNonRoot
+    ##
+    containerSecurityContext:
+      enabled: true
+      runAsUser: 1001
+      runAsNonRoot: true
+    ## dataplatform emitter pods' Security Context
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+    ## @param dataplatform.emitter.podSecurityContext.enabled Enable dataplatform emitter pods' Security Context
+    ## @param dataplatform.emitter.podSecurityContext.fsGroup Group ID for the pods.
+    ##
+    podSecurityContext:
+      enabled: true
+      fsGroup: 1001
+    ## @param dataplatform.emitter.podAffinityPreset emitter pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+    ##
+    podAffinityPreset: ""
+    ## @param dataplatform.emitter.podAntiAffinityPreset emitter pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+    ##
+    podAntiAffinityPreset: soft
+    ## Node affinity preset
+    ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+    ##
+    nodeAffinityPreset:
+      ## @param dataplatform.emitter.nodeAffinityPreset.type emitter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+      type: ""
+      ## @param dataplatform.emitter.nodeAffinityPreset.key emitter node label key to match Ignored if `affinity` is set.
+      ## E.g.
+      ## key: "kubernetes.io/e2e-az-name"
+      ##
+      key: ""
+      ## @param dataplatform.emitter.nodeAffinityPreset.values emitter node label values to match. Ignored if `affinity` is set.
+      ## E.g.
+      ## values:
+      ##   - e2e-az1
+      ##   - e2e-az2
+      ##
+      values: []
+    ## @param dataplatform.emitter.affinity Affinity settings for emitter pod assignment. Evaluated as a template
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+    ##
+    affinity: {}
+    ## @param dataplatform.emitter.nodeSelector Node labels for emitter pods assignment. Evaluated as a template
+    ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+    ##
+    nodeSelector: {}
+    ## @param dataplatform.emitter.tolerations Tolerations for emitter pods assignment. Evaluated as a template
+    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ##
+    tolerations: []
+    ## @param dataplatform.emitter.podLabels Additional labels for Metrics emitter pod
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+    ##
+    podLabels: {}
+    ## @param dataplatform.emitter.podAnnotations Additional annotations for Metrics emitter pod
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    podAnnotations: {}
+    ## @param dataplatform.emitter.customLivenessProbe Override default liveness probe%%MAIN_CONTAINER_NAME%%
+    ##
+    customLivenessProbe: {}
+    ## @param dataplatform.emitter.customReadinessProbe Override default readiness probe%%MAIN_CONTAINER_NAME%%
+    ##
+    customReadinessProbe: {}
+    ## Update strategy
+    ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
+    ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
+    ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
+    ## @param dataplatform.emitter.updateStrategy.type Update strategy - only really applicable for deployments with RWO PVs attached
+    ## @param dataplatform.emitter.updateStrategy.rollingUpdate Deployment rolling update configuration parameters
+    ##
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate: {}
+    ## @param dataplatform.emitter.extraEnvVars Additional environment variables to set
+    ## Example:
+    ## extraEnvVars:
+    ##   - name: FOO
+    ##     value: "bar"
+    ##
+    extraEnvVars: []
+    ## @param dataplatform.emitter.extraEnvVarsCM ConfigMap with extra environment variables
+    ##
+    extraEnvVarsCM: ""
+    ## @param dataplatform.emitter.extraEnvVarsSecret Secret with extra environment variables
+    ##
+    extraEnvVarsSecret: ""
+    ## @param dataplatform.emitter.extraVolumes Extra volumes to add to the deployment
+    ##
+    extraVolumes: []
+    ## @param dataplatform.emitter.extraVolumeMounts Extra volume mounts to add to the container
+    ##
+    extraVolumeMounts: []
+    ## @param dataplatform.emitter.initContainers Add init containers to the %%MAIN_CONTAINER_NAME%% pods
+    ## Example:
+    ## initContainers:
+    ##   - name: your-image-name
+    ##     image: your-image
+    ##     imagePullPolicy: Always
+    ##     ports:
+    ##       - name: portname
+    ##         containerPort: 1234
+    ##
+    initContainers: []
+    ## @param dataplatform.emitter.sidecars Add sidecars to the %%MAIN_CONTAINER_NAME%% pods
+    ## Example:
+    ## sidecars:
+    ##   - name: your-image-name
+    ##     image: your-image
+    ##     imagePullPolicy: Always
+    ##     ports:
+    ##       - name: portname
+    ##         containerPort: 1234
+    ##
+    sidecars: []
+    ## Service for the dataplatform emitter deployment
+    ##
+    service:
+      ## @param dataplatform.emitter.service.type Service type for default dataplatform metrics emitter service
+      ##
+      type: ClusterIP
+      ## @param dataplatform.emitter.service.annotations annotations for dataplatform emitter service
+      ##
+      annotations: {}
+      ## @param dataplatform.emitter.service.labels Additional labels for dataplatform emitter service
+      ##
+      labels: {}
+      ## @param dataplatform.emitter.service.port Kubernetes Service port
+      ##
+      port: 8091
+      ## @param dataplatform.emitter.service.loadBalancerIP Load balancer IP for the dataplatform emitter Service (optional, cloud specific)
+      ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+      ##
+      loadBalancerIP: ""
+      ## @param dataplatform.emitter.service.nodePorts.http Node ports for the HTTP emitter service
+      ## @param dataplatform.emitter.service.nodePorts.https Node ports for the HTTPS emitter service
+      ## nodePorts:
+      ##   http: <to set explicitly, choose port between 30000-32767>
+      ##   https: <to set explicitly, choose port between 30000-32767>
+      nodePorts:
+        http: ""
+        https: ""
+      ## @param dataplatform.emitter.service.loadBalancerSourceRanges Emitter Load Balancer Source ranges
+      ## loadBalancerSourceRanges:
+      ##   - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []     
+    ## @param dataplatform.emitter.hostAliases Deployment pod host aliases
+    ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+    ##
+    hostAliases: []
+
 ## @section Kafka parameters
 
 kafka:

--- a/bitnami/dataplatform-bp2/values.yaml
+++ b/bitnami/dataplatform-bp2/values.yaml
@@ -65,7 +65,7 @@ dataplatform:
     image:
       registry: docker.io
       repository: bitnami/dataplatform-exporter
-      tag: latest
+      tag: 0.0.11-scratch-r0
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -344,7 +344,7 @@ dataplatform:
     image:
       registry: docker.io
       repository: bitnami/dataplatform-emitter
-      tag: latest
+      tag: 0.0.10-scratch-r1
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/dataplatform-bp2/values.yaml
+++ b/bitnami/dataplatform-bp2/values.yaml
@@ -540,7 +540,7 @@ dataplatform:
       ## loadBalancerSourceRanges:
       ##   - 10.10.10.0/24
       ##
-      loadBalancerSourceRanges: []     
+      loadBalancerSourceRanges: []
     ## @param dataplatform.emitter.hostAliases Deployment pod host aliases
     ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
     ##

--- a/bitnami/dataplatform-bp2/values.yaml
+++ b/bitnami/dataplatform-bp2/values.yaml
@@ -55,8 +55,8 @@ dataplatform:
     ## @param dataplatform.exporter.image.pullSecrets Specify docker-registry secret names as an array
     ##
     image:
-      registry: harbor-repo.vmware.com
-      repository: octo_data_platforms/dp-exporter
+      registry: docker.io
+      repository: bitnami/dataplatform-exporter
       tag: latest
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -308,8 +308,8 @@ dataplatform:
     ## @param dataplatform.emitter.image.pullSecrets Specify docker-registry secret names as an array
     ##
     image:
-      registry: harbor-repo.vmware.com
-      repository: octo_data_platforms/dp-emitter
+      registry: docker.io
+      repository: bitnami/dataplatform-emitter
       tag: latest
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/dataplatform-bp2/values.yaml
+++ b/bitnami/dataplatform-bp2/values.yaml
@@ -263,7 +263,10 @@ dataplatform:
       type: ClusterIP
       ## @param dataplatform.exporter.service.annotations annotations for dataplatform exporter service
       ##
-      annotations: {}
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
       ## @param dataplatform.exporter.service.labels Additional labels for dataplatform exporter service
       ##
       labels: {}
@@ -287,10 +290,6 @@ dataplatform:
       ##   - 10.10.10.0/24
       ##
       loadBalancerSourceRanges: []
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9090"
-        prometheus.io/path: "/metrics"
     ## @param dataplatform.exporter.hostAliases Deployment pod host aliases
     ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
     ##

--- a/bitnami/dataplatform-bp2/values.yaml
+++ b/bitnami/dataplatform-bp2/values.yaml
@@ -16,8 +16,7 @@ global:
   imagePullSecrets: []
   storageClass: ""
 
-## @section Data Platform Exporter deployment parameters
-
+## @section Data Platform Chart parameters
 ## Configuration for the dataplatform prometheus exporter
 ##
 dataplatform:
@@ -102,13 +101,13 @@ dataplatform:
       timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 15
-    ## @param dataplatform.exporter.port dataplatform exporter port
+    ## @param dataplatform.exporter.port Data Platform Prometheus exporter port
     ##
     port: 9090
-    ## @param dataplatform.exporter.threads Number of dataplatform exporter threads
+    ## @param dataplatform.exporter.threads Number of Data Platform exporter threads
     ##
     threads: 7
-    ## @param dataplatform.exporter.command Override dataplatform entrypoint string.
+    ## @param dataplatform.exporter.command Override Data Platform Exporter entrypoint string.
     ##
     command: []
     ## @param dataplatform.exporter.args Arguments for the provided command if needed
@@ -120,8 +119,8 @@ dataplatform:
     ## choice for the user. This also increases chances charts run on environments with little
     ## resources, such as Minikube. If you do want to specify resources, uncomment the following
     ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    ## @param exporter.resources.limits The resources limits for the container
-    ## @param exporter.resources.requests The requested resources for the container
+    ## @param dataplatform.exporter.resources.limits The resources limits for the container
+    ## @param dataplatform.exporter.resources.requests The requested resources for the container
     ##
     resources:
       ## Example:
@@ -136,9 +135,9 @@ dataplatform:
       requests: {}
     ## dataplatform exporter containers' Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-    ## @param dataplatform.exporter.containerSecurityContext.enabled Enable dataplatform exporter containers' Security Context
+    ## @param dataplatform.exporter.containerSecurityContext.enabled Enable Data Platform exporter containers' Security Context
     ## @param dataplatform.exporter.containerSecurityContext.runAsUser User ID for the containers.
-    ## @param dataplatform.exporter.containerSecurityContext.runAsNonRoot Enable dataplatform exporter containers' Security Context runAsNonRoot
+    ## @param dataplatform.exporter.containerSecurityContext.runAsNonRoot Enable Data Platform exporter containers' Security Context runAsNonRoot
     ##
     containerSecurityContext:
       enabled: true
@@ -146,17 +145,17 @@ dataplatform:
       runAsNonRoot: true
     ## dataplatform exporter pods' Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-    ## @param dataplatform.exporter.podSecurityContext.enabled Enable exporter pods' Security Context
+    ## @param dataplatform.exporter.podSecurityContext.enabled Enable Data Platform exporter pods' Security Context
     ## @param dataplatform.exporter.podSecurityContext.fsGroup Group ID for the pods.
     ##
     podSecurityContext:
       enabled: true
       fsGroup: 1001
-    ## @param dataplatform.exporter.podAffinityPreset exporter pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## @param dataplatform.exporter.podAffinityPreset Data Platform exporter pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
     ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
     ##
     podAffinityPreset: ""
-    ## @param dataplatform.exporter.podAntiAffinityPreset exporter pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## @param dataplatform.exporter.podAntiAffinityPreset Data Platform exporter pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
     ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
     ##
     podAntiAffinityPreset: soft
@@ -164,14 +163,14 @@ dataplatform:
     ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
     ##
     nodeAffinityPreset:
-      ## @param dataplatform.exporter.nodeAffinityPreset.type exporter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+      ## @param dataplatform.exporter.nodeAffinityPreset.type Data Platform exporter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
       type: ""
-      ## @param dataplatform.exporter.nodeAffinityPreset.key exporter node label key to match Ignored if `affinity` is set.
+      ## @param dataplatform.exporter.nodeAffinityPreset.key Data Platform exporter node label key to match Ignored if `affinity` is set.
       ## E.g.
       ## key: "kubernetes.io/e2e-az-name"
       ##
       key: ""
-      ## @param dataplatform.exporter.nodeAffinityPreset.values exporter node label values to match. Ignored if `affinity` is set.
+      ## @param dataplatform.exporter.nodeAffinityPreset.values Data Platform exporter node label values to match. Ignored if `affinity` is set.
       ## E.g.
       ## values:
       ##   - e2e-az1
@@ -255,25 +254,27 @@ dataplatform:
     ##         containerPort: 1234
     ##
     sidecars: []
-    ## Service for the dataplatform exporter deployment
+    ## Service for the Data Platform exporter deployment
     ##
     service:
-      ## @param dataplatform.exporter.service.type Service type for default dataplatform exporter service
+      ## @param dataplatform.exporter.service.type Service type for default Data Platform Prometheus exporter service
       ##
       type: ClusterIP
-      ## @param dataplatform.exporter.service.annotations annotations for dataplatform exporter service
+      ## @param dataplatform.exporter.service.annotations.prometheus.io/scrape Enable Data Platform Prometheus exporter
+      ## @param dataplatform.exporter.service.annotations.prometheus.io/port Data Platform Prometheus exporter port
+      ## @param dataplatform.exporter.service.annotations.prometheus.io/path Data Platform Prometheus exporter metrics path
       ##
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
-      ## @param dataplatform.exporter.service.labels Additional labels for dataplatform exporter service
+      ## @param dataplatform.exporter.service.labels Additional labels for Data Platform exporter service
       ##
       labels: {}
       ## @param dataplatform.exporter.service.port Kubernetes Service port
       ##
       port: 9090
-      ## @param dataplatform.exporter.service.loadBalancerIP Load balancer IP for the dataplatform Exporter Service (optional, cloud specific)
+      ## @param dataplatform.exporter.service.loadBalancerIP Load balancer IP for the Data Platform Exporter Service (optional, cloud specific)
       ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
       ##
       loadBalancerIP: ""
@@ -296,15 +297,15 @@ dataplatform:
     hostAliases: []
 
   emitter:
-    ## @param dataplatform.emitter.enabled Start dataplatform metrics emitter
+    ## @param dataplatform.emitter.enabled Start Data Platform metrics emitter
     ##
     enabled: true
     ## Data Platform BP2 emitter image
     ## ref: https://hub.docker.com/r/bitnami/dataplatform-emitter/tags/
-    ## @param dataplatform.emitter.image.registry dataplatform emitter image registry
-    ## @param dataplatform.emitter.image.repository dataplatform emitter image repository
-    ## @param dataplatform.emitter.image.tag dataplatform emitter image tag (immutable tags are recommended)
-    ## @param dataplatform.emitter.image.pullPolicy dataplatform emitter image pull policy
+    ## @param dataplatform.emitter.image.registry Data Platform emitter image registry
+    ## @param dataplatform.emitter.image.repository Data Platform emitter image repository
+    ## @param dataplatform.emitter.image.tag Data Platform emitter image tag (immutable tags are recommended)
+    ## @param dataplatform.emitter.image.pullPolicy Data Platform emitter image pull policy
     ## @param dataplatform.emitter.image.pullSecrets Specify docker-registry secret names as an array
     ##
     image:
@@ -355,19 +356,19 @@ dataplatform:
       timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 15
-    ## @param dataplatform.emitter.port dataplatform emitter port
+    ## @param dataplatform.emitter.port Data Platform emitter port
     ##
     port: 8091
-    ## @param dataplatform.emitter.threads Number of dataplatform emitter threads
+    ## @param dataplatform.emitter.threads Number of Data Platform emitter threads
     ##
     threads: 7
-    ## @param dataplatform.emitter.command Override dataplatform entrypoint string.
+    ## @param dataplatform.emitter.command Override Data Platform entrypoint string.
     ##
     command: []
     ## @param dataplatform.emitter.args Arguments for the provided command if needed
     ##
     args: []
-    ## Dataplatform metrics emitter resource requests and limits
+    ## Data Platform metrics emitter resource requests and limits
     ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
     ## We usually recommend not to specify default resources and to leave this as a conscious
     ## choice for the user. This also increases chances charts run on environments with little
@@ -387,29 +388,29 @@ dataplatform:
       ##    cpu: 200m
       ##    memory: 10Mi
       requests: {}
-    ## dataplatform emitter containers' Security Context
+    ## Data Platform emitter containers' Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-    ## @param dataplatform.emitter.containerSecurityContext.enabled Enable dataplatform emitter containers' Security Context
+    ## @param dataplatform.emitter.containerSecurityContext.enabled Enable Data Platform emitter containers' Security Context
     ## @param dataplatform.emitter.containerSecurityContext.runAsUser User ID for the containers.
-    ## @param dataplatform.emitter.containerSecurityContext.runAsNonRoot Enable dataplatform emitter containers' Security Context runAsNonRoot
+    ## @param dataplatform.emitter.containerSecurityContext.runAsNonRoot Enable Data Platform emitter containers' Security Context runAsNonRoot
     ##
     containerSecurityContext:
       enabled: true
       runAsUser: 1001
       runAsNonRoot: true
-    ## dataplatform emitter pods' Security Context
+    ## Data Platform emitter pods' Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-    ## @param dataplatform.emitter.podSecurityContext.enabled Enable dataplatform emitter pods' Security Context
+    ## @param dataplatform.emitter.podSecurityContext.enabled Enable Data Platform emitter pods' Security Context
     ## @param dataplatform.emitter.podSecurityContext.fsGroup Group ID for the pods.
     ##
     podSecurityContext:
       enabled: true
       fsGroup: 1001
-    ## @param dataplatform.emitter.podAffinityPreset emitter pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## @param dataplatform.emitter.podAffinityPreset Data Platform emitter pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
     ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
     ##
     podAffinityPreset: ""
-    ## @param dataplatform.emitter.podAntiAffinityPreset emitter pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+    ## @param dataplatform.emitter.podAntiAffinityPreset Data Platform emitter pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
     ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
     ##
     podAntiAffinityPreset: soft
@@ -417,14 +418,14 @@ dataplatform:
     ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
     ##
     nodeAffinityPreset:
-      ## @param dataplatform.emitter.nodeAffinityPreset.type emitter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+      ## @param dataplatform.emitter.nodeAffinityPreset.type Data Platform emitter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
       type: ""
-      ## @param dataplatform.emitter.nodeAffinityPreset.key emitter node label key to match Ignored if `affinity` is set.
+      ## @param dataplatform.emitter.nodeAffinityPreset.key Data Platform emitter node label key to match Ignored if `affinity` is set.
       ## E.g.
       ## key: "kubernetes.io/e2e-az-name"
       ##
       key: ""
-      ## @param dataplatform.emitter.nodeAffinityPreset.values emitter node label values to match. Ignored if `affinity` is set.
+      ## @param dataplatform.emitter.nodeAffinityPreset.values Data Platform emitter node label values to match. Ignored if `affinity` is set.
       ## E.g.
       ## values:
       ##   - e2e-az1
@@ -508,16 +509,16 @@ dataplatform:
     ##         containerPort: 1234
     ##
     sidecars: []
-    ## Service for the dataplatform emitter deployment
+    ## Service for the Data Platform emitter deployment
     ##
     service:
-      ## @param dataplatform.emitter.service.type Service type for default dataplatform metrics emitter service
+      ## @param dataplatform.emitter.service.type Service type for default Data Platform metrics emitter service
       ##
       type: ClusterIP
-      ## @param dataplatform.emitter.service.annotations annotations for dataplatform emitter service
+      ## @param dataplatform.emitter.service.annotations annotations for Data Platform emitter service
       ##
       annotations: {}
-      ## @param dataplatform.emitter.service.labels Additional labels for dataplatform emitter service
+      ## @param dataplatform.emitter.service.labels Additional labels for Data Platform emitter service
       ##
       labels: {}
       ## @param dataplatform.emitter.service.port Kubernetes Service port
@@ -535,7 +536,7 @@ dataplatform:
       nodePorts:
         http: ""
         https: ""
-      ## @param dataplatform.emitter.service.loadBalancerSourceRanges Emitter Load Balancer Source ranges
+      ## @param dataplatform.emitter.service.loadBalancerSourceRanges Data Platform Emitter Load Balancer Source ranges
       ## loadBalancerSourceRanges:
       ##   - 10.10.10.0/24
       ##

--- a/bitnami/dataplatform-bp2/values.yaml
+++ b/bitnami/dataplatform-bp2/values.yaml
@@ -2,6 +2,7 @@
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+##
 
 ## @param global.imageRegistry Global Docker image registry
 ## @param global.imagePullSecrets Global Docker registry secret names as an array
@@ -15,6 +16,14 @@ global:
   ##
   imagePullSecrets: []
   storageClass: ""
+
+## @section Common parameters
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
 
 ## @section Data Platform Chart parameters
 ## Configuration for the dataplatform prometheus exporter
@@ -101,12 +110,30 @@ dataplatform:
       timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 15
-    ## @param dataplatform.exporter.port Data Platform Prometheus exporter port
+    ## Configure extra options for startup probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-startup-probes/#configure-probes
+    ## @param dataplatform.exporter.startupProbe.enabled Enable startupProbe
+    ## @param dataplatform.exporter.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+    ## @param dataplatform.exporter.startupProbe.periodSeconds Period seconds for startupProbe
+    ## @param dataplatform.exporter.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+    ## @param dataplatform.exporter.startupProbe.failureThreshold Failure threshold for startupProbe
+    ## @param dataplatform.exporter.startupProbe.successThreshold Success threshold for startupProbe
     ##
-    port: 9090
-    ## @param dataplatform.exporter.threads Number of Data Platform exporter threads
+    startupProbe:
+      enabled: false
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      timeoutSeconds: 15
+      failureThreshold: 15
+      successThreshold: 15
+    ## @param dataplatform.exporter.containerPorts.http Data Platform Prometheus exporter port
     ##
-    threads: 7
+    containerPorts:
+      http: 9090
+    ## @param dataplatform.exporter.priorityClassName exporter priorityClassName
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    ##
+    priorityClassName: ""
     ## @param dataplatform.exporter.command Override Data Platform Exporter entrypoint string.
     ##
     command: []
@@ -127,11 +154,13 @@ dataplatform:
       ## limits:
       ##    cpu: 200m
       ##    memory: 256Mi
+      ##
       limits: {}
       ## Examples:
       ## requests:
       ##    cpu: 200m
       ##    memory: 10Mi
+      ##
       requests: {}
     ## dataplatform exporter containers' Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
@@ -164,6 +193,7 @@ dataplatform:
     ##
     nodeAffinityPreset:
       ## @param dataplatform.exporter.nodeAffinityPreset.type Data Platform exporter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+      ##
       type: ""
       ## @param dataplatform.exporter.nodeAffinityPreset.key Data Platform exporter node label key to match Ignored if `affinity` is set.
       ## E.g.
@@ -197,12 +227,15 @@ dataplatform:
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     ##
     podAnnotations: {}
-    ## @param dataplatform.exporter.customLivenessProbe Override default liveness probe%%MAIN_CONTAINER_NAME%%
+    ## @param dataplatform.exporter.customLivenessProbe Override default liveness probe
     ##
     customLivenessProbe: {}
-    ## @param dataplatform.exporter.customReadinessProbe Override default readiness probe%%MAIN_CONTAINER_NAME%%
+    ## @param dataplatform.exporter.customReadinessProbe Override default readiness probe
     ##
     customReadinessProbe: {}
+    ## @param dataplatform.exporter.customStartupProbe Override default startup probe
+    ##
+    customStartupProbe: {}
     ## Update strategy
     ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
     ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
@@ -271,21 +304,21 @@ dataplatform:
       ## @param dataplatform.exporter.service.labels Additional labels for Data Platform exporter service
       ##
       labels: {}
-      ## @param dataplatform.exporter.service.port Kubernetes Service port
+      ## @param dataplatform.exporter.service.ports.http Kubernetes Service port
       ##
-      port: 9090
+      ports:
+        http: 9090
       ## @param dataplatform.exporter.service.loadBalancerIP Load balancer IP for the Data Platform Exporter Service (optional, cloud specific)
       ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
       ##
       loadBalancerIP: ""
       ## @param dataplatform.exporter.service.nodePorts.http Node ports for the HTTP exporter service
-      ## @param dataplatform.exporter.service.nodePorts.https Node ports for the HTTPS exporter service
       ## nodePorts:
       ##   http: <to set explicitly, choose port between 30000-32767>
       ##   https: <to set explicitly, choose port between 30000-32767>
+      ##
       nodePorts:
         http: ""
-        https: ""
       ## @param dataplatform.exporter.service.loadBalancerSourceRanges Exporter Load Balancer Source ranges
       ## loadBalancerSourceRanges:
       ##   - 10.10.10.0/24
@@ -356,12 +389,30 @@ dataplatform:
       timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 15
-    ## @param dataplatform.emitter.port Data Platform emitter port
+    ## Configure extra options for startup probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-startup-probes/#configure-probes
+    ## @param dataplatform.emitter.startupProbe.enabled Enable startupProbe
+    ## @param dataplatform.emitter.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+    ## @param dataplatform.emitter.startupProbe.periodSeconds Period seconds for startupProbe
+    ## @param dataplatform.emitter.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+    ## @param dataplatform.emitter.startupProbe.failureThreshold Failure threshold for startupProbe
+    ## @param dataplatform.emitter.startupProbe.successThreshold Success threshold for startupProbe
     ##
-    port: 8091
-    ## @param dataplatform.emitter.threads Number of Data Platform emitter threads
+    startupProbe:
+      enabled: false
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      timeoutSeconds: 15
+      failureThreshold: 15
+      successThreshold: 15
+    ## @param dataplatform.emitter.containerPorts.http Data Platform emitter port
     ##
-    threads: 7
+    containerPorts:
+      http: 8091
+    ## @param dataplatform.emitter.priorityClassName exporter priorityClassName
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+    ##
+    priorityClassName: ""
     ## @param dataplatform.emitter.command Override Data Platform entrypoint string.
     ##
     command: []
@@ -382,11 +433,13 @@ dataplatform:
       ## limits:
       ##    cpu: 200m
       ##    memory: 256Mi
+      ##
       limits: {}
       ## Examples:
       ## requests:
       ##    cpu: 200m
       ##    memory: 10Mi
+      ##
       requests: {}
     ## Data Platform emitter containers' Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
@@ -419,6 +472,7 @@ dataplatform:
     ##
     nodeAffinityPreset:
       ## @param dataplatform.emitter.nodeAffinityPreset.type Data Platform emitter node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+      ##
       type: ""
       ## @param dataplatform.emitter.nodeAffinityPreset.key Data Platform emitter node label key to match Ignored if `affinity` is set.
       ## E.g.
@@ -458,6 +512,9 @@ dataplatform:
     ## @param dataplatform.emitter.customReadinessProbe Override default readiness probe%%MAIN_CONTAINER_NAME%%
     ##
     customReadinessProbe: {}
+    ## @param dataplatform.emitter.customStartupProbe Override default startup probe
+    ##
+    customStartupProbe: {}
     ## Update strategy
     ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
     ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
@@ -521,21 +578,21 @@ dataplatform:
       ## @param dataplatform.emitter.service.labels Additional labels for Data Platform emitter service
       ##
       labels: {}
-      ## @param dataplatform.emitter.service.port Kubernetes Service port
+      ## @param dataplatform.emitter.service.ports.http Kubernetes Service port
       ##
-      port: 8091
+      ports:
+        http: 8091
       ## @param dataplatform.emitter.service.loadBalancerIP Load balancer IP for the dataplatform emitter Service (optional, cloud specific)
       ## ref: http://kubernetes.io/docs/user-guide/services/#type-loadbalancer
       ##
       loadBalancerIP: ""
       ## @param dataplatform.emitter.service.nodePorts.http Node ports for the HTTP emitter service
-      ## @param dataplatform.emitter.service.nodePorts.https Node ports for the HTTPS emitter service
       ## nodePorts:
       ##   http: <to set explicitly, choose port between 30000-32767>
       ##   https: <to set explicitly, choose port between 30000-32767>
+      ##
       nodePorts:
         http: ""
-        https: ""
       ## @param dataplatform.emitter.service.loadBalancerSourceRanges Data Platform Emitter Load Balancer Source ranges
       ## loadBalancerSourceRanges:
       ##   - 10.10.10.0/24
@@ -547,6 +604,7 @@ dataplatform:
     hostAliases: []
 
 ## @section Kafka parameters
+##
 
 kafka:
   ## @param kafka.enabled Enable Kafka subchart
@@ -586,7 +644,7 @@ kafka:
               - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                  - '{{ .Release.Name }}'
+                  - "{{ .Release.Name }}"
           topologyKey: "kubernetes.io/hostname"
     podAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -601,7 +659,7 @@ kafka:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'
+                    - "{{ .Release.Name }}"
             topologyKey: "kubernetes.io/hostname"
   ## Prometheus Exporters / Metrics
   ##
@@ -632,6 +690,7 @@ kafka:
     ##
     jmx:
       ## @param kafka.metrics.jmx.enabled Enable JMX exporter for Kafka
+      ##
       enabled: false
       ## Prometheus JMX Exporter' resource requests and limits
       ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -687,7 +746,7 @@ kafka:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'
+                    - "{{ .Release.Name }}"
             topologyKey: "kubernetes.io/hostname"
   ## This value is only used when zookeeper.enabled is set to false.
   ##
@@ -698,6 +757,7 @@ kafka:
     servers: []
 
 ## @section Spark parameters
+##
 
 spark:
   ## @param spark.enabled Enable Spark subchart
@@ -734,7 +794,7 @@ spark:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'
+                    - "{{ .Release.Name }}"
             topologyKey: "kubernetes.io/hostname"
   ## Spark worker specific configuration
   ## @param spark.worker.replicaCount Number of spark workers
@@ -774,7 +834,7 @@ spark:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'
+                    - "{{ .Release.Name }}"
             topologyKey: "kubernetes.io/hostname"
   ## Metrics configuration
   ## @param spark.metrics.enabled Enable Prometheus exporter for Spark
@@ -786,17 +846,18 @@ spark:
     ## Annotations for the Prometheus metrics on master nodes
     ##
     masterAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: '/metrics/'
-      prometheus.io/port: '8080'
+      prometheus.io/scrape: "true"
+      prometheus.io/path: "/metrics/"
+      prometheus.io/port: "8080"
     ## Annotations for the Prometheus metrics on worker nodes
     ##
     workerAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/path: '/metrics/'
-      prometheus.io/port: '8081'
+      prometheus.io/scrape: "true"
+      prometheus.io/path: "/metrics/"
+      prometheus.io/port: "8081"
 
 ## @section Elasticsearch parameters
+##
 
 elasticsearch:
   ## @param elasticsearch.enabled Enable Elasticsearch
@@ -841,7 +902,7 @@ elasticsearch:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'
+                    - "{{ .Release.Name }}"
             topologyKey: "kubernetes.io/hostname"
 
     ## Elasticsearch master-eligible container's resource requests and limits
@@ -865,6 +926,7 @@ elasticsearch:
   ## @param elasticsearch.data.resources.limits Elasticsearch data node resource limits
   ## @param elasticsearch.data.resources.requests.cpu Elasticsearch data node CPUs
   ## @param elasticsearch.data.resources.requests.memory Elasticsearch data node requested memory
+  ##
   data:
     name: data
     ## Number of data node(s) replicas to deploy
@@ -891,7 +953,7 @@ elasticsearch:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'
+                    - "{{ .Release.Name }}"
             topologyKey: "kubernetes.io/hostname"
 
     ## Elasticsearch data container's resource requests and limits
@@ -936,7 +998,7 @@ elasticsearch:
                 - key: app.kubernetes.io/instance
                   operator: In
                   values:
-                    - '{{ .Release.Name }}'
+                    - "{{ .Release.Name }}"
             topologyKey: "kubernetes.io/hostname"
     ## Elasticsearch coordinating-only container's resource requests and limits
     ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -958,6 +1020,7 @@ elasticsearch:
   ## @param elasticsearch.metrics.resources.requests.cpu Elasticsearch metrics CPUs
   ## @param elasticsearch.metrics.resources.requests.memory Elasticsearch metrics requested memory
   ## @param elasticsearch.metrics.service.annotations [object] Elasticsearch metrics service annotations
+  ##
   metrics:
     enabled: false
     ## Elasticsearch Prometheus exporter resource requests and limits
@@ -982,6 +1045,7 @@ elasticsearch:
         prometheus.io/port: "9114"
 
 ## @section Logstash parameters
+##
 
 logstash:
   ## @param logstash.enabled Enable Logstash
@@ -1009,7 +1073,7 @@ logstash:
               - key: app.kubernetes.io/instance
                 operator: In
                 values:
-                  - '{{ .Release.Name }}'
+                  - "{{ .Release.Name }}"
           topologyKey: "kubernetes.io/hostname"
   ## @param logstash.extraEnvVars Array containing extra env vars to configure Logstash
   ## For example:
@@ -1050,6 +1114,7 @@ logstash:
         memory: 128Mi
     ## @param logstash.metrics.service.port Logstash Prometheus port
     ## @param logstash.metrics.service.annotations [object] Annotations for the Prometheus metrics service
+    ##
     service:
       port: 9198
       annotations:
@@ -1058,6 +1123,7 @@ logstash:
         prometheus.io/path: "/metrics"
 
 ## @section Tanzu Observability (Wavefront) parameters
+##
 
 wavefront:
   ## @param wavefront.enabled Enable Tanzu Observability Framework
@@ -1113,7 +1179,7 @@ wavefront:
           type: prometheus
           selectors:
             images:
-              - '*bitnami/kafka-exporter*'
+              - "*bitnami/kafka-exporter*"
           port: 9308
           path: /metrics
           scheme: http
@@ -1124,7 +1190,7 @@ wavefront:
           type: prometheus
           selectors:
             images:
-              - '*bitnami/jmx-exporter*'
+              - "*bitnami/jmx-exporter*"
           port: 5556
           path: /metrics
           scheme: http
@@ -1135,7 +1201,7 @@ wavefront:
           type: prometheus
           selectors:
             images:
-              - '*bitnami/elasticsearch-exporter*'
+              - "*bitnami/elasticsearch-exporter*"
           port: 9114
           path: /metrics
           scheme: http
@@ -1145,7 +1211,7 @@ wavefront:
           type: prometheus
           selectors:
             images:
-              - '*bitnami/logstash-exporter*'
+              - "*bitnami/logstash-exporter*"
           port: 9198
           path: /metrics
           scheme: http
@@ -1155,7 +1221,7 @@ wavefront:
           type: prometheus
           selectors:
             images:
-              - '*bitnami/spark*'
+              - "*bitnami/spark*"
           port: 8081
           path: /metrics/
           scheme: http
@@ -1166,7 +1232,7 @@ wavefront:
           type: prometheus
           selectors:
             images:
-              - '*bitnami/spark*'
+              - "*bitnami/spark*"
           port: 8080
           path: /metrics/
           scheme: http


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

1. Add Deployment and Service for Data Platform Metrics Emitter and Prometheus Exporters to the chart (enabled by default)
2. Add ServiceAccount, RBAC creation by default for the data platform

**Benefits**

Prometheus exporter emits Health Metrics for the data platform

**Possible drawbacks**

NA

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
