### PR TITLE
[bitnami/contour] Make envoy minReadySeconds configurable

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 5.5.4
+version: 5.6.0

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 5.5.3
+version: 5.5.4

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -147,6 +147,7 @@ $ helm uninstall my-release
 | `envoy.kind`                                        | Install as deployment or daemonset                                                                                    | `daemonset`            |
 | `envoy.replicaCount`                                | Desired number of Controller pods                                                                                     | `1`                    |
 | `envoy.updateStrategy`                              | Strategy to use to update Pods                                                                                        | `{}`                   |
+| `envoy.minReadySeconds`                             | The minimum number of seconds for which a newly created Pod should be ready                                           | `0`                    |
 | `envoy.revisionHistoryLimit`                        | The number of old history to retain to allow rollback                                                                 | `10`                   |
 | `envoy.autoscaling.enabled`                         | Enable autoscaling for Controller                                                                                     | `false`                |
 | `envoy.autoscaling.minReplicas`                     | Minimum number of Controller replicas                                                                                 | `1`                    |

--- a/bitnami/contour/templates/envoy/daemonset.yaml
+++ b/bitnami/contour/templates/envoy/daemonset.yaml
@@ -11,6 +11,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 10%
+  minReadySeconds: {{ .Values.envoy.minReadySeconds }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: envoy

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -20,6 +20,7 @@ spec:
   {{- if .Values.envoy.updateStrategy }}
   strategy: {{- toYaml .Values.envoy.updateStrategy | nindent 4 }}
   {{- end }}
+  minReadySeconds: {{ .Values.envoy.minReadySeconds }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: envoy

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -345,6 +345,9 @@ envoy:
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy: {}
+  ## @param envoy.minReadySeconds The minimum number of seconds for which a newly created Pod should be ready
+  ##
+  minReadySeconds: 0
   ## @param envoy.revisionHistoryLimit The number of old history to retain to allow rollback
   ##
   revisionHistoryLimit: 10


### PR DESCRIPTION
**Description of the change**

Make envoy minReadySeconds configurable

**Benefits**

Let users override `minReadySeconds` value of envoy Deployment or DaemonSet.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None

**Checklist** 

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])