### PR TITLE
[bitnami/kubernetes-event-exporter] Support multiple replicas

### DIFF
--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -26,4 +26,4 @@ name: kubernetes-event-exporter
 sources:
   - https://github.com/bitnami/bitnami-docker-kubernetes-event-exporter
   - https://github.com/opsgenie/kubernetes-event-exporter
-version: 1.1.17
+version: 1.2.0

--- a/bitnami/kubernetes-event-exporter/README.md
+++ b/bitnami/kubernetes-event-exporter/README.md
@@ -66,6 +66,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                                              | Description                                                                               | Value                               |
 | ------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------- |
+| `replicaCount`                                    | Desired number of pod replicas                                                            | `1`                                 |
 | `image.registry`                                  | Container image registry                                                                  | `docker.io`                         |
 | `image.repository`                                | Container image name                                                                      | `bitnami/kubernetes-event-exporter` |
 | `image.tag`                                       | Container image tag                                                                       | `0.10.0-debian-10-r117`             |

--- a/bitnami/kubernetes-event-exporter/templates/_helpers.tpl
+++ b/bitnami/kubernetes-event-exporter/templates/_helpers.tpl
@@ -10,3 +10,24 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create default config for leader election when replicaCount is greater than 1
+*/}}
+{{- define "kubernetes-event-exporter.leaderElectionConfig" -}}
+  {{- if gt (int64 .Values.replicaCount) 1 -}}
+leaderElection:
+  enabled: true
+  leaderElectionID: {{ include "common.names.fullname" . }}-leader-election
+  {{- else -}}
+leaderElection: {}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Create final config by merging user supplied config and default config
+*/}}
+{{- define "kubernetes-event-exporter.config" -}}
+  {{- $leaderElectionConfig := fromYaml (include "kubernetes-event-exporter.leaderElectionConfig" .) -}}
+  {{- toYaml (mergeOverwrite $leaderElectionConfig .Values.config) }}
+{{- end -}}

--- a/bitnami/kubernetes-event-exporter/templates/configmap.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/configmap.yaml
@@ -11,4 +11,4 @@ metadata:
     {{- end }}
 data:
   config.yaml: |
-    {{- toYaml .Values.config | nindent 4 }}
+    {{- include "kubernetes-event-exporter.config" . | nindent 4 }}

--- a/bitnami/kubernetes-event-exporter/templates/deployment.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   template:

--- a/bitnami/kubernetes-event-exporter/templates/rbac-leader-election.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/rbac-leader-election.yaml
@@ -1,0 +1,51 @@
+{{- $config := fromYaml (include "kubernetes-event-exporter.config" .) -}}
+{{- if and .Values.rbac.create $config.leaderElection.enabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ include "common.names.fullname" . }}-leader-election
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - {{ $config.leaderElection.leaderElectionID }}
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  name: {{ include "common.names.fullname" . }}-leader-election
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "common.names.fullname" . }}-leader-election
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubernetes-event-exporter.serviceAccountName" . }}
+  namespace: monitoring
+{{- end -}}

--- a/bitnami/kubernetes-event-exporter/values.yaml
+++ b/bitnami/kubernetes-event-exporter/values.yaml
@@ -34,6 +34,9 @@ extraDeploy: []
 
 ## @section Kubernetes Event Exporter parameters
 
+## @param replicaCount Desired number of pod replicas
+replicaCount: 1
+
 image:
   ## @param image.registry Container image registry
   ## @param image.repository Container image name


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Opsgenie's Event-exporter supports multiple replicas with by doing leader election. While it's not yet documented upstream, it exists in source for 4 minor versions (0.7 .. 0.10):
https://github.com/opsgenie/kubernetes-event-exporter/blob/v0.7/pkg/kube/leaderelection.go

**Benefits**
Run event-exporter in a cloud native way

**Possible drawbacks**
more complex config

**Applicable issues**
`-`

**Additional information**
`-`

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
