### PR TITLE
[bitnami/geode] Add support for custom start flags

### DIFF
--- a/bitnami/geode/Chart.yaml
+++ b/bitnami/geode/Chart.yaml
@@ -22,4 +22,4 @@ name: geode
 sources:
   - https://github.com/bitnami/bitnami-docker-geode
   - https://github.com/apache/geode
-version: 0.2.0
+version: 0.3.0

--- a/bitnami/geode/README.md
+++ b/bitnami/geode/README.md
@@ -159,6 +159,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `locator.priorityClassName`                     | Locator pods' priorityClassName                                                                             | `""`                |
 | `locator.schedulerName`                         | Name of the k8s scheduler (other than default) for Locator pods                                             | `""`                |
 | `locator.lifecycleHooks`                        | for the Locator container(s) to automate configuration before or after startup                              | `{}`                |
+| `locator.extraFlags`                            | Additional command line flags to start Locator nodes                                                        | `[]`                |
 | `locator.extraEnvVars`                          | Array with extra environment variables to add to Locator nodes                                              | `[]`                |
 | `locator.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for Locator nodes                                      | `""`                |
 | `locator.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for Locator nodes                                         | `""`                |
@@ -251,6 +252,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.priorityClassName`                       | Cache server pods' priorityClassName                                                                                                        | `""`                |
 | `server.schedulerName`                           | Name of the k8s scheduler (other than default) for Cache server pods                                                                        | `""`                |
 | `server.lifecycleHooks`                          | for the Cache server container(s) to automate configuration before or after startup                                                         | `{}`                |
+| `server.extraFlags`                              | Additional command line flags to start Cache server nodes                                                                                   | `[]`                |
 | `server.extraEnvVars`                            | Array with extra environment variables to add to Cache server nodes                                                                         | `[]`                |
 | `server.extraEnvVarsCM`                          | Name of existing ConfigMap containing extra env vars for Cache server nodes                                                                 | `""`                |
 | `server.extraEnvVarsSecret`                      | Name of existing Secret containing extra env vars for Cache server nodes                                                                    | `""`                |

--- a/bitnami/geode/templates/locator/statefulset.yaml
+++ b/bitnami/geode/templates/locator/statefulset.yaml
@@ -121,7 +121,7 @@ spec:
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           {{- else if .Values.locator.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.locator.command "context" $) | nindent 12 }}
-          {{- else if .Values.auth.tls.enabled }}
+          {{- else }}
           command:
             - /bin/bash
           {{- end }}
@@ -129,10 +129,11 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else if .Values.locator.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.locator.args "context" $) | nindent 12 }}
-          {{- else if .Values.auth.tls.enabled }}
+          {{- else }}
           args:
             - -ec
             - |
+              {{- if .Values.auth.tls.enabled }}
               ID="${MY_POD_NAME#"{{ $fullname }}-"}"
               mkdir -p /opt/bitnami/geode/config/certs
               if [[ -f "/certs/geode.truststore.jks" ]] && [[ -f "/certs/geode-locator-${ID}.truststore.jks" ]]; then
@@ -142,7 +143,8 @@ spec:
                   echo "Couldn't find the expected Java Key Stores (JKS) files! They are mandatory when encryption via TLS is enabled."
                   exit 1
               fi
-              exec /opt/bitnami/scripts/geode/entrypoint.sh /opt/bitnami/scripts/geode/run.sh
+              {{- end }}
+              /opt/bitnami/scripts/geode/entrypoint.sh /opt/bitnami/scripts/geode/run.sh {{ join " " .Values.locator.extraFlags }}
           {{- end }}
           env:
             - name: BITNAMI_DEBUG

--- a/bitnami/geode/templates/server/statefulset.yaml
+++ b/bitnami/geode/templates/server/statefulset.yaml
@@ -155,7 +155,7 @@ spec:
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           {{- else if .Values.server.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.server.command "context" $) | nindent 12 }}
-          {{- else if .Values.auth.tls.enabled }}
+          {{- else }}
           command:
             - /bin/bash
           {{- end }}
@@ -163,10 +163,11 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else if .Values.server.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.server.args "context" $) | nindent 12 }}
-          {{- else if .Values.auth.tls.enabled }}
+          {{- else }}
           args:
             - -ec
             - |
+              {{- if .Values.auth.tls.enabled }}
               ID="${MY_POD_NAME#"{{ $fullname }}-"}"
               mkdir -p /opt/bitnami/geode/config/certs
               if [[ -f "/certs/geode.truststore.jks" ]] && [[ -f "/certs/geode-server-${ID}.truststore.jks" ]]; then
@@ -176,7 +177,8 @@ spec:
                   echo "Couldn't find the expected Java Key Stores (JKS) files! They are mandatory when encryption via TLS is enabled."
                   exit 1
               fi
-              exec /opt/bitnami/scripts/geode/entrypoint.sh /opt/bitnami/scripts/geode/run.sh
+              {{- end }}
+              /opt/bitnami/scripts/geode/entrypoint.sh /opt/bitnami/scripts/geode/run.sh {{ join " " .Values.server.extraFlags }}
           {{- end }}
           env:
             - name: BITNAMI_DEBUG

--- a/bitnami/geode/values.yaml
+++ b/bitnami/geode/values.yaml
@@ -359,6 +359,12 @@ locator:
   ## @param locator.lifecycleHooks for the Locator container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param locator.extraFlags Additional command line flags to start Locator nodes
+  ## e.g.
+  ## extraFlags:
+  ##   - "--J=-Dfoo.bar=true"
+  ##
+  extraFlags: []
   ## @param locator.extraEnvVars Array with extra environment variables to add to Locator nodes
   ## e.g:
   ## extraEnvVars:
@@ -695,6 +701,12 @@ server:
   ## @param server.lifecycleHooks for the Cache server container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
+  ## @param server.extraFlags Additional command line flags to start Cache server nodes
+  ## e.g.
+  ## extraFlags:
+  ##   - "--J=-Dfoo.bar=true"
+  ##
+  extraFlags: []
   ## @param server.extraEnvVars Array with extra environment variables to add to Cache server nodes
   ## e.g:
   ## extraEnvVars:


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR adds 2 new parameters that allow users to set custom start flags for Locator and Cache server nodes.

**Benefits**

Flexibility

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
