### PR TITLE
[bitnami/grafana] Add support for custom ldap.toml configuration file from secrets

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 6.2.1
+version: 6.3.0

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -174,7 +174,9 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | `plugins`                          | Grafana plugins to be installed in deployment time separated by commas            | `""`                 |
 | `ldap.enabled`                     | Enable LDAP for Grafana                                                           | `false`              |
 | `ldap.allowSignUp`                 | Allows LDAP sign up for Grafana                                                   | `false`              |
-| `ldap.configMapName`               | Name of the ConfigMap with the LDAP configuration file for Grafana                | `""`                 |
+| `ldap.configuration`               | Specify content for ldap.toml configuration file                                  | `""`                 |
+| `ldap.configMapName`               | Name of the ConfigMap with the ldap.toml configuration file for Grafana           | `""`                 |
+| `ldap.secretName`                  | Name of the Secret with the ldap.toml configuration file for Grafana              | `""`                 |
 | `extraEnvVars`                     | Array containing extra env vars to configure Grafana                              | `{}`                 |
 | `extraConfigmaps`                  | Array to mount extra ConfigMaps to configure Grafana                              | `{}`                 |
 | `config.useGrafanaIniFile`         | Allows to load a `grafana.ini` file                                               | `false`              |

--- a/bitnami/grafana/templates/_helpers.tpl
+++ b/bitnami/grafana/templates/_helpers.tpl
@@ -104,55 +104,6 @@ Return true if a secret object should be created
 {{- end -}}
 
 {{/*
-Validate values for Grafana.
-*/}}
-{{- define "grafana.validateValues" -}}
-{{- $messages := list -}}
-{{- $messages := append $messages (include "grafana.validateValues.database" .) -}}
-{{- $messages := append $messages (include "grafana.validateValues.configmapsOrSecrets" .) -}}
-{{- $messages := without $messages "" -}}
-{{- $message := join "\n" $messages -}}
-
-{{- if $message -}}
-{{-   printf "\nVALUES VALIDATION:\n%s" $message -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Function to validate the external database
-*/}}
-{{- define "grafana.validateValues.database" -}}
-{{- $replicaCount := int .Values.replicaCount }}
-{{- if gt $replicaCount 1 -}}
-WARNING: Using more than one replica requires using an external database to share data between Grafana instances.
-         By default Grafana uses an internal sqlite3 per instance but you can configure an external MySQL or PostgreSQL.
-         Please, ensure you provide a configuration file configuring the external database to share data between replicas.
-{{- end -}}
-{{- end -}}
-
-{{/*
-Function to validate grafana confirmaps and secrets
-*/}}
-{{- define "grafana.validateValues.configmapsOrSecrets" -}}
-{{- if and .Values.config.useGrafanaIniFile (not .Values.config.grafanaIniSecret) (not .Values.config.grafanaIniConfigMap) -}}
-WARNING: You enabled config.useGrafanaIniFile but did not specify config.grafanaIniSecret nor config.grafanaIniConfigMap
-{{- end -}}
-{{- end -}}
-
-{{/*
-Renders a value that contains template.
-Usage:
-{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
-*/}}
-{{- define "common.tplvalues.render" -}}
-    {{- if typeIs "string" .value }}
-        {{- tpl .value .context }}
-    {{- else }}
-        {{- tpl (.value | toYaml) .context }}
-    {{- end }}
-{{- end -}}
-
-{{/*
 Returns the proper service account name depending if an explicit service account name is set
 in the values file. If the name is not set it will default to either common.names.fullname if serviceAccount.create
 is true or default otherwise.
@@ -166,12 +117,55 @@ is true or default otherwise.
 {{- end -}}
 
 {{/*
-Return the appropriate apiVersion for deployment.
+Validate values for Grafana.
 */}}
-{{- define "grafana.ingress.apiVersion" -}}
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
-{{- print "networking.k8s.io/v1beta1" -}}
+{{- define "grafana.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "grafana.validateValues.database" .) -}}
+{{- $messages := append $messages (include "grafana.validateValues.configmapsOrSecrets" .) -}}
+{{- $messages := append $messages (include "grafana.validateValues.ldap.configuration" .) -}}
+{{- $messages := append $messages (include "grafana.validateValues.ldap.configmapsecret" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Grafana - Requirements to use an external database */}}
+{{- define "grafana.validateValues.database" -}}
+{{- $replicaCount := int .Values.replicaCount }}
+{{- if gt $replicaCount 1 -}}
+grafana: replicaCount
+        Using more than one replica requires using an external database to share data between Grafana instances.
+        By default Grafana uses an internal sqlite3 per instance but you can configure an external MySQL or PostgreSQL.
+        Please, ensure you provide a configuration file configuring the external database to share data between replicas.
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Grafana - A ConfigMap or Secret name must be provided when loading a custom grafana.ini file */}}
+{{- define "grafana.validateValues.configmapsOrSecrets" -}}
+{{- if and .Values.config.useGrafanaIniFile (not .Values.config.grafanaIniSecret) (not .Values.config.grafanaIniConfigMap) -}}
+grafana: config.useGrafanaIniFile config.grafanaIniSecret and config.grafanaIniConfigMap
+        You enabled config.useGrafanaIniFile but did not specify config.grafanaIniSecret nor config.grafanaIniConfigMap
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Grafana - A custom ldap.toml file must be provided when enabling LDAP */}}
+{{- define "grafana.validateValues.ldap.configuration" -}}
+{{- if and .Values.ldap.enabled (empty .Values.ldap.configuration) (empty .Values.ldap.configMapName) (empty .Values.ldap.secretName) -}}
+grafana: ldap.enabled ldap.configuration ldap.configMapName and ldap.secretName
+        You must provide the content of your custom ldap.toml file when enabling LDAP (--set ldap.configuration="xxx")
+        As an alternative, you can set the name of an existing ConfigMap (--set ldap.configMapName="yyy") or
+        an an existing Secret (--set ldap.secretName="zzz") containging the custom ldap.toml file.
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Grafana - Only a ConfigMap or Secret name must be provided when loading a custom ldap.toml file */}}
+{{- define "grafana.validateValues.ldap.configmapsecret" -}}
+{{- if and .Values.ldap.enabled (not (empty .Values.ldap.configMapName)) (not (empty .Values.ldap.secretName)) -}}
+grafana: ldap.enabled ldap.configMapName and ldap.secretName
+        You cannot load a custom ldap.toml file both from a ConfigMap and a Secret simultaneously
 {{- end -}}
 {{- end -}}

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -125,7 +125,7 @@ spec:
             - name: datasources
               mountPath: /opt/bitnami/grafana/conf/provisioning/datasources
             {{- end }}
-            {{- if and .Values.ldap.enabled .Values.ldap.configMapName }}
+            {{- if .Values.ldap.enabled }}
             - name: ldap
               mountPath: /opt/bitnami/grafana/conf/ldap.toml
               subPath: ldap.toml
@@ -179,10 +179,18 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.persistence.existingClaim | default (include "common.names.fullname" .) }}
         {{- end }}
-        {{- if and .Values.ldap.enabled .Values.ldap.configMapName }}
+        {{- if .Values.ldap.enabled }}
         - name: ldap
+          {{- if not (empty .Values.ldap.configMapName) }}
           configMap:
             name: {{ .Values.ldap.configMapName }}
+          {{- else if not (empty .Values.ldap.secretName) }}
+          secret:
+            secretName: {{ .Values.ldap.secretName }}
+          {{- else }}
+          secret:
+            secretName: {{ printf "%s-ldap-conf" (include "common.names.fullname" .) }}
+          {{- end }}
         {{- end }}
         {{- if .Values.dashboardsProvider.enabled }}
         - name: dashboards-provider

--- a/bitnami/grafana/templates/ldap-secret.yaml
+++ b/bitnami/grafana/templates/ldap-secret.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.ldap.enabled (not (empty .Values.ldap.configuration)) (empty .Values.ldap.configMapName) (empty .Values.ldap.secretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-ldap-conf" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: grafana
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  ldap.toml: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.ldap.configuration "context" $) | b64enc | nindent 4 }}
+{{- end }}

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -112,14 +112,32 @@ smtp:
 ##
 plugins: ""
 ## Ldap configuration for Grafana
-## @param ldap.enabled Enable LDAP for Grafana
-## @param ldap.allowSignUp Allows LDAP sign up for Grafana
-## @param ldap.configMapName Name of the ConfigMap with the LDAP configuration file for Grafana
 ##
 ldap:
+  ## @param ldap.enabled Enable LDAP for Grafana
+  ##
   enabled: false
+  ## @param ldap.allowSignUp Allows LDAP sign up for Grafana
+  ##
   allowSignUp: false
+  ## @param ldap.configuration Specify content for ldap.toml configuration file
+  ## e.g:
+  ## configuration: |-
+  ##   [[servers]]
+  ##   host = "127.0.0.1"
+  ##   port = 389
+  ##   use_ssl = false
+  ##   ...
+  ##
+  configuration: ""
+  ## @param ldap.configMapName Name of the ConfigMap with the ldap.toml configuration file for Grafana
+  ## NOTE: When it's set the ldap.configuration parameter is ignored
+  ##
   configMapName: ""
+  ## @param ldap.secretName Name of the Secret with the ldap.toml configuration file for Grafana
+  ## NOTE: When it's set the ldap.configuration parameter is ignored
+  ##
+  secretName: ""
 ## @param extraEnvVars Array containing extra env vars to configure Grafana
 ## For example:
 ## extraEnvVars:


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

We currently expose the `ldap.configMapName` parameter that allows you to use an existing ConfigMap including you custom _ldap.toml_ to configure LDAP.

This PR adds support for using also a Secret (instead of a ConfigMap) and it also add the possibility of adding the custom content for the _ldap.toml_ file in the **values.yaml** and creates the corresponding secret for you.

**Benefits**

New possibilities to configure LDAP.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
