### PR TITLE
[bitnami/contour]fix:Changing envoy containerPorts for http & https to > 1024 range

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 7.0.1
+version: 7.0.2

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -730,8 +730,8 @@ envoy:
   ## @param envoy.containerPorts.https Sets https port inside Envoy pod  (change this to >1024 to run envoy as a non-root user)
   ##
   containerPorts:
-    http: 80
-    https: 443
+    http: 8080
+    https: 8443
   ## @param envoy.initContainers [array] Attach additional init containers to Envoy pods
   ## For example:
   ## initContainers:


### PR DESCRIPTION
This fixes #8162. Port 8080 and 8443 are the same as Contour is using:

https://github.com/projectcontour/contour/pull/3393
https://github.com/projectcontour/contour/pull/4084

Envoy is already running as `runAsUser: 1001`, the default containerPorts 80/443 do not work anymore...

https://github.com/bitnami/charts/blob/84f366af1d4c4eb5e31b27ccec84076dc3ca9bf1/bitnami/contour/values.yaml#L584

See #8162 for a more detailed example. 

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Changing the containerPorts to be > 1024 using the same values as Contour does. 

**Benefits**
Envoy ingress is accepting calls again. 

**Possible drawbacks**
n/a

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #8162

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
