### PR TITLE
[bitnami/grafana-operator] Add missing zap args and extraArgs feature

### DIFF
--- a/bitnami/grafana-operator/templates/deployment.yaml
+++ b/bitnami/grafana-operator/templates/deployment.yaml
@@ -68,6 +68,25 @@ spec:
             {{- else if .Values.operator.args.scanNamespaces }}
             - --namespaces={{ include "grafana-operator.joinListWithComma" .Values.operator.args.scanNamespaces }}
             {{- end }}
+            {{- if .Values.operator.args.zapDevel }}
+            - --zap-devel={{ .Values.operator.args.zapDevel }}
+            {{- end }}
+            {{- if .Values.operator.args.zapEncoder }}
+            - --zap-encoder={{ .Values.operator.args.zapEncoder }}
+            {{- end }}
+            {{- if .Values.operator.args.zapLevel }}
+            - --zap-level=True
+            {{- end }}
+            {{- if .Values.operator.args.zapSample }}
+            - --zap-sample={{ .Values.operator.args.zapSample }}
+            {{- end }}
+            {{- if .Values.operator.args.zapStacktraceLevel }}
+            - --zap-stacktrace-level={{ .Values.operator.args.zapStacktraceLevel }}
+            {{- end }}
+            {{- if .Values.operator.args.zapTimeEncoding }}
+            - --zap-time-encoding={{ .Values.operator.args.zapTimeEncoding }}
+            {{- end }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.operator.args.extraArgs "context" $) | nindent 12 }}
         {{- if .Values.operator.resources }}
           resources: {{- toYaml .Values.operator.resources | nindent 12 }}
         {{- end }}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -83,6 +83,13 @@ operator:
     pullSecrets: []
   ## @param operator.args.scanAllNamespaces Specify if all namespace should be scanned for dashboards and datasources. (Creates ClusterRole)
   ## @param operator.args.scanNamespaces Specify the namespaces which should be scanned for dashboards and datasources (Creates ClusterRole)
+  ## @param operator.args.zapDevel Enable zap development mode (changes defaults to console encoder, debug log level, disables sampling and stacktrace from 'warning' level)
+  ## @param operator.args.zapEncoder Zap log encoding ('json' or 'console')
+  ## @param operator.args.zapLevel Zap log level (one of 'debug', 'info', 'error' or any integer value > 0) (default info)
+  ## @param operator.args.zapSample Enable zap log sampling. Sampling will be disabled for integer log levels > 1
+  ## @param operator.args.zapStacktraceLevel Set the minimum log level that triggers stacktrace generation (default error)
+  ## @param operator.args.zapTimeEncoding Sets the zap time format ('epoch', 'millis', 'nano', or 'iso8601') (default )
+  ## @param operator.args.extraArgs Extra arguments for the grafana operator (Evaluated as a template)
   ##
   args:
     ## If one of these options is set a clusterRole and clusterRoleBinding is created to
@@ -90,6 +97,14 @@ operator:
     ##
     scanAllNamespaces: false
     scanNamespaces: []
+    zapDevel: false
+    zapEncoder: ""
+    zapLevel: ""
+    zapSample: ""
+    zapStacktraceLevel: ""
+    zapTimeEncoding: ""
+    extraArgs: []
+
   ## @param operator.rbac.create Create specifies whether to install and use RBAC rules
   ##
   rbac:


### PR DESCRIPTION
**Description of the change**

Adds missing args for the Grafana operator and feature extraArgs.

**Possible drawbacks**

Maybe these are too many extra values that could be set using extraArgs.

**Applicable issues**

  - fixes #8169

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
