### PR TITLE
[bitnami/rabbitmq-cluster-operator] Set namespace for all resources in rabbitmq-cluster-operator chart

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 1.0.1
+version: 1.0.2

--- a/bitnami/rabbitmq-cluster-operator/templates/service-account.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/service-account.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/servicemonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
**Description of the change**
- Adds the namespace to the metadata of all resources in the rabbitmq-cluster-operator chart.

**Benefits**
Currently the templates of ServiceAccount and the ServiceMonitor do not render
the namespace. With `helm install` this is not an issue because helm will
apply those resources to the namespace that is passed to it.
But if you use `helm template` it does not work. By adding the namespace to the
metadata of all resources the chart works with `helm install` and
`helm template` equally.


<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
- None I can think of

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])

Signed-off-by: Max Rosin <max.rosin@hetzner-cloud.de>