### PR TITLE
bitname/common: Fix typo in README

### DIFF
--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -93,7 +93,7 @@ The following table lists the helpers available in the library which are scoped 
 
 ### Names
 
-| Helper identifier       | Description                                                | Expected Inpput   |
+| Helper identifier       | Description                                                | Expected Input   |
 |-------------------------|------------------------------------------------------------|-------------------|
 | `common.names.name`     | Expand the name of the chart or use `.Values.nameOverride` | `.` Chart context |
 | `common.names.fullname` | Create a default fully qualified app name.                 | `.` Chart context |


### PR DESCRIPTION
**Description of the change**

Fix documentation bug/typo.

**Benefits**

No typo in documentation.

**Possible drawbacks**

None

**Applicable issues**

**Additional information**

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
