### PR TITLE
[bitnami/etcd] ETCD_LISTEN_* to use container ports instead of svc ports

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -24,4 +24,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.10.0
+version: 6.10.1

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -91,7 +91,6 @@ spec:
       {{- end }}
       containers:
         {{- $replicaCount := int .Values.replicaCount }}
-        {{- $clientPort := int .Values.service.port }}
         {{- $peerPort := int .Values.service.peerPort }}
         {{- $etcdFullname := include "common.names.fullname" . }}
         {{- $releaseNamespace := .Release.Namespace }}
@@ -158,11 +157,11 @@ spec:
             - name: ETCD_ADVERTISE_CLIENT_URLS
               value: "{{ $etcdClientProtocol }}://$(MY_POD_NAME).{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ .Values.service.port }}"
             - name: ETCD_LISTEN_CLIENT_URLS
-              value: "{{ $etcdClientProtocol }}://0.0.0.0:{{ .Values.service.port }}"
+              value: "{{ $etcdClientProtocol }}://0.0.0.0:{{ .Values.containerPorts.client }}"
             - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
               value: "{{ $etcdPeerProtocol }}://$(MY_POD_NAME).{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ .Values.service.peerPort }}"
             - name: ETCD_LISTEN_PEER_URLS
-              value: "{{ $etcdPeerProtocol }}://0.0.0.0:{{ .Values.service.peerPort }}"
+              value: "{{ $etcdPeerProtocol }}://0.0.0.0:{{ .Values.containerPorts.peer }}"
             {{- if .Values.autoCompactionMode }}
             - name: ETCD_AUTO_COMPACTION_MODE
               value: {{ .Values.autoCompactionMode | quote }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

We're using `.Values.service.*` parameters to set the the _ETCD_LISTEN_*_  environment variables. This is conceptually wrong since these parameters refer to the etcd service port instead of the container ports. We should use `.Values.containerPorts.*` parameters to customize container ports.

**Benefits**

Correct use of `.Values.service.*` and `.Values.containerPorts.*` parameters.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
