### PR TITLE
Do not enforce init containers if volumePermissions is disabled

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 7.11.0
+version: 7.11.1

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -99,7 +99,7 @@ spec:
             - name: postgresql-certificates
               mountPath: /opt/bitnami/postgresql/certs
       {{- end }}
-      {{- if and .Values.persistence.enabled (or (or (not (empty .Values.postgresql.extendedConf)) (not (empty .Values.postgresql.extendedConfCM)) ) .Values.volumePermissions.enabled) }}
+      {{- if and .Values.persistence.enabled (and (or (not (empty .Values.postgresql.extendedConf)) (not (empty .Values.postgresql.extendedConfCM)) ) .Values.volumePermissions.enabled) }}
         - name: init-chmod-data
           image: {{ include "postgresql-ha.volumePermissionsImage" . }}
           imagePullPolicy: {{ .Values.volumePermissionsImage.pullPolicy | quote }}


### PR DESCRIPTION
[bitnami/postgresql-ha]

**Description of the change**
There is no need to use a init container with a special security context
for chmod's if a extendedConf* is used and volumePermissions are
disabled. If the init container is forced the deployment of the
statefulset will fail on e.g. openshift with a error message like below.

...pods "postgresql-ha-postgresql-1" is forbidden: unable to validate
against any security context constraint:
[spec.initContainers[0].securityContext.runAsUser: Invalid value: 0:
must be in the ranges:...

**Benefits**

The statefulsets could used on openshift without additional changes if volumePermissions are disabled and extendedConfCM is used.

**Possible drawbacks**

**Applicable issues**

  - fixes #7803

**Additional information**

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
