### PR TITLE
[bitnami/redis-cluster] fix missing clusterDomain variable

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 7.0.9
+version: 7.0.10

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -78,16 +78,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Redis&trade; Cluster Common parameters
 
-| Name                     | Description                                                                                  | Value          |
-| ------------------------ | -------------------------------------------------------------------------------------------- | -------------- |
-| `nameOverride`           | String to partially override common.names.fullname template (will maintain the release name) | `""`           |
-| `fullnameOverride`       | String to fully override common.names.fullname template                                      | `""`           |
-| `commonAnnotations`      | Annotations to add to all deployed objects                                                   | `{}`           |
-| `commonLabels`           | Labels to add to all deployed objects                                                        | `{}`           |
-| `extraDeploy`            | Array of extra objects to deploy with the release (evaluated as a template)                  | `[]`           |
-| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)      | `false`        |
-| `diagnosticMode.command` | Command to override all containers in the deployment                                         | `["sleep"]`    |
-| `diagnosticMode.args`    | Args to override all containers in the deployment                                            | `["infinity"]` |
+| Name                     | Description                                                                                  | Value           |
+| ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
+| `nameOverride`           | String to partially override common.names.fullname template (will maintain the release name) | `""`            |
+| `fullnameOverride`       | String to fully override common.names.fullname template                                      | `""`            |
+| `clusterDomain`          | Kubernetes Cluster Domain                                                                    | `cluster.local` |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                                   | `{}`            |
+| `commonLabels`           | Labels to add to all deployed objects                                                        | `{}`            |
+| `extraDeploy`            | Array of extra objects to deploy with the release (evaluated as a template)                  | `[]`            |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)      | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the deployment                                         | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the deployment                                            | `["infinity"]`  |
 
 
 ### Redis&trade; Cluster Common parameters

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -27,6 +27,9 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override common.names.fullname template
 ##
 fullnameOverride: ""
+## @param clusterDomain Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
 ## @param commonAnnotations Annotations to add to all deployed objects
 ##
 commonAnnotations: {}


### PR DESCRIPTION
**Description of the change**

The TLS Certificate generation uses .Values.clusterDomain
which is not defined thus in the generated certificate SAN
field you will values like: %!s(<nil>)

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>


**Benefits**

TLS Certificate SANs will not contain entries like `%!s(<nil>)`

**Possible drawbacks**

`N/A`

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #8032

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
