### PR TITLE
[bitnami/kubeapps] Fix values.schema.json

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.5.3
+version: 7.5.4

--- a/bitnami/kubeapps/values.schema.json
+++ b/bitnami/kubeapps/values.schema.json
@@ -66,14 +66,6 @@
             "value": false,
             "path": "ingress/enabled"
           }
-        },
-          "properties": {
-            "clusterIssuer": {
-              "type": "string",
-              "title": "Cert-manager cluster issuer",
-              "form": true
-            }
-          }
         }
       }
     },


### PR DESCRIPTION
**Description of the change**

The current code (since https://github.com/bitnami/charts/pull/7656) is failing during the packaging:
```console
$ helm package .
Error: failed to save: Invalid JSON in values.schema.json
```
once fixed the JSON format everything works as expected:
```console
helm package .
Successfully packaged chart and saved it to: /home/bitnami/projects/charts/charts/bitnami/kubeapps/kubeapps-7.5.4.tgz
```