### PR TITLE
[bitnami/logstash] Make metrics service non-headless

### DIFF
--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -23,4 +23,4 @@ name: logstash
 sources:
   - https://github.com/bitnami/bitnami-docker-logstash
   - https://www.elastic.co/products/logstash
-version: 3.6.14
+version: 3.6.15

--- a/bitnami/logstash/README.md
+++ b/bitnami/logstash/README.md
@@ -191,7 +191,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.service.nodePort`                    | Kubernetes HTTP node port                                                                                                        | `""`                        |
 | `metrics.service.loadBalancerIP`              | loadBalancerIP if service type is `LoadBalancer`                                                                                 | `""`                        |
 | `metrics.service.loadBalancerSourceRanges`    | Addresses that are allowed when service is LoadBalancer                                                                          | `[]`                        |
-| `metrics.service.clusterIP`                   | Static clusterIP or None for headless services                                                                                   | `None`                      |
+| `metrics.service.clusterIP`                   | Static clusterIP or None for headless services                                                                                   | `""`                      |
 | `metrics.service.annotations`                 | Annotations for the Prometheus metrics service                                                                                   | `{}`                        |
 | `podDisruptionBudget.create`                  | If true, create a pod disruption budget for pods.                                                                                | `false`                     |
 | `podDisruptionBudget.minAvailable`            | Minimum number / percentage of pods that should remain scheduled                                                                 | `1`                         |

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -670,7 +670,7 @@ metrics:
     ## @param metrics.service.clusterIP Static clusterIP or None for headless services
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
     ##
-    clusterIP: None
+    clusterIP: ""
     ## @param metrics.service.annotations [object] Annotations for the Prometheus metrics service
     ##
     annotations:


### PR DESCRIPTION
**Description of the change**
The metrics service is headless by default, which doesn't make much sense.

**Applicable issues**
  - fixes #8029 
 
**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
