### PR TITLE
[bitnami/rabbitmq-cluster-operator] Add missing extra-list.yaml

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 0.1.3
+version: 0.1.4

--- a/bitnami/rabbitmq-cluster-operator/templates/extra-list.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Add missing `extra-list.yaml` manifest required for `extraDeploy` feature to work properly.

**Benefits**

`extraDeploy` feature is available

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
