### PR TITLE
[bitnami/thanos] Fix Receiver Distributor

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 8.0.0
+version: 8.0.1

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -925,6 +925,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 
 | Name                                                                   | Description                                                                                                                 | Value           |
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `receiveDistributor.enabled`                                           | Enable/disable Thanos Receive Distributor component                                                                         | `false`         |
 | `receiveDistributor.logLevel`                                          | Thanos Receive Distributor log level                                                                                        | `info`          |
 | `receiveDistributor.logFormat`                                         | Thanos Receive Distributor log format                                                                                       | `logfmt`        |
 | `receiveDistributor.replicaLabel`                                      | Label to treat as a replica indicator along which data is de-duplicated                                                     | `replica`       |

--- a/bitnami/thanos/templates/receive-distributor/serviceaccount.yaml
+++ b/bitnami/thanos/templates/receive-distributor/serviceaccount.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.receiveDistributor.enabled (not (include "thanos.serviceAccount.useExisting" (dict "component" "receiveDistributor" "context" $))) }}
+{{- if and .Values.receiveDistributor.enabled (not (include "thanos.serviceAccount.useExisting" (dict "component" "receive-distributor" "context" $))) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccount.name" (dict "component" "receiveDistributor" "context" $) }}
+  name: {{ include "thanos.serviceAccount.name" (dict "component" "receive-distributor" "context" $) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive-distributor

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -3233,6 +3233,9 @@ receive:
 ## @section Thanos Receive Distributor parameters
 
 receiveDistributor:
+  ## @param receiveDistributor.enabled Enable/disable Thanos Receive Distributor component
+  ##
+  enabled: false
   ## @param receiveDistributor.logLevel Thanos Receive Distributor log level
   ##
   logLevel: info


### PR DESCRIPTION
**Description of the change**
Adds the `receiveDistributor.enabled` field to the values and to the readme. 

It also fixes the deployment of the Receiver Distributor, as prior to this change, one would get this on a clean install where it is enabled.:
```
Error: UPGRADE FAILED: failed to create resource: ServiceAccount "thanos-receiveDistributor" is invalid: metadata.name: Invalid value: "thanos-receiveDistributor": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is 'a-z0-9?(\.a-z0-9?)*')
```

**Benefits**
Enabling the distributor works.

**Possible drawbacks**
N/A

**Applicable issues**
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
