### PR TITLE
[bitnami/nginx-ingress-controller] Fix missing controllerClass reference

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 8.0.9
+version: 8.0.10

--- a/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-daemonset.yaml
@@ -92,7 +92,7 @@ spec:
             - --publish-service={{ include "nginx-ingress-controller.publishServicePath" . }}
           {{- end }}
             - --election-id={{ .Values.electionID }}
-            - --controller-class={{ .Values.ingressClass }}
+            - --controller-class={{ .Values.controllerClass }}
             - --configmap={{ .Release.Namespace }}/{{ include "common.names.fullname" . }}
           {{- if .Values.tcp }}
             - --tcp-services-configmap={{ .Release.Namespace }}/{{ include "common.names.fullname" . }}-tcp

--- a/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-deployment.yaml
@@ -94,7 +94,7 @@ spec:
             - --publish-service={{ include "nginx-ingress-controller.publishServicePath" . }}
           {{- end }}
             - --election-id={{ .Values.electionID }}
-            - --controller-class={{ .Values.ingressClass }}
+            - --controller-class={{ .Values.controllerClass }}
             - --configmap={{ default .Release.Namespace .Values.configMapNamespace }}/{{ include "common.names.fullname" . }}
           {{- if .Values.tcp }}
             - --tcp-services-configmap={{ default .Release.Namespace .Values.tcpConfigMapNamespace }}/{{ include "common.names.fullname" . }}-tcp

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -99,6 +99,9 @@ watchIngressWithoutClass: false
 ## @param ingressClass Name of the ingress class to route through this controller
 ##
 ingressClass: nginx
+## @param controllerClass Name of the controller class to route through this controller
+##
+controllerClass: k8s.io/ingress-nginx
 ## Allows customization of the external service
 ## the ingress will be bound to via DNS
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add missing controllerClass parameter and assign correct reference in daemonset/deployment object for nginx controller
<!-- Describe the scope of your change - i.e. what the change does. -->

Reference to how the controllerClass is used by nginx controller: https://kubernetes.github.io/ingress-nginx/#i-have-more-than-one-controller-running-in-my-cluster-and-i-want-to-use-the-new-spec

**Benefits**
Allows for proper IngressClasses to be identified via controllerClass parameter provided.
Defaults to the convention controller class name of `k8s.io/ingress-nginx`

<!-- What benefits will be realized by the code change? -->
Previously the `--controller-class` value assigned was that of the `ingressClass` parameter. 
Default `ingressClass` parameter value was `nginx`, which is not a valid `controller class` format of `foo/bar`
Identifying correct association with ingresses by modifying `ingressClass` values to match that of controllers was not a semantically valid option.

**Possible drawbacks**
Someone who has been using `ingressClass` by setting it to the  `controller class` value may find this change breaking.
In my opinion this is a patch, as the original implementation was erroneus.
<!-- Describe any known limitations with your change -->


**Additional information**

Do I still have to manually update the README as mentioned in the checklist? I thought there was a post-process README generation in validation steps.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
