### PR TITLE
[bitnami/drupal] Fix ingressClassName default parameter and template

### DIFF
--- a/bitnami/drupal/Chart.lock
+++ b/bitnami/drupal/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.5.1
+  version: 9.6.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.9.0
-digest: sha256:2311ed53bf0082f07e424bf19e250d06ce235944c6f0df4e6380c3c93a0062e7
-generated: "2021-09-16T14:11:12.1736338+02:00"
+digest: sha256:5a71c7f947d927eb5575be42d8d44de25e82b3cd371d4b175b237767ef363e5f
+generated: "2021-09-20T07:10:59.676038487Z"

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -31,4 +31,4 @@ name: drupal
 sources:
   - https://github.com/bitnami/bitnami-docker-drupal
   - http://www.drupal.org/
-version: 10.3.0
+version: 10.3.1

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -160,7 +160,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.certManager`              | Add annotations for cert-manager                                                              | `false`                  |
 | `ingress.pathType`                 | Ingress Path type                                                                             | `ImplementationSpecific` |
 | `ingress.apiVersion`               | Override API Version (automatically detected if not set)                                      | `""`                     |
-| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                 | `nil`                    |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                 | `""`                     |
 | `ingress.hostname`                 | Default host for the ingress resource                                                         | `drupal.local`           |
 | `ingress.path`                     | The Path to Drupal. You may need to set this to '/*' in order to use this                     | `/`                      |
 | `ingress.annotations`              | Ingress annotations done as key:value pairs                                                   | `{}`                     |

--- a/bitnami/drupal/templates/ingress.yaml
+++ b/bitnami/drupal/templates/ingress.yaml
@@ -18,9 +18,9 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
-  { { - if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) } }
-  ingressClassName: { { .Values.ingress.ingressClassName | quote } }
-  { { - end } }
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
     - host: {{ .Values.ingress.hostname }}

--- a/bitnami/drupal/values.yaml
+++ b/bitnami/drupal/values.yaml
@@ -381,7 +381,7 @@ ingress:
   ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
   ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
   ##
-  ingressClassName:
+  ingressClassName: ""
   ## @param ingress.hostname Default host for the ingress resource
   ##
   hostname: drupal.local

--- a/bitnami/drupal/values.yaml
+++ b/bitnami/drupal/values.yaml
@@ -51,7 +51,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/drupal
-  tag: 9.2.6-debian-10-r0
+  tag: 9.2.6-debian-10-r5
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -525,7 +525,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r193
+    tag: 10-debian-10-r198
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -573,7 +573,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.10.0-debian-10-r47
+    tag: 0.10.0-debian-10-r52
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -641,7 +641,7 @@ certificates:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r193
+    tag: 10-debian-10-r198
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

Changes introduced at https://github.com/bitnami/charts/pull/7512 are not following our standard metadata format (`nil` value VS empty string):
```console
$ readme-generator -v ./values.yaml -m /tmp/metadata.json
Skipping check for hostAliases[0].ip
Skipping check for hostAliases[0].hostnames[0]
Skipping check for containerPorts.http
Skipping check for containerPorts.https
Skipping check for resources.requests.memory
Skipping check for resources.requests.cpu
Skipping check for service.nodePorts.http
Skipping check for service.nodePorts.https
Skipping check for metrics.podAnnotations.prometheus.io/scrape
Skipping check for metrics.podAnnotations.prometheus.io/port
INFO: Checking missing metadata...
INFO: Metadata is correct!
/home/bitnami/projects/readme-generator-for-helm/lib/parser.js:184
    throw new Error(`Invalid type 'nil' for the following values: ${nilValues.join(', ')}`);
    ^

Error: Invalid type 'nil' for the following values: ingress.ingressClassName
    at generateMetadataObject (/home/bitnami/projects/readme-generator-for-helm/lib/parser.js:184:11)
    at runReadmeGenerator (/home/bitnami/projects/readme-generator-for-helm/index.js:53:22)
    at Object.<anonymous> (/home/bitnami/projects/readme-generator-for-helm/bin/index.js:21:1)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47
```

This diff fix the above-mentioned issue and also regenerate the README table and fix another format discrepancy in the templating format