### PR TITLE
Update readme-generator pinned version in generate-chart-readme action

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: 'bitnami-labs/readme-generator-for-helm'
-          ref: '55cab5dd2191c4ffa7245cfefa428d4d9bb12730'
+          ref: '967764dacee72c05fc5d01c84c13ebb5dab7ac8b'
           path: readme-generator-for-helm
 
       - name: Cache node modules


### PR DESCRIPTION
Update `readme-generator` pinned version in `generate-chart-readme` action to use new [1.2.0 version](https://github.com/bitnami-labs/readme-generator-for-helm/commits/main).