### PR TITLE
[bitnami/mariadb] add optional startup probe to mariadb

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 9.6.5
+version: 9.7.0

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -125,6 +125,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `primary.containerSecurityContext.runAsUser` | User ID for the MariaDB primary container                                                                         | `1001`              |
 | `primary.resources.limits`                   | The resources limits for MariaDB primary containers                                                               | `{}`                |
 | `primary.resources.requests`                 | The requested resources for MariaDB primary containers                                                            | `{}`                |
+| `primary.startupProbe.enabled`               | Enable startupProbe                                                                                               | `true`              |
+| `primary.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                            | `120`               |
+| `primary.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                                   | `15`                |
+| `primary.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                                  | `5`                 |
+| `primary.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                                | `10`                |
+| `primary.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                                | `1`                 |
 | `primary.livenessProbe.enabled`              | Enable livenessProbe                                                                                              | `true`              |
 | `primary.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                           | `120`               |
 | `primary.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                  | `10`                |
@@ -137,6 +143,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `primary.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                | `1`                 |
 | `primary.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                              | `3`                 |
 | `primary.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                              | `1`                 |
+| `primary.customStartupProbe`                 | Override default startup probe for MariaDB primary containers                                                     | `{}`                |
 | `primary.customLivenessProbe`                | Override default liveness probe for MariaDB primary containers                                                    | `{}`                |
 | `primary.customReadinessProbe`               | Override default readiness probe for MariaDB primary containers                                                   | `{}`                |
 | `primary.startupWaitOptions`                 | Override default builtin startup wait check options for MariaDB primary containers                                | `{}`                |
@@ -199,6 +206,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.containerSecurityContext.runAsUser` | User ID for the MariaDB secondary container                                                                           | `1001`              |
 | `secondary.resources.limits`                   | The resources limits for MariaDB secondary containers                                                                 | `{}`                |
 | `secondary.resources.requests`                 | The requested resources for MariaDB secondary containers                                                              | `{}`                |
+| `secondary.startupProbe.enabled`               | Enable livenessProbe                                                                                                  | `true`              |
+| `secondary.startupProbe.initialDelaySeconds`   | Initial delay seconds for livenessProbe                                                                               | `120`               |
+| `secondary.startupProbe.periodSeconds`         | Period seconds for livenessProbe                                                                                      | `15`                |
+| `secondary.startupProbe.timeoutSeconds`        | Timeout seconds for livenessProbe                                                                                     | `5`                 |
+| `secondary.startupProbe.failureThreshold`      | Failure threshold for livenessProbe                                                                                   | `10`                |
+| `secondary.startupProbe.successThreshold`      | Success threshold for livenessProbe                                                                                   | `1`                 |
 | `secondary.livenessProbe.enabled`              | Enable livenessProbe                                                                                                  | `true`              |
 | `secondary.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                               | `120`               |
 | `secondary.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                      | `10`                |
@@ -211,6 +224,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                    | `1`                 |
 | `secondary.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                  | `3`                 |
 | `secondary.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                  | `1`                 |
+| `secondary.customStartupProbe`                 | Override default startup probe for MariaDB secondary containers                                                       | `{}`                |
 | `secondary.customLivenessProbe`                | Override default liveness probe for MariaDB secondary containers                                                      | `{}`                |
 | `secondary.customReadinessProbe`               | Override default readiness probe for MariaDB secondary containers                                                     | `{}`                |
 | `secondary.startupWaitOptions`                 | Override default builtin startup wait check options for MariaDB secondary containers                                  | `{}`                |

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -191,6 +191,21 @@ spec:
             - name: mysql
               containerPort: 3306
           {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.primary.startupProbe.enabled }}
+          startupProbe: {{- omit .Values.primary.startupProbe "enabled" | toYaml | nindent 12 }}
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  password_aux="${MARIADB_ROOT_PASSWORD:-}"
+                  if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
+                      password_aux=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
+                  fi
+                  mysqladmin status -uroot -p"${password_aux}"
+          {{- else if .Values.primary.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.primary.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.primary.livenessProbe.enabled }}
           livenessProbe: {{- omit .Values.primary.livenessProbe "enabled" | toYaml | nindent 12 }}
             exec:

--- a/bitnami/mariadb/templates/secondary/statefulset.yaml
+++ b/bitnami/mariadb/templates/secondary/statefulset.yaml
@@ -180,6 +180,21 @@ spec:
             - name: mysql
               containerPort: 3306
           {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.secondary.startupProbe.enabled }}
+          startupProbe: {{- omit .Values.secondary.startupProbe "enabled" | toYaml | nindent 12 }}
+            exec:
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  password_aux="${MARIADB_ROOT_PASSWORD:-}"
+                  if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
+                      password_aux=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
+                  fi
+                  mysqladmin status -uroot -p"${password_aux}"
+          {{- else if .Values.secondary.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.secondary.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.secondary.livenessProbe.enabled }}
           livenessProbe: {{- omit .Values.secondary.livenessProbe "enabled" | toYaml | nindent 12 }}
             exec:

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -295,6 +295,22 @@ primary:
     ##    cpu: 100m
     ##    memory: 256Mi
     requests: {}
+  ## Configure extra options for startup probe
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param primary.startupProbe.enabled Enable startupProbe
+  ## @param primary.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param primary.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param primary.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param primary.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param primary.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 120
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 10
+    successThreshold: 1
   ## Configure extra options for liveness probe
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
   ## @param primary.livenessProbe.enabled Enable livenessProbe
@@ -327,6 +343,9 @@ primary:
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1
+  ## @param primary.customStartupProbe Override default startup probe for MariaDB primary containers
+  ##
+  customStartupProbe: {}
   ## @param primary.customLivenessProbe Override default liveness probe for MariaDB primary containers
   ##
   customLivenessProbe: {}
@@ -614,6 +633,22 @@ secondary:
     ##    cpu: 100m
     ##    memory: 256Mi
     requests: {}
+  ## Configure extra options for startup probe
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param secondary.startupProbe.enabled Enable startupProbe
+  ## @param secondary.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param secondary.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param secondary.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param secondary.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param secondary.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 120
+    periodSeconds: 15
+    timeoutSeconds: 5
+    failureThreshold: 10
+    successThreshold: 1
   ## Configure extra options for liveness probe
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
   ## @param secondary.livenessProbe.enabled Enable livenessProbe
@@ -646,6 +681,9 @@ secondary:
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1
+  ## @param secondary.customStartupProbe Override default startup probe for MariaDB primary containers
+  ##
+  customStartupProbe: {}
   ## @param secondary.customLivenessProbe Override default liveness probe for MariaDB secondary containers
   ##
   customLivenessProbe: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
 Add optional `startupProbe` to `mariadb`
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Better handling for slow startups
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
no, disabled by default
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #7937

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
