### PR TITLE
[bitnami/minio] readinessProbe, startupProbe and LivenessProbe needs minio-api port

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 8.1.7
+version: 8.1.8

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -196,7 +196,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /minio/health/live
-              port: minio-console
+              port: minio-api
               scheme: {{ ternary "HTTPS" "HTTP" .Values.tls.enabled | quote }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -209,7 +209,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
-              port: minio-console
+              port: minio-api
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -221,7 +221,7 @@ spec:
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
             tcpSocket:
-              port: minio-console
+              port: minio-api
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}


### PR DESCRIPTION
**Description of the change**

- changes the `minio-console` port used by all the minio-pod probes to `minio-api`

**Benefits**

- startup is failing, and pods are going in `CrashLoop`, if probes keeps failing
- probes keep failing due to waiting for results from wrong port

**Possible drawbacks**
- N/A

**Applicable issues**
  - fixes #https://github.com/bitnami/charts/issues/7657

**Additional information**

**Checklist** 
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/).