### PR TITLE
[bitnami/nats] Rename configuration node for authentication user map

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/bitnami-docker-nats
   - https://nats.io/
-version: 6.5.3
+version: 6.6.0

--- a/bitnami/nats/templates/configmap.yaml
+++ b/bitnami/nats/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
       password: {{ $authPwd | quote }}
       {{- else if .Values.auth.token }}
       token: {{ .Values.auth.token | quote }}
-      {{- else if .Values.auth.users }}
+      {{- else if .Values.auth.usersCredentials }}
       users: [
         {{- range $user := .Values.auth.usersCredentials }}
           { user: {{ $user.username | quote }}, password: {{ $user.password | quote }} },


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

There was a bug introduced in PR #7791 which requires excessive configuration:
```yaml
auth:
  enabled: true
  user: ""
  users: any-value-works
  usersCredentials:
    - username: anonymous
      password: anonymous
```
The configuration node `auth.users` is unnecessary and confusing.
The configuration should just be:
```yaml
auth:
  enabled: true
  user: ""
  usersCredentials:
    - username: anonymous
      password: anonymous
```

**Benefits**

Simplifies the configuration of authentication user map.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
