### PR TITLE
[bitnami/contour] - 7571 Add targetPort as values to aws nlb ssl termination

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 5.5.2
+version: 5.5.3

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -390,11 +390,16 @@ By default, Contour is launched with a AWS Classic ELB. To launch contour backed
 
 ```yaml
 envoy:
-  hostNetwork: true
-  dnsPolicy: ClusterFirstWithHostNet
   service:
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-type: nlb
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+      service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm: arn:aws:acm:XX-XXXX-X:XXXXXXXXX:certificate/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX
+
+  containerPorts:
+    http: 80
+    https: 80
 ```
 
 ### Setting Pod's affinity

--- a/bitnami/contour/templates/envoy/service.yaml
+++ b/bitnami/contour/templates/envoy/service.yaml
@@ -44,7 +44,7 @@ spec:
     - name: http
       port: {{ .Values.envoy.service.ports.http }}
       protocol: TCP
-      targetPort: http
+      targetPort: {{ .Values.envoy.containerPorts.http }}
       {{- if and (or (eq .Values.envoy.service.type "NodePort") (eq .Values.envoy.service.type "LoadBalancer")) (not (empty .Values.envoy.service.nodePorts.http)) }}
       nodePort: {{ .Values.envoy.service.nodePorts.http }}
       {{- else if eq .Values.envoy.service.type "ClusterIP" }}
@@ -53,7 +53,7 @@ spec:
     - name: https
       port: {{ .Values.envoy.service.ports.https }}
       protocol: TCP
-      targetPort: https
+      targetPort: {{ .Values.envoy.containerPorts.https }}
       {{- if and (or (eq .Values.envoy.service.type "NodePort") (eq .Values.envoy.service.type "LoadBalancer")) (not (empty .Values.envoy.service.nodePorts.https)) }}
       nodePort: {{ .Values.envoy.service.nodePorts.https }}
       {{- else if eq .Values.envoy.service.type "ClusterIP" }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

These changes enable the SSL termination on the AWS NLB side instead of using `nodePort` which brings security issues and didn't work for private Kubernetes clusters.

**Benefits**

Make easier to people change the value of `targetPort` from __https__ to **http** to enable SSL termination on AWS ELB.

**Possible drawbacks**

None.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
