### PR TITLE
[bitnami/node] [bitnami/parse] Fix mongodb password key

### DIFF
--- a/bitnami/node/Chart.lock
+++ b/bitnami/node/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.28.6
+  version: 10.29.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.10.1
-digest: sha256:baeebaaa20faf0efd3c8b10cbb25c927fd63787e781edcb057bd97c1f5c11df3
-generated: "2021-10-28T17:58:39.704090276Z"
+digest: sha256:0ba84f97baaa28347d20bb679a34c38a8df2d643dd7b21c26f0e803be983a053
+generated: "2021-11-09T16:53:48.39126204+01:00"

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -28,4 +28,4 @@ name: node
 sources:
   - https://github.com/bitnami/bitnami-docker-node
   - http://nodejs.org/
-version: 16.0.0
+version: 16.0.1

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -123,7 +123,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ template "node.mongodb.fullname" . }}
-                  key: mongodb-password
+                  key: mongodb-passwords
             - name: DATABASE_NAME
               value: {{ .Values.mongodb.auth.database | quote }}
             - name: DATABASE_CONNECTION_OPTIONS

--- a/bitnami/parse/Chart.lock
+++ b/bitnami/parse/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.28.6
+  version: 10.29.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.10.1
-digest: sha256:9d350ff3242e63b0ca882eb511bc56cc3211e3f710fcf0584568ed3b43f7a0cd
-generated: "2021-10-28T15:25:07.797315898Z"
+digest: sha256:b2e185562fc24ca53a92047eb05c4170164abd00b25800895bdddf7f5724faf6
+generated: "2021-11-09T16:54:24.795160001+01:00"

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-parse
   - https://github.com/bitnami/bitnami-docker-parse-dashboard
   - https://parse.com/
-version: 15.0.13
+version: 15.0.14

--- a/bitnami/parse/templates/server-deployment.yaml
+++ b/bitnami/parse/templates/server-deployment.yaml
@@ -87,7 +87,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "parse.mongodb.fullname" . }}
-                  key: mongodb-password
+                  key: mongodb-passwords
             {{- end }}
             {{- if .Values.server.extraEnvVars }}
               {{- include "common.tplvalues.render" ( dict "value" .Values.server.extraEnvVars "context" $ ) | nindent 12 }}


### PR DESCRIPTION
**Description of the change**
#7930 changed MongoDB's password key from `mongodb-password` to `mongodb-passwords`. This PR updates the key in the charts that use it.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
