### PR TITLE
[bitnami/contour] Allow deploying without explicit IngressClass

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 6.0.1
+version: 6.0.2

--- a/bitnami/contour/templates/_helpers.tpl
+++ b/bitnami/contour/templates/_helpers.tpl
@@ -96,10 +96,22 @@ contour: envoy.kind
 
 {{/* Create the name of the IngressClass to use. */}}
 {{- define "contour.ingressClassName" -}}
+{{- $ingressClass := .Values.contour.ingressClass }}
+{{- if kindIs "string" $ingressClass -}}
+    {{ default "contour" $ingressClass }}
+{{- else if kindIs "map" $ingressClass -}}
+    {{ default "contour" $ingressClass.name }}
+{{- else -}}
+    contour
+{{- end -}}
+{{- end -}}
+
+{{/* Whether the name of the ingress class is defined or not */}}
+{{- define "contour.isIngressClassNameDefined" -}}
 {{- $ingressClass := .Values.contour.ingressClass -}}
 {{- if kindIs "string" $ingressClass -}}
-    {{ $ingressClass }}
+    true
 {{- else if and (kindIs "map" $ingressClass) (or $ingressClass.name $ingressClass.create) -}}
-    {{ $ingressClass.name | default "contour" }}
+    true
 {{- end -}}
 {{- end -}}

--- a/bitnami/contour/templates/_helpers.tpl
+++ b/bitnami/contour/templates/_helpers.tpl
@@ -96,12 +96,10 @@ contour: envoy.kind
 
 {{/* Create the name of the IngressClass to use. */}}
 {{- define "contour.ingressClassName" -}}
-{{- $ingressClass := .Values.contour.ingressClass }}
+{{- $ingressClass := .Values.contour.ingressClass -}}
 {{- if kindIs "string" $ingressClass -}}
-    {{ default "contour" $ingressClass }}
-{{- else if kindIs "map" $ingressClass -}}
-    {{ default "contour" $ingressClass.name }}
-{{- else -}}
-    contour
+    {{ $ingressClass }}
+{{- else if and (kindIs "map" $ingressClass) (or $ingressClass.name $ingressClass.create) -}}
+    {{ $ingressClass.name | default "contour" }}
 {{- end -}}
 {{- end -}}

--- a/bitnami/contour/templates/contour/deployment.yaml
+++ b/bitnami/contour/templates/contour/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             - --contour-cert-file=/certs/tls.crt
             - --contour-key-file=/certs/tls.key
             - --config-path=/config/contour.yaml
-            {{- if gt (len (include "contour.ingressClassName" .)) 0 }}
+            {{- if (include "contour.isIngressClassNameDefined" .) }}
             - --ingress-class-name={{ include "contour.ingressClassName" . }}
             {{- end }}
             {{- if .Values.contour.extraArgs }}

--- a/bitnami/contour/templates/contour/deployment.yaml
+++ b/bitnami/contour/templates/contour/deployment.yaml
@@ -68,7 +68,9 @@ spec:
             - --contour-cert-file=/certs/tls.crt
             - --contour-key-file=/certs/tls.key
             - --config-path=/config/contour.yaml
+            {{- if gt (len (include "contour.ingressClassName" .)) 0 }}
             - --ingress-class-name={{ include "contour.ingressClassName" . }}
+            {{- end }}
             {{- if .Values.contour.extraArgs }}
             {{- include "common.tplvalues.render" (dict "value" .Values.contour.extraArgs "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/contour/templates/default-backend/ingress.yaml
+++ b/bitnami/contour/templates/default-backend/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   annotations:
-    kubernetes.io/ingress.class: {{ include "contour.ingressClassName" . }}
+    kubernetes.io/ingress.class: {{ default "contour" (include "contour.ingressClassName" .) }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/contour/templates/default-backend/ingress.yaml
+++ b/bitnami/contour/templates/default-backend/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   annotations:
-    kubernetes.io/ingress.class: {{ default "contour" (include "contour.ingressClassName" .) }}
+    kubernetes.io/ingress.class: {{ include "contour.ingressClassName" . }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
**Description of the change**

As @Legion2 mentioned in #8041, adding `--ingress-class-name` to controller argument breaks previous deployments, since it enables controller to filter Ingresses and HTTPProxies.

**Benefits**

Users can deploy contour as a default (implicit) cluster ingress controller.

**Possible drawbacks**

None

**Applicable issues**

- Fixes #8041
- Related to https://github.com/projectcontour/contour/issues/4134

**Additional information**

Since there was a possible breaking change in #7668, I think it makes sense to applying this patch to `v5.x`.
Could anyone give an opinion? 🙇 

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
