### PR TITLE
Reduce time needed to update chart dependencies

### DIFF
--- a/githooks/pre-push/helm-lint
+++ b/githooks/pre-push/helm-lint
@@ -15,7 +15,8 @@ for chart_name in $( cut -d'/' -f1,2 <<< "$files_to_push" | uniq ); do
     # Avoid running 'helm lint|install' when modified dirs are not charts
     if [[ $chart_name = bitnami/* ]]; then
         printf '\033[01;33mUpdating dependencies for %s with helm dep update:\n\033[0m' "$chart_name"
-        helm dep update "$chart_name"
+        helm repo update bitnami
+        helm dep update --skip-refresh "$chart_name"
 
         printf '\033[01;33mValidating %s with helm lint:\n\033[0m' "$chart_name"
         if ! run_helm_lint_chart "$chart_name"; then


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

When running the `helm-lint` githook, we're currently updating every configured chart repository when we update the chart dependencies:

```console
Updating dependencies for bitnami/foo with helm dep update:
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "xxx" chart repository
...Successfully got an update from the "yyy" chart repository
...Successfully got an update from the "zzz" chart repository
...
...Successfully got an update from the "bitnami" chart repository
```

This changes ensure that only the "bitnami" chart repository is updated, saving time everytime the hook is executed.

**Benefits**

Speed

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

N/A
