### PR TITLE
[bitnami/nginx] Fix template issue in TLS secrets

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - http://www.nginx.org
-version: 9.5.7
+version: 9.5.8

--- a/bitnami/nginx/templates/tls-secrets.yaml
+++ b/bitnami/nginx/templates/tls-secrets.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if $.Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls
 data:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fix ingress TLS secret template when using `commonLabels` by always referring to root context.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->
It is now possible to use `commonLabels` together with `ingress.secrets` 

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

Fixes the following templating issue:
```
Error: template: nginx/templates/tls-secrets.yaml:13:75: executing "nginx/templates/tls-secrets.yaml" at <.Values.commonAnnotations>: nil pointer evaluating interface {}.commonAnnotations
```

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
Other bitnami charts might be affected by the same issue…

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
