### PR TITLE
[bitnami/thanos] Replace nodePorts.grpc/http to http/grpc.nodePorts in the servce sharded

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 7.0.1
+version: 7.0.2

--- a/bitnami/thanos/templates/storegateway/service-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/service-sharded.yaml
@@ -49,8 +49,8 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-      {{- if ne "false" (include "thanos.validateValues.storegateway.sharded.length" (dict "property" $.Values.storegateway.sharded.service.nodePorts.http "context" $) ) }}
-      nodePort: {{ index $.Values.storegateway.sharded.service.nodePorts.http $index }}
+      {{- if ne "false" (include "thanos.validateValues.storegateway.sharded.length" (dict "property" $.Values.storegateway.sharded.service.http.nodePorts "context" $) ) }}
+      nodePort: {{ index $.Values.storegateway.sharded.service.http.nodePorts $index }}
       {{- else if eq $.Values.storegateway.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
@@ -58,8 +58,8 @@ spec:
       targetPort: grpc
       protocol: TCP
       name: grpc
-      {{- if ne "false" (include "thanos.validateValues.storegateway.sharded.length" (dict "property" $.Values.storegateway.sharded.service.nodePorts.grpc "context" $) ) }}
-      nodePort: {{ index $.Values.storegateway.sharded.service.nodePorts.grpc $index }}
+      {{- if ne "false" (include "thanos.validateValues.storegateway.sharded.length" (dict "property" $.Values.storegateway.sharded.service.grpc.nodePorts "context" $) ) }}
+      nodePort: {{ index $.Values.storegateway.sharded.service.grpc.nodePorts $index }}
       {{- else if eq $.Values.storegateway.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}


### PR DESCRIPTION
**Description of the change**

During our last update, we have modified the sharded values to include the nodePort. Before our major change, the order of the nodes was grpc.nodePort and http.nodePort. After our major change, we have changed it and we need to keep the service-sharded using the same format (format before the major).

**Benefits**

Fix a template error.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #7935

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
