### PR TITLE
[bitnami/redis-cluster] Enable initContainers section if redis.initContainers is set (#7674)

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 6.3.9
+version: 6.3.10

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -330,7 +330,7 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.redis.sidecars "context" $ ) | nindent 8 }}
         {{- end }}
       {{- $needsVolumePermissions := and .Values.volumePermissions.enabled (and  .Values.persistence.enabled .Values.containerSecurityContext.enabled) }}
-      {{- if or $needsVolumePermissions .Values.sysctlImage.enabled }}
+      {{- if or $needsVolumePermissions (or .Values.redis.initContainers .Values.sysctlImage.enabled) }}
       initContainers:
         {{- if $needsVolumePermissions }}
         - name: volume-permissions


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Enable `initSection` in `StatefullSet` if custom `initContainer` is provided in `values.yaml`

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Chart users could supply custom `initContainer`, without the need to enable `volumePermissions`, `persistence` and `containerSecurityContext`

<!-- What benefits will be realized by the code change? -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - partly fixes #7674

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
