### PR TITLE
[bitnami/kafka] Update README.md on using default service from the ou…

### DIFF
--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -533,6 +533,8 @@ externalAccess.service.loadBalancerIPs[1]='external-ip-2'}
 
 Note: You need to know in advance the load balancer IPs so each Kafka broker advertised listener is configured with it.
 
+Following the aforementioned steps will also allow to connect the brokers from the outside using the cluster's default service (when `service.type` is `LoadBalancer` or `NodePort`). Use the property `service.externalPort` to specify the port used for external connections.
+
 #### Using NodePort services
 
 You have two alternatives to use NodePort services:
@@ -561,8 +563,6 @@ externalAccess.service.nodePorts[1]='node-port-2'
 Note: You need to know in advance the node ports that will be exposed so each Kafka broker advertised listener is configured with it.
 
 The pod will try to get the external ip of the node using `curl -s https://ipinfo.io/ip` unless `externalAccess.service.domain` or `externalAccess.service.useHostIPs` is provided.
-
-Following the aforementioned steps will also allow to connect the brokers from the outside using the cluster's default service (when `service.type` is `LoadBalancer` or `NodePort`). Use the property `service.externalPort` to specify the port used for external connections.
 
 #### Name resolution with External-DNS
 


### PR DESCRIPTION
…tside

To connect the brokers from the outside using the cluster's default
service is only possible, if `externalAccess.service.type=LoadBalancer`
and not `externalAccess.service.type=NodePort`. So we move the part to
the correct position.

Closes #7661
