### PR TITLE
[bitnami/contour-operator] Fix version

### DIFF
--- a/bitnami/contour-operator/Chart.yaml
+++ b/bitnami/contour-operator/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.18.1
+appVersion: 1.18.2
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/contour-operator/README.md
+++ b/bitnami/contour-operator/README.md
@@ -19,9 +19,8 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 
 ## Prerequisites
 
-- Kubernetes 1.12+
+- Kubernetes 1.19+
 - Helm 3.1.0
-- PV provisioner support in the underlying infrastructure
 
 ## Installing the Chart
 


### PR DESCRIPTION
Version `0.1.0` (not yet released) includes Contour Operator `1.18.2`. 

As per Contour's compatibility matrix (see: https://projectcontour.io/resources/compatibility-matrix/) this chart requires Kubernetes 1.19+.