### PR TITLE
[bitnami/kubeapps] Revert scale assetsvc down to 0 replicas

### DIFF
--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -342,7 +342,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `assetsvc.image.tag`                             | Kubeapps Assetsvc image tag (immutable tags are recommended)                              | `2.4.1-scratch-r0`          |
 | `assetsvc.image.pullPolicy`                      | Kubeapps Assetsvc image pull policy                                                       | `IfNotPresent`              |
 | `assetsvc.image.pullSecrets`                     | Kubeapps Assetsvc image pull secrets                                                      | `[]`                        |
-| `assetsvc.replicaCount`                          | Number of Assetsvc replicas to deploy                                                     | `0`                         |
+| `assetsvc.replicaCount`                          | Number of Assetsvc replicas to deploy                                                     | `1`                         |
 | `assetsvc.extraEnvVars`                          | Array with extra environment variables to add to the Assetsvc container                   | `[]`                        |
 | `assetsvc.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for the Assetsvc container           | `""`                        |
 | `assetsvc.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for the Assetsvc container              | `""`                        |

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1114,7 +1114,7 @@ assetsvc:
     pullSecrets: []
   ## @param assetsvc.replicaCount Number of Assetsvc replicas to deploy
   ##
-  replicaCount: 0
+  replicaCount: 1
   ## @param assetsvc.extraEnvVars Array with extra environment variables to add to the Assetsvc container
   ## e.g:
   ## extraEnvVars:


### PR DESCRIPTION
**Description of the change**

Due to some failures while performing the final chart tests, this PR is to revert a change we performed for the chart version (yet unreleased) 7.5.6.

**Benefits**

The liveness/readiness probes won't fail due to a pod having 0 replicas.

**Possible drawbacks**

We aren't deprecating the `assetsvc` service now as we wanted.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). ->no, this is to unblock the the v7.5.6
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
