### PR TITLE
[bitnami/grafana-tempo] Compactor servicemonitor template fix

### DIFF
--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -27,4 +27,4 @@ name: grafana-tempo
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana-tempo
   - https://github.com/grafana/tempo/
-version: 0.2.11
+version: 0.2.12

--- a/bitnami/grafana-tempo/templates/compactor/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-      app.kubernetes.io/component: compactor
+    app.kubernetes.io/component: compactor
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
Fixed the servicemonitor template for compactor

**Description of the change**

Changed labels section for servicemonitor of compactor application, fixes #7931

**Benefits**

Ability to enable servicemonitor for all components now 

**Possible drawbacks**

Not found


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
