### PR TITLE
[bitnami/apache, bitnami/fluentd] Fix metadata used to generate README table

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -26,4 +26,4 @@ name: apache
 sources:
   - https://github.com/bitnami/bitnami-docker-apache
   - https://httpd.apache.org
-version: 8.9.0
+version: 8.9.1

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -135,16 +135,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other Parameters
 
-| Name                       | Description                                                      | Value                 |
-| -------------------------- | ---------------------------------------------------------------- | --------------------- |
-| `pdb.create`               | Enable a Pod Disruption Budget creation                          | `false`               |
-| `pdb.minAvailable`         | Minimum number/percentage of pods that should remain scheduled   | `1`                   |
-| `pdb.maxUnavailable`       | Maximum number/percentage of pods that may be made unavailable   | `""`                  |
-| `autoscaling.enabled`      | Enable Horizontal POD autoscaling for Apache                     | `false`               |
-| `autoscaling.minReplicas`  | Minimum number of Apache replicas                                | `1`                   |
-| `autoscaling.maxReplicas`  | Maximum number of Apache replicas                                | `11`                  |
-| `autoscaling.targetCPU`    | Target CPU utilization percentage                                | `50`                  |
-| `autoscaling.targetMemory` | Target Memory utilization percentage                             | `50`                  |
+| Name                       | Description                                                    | Value   |
+| -------------------------- | -------------------------------------------------------------- | ------- |
+| `pdb.create`               | Enable a Pod Disruption Budget creation                        | `false` |
+| `pdb.minAvailable`         | Minimum number/percentage of pods that should remain scheduled | `1`     |
+| `pdb.maxUnavailable`       | Maximum number/percentage of pods that may be made unavailable | `""`    |
+| `autoscaling.enabled`      | Enable Horizontal POD autoscaling for Apache                   | `false` |
+| `autoscaling.minReplicas`  | Minimum number of Apache replicas                              | `1`     |
+| `autoscaling.maxReplicas`  | Maximum number of Apache replicas                              | `11`    |
+| `autoscaling.targetCPU`    | Target CPU utilization percentage                              | `50`    |
+| `autoscaling.targetMemory` | Target Memory utilization percentage                           | `50`    |
 
 
 ### Traffic Exposure Parameters

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -275,6 +275,34 @@ initContainers: []
 ##
 sidecars: []
 
+## @section Other Parameters
+
+## Apache Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+## @param pdb.create Enable a Pod Disruption Budget creation
+## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+##
+pdb:
+  create: false
+  minAvailable: 1
+  maxUnavailable: ""
+
+## Apache Autoscaling parameters
+## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+## @param autoscaling.enabled Enable Horizontal POD autoscaling for Apache
+## @param autoscaling.minReplicas Minimum number of Apache replicas
+## @param autoscaling.maxReplicas Maximum number of Apache replicas
+## @param autoscaling.targetCPU Target CPU utilization percentage
+## @param autoscaling.targetMemory Target Memory utilization percentage
+##
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 11
+  targetCPU: 50
+  targetMemory: 50
+
 ## @section Traffic Exposure Parameters
 
 ## Apache service parameters
@@ -390,32 +418,6 @@ ingress:
   ##       -----END CERTIFICATE-----
   ##
   secrets: []
-
-## Apache Pod Disruption Budget configuration
-## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
-## @param pdb.create Enable a Pod Disruption Budget creation
-## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
-## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
-##
-pdb:
-  create: false
-  minAvailable: 1
-  maxUnavailable: ""
-
-## Apache Autoscaling parameters
-## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
-## @param autoscaling.enabled Enable autoscaling for Apache deployment
-## @param autoscaling.minReplicas Minimum number of replicas to scale back
-## @param autoscaling.maxReplicas Maximum number of replicas to scale out
-## @param autoscaling.targetCPU Target CPU utilization percentage
-## @param autoscaling.targetMemory Target Memory utilization percentage
-##
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 11
-  targetCPU: 50
-  targetMemory: 50
 
 ## @section Metrics Parameters
 

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/bitnami-docker-fluentd
   - https://www.fluentd.org/
-version: 4.4.0
+version: 4.4.1

--- a/bitnami/fluentd/values.yaml
+++ b/bitnami/fluentd/values.yaml
@@ -85,9 +85,9 @@ forwarder:
   ## @param forwarder.enabled Enable forwarder daemonset
   ##
   enabled: true
-  ## @param forwarder.image.registry Fluentd image registry
-  ## @param forwarder.image.repository Fluentd image repository
-  ## @param forwarder.image.tag Fluentd image tag (immutable tags are recommended)
+  ## @param forwarder.image.registry Fluentd forwarder image registry override
+  ## @param forwarder.image.repository Fluentd forwarder image repository override
+  ## @param forwarder.image.tag Fluentd forwarder image tag override (immutable tags are recommended)
   image:
     registry: ""
     repository: ""
@@ -533,9 +533,9 @@ aggregator:
   ## @param aggregator.enabled Enable Fluentd aggregator statefulset
   ##
   enabled: true
-  ## @param aggregator.image.registry Fluentd image registry
-  ## @param aggregator.image.repository Fluentd image repository
-  ## @param aggregator.image.tag Fluentd image tag (immutable tags are recommended)
+  ## @param aggregator.image.registry Fluentd aggregator image registry override
+  ## @param aggregator.image.repository Fluentd aggregator image repository override
+  ## @param aggregator.image.tag Fluentd aggregator image tag override (immutable tags are recommended)
   image:
     registry: ""
     repository: ""


### PR DESCRIPTION
As part of https://github.com/bitnami/charts/pull/7979 and https://github.com/bitnami/charts/pull/7990, some parameters were added to the _values.yaml_ and **manually** added to the _README.md_; when executing the `readme-generator` tool, some inconsistencies appeared. The goal of this PR is to fix those inconsistencies.