### PR TITLE
[bitnami/minio] allow additional from clauses in NetworkPolicy

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 9.1.0
+version: 9.2.0

--- a/bitnami/minio/templates/networkpolicy.yaml
+++ b/bitnami/minio/templates/networkpolicy.yaml
@@ -26,5 +26,9 @@ spec:
               {{ include "common.names.fullname" . }}-client: "true"
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" . | nindent 14 }}
+        
+        {{- if .Values.networkPolicy.extraFromClauses }}
+        {{- toYaml .Values.networkPolicy.extraFromClauses | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -746,7 +746,6 @@ networkPolicy:
   ## listening on. When true, MinIO&reg; will accept connections from any source (with the correct destination port).
   ##
   allowExternal: true
-  
   ## @param networkPolicy.extraFromClauses Allows to add extra 'from' clauses to the NetworkPolicy
   extraFromClauses: {}
   ## Example

--- a/bitnami/minio/values.yaml
+++ b/bitnami/minio/values.yaml
@@ -746,6 +746,14 @@ networkPolicy:
   ## listening on. When true, MinIO&reg; will accept connections from any source (with the correct destination port).
   ##
   allowExternal: true
+  
+  ## @param networkPolicy.extraFromClauses Allows to add extra 'from' clauses to the NetworkPolicy
+  extraFromClauses: {}
+  ## Example
+  ## extraFromClauses:
+  ## - podSelector:
+  ##     matchLabels:
+  ##       a: b
 
 ## @section Persistence parameters
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Currently if `networkPolicy.allowExternal` is `false` the `podSelector` added in the `from` clause allows connection from Pods having pre-defined labels, which is not always applicable/desiderable.

This PR adds the possibility for for additional `from` clauses in `NetworkPolicy` to add custom behavior.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

This PR adds the possibility for for additional `from` clauses in `NetworkPolicy` to add custom behavior.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
