### PR TITLE
[bitnami/haproxy] Add service.labels input

### DIFF
--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -23,4 +23,4 @@ name: haproxy
 sources:
   - https://github.com/bitnami/bitnami-docker-haproxy
   - https://github.com/haproxytech/haproxy
-version: 0.2.16
+version: 0.2.17

--- a/bitnami/haproxy/README.md
+++ b/bitnami/haproxy/README.md
@@ -84,6 +84,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.loadBalancerSourceRanges` | haproxy service Load Balancer sources             | `[]`           |
 | `service.externalTrafficPolicy`    | haproxy service external traffic policy           | `Cluster`      |
 | `service.annotations`              | Additional custom annotations for haproxy service | `{}`           |
+| `service.labels`                   | Additional custom labels for haproxy service      | `{}`           |
 
 
 ### HAProxy Parameters

--- a/bitnami/haproxy/templates/service.yaml
+++ b/bitnami/haproxy/templates/service.yaml
@@ -9,6 +9,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.service.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.labels "context" $) | nindent 4 }}
+    {{- end }}
   annotations:
     {{- if .Values.service.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $ ) | nindent 4 }}

--- a/bitnami/haproxy/values.yaml
+++ b/bitnami/haproxy/values.yaml
@@ -96,6 +96,9 @@ service:
   ## @param service.annotations Additional custom annotations for haproxy service
   ##
   annotations: {}
+  ## @param service.labels Additional custom labels for haproxy service
+  ##
+  labels: {}
 
 ## @section HAProxy Parameters
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add service.labels input to the bitnami/haproxy chart to allow custom labels to be passed to the service.

**Benefits**

Currently the only way to accomplish a user specified label on the HAProxy service is to use `commonLabels` which also adds the label to all other Kubernetes resources created in the chart. This addition allows for a more intuitive solution.

**Possible drawbacks**

- Adds more inputs to the chart

**Applicable issues**

**Additional information**

My use case is that I'm using a label selector in our external-dns controller to control which resources it creates records for. Creation is opt-in via a specific label. My current workaround for this haproxy chart is to use the commonLabels value to add the label to  each resource in the installation.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
