### PR TITLE
[bitnami/redis] Ignore auth for sentinel liveness if auth is disabled

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 15.5.3
+version: 15.5.4

--- a/bitnami/redis/templates/health-configmap.yaml
+++ b/bitnami/redis/templates/health-configmap.yaml
@@ -67,8 +67,10 @@ data:
   ping_sentinel.sh: |-
     #!/bin/bash
 
+{{- if .Values.auth.sentinel }}
     [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
     [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
+{{- end }}
     response=$(
       timeout -s 3 $1 \
       redis-cli \


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Add logic to the health-configmap to omit the auth lines for the sentinel liveness check if `.Values.auth.sentinel` is `false`

**Benefits**

<!-- What benefits will be realized by the code change? -->
If auth is enabled for redis, but disabled for the sentinels, the sentinel liveness probe will fail and the pods will be killed due to using a password when one is not required.  The error message encountered is: `AUTH failed: ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?`  Removing the lines for password env and file allow the pods to successfully pass the liveness check on the sentinel containers.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
If auth is disabled, but sentinel auth is left as enabled, these lines will appear in the script.  However, the current logic is maintained so it will appropriately skip using credentials.  I'm not sure there's a good way to have this be consistent with how auth is handled for the other cases and always have the lines present in the file without adding new variables for `SENTINEL_PASSWORD_FILE` AND `SENTINEL_PASSWORD`

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
