### PR TITLE
[bitnami/redis] Support custom dataSource to allow creating volumes from VolumeSnapshots

### DIFF
--- a/bitnami/redis/Chart.lock
+++ b/bitnami/redis/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.10.0
-digest: sha256:d6f283322d34efda54721ddd67aec935f1bea501c7b45dfbe89814aed21ae5dc
-generated: "2021-10-04T14:32:42.919560577Z"
+  version: 1.10.1
+digest: sha256:46a0218b2fbb421c87da91166dc5230d3ec85aa7d822dff1d479619fff8314e7
+generated: "2021-11-18T17:38:31.365659-05:00"

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 15.5.5
+version: 15.6.0

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -179,6 +179,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.persistence.size`                   | Persistent Volume size                                                                            | `8Gi`           |
 | `master.persistence.annotations`            | Additional custom annotations for the PVC                                                         | `{}`            |
 | `master.persistence.selector`               | Additional labels to match for the PVC                                                            | `{}`            |
+| `master.persistence.dataSource`             | Custom PVC data source                                                                            | `{}`            |
 | `master.persistence.existingClaim`          | Use a existing PVC which must be created manually before bound                                    | `""`            |
 | `master.service.type`                       | Redis&trade; master service type                                                                  | `ClusterIP`     |
 | `master.service.port`                       | Redis&trade; master service port                                                                  | `6379`          |
@@ -256,6 +257,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replica.persistence.size`                   | Persistent Volume size                                                                              | `8Gi`           |
 | `replica.persistence.annotations`            | Additional custom annotations for the PVC                                                           | `{}`            |
 | `replica.persistence.selector`               | Additional labels to match for the PVC                                                              | `{}`            |
+| `replica.persistence.dataSource`             | Custom PVC data source                                                                              | `{}`            |
 | `replica.service.type`                       | Redis&trade; replicas service type                                                                  | `ClusterIP`     |
 | `replica.service.port`                       | Redis&trade; replicas service port                                                                  | `6379`          |
 | `replica.service.nodePort`                   | Node port for Redis&trade; replicas                                                                 | `""`            |

--- a/bitnami/redis/templates/master/statefulset.yaml
+++ b/bitnami/redis/templates/master/statefulset.yaml
@@ -435,6 +435,9 @@ spec:
         {{- if .Values.master.persistence.selector }}
         selector: {{- include "common.tplvalues.render" (dict "value" .Values.master.persistence.selector "context" $) | nindent 10 }}
         {{- end }}
+        {{- if .Values.master.persistence.dataSource }}
+        dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.master.persistence.dataSource "context" $) | nindent 10 }}
+        {{- end }}
         {{- include "common.storage.class" (dict "persistence" .Values.master.persistence "global" .Values.global) | nindent 8 }}
   {{- end }}
 {{- end }}

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -435,6 +435,9 @@ spec:
         {{- if .Values.replica.persistence.selector }}
         selector: {{- include "common.tplvalues.render" (dict "value" .Values.replica.persistence.selector "context" $) | nindent 10 }}
         {{- end }}
+        {{- if .Values.replica.persistence.dataSource }}
+        dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.replica.persistence.dataSource "context" $) | nindent 10 }}
+        {{- end }}
         {{- include "common.storage.class" (dict "persistence" .Values.replica.persistence "global" .Values.global) | nindent 8 }}
   {{- end }}
 {{- end }}

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -395,6 +395,8 @@ master:
     ##     app: my-app
     ##
     selector: {}
+    ## @param master.persistence.dataSource Custom PVC data source
+    dataSource: {}
     ## @param master.persistence.existingClaim Use a existing PVC which must be created manually before bound
     ## NOTE: requires master.persistence.enabled: true
     ##
@@ -707,6 +709,8 @@ replica:
     ##     app: my-app
     ##
     selector: {}
+    ## @param replica.persistence.dataSource Custom PVC data source
+    dataSource: {}
   ## Redis&trade; replicas service parameters
   ##
   service:


### PR DESCRIPTION
**Description of the change**

This PR allows users to provide a custom dataSource on the redis StatefulSets.

**Benefits**

The main reason people might want to set this is to be able to restore redis data from a [VolumeSnapshot](https://kubernetes.io/docs/concepts/storage/volume-snapshots/).

**Possible drawbacks**

It's a pretty complex process to restore from backup. You have to delete the statefulset with cascade=false, then recreate it, then repeat to remove the dataSource line from the StatefulSet. So that may confuse users. But I figure they'll ignore this extra setting in the mountain of other settings :)

**Applicable issues**
n/a

**Additional information**

This code is already used in a few other charts like [sonarqube and wordpress](https://github.com/bitnami/charts/search?q=persistence.dataSource) so I just copied it here.

I also tested this (the master setting, at least) on my cluster. If this PR looks good, we may want to consider adding the dataSource to many other statefulsets, like postgres.


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
