### PR TITLE
[bitnami/thanos] Corrects Thanos Query GRPC ingress service port for extraHosts

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 7.0.3
+version: 7.0.4

--- a/bitnami/thanos/templates/query/ingress-grpc.yaml
+++ b/bitnami/thanos/templates/query/ingress-grpc.yaml
@@ -39,7 +39,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "query") "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-%s"  (include "common.names.fullname" $) "query") "servicePort" "grpc" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or (and .Values.query.ingress.grpc.tls (or (include "thanos.ingress.certManagerRequest" .Values.query.ingress.grpc.annotations) .Values.query.ingress.grpc.selfSigned)) .Values.query.ingress.grpc.extraTls }}
   tls:


### PR DESCRIPTION
**Description of the change**

v7.0.0 broke Thanos query GRPC ingress. It should be set to `grpc` and not `http` for the GRPC Ingress service backend port for extraHosts

This is actually a correction for PR:  https://github.com/bitnami/charts/pull/7968

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
