### PR TITLE
[bitnami/redis] Use the REDIS_SENTINEL_TLS_ prefix in start-sentinel.sh instead of REDIS_TLS_

### DIFF
--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -296,8 +296,8 @@ data:
         return 0
     }
     get_sentinel_master_info() {
-        if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-            sentinel_info_command="redis-cli {{- if and .Values.auth.enabled .Values.auth.sentinel }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_SERVICE -p $SENTINEL_SERVICE_PORT --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+        if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then
+            sentinel_info_command="redis-cli {{- if and .Values.auth.enabled .Values.auth.sentinel }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_SERVICE -p $SENTINEL_SERVICE_PORT --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
         else
             sentinel_info_command="redis-cli {{- if and .Values.auth.enabled .Values.auth.sentinel }} -a $REDIS_PASSWORD {{- end }} -h $REDIS_SERVICE -p $SENTINEL_SERVICE_PORT sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
         fi


### PR DESCRIPTION
**Description of the change**
The `REDIS_TLS_*` environment variables are not accessible to the `start-sentinel.sh` script within the Sentinel container. I changed instances of the `REDIS_SENTINEL_TLS_` prefix to `REDIS_TLS_`.

**Benefits**
Sentinel + TLS is working

**Possible drawbacks**
Unknown

**Applicable issues**
  - fixes #7670

**Additional information**
None

**Checklist** 
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
