### PR TITLE
[bitnami/mongodb] Fix service name in TLS init container

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.29.1
+version: 10.29.2

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -134,7 +134,7 @@ spec:
             - |
               /bin/bash <<'EOF'
               my_hostname=$(hostname)
-              svc=$(echo -n "$my_hostname" | sed s/-[0-9]*$//)-headless
+              svc={{ include "mongodb.service.nameOverride" . }}
               cp /certs/CAs/* /certs/
               cat >/certs/openssl.cnf <<EOL
               [req]


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This PR fixes a bug in the MongoDB Helm chart, where TLS doesn't work, when a user specified a value for `service.nameOverride` in the values file. When this property is set, the generated certificates are not working because, the certificate does not match the host name:

```
2021-11-10T08:18:39.984+0000 E  NETWORK  [Replication] The server certificate does not match the host name. Hostname: mongodb-rs-1.mongodb-rs.default.svc.cluster.local does not match SAN(s): mongodb-rs-headless, mongodb-rs-1, mongodb-rs-1.mongodb-rs-headless.default.svc.cluster.local, localhost, 127.0.0.1, CN: mongodb-rs-1
```

```yaml
service:
  nameOverride: mongodb-rs
```

**Benefits**

This allows users to use TLS when `service.nameOverride` was set.

**Possible drawbacks**

I think there shouldn't be any drawbacks, because the service name should still be correct when `service.nameOverride` wasn't set.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
