### PR TITLE
[bitnami/apache] Add Autoscaling and Disruption Budget options

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -26,4 +26,4 @@ name: apache
 sources:
   - https://github.com/bitnami/bitnami-docker-apache
   - https://httpd.apache.org
-version: 8.8.6
+version: 8.9.0

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -141,7 +141,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `pdb.minAvailable`         | Minimum number/percentage of pods that should remain scheduled   | `1`                   |
 | `pdb.maxUnavailable`       | Maximum number/percentage of pods that may be made unavailable   | `""`                  |
 | `autoscaling.enabled`      | Enable Horizontal POD autoscaling for Apache                     | `false`               |
-| `autoscaling.apiVersion`   | API Version of the HPA object (for compatibility with Openshift) | `autoscaling/v2beta1` |
 | `autoscaling.minReplicas`  | Minimum number of Apache replicas                                | `1`                   |
 | `autoscaling.maxReplicas`  | Maximum number of Apache replicas                                | `11`                  |
 | `autoscaling.targetCPU`    | Target CPU utilization percentage                                | `50`                  |

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -133,6 +133,21 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sidecars`                             | Add additional sidecar containers to the Apache pods                                                                     | `[]`                   |
 
 
+### Other Parameters
+
+| Name                       | Description                                                      | Value                 |
+| -------------------------- | ---------------------------------------------------------------- | --------------------- |
+| `pdb.create`               | Enable a Pod Disruption Budget creation                          | `false`               |
+| `pdb.minAvailable`         | Minimum number/percentage of pods that should remain scheduled   | `1`                   |
+| `pdb.maxUnavailable`       | Maximum number/percentage of pods that may be made unavailable   | `""`                  |
+| `autoscaling.enabled`      | Enable Horizontal POD autoscaling for Apache                     | `false`               |
+| `autoscaling.apiVersion`   | API Version of the HPA object (for compatibility with Openshift) | `autoscaling/v2beta1` |
+| `autoscaling.minReplicas`  | Minimum number of Apache replicas                                | `1`                   |
+| `autoscaling.maxReplicas`  | Maximum number of Apache replicas                                | `11`                  |
+| `autoscaling.targetCPU`    | Target CPU utilization percentage                                | `50`                  |
+| `autoscaling.targetMemory` | Target Memory utilization percentage                             | `50`                  |
+
+
 ### Traffic Exposure Parameters
 
 | Name                            | Description                                                                                                                      | Value                    |

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}

--- a/bitnami/apache/templates/hpa.yaml
+++ b/bitnami/apache/templates/hpa.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1
+    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
     kind: Deployment
     name: {{ template "common.names.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}

--- a/bitnami/apache/templates/hpa.yaml
+++ b/bitnami/apache/templates/hpa.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: {{ .Values.autoscaling.apiVersion }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "common.names.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemory  }}
+    {{- end }}
+{{- end }}

--- a/bitnami/apache/templates/hpa.yaml
+++ b/bitnami/apache/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: {{ .Values.autoscaling.apiVersion }}
+apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/apache/templates/pdb.yaml
+++ b/bitnami/apache/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.pdb.create }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -385,6 +385,34 @@ ingress:
   ##
   secrets: []
 
+## Apache Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+## @param pdb.create Enable a Pod Disruption Budget creation
+## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+##
+pdb:
+  create: false
+  minAvailable: 1
+  maxUnavailable: ""
+
+## Apache Autoscaling parameters
+## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+## @param autoscaling.enabled Enable autoscaling for Apache deployment
+## @param autoscaling.apiVersion API Version of the HPA object (for compatibility with Openshift)
+## @param autoscaling.minReplicas Minimum number of replicas to scale back
+## @param autoscaling.maxReplicas Maximum number of replicas to scale out
+## @param autoscaling.targetCPU Target CPU utilization percentage
+## @param autoscaling.targetMemory Target Memory utilization percentage
+##
+autoscaling:
+  enabled: false
+  apiVersion: autoscaling/v2beta1
+  minReplicas: 1
+  maxReplicas: 11
+  targetCPU: 50
+  targetMemory: 50
+
 ## @section Metrics Parameters
 
 metrics:

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -399,7 +399,6 @@ pdb:
 ## Apache Autoscaling parameters
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 ## @param autoscaling.enabled Enable autoscaling for Apache deployment
-## @param autoscaling.apiVersion API Version of the HPA object (for compatibility with Openshift)
 ## @param autoscaling.minReplicas Minimum number of replicas to scale back
 ## @param autoscaling.maxReplicas Maximum number of replicas to scale out
 ## @param autoscaling.targetCPU Target CPU utilization percentage
@@ -407,7 +406,6 @@ pdb:
 ##
 autoscaling:
   enabled: false
-  apiVersion: autoscaling/v2beta1
   minReplicas: 1
   maxReplicas: 11
   targetCPU: 50


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Introduce `autoscaling` and `pdb` options in the values file to create `HorizontalPodAutoscaler` and `PodDisruptionBudget` objects

**Benefits**

Allows Apache deployment to scale dynamically and limit the number of concurrent disruptions.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**



**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
