### PR TITLE
[bitnami/kubeapps] Allow passing extraEnvVars to authProxy

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.5.7
+version: 7.5.8

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -409,6 +409,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `authProxy.scope`                                 | OAuth scope specification                                                     | `openid email groups`  |
 | `authProxy.emailDomain`                           | Allowed email domains                                                         | `*`                    |
 | `authProxy.additionalFlags`                       | Additional flags for oauth2-proxy                                             | `[]`                   |
+| `authProxy.extraEnvVars`                          | Array with extra environment variables to add to the Auth Proxy container                      | `[]`                   |
 | `authProxy.containerPort`                         | Auth Proxy HTTP container port                                                | `3000`                 |
 | `authProxy.containerSecurityContext.enabled`      | Enabled Auth Proxy containers' Security Context                               | `true`                 |
 | `authProxy.containerSecurityContext.runAsUser`    | Set Auth Proxy container's Security Context runAsUser                         | `1001`                 |

--- a/bitnami/kubeapps/templates/frontend/deployment.yaml
+++ b/bitnami/kubeapps/templates/frontend/deployment.yaml
@@ -151,6 +151,9 @@ spec:
                 secretKeyRef:
                   name: {{ template "kubeapps.oauth2_proxy-secret.name" . }}
                   key: cookieSecret
+            {{- if .Values.authProxy.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.authProxy.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: proxy
               containerPort: {{ .Values.authProxy.containerPort }}

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1354,6 +1354,13 @@ authProxy:
   ##   - --oidc-issuer-url=https://accounts.google.com # Only needed if provider is oidc
   ##
   additionalFlags: []
+  ## @param authProxy.extraEnvVars Array with extra environment variables to add to the Auth Proxy container
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
   ## @param authProxy.containerPort Auth Proxy HTTP container port
   ##
   containerPort: 3000


### PR DESCRIPTION
**Description of the change**

Allow passing extraEnvVars to the authProxy container.

**Benefits**

My use-case is that I need to pass HTTPS_PROXY environment variables for the authproxy to access my OIDC provider.

**Possible drawbacks**

Not a very common use-case, so could clutter the values.

**Applicable issues**

N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
