### PR TITLE
[bitnami/keycloak] Implement support for startupProbe for faster pod startups

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 5.0.7
+version: 5.1.7

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 5.1.7
+version: 5.1.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -163,7 +163,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `resources.limits`                      | The resources limits for the Keycloak container                                           | `{}`                  |
 | `resources.requests`                    | The requested resources for the Keycloak container                                        | `{}`                  |
 | `startupProbe.enabled`                  | Enable startupProbe                                                                       | `false`               |
-| `startupProbe.httpGet.path`             | Request path for startupProbe                                                             | `/auth/realms/master` |
+| `startupProbe.httpGet.path`             | Request path for startupProbe                                                             | `/auth/`              |
 | `startupProbe.httpGet.port`             | Port for startupProbe                                                                     | `http`                |
 | `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                    | `30`                  |
 | `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                           | `5`                   |

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -162,6 +162,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | `containerSecurityContext.runAsNonRoot` | Set Keykloak container's Security Context runAsNonRoot                                    | `true`                |
 | `resources.limits`                      | The resources limits for the Keycloak container                                           | `{}`                  |
 | `resources.requests`                    | The requested resources for the Keycloak container                                        | `{}`                  |
+| `startupProbe.enabled`                  | Enable startupProbe                                                                       | `false`               |
+| `startupProbe.httpGet.path`             | Request path for startupProbe                                                             | `/auth/realms/master` |
+| `startupProbe.httpGet.port`             | Port for startupProbe                                                                     | `http`                |
+| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                    | `30`                  |
+| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                           | `5`                   |
+| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                          | `1`                   |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                        | `270`                 |
+| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                        | `1`                   |
 | `livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`                |
 | `livenessProbe.httpGet.path`            | Request path for livenessProbe                                                            | `/auth/`              |
 | `livenessProbe.httpGet.port`            | Port for livenessProbe                                                                    | `http`                |
@@ -178,6 +186,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                        | `1`                   |
 | `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                      | `3`                   |
 | `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                      | `1`                   |
+| `customStartupProbe`                    | Custom Startup probes for Keycloak                                                        | `{}`                  |
 | `customLivenessProbe`                   | Custom Liveness probes for Keycloak                                                       | `{}`                  |
 | `customReadinessProbe`                  | Custom Rediness probes Keycloak                                                           | `{}`                  |
 | `updateStrategy.type`                   | StrategyType                                                                              | `RollingUpdate`       |

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -168,7 +168,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                    | `30`                  |
 | `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                           | `5`                   |
 | `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                          | `1`                   |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                        | `270`                 |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                        | `60`                 |
 | `startupProbe.successThreshold`         | Success threshold for startupProbe                                                        | `1`                   |
 | `livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`                |
 | `livenessProbe.httpGet.path`            | Request path for livenessProbe                                                            | `/auth/`              |

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -275,6 +275,11 @@ spec:
             - name: http-management
               containerPort: 9990
               protocol: TCP
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe: {{- omit .Values.startupProbe "enabled" | toYaml | nindent 12 }}
+          {{- else if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe: {{- omit .Values.livenessProbe "enabled" | toYaml | nindent 12 }}
           {{- else if .Values.customLivenessProbe }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -473,7 +473,7 @@ resources:
 startupProbe:
   enabled: false
   httpGet:
-    path: /auth/realms/master
+    path: /auth/
     port: http
   initialDelaySeconds: 30
   periodSeconds: 5

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -458,6 +458,28 @@ resources:
   ##    cpu: 200m
   ##    memory: 10Mi
   requests: {}
+## Configure extra options for startup probe
+## When enabling this, make sure to set initialDelaySeconds to 0 for livenessProbe and readinessProbe
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param startupProbe.enabled Enable startupProbe
+## @param startupProbe.httpGet.path Request path for startupProbe
+## @param startupProbe.httpGet.port Port for startupProbe
+## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+## @param startupProbe.periodSeconds Period seconds for startupProbe
+## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.successThreshold Success threshold for startupProbe
+##
+startupProbe:
+  enabled: false
+  httpGet:
+    path: /auth/realms/master
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 5
+  timeoutSeconds: 1
+  failureThreshold: 60
+  successThreshold: 1
 ## Configure extra options for liveness probe
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
 ## @param livenessProbe.enabled Enable livenessProbe
@@ -500,6 +522,9 @@ readinessProbe:
   timeoutSeconds: 1
   failureThreshold: 3
   successThreshold: 1
+## @param customStartupProbe Custom Startup probes for Keycloak
+##
+customStartupProbe: {}
 ## @param customLivenessProbe Custom Liveness probes for Keycloak
 ##
 customLivenessProbe: {}


### PR DESCRIPTION
 **Describe the scope of your change - i.e. what the change does.**

We saw that the startup time when using the Keycloak helm chart is very long, because already the configuration generation and testing takes up to a minute.
startupProbe is a new pod feature enabled by default since Kubernetes 1.18.x. It allows pods to be faster ready, because you can set initialDelaySeconds to 0 for livenessProbe and readinessProbe.
livenessProbe and readinessProbe will wait until the startupProbe has succeeded.
This change adds the new configuration options startupProbe (with sub keys) and customStartupProbe.

**Describe any known limitations with your change.**

startupProbe is not available ot not enabled by default before Kubernetes 1.18.x, that's why I've disabled it by default for this chart.

**Please run any tests or examples that can exercise your modified code.**

Done

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
