### PR TITLE
[stable/phabricator] Mark Phabricator chart as deprecated

### DIFF
--- a/bitnami/phabricator/Chart.yaml
+++ b/bitnami/phabricator/Chart.yaml
@@ -12,6 +12,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
+# The Phabricator chart is deprecated and no longer maintained.
 deprecated: true
 description: DEPRECATED Collection of open source web applications that help software companies build better software.
 engine: gotpl

--- a/bitnami/phabricator/Chart.yaml
+++ b/bitnami/phabricator/Chart.yaml
@@ -12,7 +12,8 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: Collection of open source web applications that help software companies build better software.
+deprecated: true
+description: DEPRECATED Collection of open source web applications that help software companies build better software.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/phabricator
 icon: https://bitnami.com/assets/stacks/phabricator/img/phabricator-stack-220x234.png
@@ -30,11 +31,9 @@ keywords:
   - git
   - mercurial
   - subversion
-maintainers:
-  - email: containers@bitnami.com
-    name: Bitnami
+maintainers: []
 name: phabricator
 sources:
   - https://github.com/bitnami/bitnami-docker-phabricator
   - https://www.phacility.com/phabricator/
-version: 11.0.29
+version: 11.0.30

--- a/bitnami/phabricator/README.md
+++ b/bitnami/phabricator/README.md
@@ -4,24 +4,7 @@
 
 ## This Helm chart is deprecated
 
-Given the [`stable` deprecation timeline](https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Phabricator Helm chart is now located at [bitnami/charts](https://github.com/bitnami/charts/).
-
-The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/<chart>           # Helm 3
-$ helm install --name my-release bitnami/<chart>    # Helm 2
-```
-
-To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm upgrade my-release bitnami/<chart>
-```
-
-Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to answer questions related to this migration process in [this issue](https://github.com/helm/charts/issues/20969) created as a common place for discussion.
+The upstream project has been discontinued and no new features.
 
 ## TL;DR
 

--- a/bitnami/phabricator/README.md
+++ b/bitnami/phabricator/README.md
@@ -2,6 +2,27 @@
 
 [Phabricator](https://www.phacility.com) is a collection of open source web applications that help software companies build better software. Phabricator is built by developers for developers. Every feature is optimized around developer efficiency for however you like to work. Code Quality starts with an effective collaboration between team members.
 
+## This Helm chart is deprecated
+
+Given the [`stable` deprecation timeline](https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Phabricator Helm chart is now located at [bitnami/charts](https://github.com/bitnami/charts/).
+
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
+
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm upgrade my-release bitnami/<chart>
+```
+
+Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to answer questions related to this migration process in [this issue](https://github.com/helm/charts/issues/20969) created as a common place for discussion.
+
 ## TL;DR
 
 ```console

--- a/bitnami/phabricator/templates/NOTES.txt
+++ b/bitnami/phabricator/templates/NOTES.txt
@@ -1,23 +1,6 @@
 This Helm chart is deprecated
 
-Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Helm chart is now located at bitnami/charts (https://github.com/bitnami/charts/).
-
-The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/<chart>           # Helm 3
-$ helm install --name my-release bitnami/<chart>    # Helm 2
-```
-
-To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm upgrade my-release bitnami/<chart>
-```
-
-Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to answer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for discussion.
+The upstream project has been discontinued and no new features.
 
 {{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 

--- a/bitnami/phabricator/templates/NOTES.txt
+++ b/bitnami/phabricator/templates/NOTES.txt
@@ -1,3 +1,24 @@
+This Helm chart is deprecated
+
+Given the `stable` deprecation timeline (https://github.com/helm/charts#deprecation-timeline), the Bitnami maintained Helm chart is now located at bitnami/charts (https://github.com/bitnami/charts/).
+
+The Bitnami repository is already included in the Hubs and we will continue providing the same cadence of updates, support, etc that we've been keeping here these years. Installation instructions are very similar, just adding the _bitnami_ repo and using it during the installation (`bitnami/<chart>` instead of `stable/<chart>`)
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/<chart>           # Helm 3
+$ helm install --name my-release bitnami/<chart>    # Helm 2
+```
+
+To update an exisiting _stable_ deployment with a chart hosted in the bitnami repository you can execute
+
+```bash
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm upgrade my-release bitnami/<chart>
+```
+
+Issues and PRs related to the chart itself will be redirected to `bitnami/charts` GitHub repository. In the same way, we'll be happy to answer questions related to this migration process in this issue (https://github.com/helm/charts/issues/20969) created as a common place for discussion.
+
 {{- if or .Values.mariadb.enabled .Values.externalDatabase.host -}}
 
 {{- if empty (include "phabricator.host" .) -}}

--- a/bitnami/phabricator/values.yaml
+++ b/bitnami/phabricator/values.yaml
@@ -54,7 +54,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/phabricator
-  tag: 2021.26.0-debian-10-r85
+  tag: 2021.26.0-debian-10-r90
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -617,7 +617,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r202
+    tag: 10-debian-10-r207
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -665,7 +665,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.10.1-debian-10-r4
+    tag: 0.10.1-debian-10-r8
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
**Description of the change**

Phabricator helm chart will be deprecated since the upstream project has been [discontinued](https://admin.phacility.com/phame/post/view/11/phacility_is_winding_down_operations/) and no new features. 


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
