### PR TITLE
bitnami/grafana-operator add opt-in dashboardNamespaceSelector

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 1.4.1
+version: 1.5.0

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 1.4.0
+version: 1.4.1

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -196,6 +196,7 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.secrets`                                           | Extra secrets to mount into the grafana pod                                                   | `[]`                 |
 | `grafana.jsonnetLibrarySelector`                            | Configuring the read for jsonnetLibraries to pull in.                                         | `{}`                 |
 | `grafana.dashboardLabelSelectors`                           | This selects dashboards on the label.                                                         | `{}`                 |
+| `grafana.dashboardNamespaceSelector`                        | This selects dashboards only in the Namespaces that have the specified namespace label.       | `{}`                 |
 | `grafana.livenessProbe.enabled`                             | Enable livenessProbe                                                                          | `true`               |
 | `grafana.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                       | `120`                |
 | `grafana.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                              | `10`                 |

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -196,7 +196,7 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.secrets`                                           | Extra secrets to mount into the grafana pod                                                   | `[]`                 |
 | `grafana.jsonnetLibrarySelector`                            | Configuring the read for jsonnetLibraries to pull in.                                         | `{}`                 |
 | `grafana.dashboardLabelSelectors`                           | This selects dashboards on the label.                                                         | `{}`                 |
-| `grafana.dashboardNamespaceSelector`                        | This selects dashboards only in the Namespaces that have the specified namespace label.       | `{}`                 |
+| `grafana.dashboardNamespaceSelector`                        | This selects dashboards only in the Namespaces that have the specified namespace label.       | `[]`                 |
 | `grafana.livenessProbe.enabled`                             | Enable livenessProbe                                                                          | `true`               |
 | `grafana.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                       | `120`                |
 | `grafana.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                              | `10`                 |

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -196,7 +196,7 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.secrets`                                           | Extra secrets to mount into the grafana pod                                                   | `[]`                 |
 | `grafana.jsonnetLibrarySelector`                            | Configuring the read for jsonnetLibraries to pull in.                                         | `{}`                 |
 | `grafana.dashboardLabelSelectors`                           | This selects dashboards on the label.                                                         | `{}`                 |
-| `grafana.dashboardNamespaceSelector`                        | This selects dashboards only in the Namespaces that have the specified namespace label.       | `[]`                 |
+| `grafana.dashboardNamespaceSelector`                        | Watch for dashboards only in the Namespaces that have the specified namespace label       | `[]`                 |
 | `grafana.livenessProbe.enabled`                             | Enable livenessProbe                                                                          | `true`               |
 | `grafana.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                       | `120`                |
 | `grafana.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                              | `10`                 |

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -153,7 +153,7 @@ spec:
   secrets: {{ toYaml .Values.grafana.secrets | nindent 4 }}
   {{- end }}
   dashboardLabelSelector: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.dashboardLabelSelectors "context" $ ) | nindent 4 }}
-  {{ -if .Values.grafana.dashboardNamespaceSelector }}
+  {{- if .Values.grafana.dashboardNamespaceSelector }}
   dashboardNamespaceSelector: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.dashboardNamespaceSelector "context" $ ) | nindent 4 }}
   {{- end }}
   jsonnet:

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -153,6 +153,9 @@ spec:
   secrets: {{ toYaml .Values.grafana.secrets | nindent 4 }}
   {{- end }}
   dashboardLabelSelector: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.dashboardLabelSelectors "context" $ ) | nindent 4 }}
+  {{ -if .Values.grafana.dashboardNamespaceSelector }}
+  dashboardNamespaceSelector: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.dashboardNamespaceSelector "context" $ ) | nindent 4 }}
+  {{- end }}
   jsonnet:
     libraryLabelSelector: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.jsonnetLibrarySelector "context" $ ) | nindent 6 }}
 {{- end }}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -548,10 +548,12 @@ grafana:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
   ## @param grafana.dashboardNamespaceSelector Watch for dashboards only in the Namespaces that have the specified namespace label
   ## Ref: https://github.com/grafana-operator/grafana-operator/blob/master/documentation/multi_namespace_support.md#2-dashboardnamespaceselector
+  ## e.g:
+  ## dashboardNamespaceSelector:
+  ##   - matchLabels:
+  ##     key: value
   ##
   dashboardNamespaceSelector: []
-  # - matchLabels:
-  #     key: value
   ## Grafana containers' liveness probe
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ## @param grafana.livenessProbe.enabled Enable livenessProbe

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -546,7 +546,7 @@ grafana:
   dashboardLabelSelectors:
     - matchLabels:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
-  ## @param grafana.dashboardNamespaceSelector [object] This selects namespaces on the label.
+  ## @param grafana.dashboardNamespaceSelector Watch for dashboards only in the Namespaces that have the specified namespace label
   ## Ref: https://github.com/grafana-operator/grafana-operator/blob/master/documentation/multi_namespace_support.md#2-dashboardnamespaceselector
   ##
   dashboardNamespaceSelector: []

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -547,7 +547,7 @@ grafana:
     - matchLabels:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
   ## @param grafana.dashboardNamespaceSelector [object] This selects namespaces on the label.
-  ## Ref: https://github.com/grafana-operator/grafana-operator/blob/9bd3f95c0a6ecc9d3e5f9e6c0c5cadf6e87e9232/documentation/multi_namespace_support.md#2-dashboardnamespaceselector
+  ## Ref: https://github.com/grafana-operator/grafana-operator/blob/master/documentation/multi_namespace_support.md#2-dashboardnamespaceselector
   ##
   dashboardNamespaceSelector: []
     #- matchLabels:

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -550,8 +550,8 @@ grafana:
   ## Ref: https://github.com/grafana-operator/grafana-operator/blob/master/documentation/multi_namespace_support.md#2-dashboardnamespaceselector
   ##
   dashboardNamespaceSelector: []
-    #- matchLabels:
-    #    key: value
+  # - matchLabels:
+  #     key: value
   ## Grafana containers' liveness probe
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ## @param grafana.livenessProbe.enabled Enable livenessProbe

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -546,6 +546,12 @@ grafana:
   dashboardLabelSelectors:
     - matchLabels:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
+  ## @param grafana.dashboardNamespaceSelector [object] This selects namespaces on the label.
+  ## Ref: https://github.com/grafana-operator/grafana-operator/blob/9bd3f95c0a6ecc9d3e5f9e6c0c5cadf6e87e9232/documentation/multi_namespace_support.md#2-dashboardnamespaceselector
+  ##
+  dashboardNamespaceSelector: []
+    #- matchLabels:
+    #    key: value
   ## Grafana containers' liveness probe
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ## @param grafana.livenessProbe.enabled Enable livenessProbe


### PR DESCRIPTION
**Description of the change**

honor dashboardNamespaceSelector for multi namespace support

**Benefits**

possibility to enable or disable dashboard deployment from other namespaces

**Possible drawbacks**

opt-in features

**Applicable issues**

-

**Additional information**


**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
