### PR TITLE
[bitnami/grafana] Fix servicemonitor nil pointer

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 7.0.6
+version: 7.0.7

--- a/bitnami/grafana/templates/servicemonitor.yaml
+++ b/bitnami/grafana/templates/servicemonitor.yaml
@@ -17,8 +17,8 @@ metadata:
     {{- end }}
     app.kubernetes.io/component: grafana
 spec:
-  {{- if .Values.serviceMonitor.jobLabel }}
-  jobLabel: {{ .Values.serviceMonitor.jobLabel }}
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
   {{- end }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}


### PR DESCRIPTION
**Description of the change**

Modify helm chart references.

**Benefits**

Fixes a nil pointer reference when configuring a servicemonitor.

**Possible drawbacks**

Not known

**Applicable issues**


**Additional information**

```
metrics:
  enabled: true
  serviceMonitor:
    enabled: true
```

```
Error: UPGRADE FAILED: template: grafana/templates/servicemonitor.yaml:20:16: executing "grafana/templates/servicemonitor.yaml"
at <.Values.serviceMonitor.jobLabel>: nil pointer evaluating interface {}.jobLabel
```


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
