### PR TITLE
[bitnami/thanos] Fix autogenerated TLS key values

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 8.1.0
+version: 8.1.1

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 8.1.1
+version: 8.1.3

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -133,15 +133,15 @@ spec:
             - --store={{ . }}
             {{- end }}
             {{- if .Values.query.grpc.server.tls.enabled }}
-            - --grpc-server-tls-cert=/certs/server/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.server.tls.existingSecret "key" "tls-cert") }}
-            - --grpc-server-tls-key=/certs/server/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.server.tls.existingSecret "key" "tls-key") }}
-            - --grpc-server-tls-client-ca=/certs/server/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.server.tls.existingSecret "key" "ca-cert") }}
+            - --grpc-server-tls-cert=/certs/server/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.server.tls.existingSecret "key" "tls.crt") }}
+            - --grpc-server-tls-key=/certs/server/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.server.tls.existingSecret "key" "tls.key") }}
+            - --grpc-server-tls-client-ca=/certs/server/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.server.tls.existingSecret "key" "ca.crt") }}
             {{- end }}
             {{- if .Values.query.grpc.client.tls.enabled }}
             - --grpc-client-tls-secure
-            - --grpc-client-tls-cert=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "tls-cert") }}
-            - --grpc-client-tls-key=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "tls-key") }}
-            - --grpc-client-tls-ca=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "ca-cert") }}
+            - --grpc-client-tls-cert=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "tls.crt") }}
+            - --grpc-client-tls-key=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "tls.key") }}
+            - --grpc-client-tls-ca=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "ca.crt") }}
             {{- end }}
             {{- if .Values.query.grpc.client.servername }}
             - --grpc-client-server-name={{.Values.query.grpc.client.servername}}

--- a/bitnami/thanos/templates/query/grpc-client-tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/grpc-client-tls-secrets.yaml
@@ -22,8 +22,8 @@ data:
   tls.key: {{ $cert.Key | b64enc | quote }}
   ca.crt: {{ $ca.Cert | b64enc | quote }}
   {{- else }}
-  tls-cert: {{ .Values.query.grpc.client.tls.cert | b64enc | quote }}
-  tls-key: {{ .Values.query.grpc.client.tls.key | b64enc | quote }}
+  tls.crt: {{ .Values.query.grpc.client.tls.cert | b64enc | quote }}
+  tls.key: {{ .Values.query.grpc.client.tls.key | b64enc | quote }}
   ca-cert : {{ .Values.query.grpc.client.tls.ca | b64enc | quote }}
   {{- end }}
 {{ end }}

--- a/bitnami/thanos/templates/query/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/grpc-server-tls-secrets.yaml
@@ -22,8 +22,8 @@ data:
   tls.key: {{ $cert.Key | b64enc | quote }}
   ca.crt: {{ $ca.Cert | b64enc | quote }}
   {{- else }}
-  tls-cert: {{ .Values.query.grpc.server.tls.cert | b64enc | quote }}
-  tls-key: {{ .Values.query.grpc.server.tls.key | b64enc | quote }}
+  tls.crt: {{ .Values.query.grpc.server.tls.cert | b64enc | quote }}
+  tls.key: {{ .Values.query.grpc.server.tls.key | b64enc | quote }}
   ca-cert : {{ .Values.query.grpc.server.tls.ca | b64enc | quote }}
   {{- end }}
 {{ end }}

--- a/bitnami/thanos/templates/receive/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/receive/grpc-server-tls-secrets.yaml
@@ -23,8 +23,8 @@ data:
   tls.key: {{ $cert.Key | b64enc | quote }}
   ca.crt: {{ $ca.Cert | b64enc | quote }}
   {{- else }}
-  tls-cert: {{ .Values.receive.grpc.server.tls.cert | b64enc | quote }}
-  tls-key: {{ .Values.receive.grpc.server.tls.key | b64enc | quote }}
+  tls.crt: {{ .Values.receive.grpc.server.tls.cert | b64enc | quote }}
+  tls.key: {{ .Values.receive.grpc.server.tls.key | b64enc | quote }}
   ca-cert : {{ .Values.receive.grpc.server.tls.ca | b64enc | quote }}
   {{- end }}
 {{ end }}

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -113,9 +113,9 @@ spec:
             - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
             {{- end }}
             {{- if .Values.receive.grpc.server.tls.enabled }}
-            - --grpc-server-tls-cert=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.receive.grpc.server.tls.existingSecret "key" "tls-cert") }}
-            - --grpc-server-tls-key=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.receive.grpc.server.tls.existingSecret "key" "tls-key") }}
-            - --grpc-server-tls-client-ca=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.receive.grpc.server.tls.existingSecret "key" "ca-cert") }}
+            - --grpc-server-tls-cert=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.receive.grpc.server.tls.existingSecret "key" "tls.crt") }}
+            - --grpc-server-tls-key=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.receive.grpc.server.tls.existingSecret "key" "tls.key") }}
+            - --grpc-server-tls-client-ca=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.receive.grpc.server.tls.existingSecret "key" "ca.crt") }}
             {{- end }}
             {{- if .Values.receive.extraFlags }}
             {{- .Values.receive.extraFlags | toYaml | nindent 12 }}

--- a/bitnami/thanos/templates/storegateway/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/storegateway/grpc-server-tls-secrets.yaml
@@ -22,8 +22,8 @@ data:
   tls.key: {{ $cert.Key | b64enc | quote }}
   ca.crt: {{ $ca.Cert | b64enc | quote }}
   {{- else }}
-  tls-cert: {{ .Values.storegateway.grpc.server.tls.cert | b64enc | quote }}
-  tls-key: {{ .Values.storegateway.grpc.server.tls.key | b64enc | quote }}
-  ca-cert : {{ .Values.storegateway.grpc.server.tls.ca | b64enc | quote }}
+  tls.crt: {{ .Values.storegateway.grpc.server.tls.cert | b64enc | quote }}
+  tls.key: {{ .Values.storegateway.grpc.server.tls.key | b64enc | quote }}
+  ca.crt: {{ .Values.storegateway.grpc.server.tls.ca | b64enc | quote }}
   {{- end }}
 {{ end }}

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -144,9 +144,9 @@ spec:
             - --index-cache.config-file=/conf/cache/config.yml
             {{- end }}
             {{- if $.Values.storegateway.grpc.server.tls.enabled }}
-            - --grpc-server-tls-cert=/certs/{{ include "common.secrets.key" (dict "existingSecret" $.Values.storegateway.grpc.server.tls.existingSecret "key" "tls-cert") }}
-            - --grpc-server-tls-key=/certs/{{ include "common.secrets.key" (dict "existingSecret" $.Values.storegateway.grpc.server.tls.existingSecret "key" "tls-key") }}
-            - --grpc-server-tls-client-ca=/certs/{{ include "common.secrets.key" (dict "existingSecret" $.Values.storegateway.grpc.server.tls.existingSecret "key" "ca-cert") }}
+            - --grpc-server-tls-cert=/certs/{{ include "common.secrets.key" (dict "existingSecret" $.Values.storegateway.grpc.server.tls.existingSecret "key" "tls.crt") }}
+            - --grpc-server-tls-key=/certs/{{ include "common.secrets.key" (dict "existingSecret" $.Values.storegateway.grpc.server.tls.existingSecret "key" "tls.key") }}
+            - --grpc-server-tls-client-ca=/certs/{{ include "common.secrets.key" (dict "existingSecret" $.Values.storegateway.grpc.server.tls.existingSecret "key" "ca.crt") }}
             {{- end }}
             {{- if $hashPartitioning }}
             - |

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -128,9 +128,9 @@ spec:
             - --index-cache.config-file=/conf/cache/config.yml
             {{- end }}
             {{- if .Values.storegateway.grpc.server.tls.enabled }}
-            - --grpc-server-tls-cert=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.storegateway.grpc.server.tls.existingSecret "key" "tls-cert") }}
-            - --grpc-server-tls-key=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.storegateway.grpc.server.tls.existingSecret "key" "tls-key") }}
-            - --grpc-server-tls-client-ca=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.storegateway.grpc.server.tls.existingSecret "key" "ca-cert") }}
+            - --grpc-server-tls-cert=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.storegateway.grpc.server.tls.existingSecret "key" "tls.crt") }}
+            - --grpc-server-tls-key=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.storegateway.grpc.server.tls.existingSecret "key" "tls.key") }}
+            - --grpc-server-tls-client-ca=/certs/{{ include "common.secrets.key" (dict "existingSecret" .Values.storegateway.grpc.server.tls.existingSecret "key" "ca.crt") }}
             {{- end }}
             {{- if .Values.storegateway.extraFlags }}
             {{- .Values.storegateway.extraFlags | toYaml | nindent 12 }}


### PR DESCRIPTION
**Description of the change**

This change just fix TLS autogenerated key values on secret files. For now, when we use autogenerated TLS, some pods won't start because TLS key doesn't exist.

**Benefits**

Autogenerated TLS is able to work now.

**Possible drawbacks**

Maybe a new PR is mandatory to fix CA issue : https://github.com/bitnami/charts/issues/8172

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])