### PR TITLE
[bitnami/mongodb] Fix custom passwords

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.29.0
+version: 10.29.1

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -247,7 +247,7 @@ spec:
               value: {{ $customDatabases | quote }}
             {{- end }}
             {{- if .Values.auth.enabled }}
-            {{- if and .Values.auth.username .Values.auth.database }}
+            {{- if and (not (empty $customUsers)) (not (empty $customDatabases)) }}
             - name: MONGODB_EXTRA_PASSWORDS
               valueFrom:
                 secretKeyRef:

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -252,7 +252,7 @@ spec:
               value: {{ $customDatabases | quote }}
             {{- end }}
             {{- if .Values.auth.enabled }}
-            {{- if and .Values.auth.username .Values.auth.database }}
+            {{- if and (not (empty $customUsers)) (not (empty $customDatabases)) }}
             - name: MONGODB_EXTRA_PASSWORDS
               valueFrom:
                 secretKeyRef:

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -211,7 +211,7 @@ spec:
               value: {{ $customDatabases | quote }}
             {{- end }}
             {{- if .Values.auth.enabled }}
-            {{- if and .Values.auth.username .Values.auth.database }}
+            {{- if and (not (empty $customUsers)) (not (empty $customDatabases)) }}
             - name: MONGODB_EXTRA_PASSWORDS
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR fixes an issue reported by @mtimm and introduced by me at https://github.com/bitnami/charts/pull/7930.

There's a condition that's not taken into account the users & dbs set at `auth.usernames` and `auth.databases` to decide whether to set the `MONGODB_EXTRA_PASSWORDS` env. var or not.

**Benefits**

Users can add use `auth.usernames` and `auth.passwords` without requiring to set deprecated `auth.username` and `auth.database` parameters.

**Possible drawbacks**

None

**Applicable issues**

  - fixes https://github.com/bitnami/charts/issues/8063

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
