### PR TITLE
[bitnami/redis] Use timeoutSeconds to timeout health checks

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 15.3.2
+version: 15.3.3

--- a/bitnami/redis/templates/health-configmap.yaml
+++ b/bitnami/redis/templates/health-configmap.yaml
@@ -17,7 +17,6 @@ data:
     [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
     [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
     response=$(
-      timeout -s 3 $1 \
       redis-cli \
         -h localhost \
 {{- if .Values.tls.enabled }}
@@ -43,7 +42,6 @@ data:
     [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
     [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
     response=$(
-      timeout -s 3 $1 \
       redis-cli \
         -h localhost \
 {{- if .Values.tls.enabled }}
@@ -70,7 +68,6 @@ data:
     [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
     [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
     response=$(
-      timeout -s 3 $1 \
       redis-cli \
         -h localhost \
 {{- if .Values.tls.enabled }}
@@ -112,7 +109,6 @@ data:
     [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
     [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
     response=$(
-      timeout -s 3 $1 \
       redis-cli \
         -h $REDIS_MASTER_HOST \
         -p $REDIS_MASTER_PORT_NUMBER \
@@ -136,7 +132,6 @@ data:
     [[ -f $REDIS_MASTER_PASSWORD_FILE ]] && export REDIS_MASTER_PASSWORD="$(< "${REDIS_MASTER_PASSWORD_FILE}")"
     [[ -n "$REDIS_MASTER_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_MASTER_PASSWORD"
     response=$(
-      timeout -s 3 $1 \
       redis-cli \
         -h $REDIS_MASTER_HOST \
         -p $REDIS_MASTER_PORT_NUMBER \
@@ -157,12 +152,12 @@ data:
   ping_readiness_local_and_master.sh: |-
     script_dir="$(dirname "$0")"
     exit_status=0
-    "$script_dir/ping_readiness_local.sh" $1 || exit_status=$?
-    "$script_dir/ping_readiness_master.sh" $1 || exit_status=$?
+    "$script_dir/ping_readiness_local.sh" || exit_status=$?
+    "$script_dir/ping_readiness_master.sh" || exit_status=$?
     exit $exit_status
   ping_liveness_local_and_master.sh: |-
     script_dir="$(dirname "$0")"
     exit_status=0
-    "$script_dir/ping_liveness_local.sh" $1 || exit_status=$?
-    "$script_dir/ping_liveness_master.sh" $1 || exit_status=$?
+    "$script_dir/ping_liveness_local.sh" || exit_status=$?
+    "$script_dir/ping_liveness_master.sh" || exit_status=$?
     exit $exit_status

--- a/bitnami/redis/templates/master/statefulset.yaml
+++ b/bitnami/redis/templates/master/statefulset.yaml
@@ -169,15 +169,14 @@ spec:
           livenessProbe:
             initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.master.livenessProbe.periodSeconds }}
-            # One second longer than command timeout should prevent generation of zombie processes.
-            timeoutSeconds: {{ add1 .Values.master.livenessProbe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.master.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.master.livenessProbe.failureThreshold }}
             exec:
               command:
                 - sh
                 - -c
-                - /health/ping_liveness_local.sh {{ .Values.master.livenessProbe.timeoutSeconds }}
+                - /health/ping_liveness_local.sh
           {{- else if .Values.master.customLivenessProbe }}
           livenessProbe: {{- toYaml .Values.master.customLivenessProbe | nindent 12 }}
           {{- end }}
@@ -185,14 +184,14 @@ spec:
           readinessProbe:
             initialDelaySeconds: {{ .Values.master.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.master.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ add1 .Values.master.readinessProbe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.master.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.master.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.master.readinessProbe.failureThreshold }}
             exec:
               command:
                 - sh
                 - -c
-                - /health/ping_readiness_local.sh {{ .Values.master.readinessProbe.timeoutSeconds }}
+                - /health/ping_readiness_local.sh
           {{- else if .Values.master.customReadinessProbe }}
           readinessProbe: {{- toYaml .Values.master.customReadinessProbe | nindent 12 }}
           {{- end }}

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -184,14 +184,14 @@ spec:
           livenessProbe:
             initialDelaySeconds: {{ .Values.replica.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.replica.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ add1 .Values.replica.livenessProbe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.replica.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.replica.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.replica.livenessProbe.failureThreshold}}
             exec:
               command:
                 - sh
                 - -c
-                - /health/ping_liveness_local_and_master.sh {{ .Values.replica.livenessProbe.timeoutSeconds }}
+                - /health/ping_liveness_local_and_master.sh
           {{- else if .Values.replica.customLivenessProbe }}
           livenessProbe: {{- toYaml .Values.replica.customLivenessProbe | nindent 12 }}
           {{- end }}
@@ -199,14 +199,14 @@ spec:
           readinessProbe:
             initialDelaySeconds: {{ .Values.replica.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.replica.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ add1 .Values.replica.readinessProbe.timeoutSeconds }}
+            timeoutSeconds: {{ .Values.replica.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.replica.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.replica.readinessProbe.failureThreshold }}
             exec:
               command:
                 - sh
                 - -c
-                - /health/ping_readiness_local_and_master.sh {{ .Values.replica.readinessProbe.timeoutSeconds }}
+                - /health/ping_readiness_local_and_master.sh
           {{- else if .Values.replica.customReadinessProbe }}
           readinessProbe: {{- toYaml .Values.replica.customReadinessProbe | nindent 12 }}
           {{- end }}

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -187,7 +187,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_liveness_local.sh {{ .Values.replica.livenessProbe.timeoutSeconds }}
+                - /health/ping_liveness_local.sh
           {{- else if .Values.replica.customLivenessProbe }}
           livenessProbe: {{- toYaml .Values.replica.customLivenessProbe | nindent 12 }}
           {{- end }}
@@ -202,7 +202,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_readiness_local.sh {{ .Values.replica.livenessProbe.timeoutSeconds }}
+                - /health/ping_readiness_local.sh
           {{- else if .Values.replica.customReadinessProbe }}
           readinessProbe: {{- toYaml .Values.replica.customReadinessProbe | nindent 12 }}
           {{- end }}
@@ -337,7 +337,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_sentinel.sh {{ .Values.sentinel.livenessProbe.timeoutSeconds }}
+                - /health/ping_sentinel.sh
           {{- else if .Values.sentinel.customLivenessProbe }}
           livenessProbe: {{- toYaml .Values.sentinel.customLivenessProbe | nindent 12 }}
           {{- end }}
@@ -354,7 +354,7 @@ spec:
               command:
                 - sh
                 - -c
-                - /health/ping_sentinel.sh {{ .Values.sentinel.livenessProbe.timeoutSeconds }}
+                - /health/ping_sentinel.sh
           {{- else if .Values.sentinel.customReadinessProbe }}
           readinessProbe: {{- toYaml .Values.sentinel.customReadinessProbe | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
The timeout wrapper in health checks was added in helm/charts#11355
to work around Docker/containerd not respecting timeouts in probes
(cf. kubernetes/kubernetes#58925). The upstream issue has been fixed
since Kubernetes 1.20 (kubernetes/kubernetes#94115), and this wrapper
causes degraded behavior (ie. any failure in the wrapped command only
gets reported as "The monitored command dumped core", without details
for the specific failure), so the original behavior should be restored.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
