### PR TITLE
Update readme to correct parameter name.

### DIFF
--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -219,7 +219,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm install my-release \
-  --set tomcatUser=manager,tomcatPassword=password bitnami/tomcat
+  --set tomcatUsername=manager,tomcatPassword=password bitnami/tomcat
 ```
 
 The above command sets the Tomcat management username and password to `manager` and `password` respectively.


### PR DESCRIPTION
It seems **tomcatUser** is not a valid parameter name according to the parameter table showed in this README file.
This commit replaces **tomcatUser** to **tomcatUsername**.