### PR TITLE
[bitnami/etcd] Fix etcd when using a custom svc port

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -24,4 +24,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.10.2
+version: 6.10.3

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -91,7 +91,7 @@ spec:
       {{- end }}
       containers:
         {{- $replicaCount := int .Values.replicaCount }}
-        {{- $peerPort := int .Values.service.peerPort }}
+        {{- $peerPort := int .Values.containerPorts.peer }}
         {{- $etcdFullname := include "common.names.fullname" . }}
         {{- $releaseNamespace := .Release.Namespace }}
         {{- $etcdHeadlessServiceName := printf "%s-%s" $etcdFullname "headless" }}
@@ -155,11 +155,11 @@ spec:
               value: "simple"
               {{- end }}
             - name: ETCD_ADVERTISE_CLIENT_URLS
-              value: "{{ $etcdClientProtocol }}://$(MY_POD_NAME).{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ .Values.service.port }}"
+              value: "{{ $etcdClientProtocol }}://$(MY_POD_NAME).{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ .Values.containerPorts.client }},{{ $etcdClientProtocol }}://{{ $etcdFullname }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ .Values.service.port }}"
             - name: ETCD_LISTEN_CLIENT_URLS
               value: "{{ $etcdClientProtocol }}://0.0.0.0:{{ .Values.containerPorts.client }}"
             - name: ETCD_INITIAL_ADVERTISE_PEER_URLS
-              value: "{{ $etcdPeerProtocol }}://$(MY_POD_NAME).{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ .Values.service.peerPort }}"
+              value: "{{ $etcdPeerProtocol }}://$(MY_POD_NAME).{{ $etcdHeadlessServiceName }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}:{{ .Values.containerPorts.peer }}"
             - name: ETCD_LISTEN_PEER_URLS
               value: "{{ $etcdPeerProtocol }}://0.0.0.0:{{ .Values.containerPorts.peer }}"
             {{- if .Values.autoCompactionMode }}

--- a/bitnami/etcd/templates/svc-headless.yaml
+++ b/bitnami/etcd/templates/svc-headless.yaml
@@ -24,9 +24,9 @@ spec:
     - name: {{ .Values.service.clientPortNameOverride }}
     {{- end }}
     {{- else}}
-    - name: "client"
+    - name: client
     {{- end }}
-      port: {{ .Values.service.port  }}
+      port: {{ .Values.containerPorts.client }}
       targetPort: client
     {{- if .Values.service.peerPortNameOverride }}
     {{- if .Values.auth.peer.secureTransport }}
@@ -35,8 +35,8 @@ spec:
     - name: {{ .Values.service.peerPortNameOverride }}
     {{- end }}
     {{- else}}
-    - name: "peer"
+    - name: peer
     {{- end }}
-      port: {{ .Values.service.peerPort  }}
+      port: {{ .Values.containerPorts.peer }}
       targetPort: peer
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -69,7 +69,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/etcd
-  tag: 3.5.1-debian-10-r30
+  tag: 3.5.1-debian-10-r31
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -546,7 +546,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r255
+    tag: 10-debian-10-r256
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

We recently adapted the chat so you can use a port different from 2379 as the "service port". However, this isn't working as expected since the headless svc should've been adapted to use the container port too (since this svc is used to generate unique FQDN to access specific etcd pods).

Also, the `ETCD_ADVERTISE_CLIENT_URLS` env. var has been adapted so it advertised both the URL to access etcd through the service and the URL to access etcd by addressing the pod's hostname directly.

**Benefits**

User can set a custom svc port

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

Follow up from https://github.com/bitnami/charts/pull/8180

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
