### PR TITLE
[bitnami/consul, cassandra] Apply standardizations

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -23,4 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/bitnami-docker-cassandra
   - http://cassandra.apache.org
-version: 8.0.4
+version: 9.0.0

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -49,18 +49,18 @@ The command removes all the Kubernetes components associated with the chart and 
 ### Global parameters
 
 | Name                      | Description                                     | Value |
-| ------------------------- | ----------------------------------------------- | ----- |
+|---------------------------|-------------------------------------------------|-------|
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
-
 ### Common parameters
 
 | Name                     | Description                                                                             | Value           |
-| ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
+|--------------------------|-----------------------------------------------------------------------------------------|-----------------|
 | `nameOverride`           | String to partially override common.names.fullname                                      | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
+| `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                    | `""`            |
 | `commonLabels`           | Labels to add to all deployed objects (sub-charts are not considered)                   | `{}`            |
 | `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
 | `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
@@ -69,11 +69,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `diagnosticMode.command` | Command to override all containers in the deployment                                    | `[]`            |
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `[]`            |
 
-
 ### Cassandra parameters
 
 | Name                          | Description                                                                                                            | Value                |
-| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------- |
+|-------------------------------|------------------------------------------------------------------------------------------------------------------------|----------------------|
 | `image.registry`              | Cassandra image registry                                                                                               | `docker.io`          |
 | `image.repository`            | Cassandra image repository                                                                                             | `bitnami/cassandra`  |
 | `image.tag`                   | Cassandra image tag (immutable tags are recommended)                                                                   | `4.0.1-debian-10-r0` |
@@ -96,6 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cluster.internodeEncryption` | DEPRECATED: use tls.internode and tls.client instead. Encryption values.                                               | `none`               |
 | `cluster.clientEncryption`    | Client Encryption                                                                                                      | `false`              |
 | `cluster.extraSeeds`          | For an external/second cassandra ring.                                                                                 | `[]`                 |
+| `cluster.enableUDF`           | Enable User defined functions                                                                                          | `false`              |
 | `jvm.extraOpts`               | Set the value for Java Virtual Machine extra options                                                                   | `""`                 |
 | `jvm.maxHeapSize`             | Set Java Virtual Machine maximum heap size (MAX_HEAP_SIZE). Calculated automatically if `nil`                          | `""`                 |
 | `jvm.newHeapSize`             | Set Java Virtual Machine new heap size (HEAP_NEWSIZE). Calculated automatically if `nil`                               | `""`                 |
@@ -105,90 +105,100 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraEnvVarsCM`              | Name of existing ConfigMap containing extra env vars                                                                   | `""`                 |
 | `extraEnvVarsSecret`          | Name of existing Secret containing extra env vars                                                                      | `""`                 |
 
-
 ### Statefulset parameters
 
-| Name                                 | Description                                                                               | Value           |
-| ------------------------------------ | ----------------------------------------------------------------------------------------- | --------------- |
-| `replicaCount`                       | Number of Cassandra replicas                                                              | `1`             |
-| `updateStrategy`                     | updateStrategy for Cassandra statefulset                                                  | `RollingUpdate` |
-| `hostAliases`                        | Add deployment host aliases                                                               | `[]`            |
-| `rollingUpdatePartition`             | Partition update strategy                                                                 | `""`            |
-| `podManagementPolicy`                | StatefulSet pod management policy                                                         | `OrderedReady`  |
-| `priorityClassName`                  | Cassandra pods' priority.                                                                 | `""`            |
-| `podAnnotations`                     | Additional pod annotations                                                                | `{}`            |
-| `podLabels`                          | Additional pod labels                                                                     | `{}`            |
-| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`            |
-| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set                                     | `""`            |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set                                  | `[]`            |
-| `affinity`                           | Affinity for pod assignment                                                               | `{}`            |
-| `nodeSelector`                       | Node labels for pod assignment                                                            | `{}`            |
-| `tolerations`                        | Tolerations for pod assignment                                                            | `[]`            |
-| `topologySpreadConstraints`          | Topology Spread Constraints for pod assignment                                            | `[]`            |
-| `podSecurityContext.enabled`         | Enabled Cassandra pods' Security Context                                                  | `true`          |
-| `podSecurityContext.fsGroup`         | Set Cassandra pod's Security Context fsGroup                                              | `1001`          |
-| `containerSecurityContext.enabled`   | Enabled Cassandra containers' Security Context                                            | `true`          |
-| `containerSecurityContext.runAsUser` | et Cassandra container's Security Context runAsUser                                       | `1001`          |
-| `resources.limits`                   | The resources limits for Cassandra containers                                             | `{}`            |
-| `resources.requests`                 | The requested resources for Cassandra containers                                          | `{}`            |
-| `livenessProbe.enabled`              | Enable livenessProbe                                                                      | `true`          |
-| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                   | `60`            |
-| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                          | `30`            |
-| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                         | `5`             |
-| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                       | `5`             |
-| `livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                       | `1`             |
-| `readinessProbe.enabled`             | Enable readinessProbe                                                                     | `true`          |
-| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                  | `60`            |
-| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                         | `10`            |
-| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                        | `5`             |
-| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                      | `5`             |
-| `readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                      | `1`             |
-| `customLivenessProbe`                | Custom livenessProbe that overrides the default one                                       | `{}`            |
-| `customReadinessProbe`               | Custom readinessProbe that overrides the default one                                      | `{}`            |
-| `extraVolumes`                       | Optionally specify extra list of additional volumes for cassandra container               | `[]`            |
-| `extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for cassandra container          | `[]`            |
-| `initContainers`                     | Add additional init containers to the cassandra pods                                      | `[]`            |
-| `sidecars`                           | Add additional sidecar containers to the cassandra pods                                   | `[]`            |
-| `pdb.create`                         | Enable/disable a Pod Disruption Budget creation                                           | `false`         |
-| `pdb.minAvailable`                   | Mininimum number of pods that must still be available after the eviction                  | `1`             |
-| `pdb.maxUnavailable`                 | Max number of pods that can be unavailable after the eviction                             | `""`            |
-| `hostNetwork`                        | Enable HOST Network                                                                       | `false`         |
-| `containerPorts.intra`               | Intra Port on the Host and Container                                                      | `7000`          |
-| `containerPorts.tls`                 | TLS Port on the Host and Container                                                        | `7001`          |
-| `containerPorts.jmx`                 | JMX Port on the Host and Container                                                        | `7199`          |
-| `containerPorts.cql`                 | CQL Port on the Host and Container                                                        | `9042`          |
-
+| Name                                    | Description                                                                               | Value           |
+|-----------------------------------------|-------------------------------------------------------------------------------------------|-----------------|
+| `replicaCount`                          | Number of Cassandra replicas                                                              | `1`             |
+| `updateStrategy.type`                   | updateStrategy for Cassandra statefulset                                                  | `RollingUpdate` |
+| `hostAliases`                           | Add deployment host aliases                                                               | `[]`            |
+| `podManagementPolicy`                   | StatefulSet pod management policy                                                         | `OrderedReady`  |
+| `priorityClassName`                     | Cassandra pods' priority.                                                                 | `""`            |
+| `podAnnotations`                        | Additional pod annotations                                                                | `{}`            |
+| `podLabels`                             | Additional pod labels                                                                     | `{}`            |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`            |
+| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set                                     | `""`            |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set                                  | `[]`            |
+| `affinity`                              | Affinity for pod assignment                                                               | `{}`            |
+| `nodeSelector`                          | Node labels for pod assignment                                                            | `{}`            |
+| `tolerations`                           | Tolerations for pod assignment                                                            | `[]`            |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                            | `[]`            |
+| `podSecurityContext.enabled`            | Enabled Cassandra pods' Security Context                                                  | `true`          |
+| `podSecurityContext.fsGroup`            | Set Cassandra pod's Security Context fsGroup                                              | `1001`          |
+| `containerSecurityContext.enabled`      | Enabled Cassandra containers' Security Context                                            | `true`          |
+| `containerSecurityContext.runAsUser`    | Set Cassandra container's Security Context runAsUser                                      | `1001`          |
+| `containerSecurityContext.runAsNonRoot` | Force the container to be run as non root                                                 | `true`          |
+| `resources.limits`                      | The resources limits for Cassandra containers                                             | `{}`            |
+| `resources.requests`                    | The requested resources for Cassandra containers                                          | `{}`            |
+| `livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`          |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                   | `60`            |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                          | `30`            |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                         | `5`             |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                       | `5`             |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                       | `1`             |
+| `readinessProbe.enabled`                | Enable readinessProbe                                                                     | `true`          |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                  | `60`            |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                         | `10`            |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                        | `5`             |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                      | `5`             |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                      | `1`             |
+| `startupProbe.enabled`                  | Enable startupProbe                                                                       | `false`         |
+| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                    | `0`             |
+| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                           | `10`            |
+| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                          | `5`             |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                        | `60`            |
+| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                        | `1`             |
+| `customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                       | `{}`            |
+| `customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                      | `{}`            |
+| `customStartupProbe`                    | Override default startup probe                                                            | `{}`            |
+| `lifecycleHooks`                        | Override default etcd container hooks                                                     | `{}`            |
+| `schedulerName`                         | Alternative scheduler                                                                     | `""`            |
+| `extraVolumes`                          | Optionally specify extra list of additional volumes for cassandra container               | `[]`            |
+| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for cassandra container          | `[]`            |
+| `initContainers`                        | Add additional init containers to the cassandra pods                                      | `[]`            |
+| `sidecars`                              | Add additional sidecar containers to the cassandra pods                                   | `[]`            |
+| `pdb.create`                            | Enable/disable a Pod Disruption Budget creation                                           | `false`         |
+| `pdb.minAvailable`                      | Mininimum number of pods that must still be available after the eviction                  | `1`             |
+| `pdb.maxUnavailable`                    | Max number of pods that can be unavailable after the eviction                             | `""`            |
+| `hostNetwork`                           | Enable HOST Network                                                                       | `false`         |
+| `containerPorts.intra`                  | Intra Port on the Host and Container                                                      | `7000`          |
+| `containerPorts.tls`                    | TLS Port on the Host and Container                                                        | `7001`          |
+| `containerPorts.jmx`                    | JMX Port on the Host and Container                                                        | `7199`          |
+| `containerPorts.cql`                    | CQL Port on the Host and Container                                                        | `9042`          |
 
 ### RBAC parameters
 
-| Name                         | Description                                                | Value  |
-| ---------------------------- | ---------------------------------------------------------- | ------ |
-| `serviceAccount.create`      | Enable the creation of a ServiceAccount for Cassandra pods | `true` |
-| `serviceAccount.name`        | The name of the ServiceAccount to use.                     | `""`   |
-| `serviceAccount.annotations` | Annotations for Cassandra Service Account                  | `{}`   |
-
+| Name                                          | Description                                                | Value  |
+|-----------------------------------------------|------------------------------------------------------------|--------|
+| `serviceAccount.create`                       | Enable the creation of a ServiceAccount for Cassandra pods | `true` |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                     | `""`   |
+| `serviceAccount.annotations`                  | Annotations for Cassandra Service Account                  | `{}`   |
+| `serviceAccount.automountServiceAccountToken` | Automount API credentials for a service account.           | `true` |
 
 ### Traffic Exposure Parameters
 
-| Name                          | Description                                               | Value       |
-| ----------------------------- | --------------------------------------------------------- | ----------- |
-| `service.type`                | Cassandra service type                                    | `ClusterIP` |
-| `service.port`                | Cassandra service CQL Port                                | `9042`      |
-| `service.metricsPort`         | Cassandra service metrics port                            | `8080`      |
-| `service.nodePorts.cql`       | Node port for CQL                                         | `""`        |
-| `service.nodePorts.metrics`   | Node port for metrics                                     | `""`        |
-| `service.loadBalancerIP`      | LoadBalancerIP if service type is `LoadBalancer`          | `""`        |
-| `service.annotations`         | Provide any additional annotations which may be required. | `{}`        |
-| `networkPolicy.enabled`       | Specifies whether a NetworkPolicy should be created       | `false`     |
-| `networkPolicy.allowExternal` | Don't require client label for connections                | `true`      |
-
+| Name                               | Description                                                                   | Value       |
+|------------------------------------|-------------------------------------------------------------------------------|-------------|
+| `service.type`                     | Cassandra service type                                                        | `ClusterIP` |
+| `service.ports.cql`                | Cassandra service CQL Port                                                    | `9042`      |
+| `service.ports.metrics`            | Cassandra service metrics port                                                | `8080`      |
+| `service.nodePorts.cql`            | Node port for CQL                                                             | `""`        |
+| `service.nodePorts.metrics`        | Node port for metrics                                                         | `""`        |
+| `service.extraPorts`               | Extra ports to expose in the service (normally used with the `sidecar` value) | `[]`        |
+| `service.loadBalancerIP`           | LoadBalancerIP if service type is `LoadBalancer`                              | `""`        |
+| `service.loadBalancerSourceRanges` | Service Load Balancer sources                                                 | `[]`        |
+| `service.clusterIP`                | Service Cluster IP                                                            | `""`        |
+| `service.externalTrafficPolicy`    | Service external traffic policy                                               | `Cluster`   |
+| `service.annotations`              | Provide any additional annotations which may be required.                     | `{}`        |
+| `networkPolicy.enabled`            | Specifies whether a NetworkPolicy should be created                           | `false`     |
+| `networkPolicy.allowExternal`      | Don't require client label for connections                                    | `true`      |
 
 ### Persistence parameters
 
 | Name                             | Description                                                                                        | Value                |
-| -------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------- |
+|----------------------------------|----------------------------------------------------------------------------------------------------|----------------------|
 | `persistence.enabled`            | Enable Cassandra data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir | `true`               |
 | `persistence.storageClass`       | PVC Storage Class for Cassandra data volume                                                        | `""`                 |
 | `persistence.commitStorageClass` | PVC Storage Class for Cassandra Commit Log volume                                                  | `""`                 |
@@ -197,11 +207,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.size`               | PVC Storage Request for Cassandra data volume                                                      | `8Gi`                |
 | `persistence.mountPath`          | The path the data volume will be mounted at                                                        | `/bitnami/cassandra` |
 
-
 ### Volume Permissions parameters
 
 | Name                                          | Description                                                                     | Value                   |
-| --------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------- |
+|-----------------------------------------------|---------------------------------------------------------------------------------|-------------------------|
 | `volumePermissions.enabled`                   | Enable init container that changes the owner and group of the persistent volume | `false`                 |
 | `volumePermissions.image.registry`            | Init container volume                                                           | `docker.io`             |
 | `volumePermissions.image.repository`          | Init container volume                                                           | `bitnami/bitnami-shell` |
@@ -212,43 +221,46 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.resources.requests`        | The requested resources for the container                                       | `{}`                    |
 | `volumePermissions.securityContext.runAsUser` | User ID for the init container                                                  | `0`                     |
 
-
 ### Metrics parameters
 
-| Name                                   | Description                                                                                            | Value                        |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------------- |
-| `metrics.enabled`                      | Start a side-car prometheus exporter                                                                   | `false`                      |
-| `metrics.image.registry`               | Cassandra exporter image registry                                                                      | `docker.io`                  |
-| `metrics.image.repository`             | Cassandra exporter image name                                                                          | `bitnami/cassandra-exporter` |
-| `metrics.image.tag`                    | Cassandra exporter image tag                                                                           | `2.3.4-debian-10-r510`       |
-| `metrics.image.pullPolicy`             | image pull policy                                                                                      | `IfNotPresent`               |
-| `metrics.image.pullSecrets`            | Specify docker-registry secret names as an array                                                       | `[]`                         |
-| `metrics.resources.limits`             | The resources limits for the container                                                                 | `{}`                         |
-| `metrics.resources.requests`           | The requested resources for the container                                                              | `{}`                         |
-| `metrics.podAnnotations`               | Metrics exporter pod Annotation and Labels                                                             | `{}`                         |
-| `metrics.serviceMonitor.enabled`       | If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                      |
-| `metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                                               | `monitoring`                 |
-| `metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped.                                                           | `""`                         |
-| `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                                | `""`                         |
-| `metrics.serviceMonitor.selector`      | Prometheus instance selector labels                                                                    | `{}`                         |
-| `metrics.containerPorts.http`          | HTTP Port on the Host and Container                                                                    | `8080`                       |
-| `metrics.containerPorts.jmx`           | JMX Port on the Host and Container                                                                     | `5555`                       |
-
+| Name                                       | Description                                                                                            | Value                        |
+|--------------------------------------------|--------------------------------------------------------------------------------------------------------|------------------------------|
+| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                   | `false`                      |
+| `metrics.image.registry`                   | Cassandra exporter image registry                                                                      | `docker.io`                  |
+| `metrics.image.repository`                 | Cassandra exporter image name                                                                          | `bitnami/cassandra-exporter` |
+| `metrics.image.tag`                        | Cassandra exporter image tag                                                                           | `2.3.4-debian-10-r510`       |
+| `metrics.image.pullPolicy`                 | image pull policy                                                                                      | `IfNotPresent`               |
+| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                       | `[]`                         |
+| `metrics.resources.limits`                 | The resources limits for the container                                                                 | `{}`                         |
+| `metrics.resources.requests`               | The requested resources for the container                                                              | `{}`                         |
+| `metrics.podAnnotations`                   | Metrics exporter pod Annotation and Labels                                                             | `{}`                         |
+| `metrics.serviceMonitor.enabled`           | If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                      |
+| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                               | `monitoring`                 |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                           | `""`                         |
+| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                | `""`                         |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                    | `{}`                         |
+| `metrics.serviceMonitor.metricRelabelings` | Specify Metric Relabelings to add to the scrape endpoint                                               | `[]`                         |
+| `metrics.serviceMonitor.honorLabels`       | Specify honorLabels parameter to add the scrape endpoint                                               | `false`                      |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                      | `""`                         |
+| `metrics.serviceMonitor.additionalLabels`  | Used to pass Labels that are required by the installed Prometheus Operator                             | `{}`                         |
+| `metrics.containerPorts.http`              | HTTP Port on the Host and Container                                                                    | `8080`                       |
+| `metrics.containerPorts.jmx`               | JMX Port on the Host and Container                                                                     | `5555`                       |
 
 ### TLS/SSL parameters
 
-| Name                      | Description                                                                                   | Value   |
-| ------------------------- | --------------------------------------------------------------------------------------------- | ------- |
-| `tls.internodeEncryption` | Set internode encryption                                                                      | `none`  |
-| `tls.clientEncryption`    | Set client-server encryption                                                                  | `false` |
-| `tls.autoGenerated`       | Generate automatically self-signed TLS certificates. Currently only supports PEM certificates | `false` |
-| `tls.existingSecret`      | Existing secret that contains Cassandra Keystore and truststore                               | `""`    |
-| `tls.passwordsSecret`     | Secret containing the Keystore and Truststore passwords if needed                             | `""`    |
-| `tls.keystorePassword`    | Password for the keystore, if needed.                                                         | `""`    |
-| `tls.truststorePassword`  | Password for the truststore, if needed.                                                       | `""`    |
-| `tls.resources.limits`    | The resources limits for the TLS init container                                               | `{}`    |
-| `tls.resources.requests`  | The requested resources for the TLS init container                                            | `{}`    |
-
+| Name                          | Description                                                                                   | Value   |
+|-------------------------------|-----------------------------------------------------------------------------------------------|---------|
+| `tls.internodeEncryption`     | Set internode encryption                                                                      | `none`  |
+| `tls.clientEncryption`        | Set client-server encryption                                                                  | `false` |
+| `tls.autoGenerated`           | Generate automatically self-signed TLS certificates. Currently only supports PEM certificates | `false` |
+| `tls.existingSecret`          | Existing secret that contains Cassandra Keystore and truststore                               | `""`    |
+| `tls.passwordsSecret`         | Secret containing the Keystore and Truststore passwords if needed                             | `""`    |
+| `tls.keystorePassword`        | Password for the keystore, if needed.                                                         | `""`    |
+| `tls.truststorePassword`      | Password for the truststore, if needed.                                                       | `""`    |
+| `tls.resources.limits`        | The resources limits for the TLS init container                                               | `{}`    |
+| `tls.resources.requests`      | The requested resources for the TLS init container                                            | `{}`    |
+| `tls.certificatesSecret`      | Secret with the TLS certificates.                                                             | `""`    |
+| `tls.tlsEncryptionSecretName` | Secret with the encryption of the TLS certificates                                            | `""`    |
 
 The above parameters map to the env variables defined in [bitnami/cassandra](http://github.com/bitnami/bitnami-docker-cassandra). For more information please refer to the [bitnami/cassandra](http://github.com/bitnami/bitnami-docker-cassandra) image documentation.
 
@@ -340,6 +352,18 @@ $ helm upgrade my-release bitnami/cassandra --set dbUser.password=[PASSWORD]
 ```
 
 | Note: you need to substitute the placeholder _[PASSWORD]_ with the value obtained in the installation notes.
+
+### To 9.0.0
+This major release renames several values in this chart and adds missing features, in order to be inline with the rest of assets in the Bitnami charts repository.
+
+Affected values:
+
+- `serviceMonitor.labels` renamed as `serviceMonitor.selector`.
+- `service.port` renamed as `service.ports.cql`.
+- `service.metricsPort` renamed as `service.ports.metrics`.
+- `service.nodePort` renamed as `service.nodePorts.cql`.
+- `updateStrategy` changed from String type (previously default to 'rollingUpdate') to Object type, allowing users to configure other updateStrategy parameters, similar to other charts.
+- Removed value `rollingUpdatePartition`, now configured using `updateStrategy` setting `updateStrategy.rollingUpdate.partition`.
 
 ### To 8.0.0
 

--- a/bitnami/cassandra/templates/headless-svc.yaml
+++ b/bitnami/cassandra/templates/headless-svc.yaml
@@ -30,6 +30,6 @@ spec:
       port: 7199
       targetPort: jmx
     - name: cql
-      port: {{ .Values.service.port }}
+      port: {{ .Values.service.ports.cql }}
       targetPort: cql
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/cassandra/templates/service.yaml
+++ b/bitnami/cassandra/templates/service.yaml
@@ -21,9 +21,18 @@ spec:
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
   ports:
     - name: cql
-      port: {{ .Values.service.port }}
+      port: {{ .Values.service.ports.cql }}
       targetPort: cql
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.cql)) }}
       nodePort: {{ .Values.service.nodePorts.cql }}
@@ -31,10 +40,13 @@ spec:
       nodePort: null
       {{- end }}
     - name: metrics
-      port: {{ .Values.service.metricsPort }}
+      port: {{ .Values.service.ports.metrics }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.metrics)) }}
       nodePort: {{ .Values.service.nodePorts.metrics }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/cassandra/templates/serviceaccount.yaml
+++ b/bitnami/cassandra/templates/serviceaccount.yaml
@@ -15,4 +15,5 @@ metadata:
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/bitnami/cassandra/templates/servicemonitor.yaml
+++ b/bitnami/cassandra/templates/servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
+    {{- end }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -19,6 +22,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   endpoints:
@@ -28,6 +34,12 @@ spec:
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -16,14 +16,7 @@ spec:
   serviceName: {{ include "common.names.fullname" . }}-headless
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   replicas: {{ .Values.replicaCount }}
-  updateStrategy:
-    type: {{ .Values.updateStrategy }}
-    {{- if (eq "Recreate" .Values.updateStrategy) }}
-    rollingUpdate: null
-    {{- else if .Values.rollingUpdatePartition }}
-    rollingUpdate:
-      partition: {{ .Values.rollingUpdatePartition }}
-    {{- end }}
+  updateStrategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
@@ -58,6 +51,9 @@ spec:
       {{- end }}
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName | quote }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
@@ -372,7 +368,23 @@ spec:
           {{- else if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if not .Values.persistence.enabled }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  nodetool status | grep -E "^UN\\s+${POD_IP}"
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- else if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if and (not .Values.lifecycleHooks) (not .Values.persistence.enabled) }}
           lifecycle:
             preStop:
               exec:
@@ -380,6 +392,8 @@ spec:
                   - bash
                   - -ec
                   - nodetool decommission
+          {{- else if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           ports:

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -2,6 +2,7 @@
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+##
 
 ## @param global.imageRegistry Global Docker image registry
 ## @param global.imagePullSecrets Global Docker registry secret names as an array
@@ -17,6 +18,7 @@ global:
   storageClass: ""
 
 ## @section Common parameters
+##
 
 ## @param nameOverride String to partially override common.names.fullname
 ##
@@ -24,6 +26,9 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override common.names.fullname
 ##
 fullnameOverride: ""
+## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
+##
+kubeVersion: ""
 ## @param commonLabels Labels to add to all deployed objects (sub-charts are not considered)
 ##
 commonLabels: {}
@@ -53,6 +58,7 @@ diagnosticMode:
     - infinity
 
 ## @section Cassandra parameters
+##
 
 ## Bitnami Cassandra image
 ## ref: https://hub.docker.com/r/bitnami/cassandra/tags/
@@ -110,6 +116,7 @@ dbUser:
   ##   ##
   ##   keyMapping:
   ##     cassandra-password: myCassandraPasswordKey
+  ##
   existingSecret: ""
 
 ## @param initDBConfigMap ConfigMap with cql scripts. Useful for creating a keyspace and pre-populating data
@@ -131,6 +138,7 @@ existingConfiguration: ""
 ## @param cluster.internodeEncryption DEPRECATED: use tls.internode and tls.client instead. Encryption values.
 ## @param cluster.clientEncryption Client Encryption
 ## @param cluster.extraSeeds For an external/second cassandra ring.
+## @param cluster.enableUDF Enable User defined functions
 ##
 cluster:
   name: cassandra
@@ -147,7 +155,10 @@ cluster:
   ## extraSeeds:
   ##   - hostname/IP
   ##   - hostname/IP
+  ##
   extraSeeds: []
+  enableUDF: false
+
 ## JVM Settings
 ## @param jvm.extraOpts Set the value for Java Virtual Machine extra options
 ## @param jvm.maxHeapSize Set Java Virtual Machine maximum heap size (MAX_HEAP_SIZE). Calculated automatically if `nil`
@@ -160,6 +171,7 @@ jvm:
   ## - calculate 1/2 ram and cap to 1024MB
   ## - calculate 1/4 ram and cap to 8192MB
   ## - pick the max
+  ##
   maxHeapSize: ""
   ## newHeapSize:
   ## A good guideline is 100 MB per CPU core.
@@ -187,22 +199,20 @@ extraEnvVarsCM: ""
 extraEnvVarsSecret: ""
 
 ## @section Statefulset parameters
+##
 
 ## @param replicaCount Number of Cassandra replicas
 ##
 replicaCount: 1
-## @param updateStrategy updateStrategy for Cassandra statefulset
+## @param updateStrategy.type updateStrategy for Cassandra statefulset
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 ##
-updateStrategy: RollingUpdate
+updateStrategy:
+  type: RollingUpdate
 ## @param hostAliases Add deployment host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
-## @param rollingUpdatePartition Partition update strategy
-## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
-##
-rollingUpdatePartition: ""
 ## @param podManagementPolicy StatefulSet pod management policy
 ##
 podManagementPolicy: OrderedReady
@@ -272,11 +282,13 @@ podSecurityContext:
 ## Configure Container Security Context (only main container)
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled Enabled Cassandra containers' Security Context
-## @param containerSecurityContext.runAsUser et Cassandra container's Security Context runAsUser
+## @param containerSecurityContext.runAsUser Set Cassandra container's Security Context runAsUser
+## @param containerSecurityContext.runAsNonRoot Force the container to be run as non root
 ##
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
+  runAsNonRoot: true
 ## Cassandra pods' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ## Minimum memory for development is 4GB and 2 CPU cores
@@ -295,11 +307,13 @@ resources:
   ## limits:
   ##    cpu: 2
   ##    memory: 4Gi
+  ##
   limits: {}
   ## Examples:
   ## requests:
   ##    cpu: 2
   ##    memory: 4Gi
+  ##
   requests: {}
 ## Configure extra options for Cassandra containers' liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
@@ -331,12 +345,38 @@ readinessProbe:
   timeoutSeconds: 5
   successThreshold: 1
   failureThreshold: 5
+## Configure extra options for startup probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+## @param startupProbe.enabled Enable startupProbe
+## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+## @param startupProbe.periodSeconds Period seconds for startupProbe
+## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.successThreshold Success threshold for startupProbe
+##
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 60
 ## @param customLivenessProbe Custom livenessProbe that overrides the default one
 ##
 customLivenessProbe: {}
 ## @param customReadinessProbe Custom readinessProbe that overrides the default one
 ##
 customReadinessProbe: {}
+## @param customStartupProbe [object] Override default startup probe
+##
+customStartupProbe: {}
+## @param lifecycleHooks [object] Override default etcd container hooks
+##
+lifecycleHooks: {}
+## @param schedulerName Alternative scheduler
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+schedulerName: ""
 ## @param extraVolumes Optionally specify extra list of additional volumes for cassandra container
 ##
 extraVolumes: []
@@ -380,6 +420,7 @@ containerPorts:
   cql: 9042
 
 ## @section RBAC parameters
+##
 
 ## Cassandra pods ServiceAccount
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -395,8 +436,12 @@ serviceAccount:
   ## @param serviceAccount.annotations Annotations for Cassandra Service Account
   ##
   annotations: {}
+  ## @param serviceAccount.automountServiceAccountToken Automount API credentials for a service account.
+  ##
+  automountServiceAccountToken: true
 
 ## @section Traffic Exposure Parameters
+##
 
 ## Cassandra service parameters
 ##
@@ -404,12 +449,12 @@ service:
   ## @param service.type Cassandra service type
   ##
   type: ClusterIP
-  ## @param service.port Cassandra service CQL Port
+  ## @param service.ports.cql Cassandra service CQL Port
+  ## @param service.ports.metrics Cassandra service metrics port
   ##
-  port: 9042
-  ## @param service.metricsPort Cassandra service metrics port
-  ##
-  metricsPort: 8080
+  ports:
+    cql: 9042
+    metrics: 8080
   ## Node ports to expose
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
   ## @param service.nodePorts.cql Node port for CQL
@@ -418,10 +463,29 @@ service:
   nodePorts:
     cql: ""
     metrics: ""
+  ## @param service.extraPorts Extra ports to expose in the service (normally used with the `sidecar` value)
+  ##
+  extraPorts: []
   ## @param service.loadBalancerIP LoadBalancerIP if service type is `LoadBalancer`
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
   loadBalancerIP: ""
+  ## @param service.loadBalancerSourceRanges Service Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## @param service.clusterIP Service Cluster IP
+  ## e.g.:
+  ## clusterIP: None
+  ##
+  clusterIP: ""
+  ## @param service.externalTrafficPolicy Service external traffic policy
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
   ## @param service.annotations Provide any additional annotations which may be required.
   ## This can be used to set the LoadBalancer service type to internal only.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
@@ -443,6 +507,7 @@ networkPolicy:
   allowExternal: true
 
 ## @section Persistence parameters
+##
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -489,6 +554,7 @@ persistence:
   # commitLogMountPath: /bitnami/cassandra/commitlog
 
 ## @section Volume Permissions parameters
+##
 
 ## Init containers parameters:
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
@@ -530,11 +596,13 @@ volumePermissions:
     ## limits:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     limits: {}
     ## Examples:
     ## requests:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     requests: {}
   ## Init container Security Context
   ## Note: the chown of the data folder is done to securityContext.runAsUser
@@ -551,6 +619,7 @@ volumePermissions:
     runAsUser: 0
 
 ## @section Metrics parameters
+##
 
 ## Cassandra Prometheus exporter configuration
 ##
@@ -593,18 +662,20 @@ metrics:
     ## limits:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     limits: {}
     ## Examples:
     ## requests:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     requests: {}
   ## @param metrics.podAnnotations [object] Metrics exporter pod Annotation and Labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations:
-    prometheus.io/scrape: 'true'
-    prometheus.io/port: '8080'
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:
@@ -633,6 +704,21 @@ metrics:
     ##   prometheus: my-prometheus
     ##
     selector: {}
+    ## @param metrics.serviceMonitor.metricRelabelings Specify Metric Relabelings to add to the scrape endpoint
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    ##
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
+    ##
+    honorLabels: false
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+    ##
+    jobLabel: ""
+    ## @param metrics.serviceMonitor.additionalLabels Used to pass Labels that are required by the installed Prometheus Operator
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ##
+    additionalLabels: {}
+
   ## Metrics container ports to open
   ## If hostNetwork true: the hostPort is set identical to the containerPort
   ## @param metrics.containerPorts.http HTTP Port on the Host and Container
@@ -643,6 +729,7 @@ metrics:
     jmx: 5555
 
 ## @section TLS/SSL parameters
+##
 
 ## TLS/SSL parameters
 ## @param tls.internodeEncryption Set internode encryption
@@ -654,6 +741,8 @@ metrics:
 ## @param tls.truststorePassword Password for the truststore, if needed.
 ## @param tls.resources.limits The resources limits for the TLS init container
 ## @param tls.resources.requests The requested resources for the TLS init container
+## @param tls.certificatesSecret Secret with the TLS certificates.
+## @param tls.tlsEncryptionSecretName Secret with the encryption of the TLS certificates
 ##
 tls:
   internodeEncryption: none
@@ -663,6 +752,8 @@ tls:
   passwordsSecret: ""
   keystorePassword: ""
   truststorePassword: ""
+  certificatesSecret: ""
+  tlsEncryptionSecretName: ""
   ## We usually recommend not to specify default resources and to leave this as a conscious
   ## choice for the user. This also increases chances charts run on environments with little
   ## resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -673,9 +764,11 @@ tls:
     ## limits:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     limits: {}
     ## Examples:
     ## requests:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     requests: {}

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -23,4 +23,4 @@ name: consul
 sources:
   - https://github.com/bitnami/bitnami-docker-consul
   - https://www.consul.io/
-version: 9.3.5
+version: 10.0.0

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -76,102 +76,117 @@ $ helm delete --purge my-release
 
 ### HashiCorp Consul parameters
 
-| Name                       | Description                                                                                  | Value                 |
-| -------------------------- | -------------------------------------------------------------------------------------------- | --------------------- |
-| `image.registry`           | HashiCorp Consul image registry                                                              | `docker.io`           |
-| `image.repository`         | HashiCorp Consul image repository                                                            | `bitnami/consul`      |
-| `image.tag`                | HashiCorp Consul image tag (immutable tags are recommended)                                  | `1.10.2-debian-10-r0` |
-| `image.pullPolicy`         | HashiCorp Consul image pull policy                                                           | `IfNotPresent`        |
-| `image.pullSecrets`        | HashiCorp Consul image pull secrets                                                          | `[]`                  |
-| `image.debug`              | Enable image debug mode                                                                      | `false`               |
-| `datacenterName`           | Datacenter name for Consul. If not supplied, will use the Consul                             | `dc1`                 |
-| `domain`                   | Consul domain name                                                                           | `consul`              |
-| `raftMultiplier`           | Multiplier used to scale key Raft timing parameters                                          | `1`                   |
-| `gossipKey`                | Gossip key for all members. The key must be 16-bytes, can be generated with $(consul keygen) | `""`                  |
-| `tlsEncryptionSecretName`  | Name of existing secret with TLS encryption data                                             | `""`                  |
-| `hostAliases`              | Deployment pod host aliases                                                                  | `[]`                  |
-| `configuration`            | HashiCorp Consul configuration to be injected as ConfigMap                                   | `""`                  |
-| `existingConfigmap`        | ConfigMap with HashiCorp Consul configuration                                                | `""`                  |
-| `localConfig`              | Extra configuration that will be added to the default one                                    | `""`                  |
-| `command`                  | Command for running the container (set to default if not set). Use array form                | `[]`                  |
-| `args`                     | Args for running the container (set to default if not set). Use array form                   | `[]`                  |
-| `extraEnvVars`             | Extra environment variables to be set on HashiCorp Consul container                          | `[]`                  |
-| `extraEnvVarsCM`           | Name of existing ConfigMap containing extra env vars                                         | `""`                  |
-| `extraEnvVarsSecret`       | Name of existing Secret containing extra env vars                                            | `""`                  |
-| `containerPorts.http`      | Port to open for HTTP in Consul                                                              | `8500`                |
-| `containerPorts.dns`       | Port to open for DNS server in Consul                                                        | `8600`                |
-| `containerPorts.rpc`       | Port to open for RPC in Consul                                                               | `8400`                |
-| `containerPorts.rpcServer` | Port to open for RPC Server in Consul                                                        | `8300`                |
-| `containerPorts.serfLAN`   | Port to open for Serf LAN in Consul                                                          | `8301`                |
+| Name                        | Description                                                                                  | Value                 |
+| --------------------------- | -------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`            | HashiCorp Consul image registry                                                              | `docker.io`           |
+| `image.repository`          | HashiCorp Consul image repository                                                            | `bitnami/consul`      |
+| `image.tag`                 | HashiCorp Consul image tag (immutable tags are recommended)                                  | `1.10.2-debian-10-r0` |
+| `image.pullPolicy`          | HashiCorp Consul image pull policy                                                           | `IfNotPresent`        |
+| `image.pullSecrets`         | HashiCorp Consul image pull secrets                                                          | `[]`                  |
+| `image.debug`               | Enable image debug mode                                                                      | `false`               |
+| `datacenterName`            | Datacenter name for Consul. If not supplied, will use the Consul                             | `dc1`                 |
+| `domain`                    | Consul domain name                                                                           | `consul`              |
+| `raftMultiplier`            | Multiplier used to scale key Raft timing parameters                                          | `1`                   |
+| `gossipKey`                 | Gossip key for all members. The key must be 16-bytes, can be generated with $(consul keygen) | `""`                  |
+| `tlsEncryptionSecretName`   | Name of existing secret with TLS encryption data                                             | `""`                  |
+| `hostAliases`               | Deployment pod host aliases                                                                  | `[]`                  |
+| `configuration`             | HashiCorp Consul configuration to be injected as ConfigMap                                   | `""`                  |
+| `existingConfigmap`         | ConfigMap with HashiCorp Consul configuration                                                | `""`                  |
+| `localConfig`               | Extra configuration that will be added to the default one                                    | `""`                  |
+| `podLabels`                 | Pod labels                                                                                   | `{}`                  |
+| `priorityClassName`         | Priority class assigned to the Pods                                                          | `""`                  |
+| `schedulerName`             | Alternative scheduler                                                                        | `""`                  |
+| `topologySpreadConstraints` | Topology Spread Constraints for pod assignment                                               | `[]`                  |
+| `command`                   | Command for running the container (set to default if not set). Use array form                | `[]`                  |
+| `args`                      | Args for running the container (set to default if not set). Use array form                   | `[]`                  |
+| `extraEnvVars`              | Extra environment variables to be set on HashiCorp Consul container                          | `[]`                  |
+| `extraEnvVarsCM`            | Name of existing ConfigMap containing extra env vars                                         | `""`                  |
+| `extraEnvVarsSecret`        | Name of existing Secret containing extra env vars                                            | `""`                  |
+| `containerPorts.http`       | Port to open for HTTP in Consul                                                              | `8500`                |
+| `containerPorts.dns`        | Port to open for DNS server in Consul                                                        | `8600`                |
+| `containerPorts.rpc`        | Port to open for RPC in Consul                                                               | `8400`                |
+| `containerPorts.rpcServer`  | Port to open for RPC Server in Consul                                                        | `8300`                |
+| `containerPorts.serfLAN`    | Port to open for Serf LAN in Consul                                                          | `8301`                |
+| `lifecycleHooks`            | Add lifecycle hooks to the ASP.NET Core deployment                                           | `{}`                  |
 
 
 ### Statefulset parameters
 
-| Name                                 | Description                                                                               | Value           |
-| ------------------------------------ | ----------------------------------------------------------------------------------------- | --------------- |
-| `replicaCount`                       | Number of HashiCorp Consul replicas to deploy                                             | `3`             |
-| `updateStrategy`                     | Update strategy type for the HashiCorp Consul statefulset                                 | `RollingUpdate` |
-| `rollingUpdatePartition`             | Partition update strategy                                                                 | `""`            |
-| `podManagementPolicy`                | StatefulSet pod management policy                                                         | `Parallel`      |
-| `podAnnotations`                     | Additional pod annotations                                                                | `{}`            |
-| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`            |
-| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                    | `""`            |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                 | `[]`            |
-| `affinity`                           | Affinity for pod assignment                                                               | `{}`            |
-| `nodeSelector`                       | Node labels for pod assignment                                                            | `{}`            |
-| `tolerations`                        | Tolerations for pod assignment                                                            | `[]`            |
-| `podSecurityContext.enabled`         | Enable security context for HashiCorp Consul pods                                         | `true`          |
-| `podSecurityContext.fsGroup`         | Group ID for the volumes of the pod                                                       | `1001`          |
-| `containerSecurityContext.enabled`   | HashiCorp Consul Container securityContext                                                | `true`          |
-| `containerSecurityContext.runAsUser` | User ID for the HashiCorp Consul container                                                | `1001`          |
-| `resources.limits`                   | The resources limits for HashiCorp Consul containers                                      | `{}`            |
-| `resources.requests`                 | The requested resources for HashiCorp Consul containers                                   | `{}`            |
-| `livenessProbe.enabled`              | Enable livenessProbe                                                                      | `true`          |
-| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                   | `30`            |
-| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                          | `10`            |
-| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                         | `5`             |
-| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                       | `6`             |
-| `livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                       | `1`             |
-| `readinessProbe.enabled`             | Enable readinessProbe                                                                     | `true`          |
-| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                  | `5`             |
-| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                         | `10`            |
-| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                        | `5`             |
-| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                      | `6`             |
-| `readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                      | `1`             |
-| `customLivenessProbe`                | Override default liveness probe                                                           | `{}`            |
-| `customReadinessProbe`               | Override default readiness probe                                                          | `{}`            |
-| `extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for Hashicorp Consul container   | `[]`            |
-| `extraVolumes`                       | Optionally specify extra list of additional volumes for Hashicorp Consul container        | `[]`            |
-| `initContainers`                     | Add additional init containers to the Hashicorp Consul pods                               | `[]`            |
-| `sidecars`                           | Add additional sidecar containers to the Hashicorp Consul pods                            | `[]`            |
-| `pdb.create`                         | Enable/disable a Pod Disruption Budget creation                                           | `false`         |
-| `pdb.minAvailable`                   | Minimum number of pods that must still be available after the eviction                    | `1`             |
-| `pdb.maxUnavailable`                 | Max number of pods that can be unavailable after the eviction                             | `""`            |
+| Name                                    | Description                                                                               | Value           |
+| --------------------------------------- | ----------------------------------------------------------------------------------------- | --------------- |
+| `replicaCount`                          | Number of HashiCorp Consul replicas to deploy                                             | `3`             |
+| `updateStrategy.type`                   | Update strategy type for the HashiCorp Consul statefulset                                 | `RollingUpdate` |
+| `podManagementPolicy`                   | StatefulSet pod management policy                                                         | `Parallel`      |
+| `podAnnotations`                        | Additional pod annotations                                                                | `{}`            |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`            |
+| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                    | `""`            |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                 | `[]`            |
+| `affinity`                              | Affinity for pod assignment                                                               | `{}`            |
+| `nodeSelector`                          | Node labels for pod assignment                                                            | `{}`            |
+| `tolerations`                           | Tolerations for pod assignment                                                            | `[]`            |
+| `podSecurityContext.enabled`            | Enable security context for HashiCorp Consul pods                                         | `true`          |
+| `podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                       | `1001`          |
+| `containerSecurityContext.enabled`      | HashiCorp Consul Container securityContext                                                | `true`          |
+| `containerSecurityContext.runAsUser`    | User ID for the HashiCorp Consul container                                                | `1001`          |
+| `containerSecurityContext.runAsNonRoot` | Force the container to be run as non root                                                 | `true`          |
+| `resources.limits`                      | The resources limits for HashiCorp Consul containers                                      | `{}`            |
+| `resources.requests`                    | The requested resources for HashiCorp Consul containers                                   | `{}`            |
+| `livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`          |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                   | `30`            |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                          | `10`            |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                         | `5`             |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                       | `6`             |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                       | `1`             |
+| `readinessProbe.enabled`                | Enable readinessProbe                                                                     | `true`          |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                  | `5`             |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                         | `10`            |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                        | `5`             |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                      | `6`             |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                      | `1`             |
+| `startupProbe.enabled`                  | Enable startupProbe                                                                       | `false`         |
+| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                    | `0`             |
+| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                           | `10`            |
+| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                          | `5`             |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                        | `60`            |
+| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                        | `1`             |
+| `customLivenessProbe`                   | Override default liveness probe                                                           | `{}`            |
+| `customReadinessProbe`                  | Override default readiness probe                                                          | `{}`            |
+| `customStartupProbe`                    | Override default startup probe                                                            | `{}`            |
+| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for Hashicorp Consul container   | `[]`            |
+| `extraVolumes`                          | Optionally specify extra list of additional volumes for Hashicorp Consul container        | `[]`            |
+| `initContainers`                        | Add additional init containers to the Hashicorp Consul pods                               | `[]`            |
+| `sidecars`                              | Add additional sidecar containers to the Hashicorp Consul pods                            | `[]`            |
+| `pdb.create`                            | Enable/disable a Pod Disruption Budget creation                                           | `false`         |
+| `pdb.minAvailable`                      | Minimum number of pods that must still be available after the eviction                    | `1`             |
+| `pdb.maxUnavailable`                    | Max number of pods that can be unavailable after the eviction                             | `""`            |
 
 
 ### Exposure parameters
 
-| Name                     | Description                                                                                   | Value                    |
-| ------------------------ | --------------------------------------------------------------------------------------------- | ------------------------ |
-| `service.enabled`        | Use a service to access HashiCorp Consul Ui                                                   | `true`                   |
-| `service.port`           | HashiCorp Consul UI svc port                                                                  | `80`                     |
-| `service.type`           | HashiCorp Consul UI Service Type                                                              | `ClusterIP`              |
-| `service.nodePort`       | Node port for HashiCorp Consul UI                                                             | `""`                     |
-| `service.loadBalancerIP` | HashiCorp Consul UI service Load Balancer IP                                                  | `""`                     |
-| `service.annotations`    | Annotations for HashiCorp Consul UI service                                                   | `{}`                     |
-| `ingress.enabled`        | Enable ingress resource for Management console                                                | `false`                  |
-| `ingress.path`           | Path for the default host                                                                     | `/`                      |
-| `ingress.apiVersion`     | Override API Version (automatically detected if not set)                                      | `""`                     |
-| `ingress.pathType`       | Ingress path type                                                                             | `ImplementationSpecific` |
-| `ingress.certManager`    | Add annotations for cert-manager                                                              | `false`                  |
-| `ingress.hostname`       | Default host for the ingress resource, a host pointing to this will be created                | `consul-ui.local`        |
-| `ingress.annotations`    | Ingress annotations done as key:value pairs                                                   | `{}`                     |
-| `ingress.tls`            | Enable TLS configuration for the hostname defined at ingress.hostname parameter               | `false`                  |
-| `ingress.extraHosts`     | An array with additional hostname(s) to be covered with the ingress record                    | `[]`                     |
-| `ingress.extraTls`       | TLS configuration for additional hostname(s) to be covered with this ingress record           | `[]`                     |
-| `ingress.secrets`        | If you're providing your own certificates, please use this to add the certificates as secrets | `[]`                     |
+| Name                            | Description                                                                                   | Value                    |
+| ------------------------------- | --------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.enabled`               | Use a service to access HashiCorp Consul Ui                                                   | `true`                   |
+| `service.ports.http`            | HashiCorp Consul UI svc port                                                                  | `80`                     |
+| `service.type`                  | HashiCorp Consul UI Service Type                                                              | `ClusterIP`              |
+| `service.nodePorts.http`        | Node port for HashiCorp Consul UI                                                             | `""`                     |
+| `service.loadBalancerIP`        | HashiCorp Consul UI service Load Balancer IP                                                  | `""`                     |
+| `service.annotations`           | Annotations for HashiCorp Consul UI service                                                   | `{}`                     |
+| `service.externalTrafficPolicy` | Service external traffic policy                                                               | `Cluster`                |
+| `ingress.enabled`               | Enable ingress resource for Management console                                                | `false`                  |
+| `ingress.path`                  | Path for the default host                                                                     | `/`                      |
+| `ingress.apiVersion`            | Override API Version (automatically detected if not set)                                      | `""`                     |
+| `ingress.pathType`              | Ingress path type                                                                             | `ImplementationSpecific` |
+| `ingress.certManager`           | Add annotations for cert-manager                                                              | `false`                  |
+| `ingress.hostname`              | Default host for the ingress resource, a host pointing to this will be created                | `consul-ui.local`        |
+| `ingress.annotations`           | Ingress annotations done as key:value pairs                                                   | `{}`                     |
+| `ingress.tls`                   | Enable TLS configuration for the hostname defined at ingress.hostname parameter               | `false`                  |
+| `ingress.extraHosts`            | An array with additional hostname(s) to be covered with the ingress record                    | `[]`                     |
+| `ingress.extraPaths`            | Any additional arbitrary paths that may need to be added to the ingress under the main host.  | `[]`                     |
+| `ingress.selfSigned`            | Create a TLS secret for this ingress record using self-signed certificates generated by Helm  | `false`                  |
+| `ingress.extraTls`              | TLS configuration for additional hostname(s) to be covered with this ingress record           | `[]`                     |
+| `ingress.secrets`               | If you're providing your own certificates, please use this to add the certificates as secrets | `[]`                     |
 
 
 ### Persistence parameters
@@ -201,27 +216,29 @@ $ helm delete --purge my-release
 
 ### Metrics parameters
 
-| Name                                      | Description                                                                                                                 | Value                     |
-| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| `metrics.enabled`                         | Start a side-car prometheus exporter                                                                                        | `false`                   |
-| `metrics.image.registry`                  | HashiCorp Consul Prometheus Exporter image registry                                                                         | `docker.io`               |
-| `metrics.image.repository`                | HashiCorp Consul Prometheus Exporter image repository                                                                       | `bitnami/consul-exporter` |
-| `metrics.image.tag`                       | HashiCorp Consul Prometheus Exporter image tag (immutable tags are recommended)                                             | `0.7.1-debian-10-r374`    |
-| `metrics.image.pullPolicy`                | HashiCorp Consul Prometheus Exporter image pull policy                                                                      | `IfNotPresent`            |
-| `metrics.image.pullSecrets`               | HashiCorp Consul Prometheus Exporter image pull secrets                                                                     | `[]`                      |
-| `metrics.service.type`                    | Kubernetes Service type                                                                                                     | `ClusterIP`               |
-| `metrics.service.loadBalancerIP`          | Service Load Balancer IP                                                                                                    | `""`                      |
-| `metrics.service.annotations`             | Provide any additional annotations which may be required.                                                                   | `{}`                      |
-| `metrics.podAnnotations`                  | Metrics exporter pod Annotation and Labels                                                                                  | `{}`                      |
-| `metrics.resources.limits`                | The resources limits for the container                                                                                      | `{}`                      |
-| `metrics.resources.requests`              | The requested resources for the container                                                                                   | `{}`                      |
-| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator, set to true to create a Service Monitor Entry | `false`                   |
-| `metrics.serviceMonitor.namespace`        | The namespace in which the ServiceMonitor will be created                                                                   | `""`                      |
-| `metrics.serviceMonitor.interval`         | Interval at which metrics should be scraped                                                                                 | `30s`                     |
-| `metrics.serviceMonitor.scrapeTimeout`    | The timeout after which the scrape is ended                                                                                 | `""`                      |
-| `metrics.serviceMonitor.relabellings`     | Metrics relabellings to add to the scrape endpoint                                                                          | `[]`                      |
-| `metrics.serviceMonitor.honorLabels`      | Specify honorLabels parameter to add the scrape endpoint                                                                    | `false`                   |
-| `metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with       | `{}`                      |
+| Name                                       | Description                                                                                                                 | Value                     |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                                        | `false`                   |
+| `metrics.image.registry`                   | HashiCorp Consul Prometheus Exporter image registry                                                                         | `docker.io`               |
+| `metrics.image.repository`                 | HashiCorp Consul Prometheus Exporter image repository                                                                       | `bitnami/consul-exporter` |
+| `metrics.image.tag`                        | HashiCorp Consul Prometheus Exporter image tag (immutable tags are recommended)                                             | `0.7.1-debian-10-r374`    |
+| `metrics.image.pullPolicy`                 | HashiCorp Consul Prometheus Exporter image pull policy                                                                      | `IfNotPresent`            |
+| `metrics.image.pullSecrets`                | HashiCorp Consul Prometheus Exporter image pull secrets                                                                     | `[]`                      |
+| `metrics.service.type`                     | Kubernetes Service type                                                                                                     | `ClusterIP`               |
+| `metrics.service.loadBalancerIP`           | Service Load Balancer IP                                                                                                    | `""`                      |
+| `metrics.service.annotations`              | Provide any additional annotations which may be required.                                                                   | `{}`                      |
+| `metrics.podAnnotations`                   | Metrics exporter pod Annotation and Labels                                                                                  | `{}`                      |
+| `metrics.resources.limits`                 | The resources limits for the container                                                                                      | `{}`                      |
+| `metrics.resources.requests`               | The requested resources for the container                                                                                   | `{}`                      |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator, set to true to create a Service Monitor Entry | `false`                   |
+| `metrics.serviceMonitor.namespace`         | The namespace in which the ServiceMonitor will be created                                                                   | `""`                      |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                                                                 | `30s`                     |
+| `metrics.serviceMonitor.scrapeTimeout`     | The timeout after which the scrape is ended                                                                                 | `""`                      |
+| `metrics.serviceMonitor.metricRelabelings` | Metrics relabellings to add to the scrape endpoint                                                                          | `[]`                      |
+| `metrics.serviceMonitor.honorLabels`       | Specify honorLabels parameter to add the scrape endpoint                                                                    | `false`                   |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                                           | `""`                      |
+| `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                                                                              | `{}`                      |
+| `metrics.serviceMonitor.additionalLabels`  | Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with       | `{}`                      |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
@@ -397,6 +414,15 @@ Find more information about how to deal with common errors related to Bitnami’
 
 ## Upgrading
 
+### To 10.0.0
+
+This major release renames several values in this chart and adds missing features, in order to be inline with the rest of assets in the Bitnami charts repository.
+
+Affected values:
+
+- `service.port` renamed as `service.port.http`.
+- `service.nodePort` renamed as `service.nodePorts.http`.
+- `updateStrategy` changed from String type (previously default to 'rollingUpdate') to Object type, allowing users to configure other updateStrategy parameters, similar to other charts.
 ### To 9.0.0
 
 [On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.

--- a/bitnami/consul/templates/configmap.yaml
+++ b/bitnami/consul/templates/configmap.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  config.json: {{- include "common.tplvalues.render" ( dict "value" .Values.configmap "context" $ ) | nindent 4 }}
+  config.json: {{- include "common.tplvalues.render" ( dict "value" .Values.configuration "context" $ ) | nindent 4 }}
   connection.json: |
     {
       "retry_join": ["{{ include "consul.retryjoin.endpoint" . }}"]

--- a/bitnami/consul/templates/ingress.yaml
+++ b/bitnami/consul/templates/ingress.yaml
@@ -24,6 +24,9 @@ spec:
     - host: {{ .Values.ingress.hostname }}
       http:
         paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- include "common.tplvalues.render" (dict "value"  .Values.ingress.extraPaths "context" $) | nindent 10 }}
+          {{- end }}
           - path: {{ .Values.ingress.path }}
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
@@ -42,9 +45,9 @@ spec:
     {{- end }}
   {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:
-    {{- if .Values.ingress.tls }}
+    {{- if and .Values.ingress.tls (or .Values.ingress.certManager .Values.ingress.selfSigned) }}
     - hosts:
-        - {{ .Values.ingress.hostname }}
+        - {{ .Values.ingress.hostname | quote }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}

--- a/bitnami/consul/templates/service.yaml
+++ b/bitnami/consul/templates/service.yaml
@@ -19,15 +19,24 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.service.port }}
+      port: {{ .Values.service.ports.http }}
       targetPort: http
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
-      nodePort: {{ .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePorts.http }}
       {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
 {{- end }}

--- a/bitnami/consul/templates/servicemonitor.yaml
+++ b/bitnami/consul/templates/servicemonitor.yaml
@@ -19,6 +19,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   endpoints:
     - port: http-metrics
       {{- if .Values.metrics.serviceMonitor.interval }}
@@ -30,8 +33,8 @@ spec:
       {{- if .Values.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
       {{- end }}
-      {{- if .Values.metrics.serviceMonitor.relabellings }}
-      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.relabellings | nindent 6 }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:
@@ -39,4 +42,7 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: metrics
+    {{- if .Values.metrics.serviceMonitor.selector }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/bitnami/consul/templates/statefulset.yaml
+++ b/bitnami/consul/templates/statefulset.yaml
@@ -16,14 +16,7 @@ spec:
   replicas: {{ .Values.replicaCount }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   serviceName: {{ printf "%s-headless" (include "common.names.fullname" .) }}
-  updateStrategy:
-    type: {{ .Values.updateStrategy }}
-    {{- if (eq "Recreate" .Values.updateStrategy) }}
-    rollingUpdate: null
-    {{- else if .Values.rollingUpdatePartition }}
-    rollingUpdate:
-      partition: {{ .Values.rollingUpdatePartition }}
-    {{- end }}
+  updateStrategy: {{- include "common.tplvalues.render" (dict "value" .Values.updateStrategy "context" $ ) | nindent 4 }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
@@ -46,6 +39,15 @@ spec:
       {{- include "consul.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
@@ -162,11 +164,11 @@ spec:
             - name: CONSUL_HTTP_PORT_NUMBER
               value: {{ .Values.containerPorts.http | quote }}
             - name: CONSUL_DNS_PORT_NUMBER
-              value: {{ .Values.service.consulDnsPort | quote }}
+              value: {{ .Values.containerPorts.dns | quote }}
             - name: CONSUL_RPC_PORT_NUMBER
-              value: {{ .Values.service.serverPort | quote }}
+              value: {{ .Values.containerPorts.rpc | quote }}
             - name: CONSUL_SERF_LAN_PORT_NUMBER
-              value: {{ .Values.service.serflanPort | quote }}
+              value: {{ .Values.containerPorts.serfLAN | quote }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -210,12 +212,30 @@ spec:
           {{- else if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            exec:
+              command:
+                - consul
+                - members
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- else if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- else }}
           lifecycle:
             preStop:
               exec:
                 command:
                   - consul
                   - leave
+          {{- end }}
           {{- end }}
           volumeMounts:
             {{- if .Values.tlsEncryptionSecretName }}

--- a/bitnami/consul/templates/tls-secrets.yaml
+++ b/bitnami/consul/templates/tls-secrets.yaml
@@ -19,7 +19,7 @@ data:
   tls.key: {{ .key | b64enc }}
 ---
 {{- end }}
-{{- else if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- else if and .Values.ingress.tls .Values.ingress.selfSigned }}
 {{- $ca := genCA "consul-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
 apiVersion: v1

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -2,6 +2,7 @@
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+##
 
 ## @param global.imageRegistry Global Docker image registry
 ## @param global.imagePullSecrets Global Docker registry secret names as an array
@@ -17,6 +18,7 @@ global:
   storageClass: ""
 
 ## @section Common parameters
+##
 
 ## @param kubeVersion Override Kubernetes version
 ##
@@ -56,6 +58,7 @@ diagnosticMode:
     - infinity
 
 ## @section HashiCorp Consul parameters
+##
 
 ## Bitnami HashiCorp Consul image
 ## ref: https://hub.docker.com/r/bitnami/consul/tags/
@@ -94,7 +97,7 @@ datacenterName: dc1
 domain: consul
 ## @param raftMultiplier Multiplier used to scale key Raft timing parameters
 ##
-raftMultiplier: '1'
+raftMultiplier: "1"
 ## @param gossipKey Gossip key for all members. The key must be 16-bytes, can be generated with $(consul keygen)
 ## Example:
 ## gossipKey: 887Syd/BOvbtvRAKviazMg==
@@ -146,6 +149,22 @@ existingConfigmap: ""
 ##   }
 ##
 localConfig: ""
+## @param podLabels Pod labels
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+## @param priorityClassName Priority class assigned to the Pods
+##
+priorityClassName: ""
+## @param schedulerName Alternative scheduler
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+schedulerName: ""
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment
+## https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+## The value is evaluated as a template
+##
+topologySpreadConstraints: []
 ## @param command Command for running the container (set to default if not set). Use array form
 ##
 command: []
@@ -178,19 +197,21 @@ containerPorts:
   rpcServer: 8300
   serfLAN: 8301
 
+## @param lifecycleHooks Add lifecycle hooks to the ASP.NET Core deployment
+##
+lifecycleHooks: {}
+
 ## @section Statefulset parameters
+##
 
 ## @param replicaCount Number of HashiCorp Consul replicas to deploy
 ##
 replicaCount: 3
-## @param updateStrategy Update strategy type for the HashiCorp Consul statefulset
+## @param updateStrategy.type Update strategy type for the HashiCorp Consul statefulset
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 ##
-updateStrategy: RollingUpdate
-## @param rollingUpdatePartition Partition update strategy
-## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#partitions
-##
-rollingUpdatePartition: ""
+updateStrategy:
+  type: RollingUpdate
 ## @param podManagementPolicy StatefulSet pod management policy
 ##
 podManagementPolicy: Parallel
@@ -250,10 +271,12 @@ podSecurityContext:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param containerSecurityContext.enabled HashiCorp Consul Container securityContext
 ## @param containerSecurityContext.runAsUser User ID for the HashiCorp Consul container
+## @param containerSecurityContext.runAsNonRoot Force the container to be run as non root
 ##
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
+  runAsNonRoot: true
 ## Container's resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -268,11 +291,13 @@ resources:
   ## limits:
   ##    cpu: 100m
   ##    memory: 128Mi
+  ##
   limits: {}
   ## Examples:
   ## requests:
   ##    cpu: 100m
   ##    memory: 128Mi
+  ##
   requests: {}
 ## Configure extra options for HashiCorp Consul containers' liveness and readiness probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
@@ -304,12 +329,31 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+## Configure extra options for startup probe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+## @param startupProbe.enabled Enable startupProbe
+## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+## @param startupProbe.periodSeconds Period seconds for startupProbe
+## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.successThreshold Success threshold for startupProbe
+##
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 60
 ## @param customLivenessProbe Override default liveness probe
 ##
 customLivenessProbe: {}
 ## @param customReadinessProbe Override default readiness probe
 ##
 customReadinessProbe: {}
+## @param customStartupProbe Override default startup probe
+##
+customStartupProbe: {}
 ## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for Hashicorp Consul container
 ##
 extraVolumeMounts: []
@@ -337,6 +381,7 @@ pdb:
   maxUnavailable: ""
 
 ## @section Exposure parameters
+##
 
 ## HashiCorp Consul UI service parameters
 ##
@@ -344,17 +389,19 @@ service:
   ## @param service.enabled Use a service to access HashiCorp Consul Ui
   ##
   enabled: true
-  ## @param service.port HashiCorp Consul UI svc port
+  ## @param service.ports.http HashiCorp Consul UI svc port
   ##
-  port: 80
+  ports:
+    http: 80
   ## @param service.type HashiCorp Consul UI Service Type
   ##
   type: ClusterIP
   ## Specify the nodePort value for the LoadBalancer and NodePort service types.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
-  ## @param service.nodePort Node port for HashiCorp Consul UI
+  ## @param service.nodePorts.http Node port for HashiCorp Consul UI
   ##
-  nodePort: ""
+  nodePorts:
+    http: ""
   ## @param service.loadBalancerIP HashiCorp Consul UI service Load Balancer IP
   ## Set the LoadBalancer service type to internal only.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
@@ -366,6 +413,10 @@ service:
   ## @param service.annotations Annotations for HashiCorp Consul UI service
   ##
   annotations: {}
+  ## @param service.externalTrafficPolicy Service external traffic policy
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
 ## Configure the ingress resource that allows you to access the Consul UI
 ## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
@@ -410,6 +461,18 @@ ingress:
   ##   path: /
   ##
   extraHosts: []
+  ## @param ingress.extraPaths Any additional arbitrary paths that may need to be added to the ingress under the main host.
+  ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+  ##
+  selfSigned: false
   ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   ## extraTls:
@@ -435,6 +498,7 @@ ingress:
   secrets: []
 
 ## @section Persistence parameters
+##
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -463,6 +527,7 @@ persistence:
   size: 8Gi
 
 ## @section Volume Permissions parameters
+##
 
 ## Init containers parameters:
 ## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the podSecurityContext section.
@@ -502,14 +567,17 @@ volumePermissions:
     ## limits:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     limits: {}
     ## Examples:
     ## requests:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     requests: {}
 
 ## @section Metrics parameters
+##
 
 ## Prometheus Exporter / Metrics
 ##
@@ -571,11 +639,13 @@ metrics:
     ## limits:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     limits: {}
     ## Examples:
     ## requests:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     requests: {}
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator
@@ -593,12 +663,22 @@ metrics:
     ## @param metrics.serviceMonitor.scrapeTimeout The timeout after which the scrape is ended
     ##
     scrapeTimeout: ""
-    ## @param metrics.serviceMonitor.relabellings Metrics relabellings to add to the scrape endpoint
+    ## @param metrics.serviceMonitor.metricRelabelings Metrics relabellings to add to the scrape endpoint
     ##
-    relabellings: []
+    metricRelabelings: []
     ## @param metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
     ##
     honorLabels: false
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+    ##
+    jobLabel: ""
+    ## @param metrics.serviceMonitor.selector ServiceMonitor selector labels
+    ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+    ##
+    ## selector:
+    ##   prometheus: my-prometheus
+    ##
+    selector: {}
     ## @param metrics.serviceMonitor.additionalLabels Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
     ##


### PR DESCRIPTION
**Description of the change**

This PR standardizes the bitnami/consul and bitnami/cassandra chart to be in line with the rest of the catalog.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
