### PR TITLE
[bitnami/grafana-tempo] Fix incorrect data folder

### DIFF
--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -27,4 +27,4 @@ name: grafana-tempo
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana-tempo
   - https://github.com/grafana/tempo/
-version: 0.2.12
+version: 0.2.13

--- a/bitnami/grafana-tempo/README.md
+++ b/bitnami/grafana-tempo/README.md
@@ -86,7 +86,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tempo.containerPort`                  | Tempo components web port                                  | `3100`                        |
 | `tempo.grpcContainerPort`              | Tempo components GRPC port                                 | `9095`                        |
 | `tempo.memBallastSizeMbs`              | Tempo components memory ballast size in MB                 | `1024`                        |
-| `tempo.dataDir`                        | Tempo components data directory                            | `/bitnami/tempo-grafana/data` |
+| `tempo.dataDir`                        | Tempo components data directory                            | `/bitnami/grafana-tempo/data` |
 | `tempo.traces.jaeger.grpc`             | Enable Tempo to ingest Jaeger GRPC traces                  | `true`                        |
 | `tempo.traces.jaeger.thriftBinary`     | Enable Tempo to ingest Jaeger Thrift Binary traces         | `false`                       |
 | `tempo.traces.jaeger.thriftCompact`    | Enable Tempo to ingest Jaeger Thrift Compact traces        | `false`                       |

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -97,7 +97,7 @@ tempo:
   memBallastSizeMbs: 1024
   ## @param tempo.dataDir Tempo components data directory
   ##
-  dataDir: /bitnami/tempo-grafana/data
+  dataDir: /bitnami/grafana-tempo/data
   traces:
     jaeger:
       ## @param tempo.traces.jaeger.grpc Enable Tempo to ingest Jaeger GRPC traces


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

For consistency, the volume folder should be /bitnami/grafana-tempo instead of /bitnami/tempo-grafana. This will also fix the issue with the latest Grafana Tempo release. 

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
