### PR TITLE
[bitnami/minio] Add CONSOLE_PORT parameter and API ingress

### DIFF
--- a/bitnami/minio/Chart.lock
+++ b/bitnami/minio/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.8.0
-digest: sha256:3e342a25057f87853e52d83e1d14e6d8727c15fd85aaae22e7594489cc129f15
-generated: "2021-08-23T23:19:03.0267674Z"
+  version: 1.9.0
+digest: sha256:6d608d323ac01a7950ba64fa7caf4169a5d9d33e442c99e23e123caaf303b6b9
+generated: "2021-09-20T08:15:48.081784297Z"

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 8.0.1
+version: 8.1.0

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -190,6 +190,19 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.extraPaths`               | Any additional paths that may need to be added to the ingress under the main host                           | `[]`                     |
 | `ingress.extraTls`                 | The tls configuration for additional hostnames to be covered with this ingress record.                      | `[]`                     |
 | `ingress.secrets`                  | If you're providing your own certificates, please use this to add the certificates as secrets               | `[]`                     |
+| `apiIngress.enabled`               | Enable ingress controller resource                                                                          | `false`                  |
+| `apiIngress.certManager`           | Set this to true in order to add the corresponding annotations for cert-manager                             | `false`                  |
+| `apiIngress.apiVersion`            | Force Ingress API version (automatically detected if not set)                                               | `""`                     |
+| `apiIngress.hostname`              | Default host for the ingress resource                                                                       | `minio.local`            |
+| `apiIngress.path`                  | The Path to MinIO&reg;. You may need to set this to '/*' in order to use this with ALB ingress controllers. | `/`                      |
+| `apiIngress.pathType`              | Ingress path type                                                                                           | `ImplementationSpecific` |
+| `apiIngress.servicePort`           | Service port to be used                                                                                     | `minio-console`          |
+| `apiIngress.annotations`           | Ingress annotations                                                                                         | `{}`                     |
+| `apiIngress.tls`                   | Enable TLS configuration for the hostname defined at `apiIngress.hostname` parameter                        | `false`                  |
+| `apiIngress.extraHosts`            | The list of additional hostnames to be covered with this ingress record.                                    | `[]`                     |
+| `apiIngress.extraPaths`            | Any additional paths that may need to be added to the ingress under the main host                           | `[]`                     |
+| `apiIngress.extraTls`              | The tls configuration for additional hostnames to be covered with this ingress record.                      | `[]`                     |
+| `apiIngress.secrets`               | If you're providing your own certificates, please use this to add the certificates as secrets               | `[]`                     |
 | `networkPolicy.enabled`            | Enable the default NetworkPolicy policy                                                                     | `false`                  |
 | `networkPolicy.allowExternal`      | Don't require client label for connections                                                                  | `true`                   |
 

--- a/bitnami/minio/templates/NOTES.txt
+++ b/bitnami/minio/templates/NOTES.txt
@@ -55,8 +55,8 @@ To access the MinIO&reg; web UI:
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
-   echo "MinIO&reg; web URL: http://127.0.0.1:9001/minio"
-   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} 9001:{{ .Values.service.ports.console }}
+   echo "MinIO&reg; web URL: http://127.0.0.1:{{ .Values.containerPorts.console }}/minio"
+   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} {{ .Values.containerPorts.console }}:{{ .Values.service.ports.console }}
 
 {{- else if contains "NodePort" .Values.service.type }}
 

--- a/bitnami/minio/templates/api-ingress.yaml
+++ b/bitnami/minio/templates/api-ingress.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.apiIngress.enabled -}}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.apiIngress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- if .Values.apiIngress.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.apiIngress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  rules:
+    {{- if .Values.apiIngress.hostname }}
+    - host: {{ .Values.apiIngress.hostname }}
+      http:
+        paths:
+          {{- if .Values.apiIngress.extraPaths }}
+          {{- toYaml .Values.apiIngress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.apiIngress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.apiIngress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "minio-api" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range .Values.apiIngress.extraHosts }}
+    - host: {{ .name | quote }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "minio-api" "context" $) | nindent 14 }}
+    {{- end }}
+  {{- if or .Values.apiIngress.tls .Values.apiIngress.extraTls }}
+  tls:
+    {{- if .Values.apiIngress.tls }}
+    - hosts:
+        - {{ .Values.apiIngress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.apiIngress.hostname }}
+    {{- end }}
+    {{- if .Values.apiIngress.extraTls }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.apiIngress.extraTls "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/bitnami/minio/templates/api-ingress.yaml
+++ b/bitnami/minio/templates/api-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.apiIngress.enabled -}}
+{{- if .Values.apiIngress.enabled -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -171,7 +171,7 @@ spec:
             - name: MINIO_CERTSDIR
               value: {{ .Values.tls.mountPath | quote }}
             - name: MINIO_CONSOLE_PORT
-              value: {{ .Values.containerPorts.console }}
+              value: {{ .Values.containerPorts.console | quote }}
             {{- end }}
             {{- if .Values.extraEnv }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -170,7 +170,7 @@ spec:
             {{- if .Values.tls.mountPath }}
             - name: MINIO_CERTSDIR
               value: {{ .Values.tls.mountPath | quote }}
-            - name: MINIO_CONSOLE_PORT
+            - name: MINIO_CONSOLE_PORT_NUMBER
               value: {{ .Values.containerPorts.console | quote }}
             {{- end }}
             {{- if .Values.extraEnv }}

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -170,6 +170,8 @@ spec:
             {{- if .Values.tls.mountPath }}
             - name: MINIO_CERTSDIR
               value: {{ .Values.tls.mountPath | quote }}
+            - name: MINIO_CONSOLE_PORT
+              value: {{ .Values.containerPorts.console }}
             {{- end }}
             {{- if .Values.extraEnv }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}

--- a/bitnami/minio/templates/gateway/deployment.yaml
+++ b/bitnami/minio/templates/gateway/deployment.yaml
@@ -136,6 +136,8 @@ spec:
                   key: secret-key
             - name: MINIO_PROMETHEUS_AUTH_TYPE
               value: {{ .Values.metrics.prometheusAuthType | quote }}
+            - name: MINIO_CONSOLE_PORT
+              value: {{ .Values.containerPorts.console | quote }}
             {{- if .Values.extraEnv }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/minio/templates/gateway/deployment.yaml
+++ b/bitnami/minio/templates/gateway/deployment.yaml
@@ -136,7 +136,7 @@ spec:
                   key: secret-key
             - name: MINIO_PROMETHEUS_AUTH_TYPE
               value: {{ .Values.metrics.prometheusAuthType | quote }}
-            - name: MINIO_CONSOLE_PORT
+            - name: MINIO_CONSOLE_PORT_NUMBER
               value: {{ .Values.containerPorts.console | quote }}
             {{- if .Values.extraEnv }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 12 }}

--- a/bitnami/minio/templates/standalone/deployment.yaml
+++ b/bitnami/minio/templates/standalone/deployment.yaml
@@ -130,7 +130,7 @@ spec:
             - name: MINIO_PROMETHEUS_AUTH_TYPE
               value: {{ .Values.metrics.prometheusAuthType | quote }}
             - name: MINIO_CONSOLE_PORT
-              value: {{ .Values.containerPorts.console }}
+              value: {{ .Values.containerPorts.console | quote }}
             {{- if .Values.tls.mountPath }}
             - name: MINIO_CERTSDIR
               value: {{ .Values.tls.mountPath | quote }}

--- a/bitnami/minio/templates/standalone/deployment.yaml
+++ b/bitnami/minio/templates/standalone/deployment.yaml
@@ -129,6 +129,8 @@ spec:
               value: {{ ternary "off" "on" .Values.disableWebUI | quote }}
             - name: MINIO_PROMETHEUS_AUTH_TYPE
               value: {{ .Values.metrics.prometheusAuthType | quote }}
+            - name: MINIO_CONSOLE_PORT
+              value: {{ .Values.containerPorts.console }}
             {{- if .Values.tls.mountPath }}
             - name: MINIO_CERTSDIR
               value: {{ .Values.tls.mountPath | quote }}

--- a/bitnami/minio/templates/standalone/deployment.yaml
+++ b/bitnami/minio/templates/standalone/deployment.yaml
@@ -129,7 +129,7 @@ spec:
               value: {{ ternary "off" "on" .Values.disableWebUI | quote }}
             - name: MINIO_PROMETHEUS_AUTH_TYPE
               value: {{ .Values.metrics.prometheusAuthType | quote }}
-            - name: MINIO_CONSOLE_PORT
+            - name: MINIO_CONSOLE_PORT_NUMBER
               value: {{ .Values.containerPorts.console | quote }}
             {{- if .Values.tls.mountPath }}
             - name: MINIO_CERTSDIR

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -62,7 +62,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/minio
-  tag: 2021.9.9-debian-10-r0
+  tag: 2021.9.9-debian-10-r8
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -88,7 +88,7 @@ image:
 clientImage:
   registry: docker.io
   repository: bitnami/minio-client
-  tag: 2021.9.2-debian-10-r7
+  tag: 2021.9.2-debian-10-r17
 ## @param mode MinIO&reg; server mode (`standalone` or `distributed`)
 ## ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
 ##
@@ -660,7 +660,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r188
+    tag: 10-debian-10-r198
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -433,7 +433,7 @@ service:
   ##
   annotations: {}
 ## Configure the ingress resource that allows you to access the
-## MinIO&reg; installation. Set up the URL
+## MinIO&reg; Console. Set up the URL
 ## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
@@ -513,6 +513,89 @@ ingress:
   ##     certificate: ""
   ##
   secrets: []
+
+## Configure the ingress resource that allows you to access the
+## MinIO&reg; API. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+apiIngress:
+  ## @param apiIngress.enabled Enable ingress controller resource
+  ##
+  enabled: false
+  ## @param apiIngress.certManager Set this to true in order to add the corresponding annotations for cert-manager
+  ##
+  certManager: false
+  ## @param apiIngress.apiVersion Force Ingress API version (automatically detected if not set)
+  ##
+  apiVersion: ""
+  ## @param apiIngress.hostname Default host for the ingress resource
+  ##
+  hostname: minio.local
+  ## @param apiIngress.path The Path to MinIO&reg;. You may need to set this to '/*' in order to use this with ALB ingress controllers.
+  ##
+  path: /
+  ## @param apiIngress.pathType Ingress path type
+  ##
+  pathType: ImplementationSpecific
+  ## @param apiIngress.servicePort Service port to be used
+  ## Default is http. Alternative is https.
+  ##
+  servicePort: minio-console
+  ## @param apiIngress.annotations Ingress annotations
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
+  ##
+  annotations: {}
+  ## @param apiIngress.tls Enable TLS configuration for the hostname defined at `apiIngress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.apiIngress.hostname }}
+  ## You can use the apiIngress.secrets parameter to create this TLS secret or relay on cert-manager to create it
+  ##
+  tls: false
+  ## @param apiIngress.extraHosts The list of additional hostnames to be covered with this ingress record.
+  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## e.g:
+  ## extraHosts:
+  ##   - name: minio.local
+  ##     path: /
+  ##
+  extraHosts: []
+  ## @param apiIngress.extraPaths Any additional paths that may need to be added to the ingress under the main host
+  ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## @param apiIngress.extraTls The tls configuration for additional hostnames to be covered with this ingress record.
+  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## e.g:
+  ## extraTls:
+  ## - hosts:
+  ##     - minio.local
+  ##   secretName: minio.local-tls
+  ##
+  extraTls: []
+  ## @param apiIngress.secrets If you're providing your own certificates, please use this to add the certificates as secrets
+  ## key and certificate are expected in PEM format
+  ## name should line up with a secretName set further up
+  ##
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ##
+  ## Example
+  ## secrets:
+  ##   - name: minio.local-tls
+  ##     key: ""
+  ##     certificate: ""
+  ##
+  secrets: []
+
 ## NetworkPolicy parameters
 ##
 networkPolicy:


### PR DESCRIPTION
**Description of the change**

Adds a secondary ingress, that would allow users to expose the MinIO API in addition to the MinIO console.

Additionally, fixes a bug that configures MINIO_CONSOLE_PORT to match the value `containerPorts.console`.

**Possible drawbacks**

None known.

**Applicable issues**

  - fixes #7495

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
