### PR TITLE
[bitnami/nginx-ingress-controller] Update ConfigMap RBAC resource

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 8.0.4
+version: 8.0.5

--- a/bitnami/nginx-ingress-controller/templates/role.yaml
+++ b/bitnami/nginx-ingress-controller/templates/role.yaml
@@ -59,7 +59,7 @@ rules:
     resources:
       - configmaps
     resourceNames:
-      - {{ .Values.electionID }}-{{ .Values.ingressClass }}
+      - {{ .Values.electionID }}
     verbs:
       - get
       - update


### PR DESCRIPTION
**Description of the change**

This PR updates the RBAC Role resource, adapting it to the latest major of the nginx-ingress-controller v1.0.x

**Benefits**

Fixes RBAC issue.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - related to #7737

**Additional information**

Version 7.6.21 installed the Configmap as `{{ .Values.electionID }}-{{ .Values.ingressClass }}`:
```
$ helm install nginx-test bitnami/nginx-ingress-controller --set electionID=custom-ingress-controller-leader --set ingressClass=custom-nginx --set rbac.create=true
$ kubectl get cm
NAME                                                  DATA   AGE
custom-ingress-controller-leader-custom-nginx         0      1s
kube-root-ca.crt                                      1      18s
nginx-test-nginx-ingress-controller-default-backend   1      3s
```

While version 8.0.4 installs the Configmap simply as `{{ .Values.electionID }}`:
```
$ helm install nginx-test bitnami/nginx-ingress-controller --set electionID=custom-ingress-controller-leader --set ingressClass=custom-nginx --set rbac.create=true
$ kubectl get cm
NAME                                                  DATA   AGE
custom-ingress-controller-leader                      0      2s
kube-root-ca.crt                                      1      18s
nginx-test-nginx-ingress-controller-default-backend   1      5s
```

These differences can also be appreciated in the upstream deploy files:
https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.48.1/deploy/static/provider/cloud/deploy.yaml
https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.3/deploy/static/provider/cloud/deploy.yaml

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
