### PR TITLE
[bitnami/nginx-ingress-controller] Revert 7485 apiGroup change

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.lock
+++ b/bitnami/nginx-ingress-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.9.1
-digest: sha256:75c2f378a4570f47cbb3c98b6f1d29d1145e5a92bf2970a5d06c32575bfe266f
-generated: "2021-09-27T07:00:39.325604232Z"
+  version: 1.10.0
+digest: sha256:d6f283322d34efda54721ddd67aec935f1bea501c7b45dfbe89814aed21ae5dc
+generated: "2021-10-01T22:00:27.471496634Z"

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 8.0.2
+version: 8.0.3

--- a/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
@@ -72,6 +72,7 @@ rules:
     verbs:
       - update
   - apiGroups:
+      - extensions
       - networking.k8s.io
     resources:
       - ingressclasses

--- a/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
+++ b/bitnami/nginx-ingress-controller/templates/clusterrole.yaml
@@ -49,6 +49,7 @@ rules:
       - update
       - watch
   - apiGroups:
+      - extensions
       - networking.k8s.io
     resources:
       - ingresses
@@ -64,6 +65,7 @@ rules:
       - create
       - patch
   - apiGroups:
+      - extensions
       - networking.k8s.io
     resources:
       - ingresses/status

--- a/bitnami/nginx-ingress-controller/templates/role.yaml
+++ b/bitnami/nginx-ingress-controller/templates/role.yaml
@@ -39,6 +39,7 @@ rules:
       - update
       - watch
   - apiGroups:
+      - extensions
       - networking.k8s.io
     resources:
       - ingresses
@@ -47,6 +48,7 @@ rules:
       - list
       - watch
   - apiGroups:
+      - extensions
       - networking.k8s.io
     resources:
       - ingresses/status

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -45,7 +45,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/nginx-ingress-controller
-  tag: 1.0.2-debian-10-r0
+  tag: 1.0.2-debian-10-r5
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -442,7 +442,7 @@ defaultBackend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.21.3-debian-10-r19
+    tag: 1.21.3-debian-10-r23
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

In #7485 the `extensions` apiGroup was removed from the role and clusterrules rules. They shouldn't have been removed as we are still supporting `apiGroup: extensions` in `podsecuritypolicy.yaml`

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->
Fixes removed support for old `apiGroups`.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
None

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
