### PR TITLE
[bitnami/common] Add new capability helper for Network Policies

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.8.0
+appVersion: 1.10.0
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - http://www.bitnami.com/
 type: library
-version: 1.9.1
+version: 1.10.0

--- a/bitnami/common/README.md
+++ b/bitnami/common/README.md
@@ -50,17 +50,18 @@ The following table lists the helpers available in the library which are scoped 
 
 ### Capabilities
 
-| Helper identifier                            | Description                                                                                    | Expected Input    |
-|----------------------------------------------|------------------------------------------------------------------------------------------------|-------------------|
-| `common.capabilities.kubeVersion`            | Return the target Kubernetes version (using client default if .Values.kubeVersion is not set). | `.` Chart context |
-| `common.capabilities.cronjob.apiVersion`     | Return the appropriate apiVersion for cronjob.                                                 | `.` Chart context |
-| `common.capabilities.deployment.apiVersion`  | Return the appropriate apiVersion for deployment.                                              | `.` Chart context |
-| `common.capabilities.statefulset.apiVersion` | Return the appropriate apiVersion for statefulset.                                             | `.` Chart context |
-| `common.capabilities.ingress.apiVersion`     | Return the appropriate apiVersion for ingress.                                                 | `.` Chart context |
-| `common.capabilities.rbac.apiVersion`        | Return the appropriate apiVersion for RBAC resources.                                          | `.` Chart context |
-| `common.capabilities.crd.apiVersion`         | Return the appropriate apiVersion for CRDs.                                                    | `.` Chart context |
-| `common.capabilities.policy.apiVersion`      | Return the appropriate apiVersion for policy                                                   | `.` Chart context |
-| `common.capabilities.supportsHelmVersion`    | Returns true if the used Helm version is 3.3+                                                  | `.` Chart context |
+| Helper identifier                              | Description                                                                                    | Expected Input    |
+|------------------------------------------------|------------------------------------------------------------------------------------------------|-------------------|
+| `common.capabilities.kubeVersion`              | Return the target Kubernetes version (using client default if .Values.kubeVersion is not set). | `.` Chart context |
+| `common.capabilities.cronjob.apiVersion`       | Return the appropriate apiVersion for cronjob.                                                 | `.` Chart context |
+| `common.capabilities.deployment.apiVersion`    | Return the appropriate apiVersion for deployment.                                              | `.` Chart context |
+| `common.capabilities.statefulset.apiVersion`   | Return the appropriate apiVersion for statefulset.                                             | `.` Chart context |
+| `common.capabilities.ingress.apiVersion`       | Return the appropriate apiVersion for ingress.                                                 | `.` Chart context |
+| `common.capabilities.rbac.apiVersion`          | Return the appropriate apiVersion for RBAC resources.                                          | `.` Chart context |
+| `common.capabilities.crd.apiVersion`           | Return the appropriate apiVersion for CRDs.                                                    | `.` Chart context |
+| `common.capabilities.policy.apiVersion`        | Return the appropriate apiVersion for podsecuritypolicy.                                       | `.` Chart context |
+| `common.capabilities.networkPolicy.apiVersion` | Return the appropriate apiVersion for networkpolicy.                                           | `.` Chart context |
+| `common.capabilities.supportsHelmVersion`      | Returns true if the used Helm version is 3.3+                                                  | `.` Chart context |
 
 ### Errors
 

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -31,7 +31,7 @@ Return the appropriate apiVersion for networkpolicy.
 */}}
 {{- define "common.capabilities.networkPolicy.apiVersion" -}}
 {{- if semverCompare "<1.7-0" (include "common.capabilities.kubeVersion" .) -}}
-{{- print "policy/v1beta1" -}}
+{{- print "extensions/v1beta1" -}}
 {{- else -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}

--- a/bitnami/common/templates/_capabilities.tpl
+++ b/bitnami/common/templates/_capabilities.tpl
@@ -16,13 +16,24 @@ Return the target Kubernetes version
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for policy.
+Return the appropriate apiVersion for podsecuritypolicy.
 */}}
 {{- define "common.capabilities.policy.apiVersion" -}}
 {{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
 {{- print "policy/v1beta1" -}}
 {{- else -}}
 {{- print "policy/v1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the appropriate apiVersion for networkpolicy.
+*/}}
+{{- define "common.capabilities.networkPolicy.apiVersion" -}}
+{{- if semverCompare "<1.7-0" (include "common.capabilities.kubeVersion" .) -}}
+{{- print "policy/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds a new capability helper for Network Policies: "common.capabilities.networkPolicy.apiVersion"

**Benefits**

Reuse logic that we currently duplicate in several charts, see:

```console
$ ag -l "networkPolicy.apiVersion" bitnami/**/templates/_helpers.tpl
bitnami/cassandra/templates/_helpers.tpl
bitnami/etcd/templates/_helpers.tpl
bitnami/influxdb/templates/_helpers.tpl
bitnami/metallb/templates/_helpers.tpl
bitnami/mysql/templates/_helpers.tpl
bitnami/nats/templates/_helpers.tpl
bitnami/postgresql-ha/templates/_helpers.tpl
bitnami/postgresql/templates/_helpers.tpl
bitnami/redis-cluster/templates/_helpers.tpl
bitnami/redis/templates/_helpers.tpl
``` 

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**
N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
