### PR TITLE
[bitnami/tomcat] Add networkpolicy support

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/bitnami-docker-tomcat
   - http://tomcat.apache.org
-version: 9.5.4
+version: 9.6.0

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -93,61 +93,64 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Tomcat deployment parameters
 
-| Name                                 | Description                                                                                                              | Value               |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ | ------------------- |
-| `replicaCount`                       | Specify number of Tomcat replicas                                                                                        | `1`                 |
-| `deployment.type`                    | Use Deployment or StatefulSet                                                                                            | `deployment`        |
-| `updateStrategy.type`                | StrategyType                                                                                                             | `RollingUpdate`     |
-| `containerPort`                      | HTTP port to expose at container level                                                                                   | `8080`              |
-| `containerExtraPorts`                | Extra ports to expose at container level                                                                                 | `{}`                |
-| `podSecurityContext.enabled`         | Enable Tomcat pods' Security Context                                                                                     | `true`              |
-| `podSecurityContext.fsGroup`         | Set Tomcat pod's Security Context fsGroup                                                                                | `1001`              |
-| `containerSecurityContext.enabled`   | Enable Tomcat containers' SecurityContext                                                                                | `true`              |
-| `containerSecurityContext.runAsUser` | User ID for the Tomcat container                                                                                         | `1001`              |
-| `resources.limits`                   | The resources limits for the Tomcat container                                                                            | `{}`                |
-| `resources.requests`                 | The requested resources for the Tomcat container                                                                         | `{}`                |
-| `livenessProbe.enabled`              | Enable livenessProbe                                                                                                     | `true`              |
-| `livenessProbe.httpGet.path`         | Request path for livenessProbe                                                                                           | `/`                 |
-| `livenessProbe.httpGet.port`         | Port for livenessProbe                                                                                                   | `http`              |
-| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                  | `120`               |
-| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                         | `10`                |
-| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                        | `5`                 |
-| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                      | `6`                 |
-| `livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                      | `1`                 |
-| `readinessProbe.enabled`             | Enable readinessProbe                                                                                                    | `true`              |
-| `readinessProbe.httpGet.path`        | Request path for readinessProbe                                                                                          | `/`                 |
-| `readinessProbe.httpGet.port`        | Port for readinessProbe                                                                                                  | `http`              |
-| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                 | `30`                |
-| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                        | `5`                 |
-| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                       | `3`                 |
-| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                     | `3`                 |
-| `readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                     | `1`                 |
-| `customLivenessProbe`                | Override default liveness probe                                                                                          | `{}`                |
-| `customReadinessProbe`               | Override default readiness probe                                                                                         | `{}`                |
-| `podLabels`                          | Extra labels for Tomcat pods                                                                                             | `{}`                |
-| `podAnnotations`                     | Annotations for Tomcat pods                                                                                              | `{}`                |
-| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                |
-| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`              |
-| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                |
-| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set.                                                                   | `""`                |
-| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                |
-| `affinity`                           | Affinity for pod assignment. Evaluated as a template.                                                                    | `{}`                |
-| `nodeSelector`                       | Node labels for pod assignment. Evaluated as a template.                                                                 | `{}`                |
-| `tolerations`                        | Tolerations for pod assignment. Evaluated as a template.                                                                 | `[]`                |
-| `topologySpreadConstraints`          | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                |
-| `extraPodSpec`                       | Optionally specify extra PodSpec                                                                                         | `{}`                |
-| `extraVolumes`                       | Optionally specify extra list of additional volumes for Tomcat pods in Deployment                                        | `[]`                |
-| `extraVolumeClaimTemplates`          | Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet                        | `[]`                |
-| `extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for Tomcat container(s)                                         | `[]`                |
-| `initContainers`                     | Add init containers to the Tomcat pods.                                                                                  | `[]`                |
-| `sidecars`                           | Add sidecars to the Tomcat pods.                                                                                         | `[]`                |
-| `persistence.enabled`                | Enable persistence                                                                                                       | `true`              |
-| `persistence.storageClass`           | PVC Storage Class for Tomcat volume                                                                                      | `""`                |
-| `persistence.annotations`            | Persistent Volume Claim annotations                                                                                      | `{}`                |
-| `persistence.accessModes`            | PVC Access Modes for Tomcat volume                                                                                       | `["ReadWriteOnce"]` |
-| `persistence.size`                   | PVC Storage Request for Tomcat volume                                                                                    | `8Gi`               |
-| `persistence.existingClaim`          | An Existing PVC name for Tomcat volume                                                                                   | `""`                |
-| `persistence.selectorLabels`         | Selector labels to use in volume claim template in statefulset                                                           | `{}`                |
+| Name                                       | Description                                                                                                              | Value               |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ | ------------------- |
+| `replicaCount`                             | Specify number of Tomcat replicas                                                                                        | `1`                 |
+| `deployment.type`                          | Use Deployment or StatefulSet                                                                                            | `deployment`        |
+| `updateStrategy.type`                      | StrategyType                                                                                                             | `RollingUpdate`     |
+| `containerPort`                            | HTTP port to expose at container level                                                                                   | `8080`              |
+| `containerExtraPorts`                      | Extra ports to expose at container level                                                                                 | `{}`                |
+| `podSecurityContext.enabled`               | Enable Tomcat pods' Security Context                                                                                     | `true`              |
+| `podSecurityContext.fsGroup`               | Set Tomcat pod's Security Context fsGroup                                                                                | `1001`              |
+| `containerSecurityContext.enabled`         | Enable Tomcat containers' SecurityContext                                                                                | `true`              |
+| `containerSecurityContext.runAsUser`       | User ID for the Tomcat container                                                                                         | `1001`              |
+| `resources.limits`                         | The resources limits for the Tomcat container                                                                            | `{}`                |
+| `resources.requests`                       | The requested resources for the Tomcat container                                                                         | `{}`                |
+| `livenessProbe.enabled`                    | Enable livenessProbe                                                                                                     | `true`              |
+| `livenessProbe.httpGet.path`               | Request path for livenessProbe                                                                                           | `/`                 |
+| `livenessProbe.httpGet.port`               | Port for livenessProbe                                                                                                   | `http`              |
+| `livenessProbe.initialDelaySeconds`        | Initial delay seconds for livenessProbe                                                                                  | `120`               |
+| `livenessProbe.periodSeconds`              | Period seconds for livenessProbe                                                                                         | `10`                |
+| `livenessProbe.timeoutSeconds`             | Timeout seconds for livenessProbe                                                                                        | `5`                 |
+| `livenessProbe.failureThreshold`           | Failure threshold for livenessProbe                                                                                      | `6`                 |
+| `livenessProbe.successThreshold`           | Success threshold for livenessProbe                                                                                      | `1`                 |
+| `readinessProbe.enabled`                   | Enable readinessProbe                                                                                                    | `true`              |
+| `readinessProbe.httpGet.path`              | Request path for readinessProbe                                                                                          | `/`                 |
+| `readinessProbe.httpGet.port`              | Port for readinessProbe                                                                                                  | `http`              |
+| `readinessProbe.initialDelaySeconds`       | Initial delay seconds for readinessProbe                                                                                 | `30`                |
+| `readinessProbe.periodSeconds`             | Period seconds for readinessProbe                                                                                        | `5`                 |
+| `readinessProbe.timeoutSeconds`            | Timeout seconds for readinessProbe                                                                                       | `3`                 |
+| `readinessProbe.failureThreshold`          | Failure threshold for readinessProbe                                                                                     | `3`                 |
+| `readinessProbe.successThreshold`          | Success threshold for readinessProbe                                                                                     | `1`                 |
+| `customLivenessProbe`                      | Override default liveness probe                                                                                          | `{}`                |
+| `customReadinessProbe`                     | Override default readiness probe                                                                                         | `{}`                |
+| `podLabels`                                | Extra labels for Tomcat pods                                                                                             | `{}`                |
+| `podAnnotations`                           | Annotations for Tomcat pods                                                                                              | `{}`                |
+| `podAffinityPreset`                        | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                |
+| `podAntiAffinityPreset`                    | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`              |
+| `nodeAffinityPreset.type`                  | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                |
+| `nodeAffinityPreset.key`                   | Node label key to match. Ignored if `affinity` is set.                                                                   | `""`                |
+| `nodeAffinityPreset.values`                | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                |
+| `affinity`                                 | Affinity for pod assignment. Evaluated as a template.                                                                    | `{}`                |
+| `nodeSelector`                             | Node labels for pod assignment. Evaluated as a template.                                                                 | `{}`                |
+| `tolerations`                              | Tolerations for pod assignment. Evaluated as a template.                                                                 | `[]`                |
+| `topologySpreadConstraints`                | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                |
+| `extraPodSpec`                             | Optionally specify extra PodSpec                                                                                         | `{}`                |
+| `extraVolumes`                             | Optionally specify extra list of additional volumes for Tomcat pods in Deployment                                        | `[]`                |
+| `extraVolumeClaimTemplates`                | Optionally specify extra list of additional volume claim templates for Tomcat pods in StatefulSet                        | `[]`                |
+| `extraVolumeMounts`                        | Optionally specify extra list of additional volumeMounts for Tomcat container(s)                                         | `[]`                |
+| `initContainers`                           | Add init containers to the Tomcat pods.                                                                                  | `[]`                |
+| `sidecars`                                 | Add sidecars to the Tomcat pods.                                                                                         | `[]`                |
+| `persistence.enabled`                      | Enable persistence                                                                                                       | `true`              |
+| `persistence.storageClass`                 | PVC Storage Class for Tomcat volume                                                                                      | `""`                |
+| `persistence.annotations`                  | Persistent Volume Claim annotations                                                                                      | `{}`                |
+| `persistence.accessModes`                  | PVC Access Modes for Tomcat volume                                                                                       | `["ReadWriteOnce"]` |
+| `persistence.size`                         | PVC Storage Request for Tomcat volume                                                                                    | `8Gi`               |
+| `persistence.existingClaim`                | An Existing PVC name for Tomcat volume                                                                                   | `""`                |
+| `persistence.selectorLabels`               | Selector labels to use in volume claim template in statefulset                                                           | `{}`                |
+| `networkPolicy.enabled`                    | Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.                                    | `false`             |
+| `networkPolicy.allowExternal`              | Don't require client label for connections                                                                               | `true`              |
+| `networkPolicy.explicitNamespacesSelector` | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                           | `{}`                |
 
 
 ### Traffic Exposure parameters
@@ -341,3 +344,4 @@ Use the workaround below to upgrade from versions previous to 1.0.0. The followi
 ```console
 $ kubectl patch deployment tomcat --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
 ```
+

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -148,7 +148,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.size`                         | PVC Storage Request for Tomcat volume                                                                                    | `8Gi`               |
 | `persistence.existingClaim`                | An Existing PVC name for Tomcat volume                                                                                   | `""`                |
 | `persistence.selectorLabels`               | Selector labels to use in volume claim template in statefulset                                                           | `{}`                |
-| `networkPolicy.enabled`                    | Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.                                    | `false`             |
+| `networkPolicy.enabled`                    | Enable creation of NetworkPolicy resources.                                                                              | `false`             |
 | `networkPolicy.allowExternal`              | Don't require client label for connections                                                                               | `true`              |
 | `networkPolicy.explicitNamespacesSelector` | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                           | `{}`                |
 

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -344,4 +344,3 @@ Use the workaround below to upgrade from versions previous to 1.0.0. The followi
 ```console
 $ kubectl patch deployment tomcat --type=json -p='[{"op": "remove", "path": "/spec/selector/matchLabels/chart"}]'
 ```
-

--- a/bitnami/tomcat/templates/_helpers.tpl
+++ b/bitnami/tomcat/templates/_helpers.tpl
@@ -8,6 +8,18 @@ Return the proper Tomcat image name
 {{- end -}}
 
 {{/*
+Return the Tomcat ports map
+*/}}
+{{- define "tomcat.ports" -}}
+- port: {{ .Values.containerPort }}
+  protocol: TCP
+{{- range .Values.containerExtraPorts }}
+- port: {{ include "common.tplvalues.render" (dict "value" .containerPort "context" $) }}
+  protocol: TCP
+{{- end }}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/bitnami/tomcat/templates/networkpolicy.yaml
+++ b/bitnami/tomcat/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.networkPolicy.enabled }}
+kind: NetworkPolicy
+apiVersion: {{ template "tomcat.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+    {{- include "common.labels.matchLabels" . | nindent 6 }}
+  ingress:
+    # Allow inbound connections
+    - ports: {{- include "tomcat.ports" . | nindent 8 }}
+      {{- if not .Values.networkPolicy.allowExternal }}
+      from:
+        - podSelector:
+            matchLabels:
+              {{ template "common.names.fullname" . }}-client: "true"
+          {{- if .Values.networkPolicy.explicitNamespacesSelector }}
+          namespaceSelector:
+{{ toYaml .Values.networkPolicy.explicitNamespacesSelector | indent 12 }}
+          {{- end }}
+        - podSelector:
+            matchLabels:
+            {{- include "common.labels.matchLabels" . | nindent 14 }}
+              role: read
+      {{- end }}
+    {{- if .Values.metrics.jmx.enabled }}
+    # Allow prometheus scrapes
+    - ports:
+        - port: {{ .Values.metrics.jmx.ports.metrics }}
+    {{- end }}
+{{- end }}

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -339,7 +339,31 @@ persistence:
   ## Applicable when deployment.type is statefulset
   ##
   selectorLabels: {}
-
+networkPolicy:
+  ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ##
+  enabled: false
+  ## @param networkPolicy.allowExternal Don't require client label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to every tomcat port defined on containerPort and containerExtraPorts.
+  ## When true, tomcat will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  allowExternal: true
+  ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
+  ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  ## and that match other criteria, the ones that have the good label, can reach the tomcat.
+  ## But sometimes, we want the tomcat to be accessible to clients from other namespaces, in this case, we can use this
+  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  ##
+  ## Example:
+  ## explicitNamespacesSelector:
+  ##   matchLabels:
+  ##     role: frontend
+  ##   matchExpressions:
+  ##    - {key: role, operator: In, values: [frontend]}
+  ##
+  explicitNamespacesSelector: {}
 ## @section Traffic Exposure parameters
 
 ## Service parameters


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add networkpolicy support on tomcat chart. 
Networkpolicy control access to containerPort and containerExtraPorts, if metrics is enabled flow are not filtered and open from any source.

<!-- Describe the scope of your change - i.e. what the change does. -->

If the chart is deployed on a K8S cluster where default rule is deny all, we need to deployed a networkpolicy but it can be tedious. we want to have a chart allign with other ones to integrate a default netwokpolicy.

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

By default network policy is disable, but when it's enabled some change must be done to be work fine.
the good label and sometime the right namespaces selector must be added to each pod, want to reach the tomcat.
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
