### PR TITLE
[bitnami/nginx-ingress-controller] Fix Ingress example in NOTES.txt

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 8.0.6
+version: 8.0.7

--- a/bitnami/nginx-ingress-controller/templates/NOTES.txt
+++ b/bitnami/nginx-ingress-controller/templates/NOTES.txt
@@ -48,7 +48,7 @@ An example Ingress that makes use of the controller:
     annotations:
       kubernetes.io/ingress.class: {{ .Values.ingressClass }}
     name: example
-    namespace: foo
+    namespace: {{ .Release.Namespace }}
   spec:
     rules:
       - host: www.example.com
@@ -56,7 +56,7 @@ An example Ingress that makes use of the controller:
           paths:
             - backend:
                 service:
-                  name: exampleService
+                  name: example-service
                   port:
                     number: 80
               path: /
@@ -73,7 +73,7 @@ If TLS is enabled for the Ingress, a Secret containing the certificate and key m
   kind: Secret
   metadata:
     name: example-tls
-    namespace: foo
+    namespace: {{ .Release.Namespace }}
   data:
     tls.crt: <base64 encoded cert>
     tls.key: <base64 encoded key>


### PR DESCRIPTION
**Description of the change**

Fix the Ingress example present in the NOTES.txt solving the following issue because of the uppercase in the `exampleService` service name:
```
$ kubectl apply -f ingress.yaml
The Ingress "my-example" is invalid: spec.rules[0].http.paths[0].backend.service.name: Invalid value: "exampleService": a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
```

Replacing `exampleService` by `example-service` works fine. In the same way, the namespace was added to the example

**Applicable issues**

  - related to #7817