### PR TITLE
[bitnami/kafka] allowPlaintextListener is now documented properly

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 14.4.1
+version: 14.4.2

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -147,7 +147,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `listeners`                                | The address(es) the socket server listens on. Auto-calculated it's set to an empty array                                                             | `[]`                                |
 | `advertisedListeners`                      | The address(es) (hostname:port) the broker will advertise to producers and consumers. Auto-calculated it's set to an empty array                     | `[]`                                |
 | `listenerSecurityProtocolMap`              | The protocol->listener mapping. Auto-calculated it's set to nil                                                                                      | `""`                                |
-| `allowPlaintextListener`                   | Allow to use the PLAINTEXT listener                                                                                                                  | `true`                              |
+| `allowPlaintextListener`                   | Allow to use the PLAINTEXT listener                                                                                                                  | `no`                              |
 | `interBrokerListenerName`                  | The listener that the brokers should communicate on                                                                                                  | `INTERNAL`                          |
 
 

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -408,7 +408,7 @@ advertisedListeners: []
 listenerSecurityProtocolMap: ""
 ## @param allowPlaintextListener Allow to use the PLAINTEXT listener
 ##
-allowPlaintextListener: true
+allowPlaintextListener: no
 ## @param interBrokerListenerName The listener that the brokers should communicate on
 ##
 interBrokerListenerName: INTERNAL


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

If you look the first time at `allowPlaintextListener` you get the impression that it is activated (because it is on true). However, because it is defined like this:

https://github.com/bitnami/charts/blob/c4e5c940d480211dd6cc50abaea33d488e8cde1d/bitnami/kafka/templates/statefulset.yaml#L228

it is actually to "false" / "no". I changed "true" to "no".

**Benefits**

The end user knows that:
1. the default behaviour is to disallow Plaintext Listener
2. ne needs to change it to yes

**Possible drawbacks**

no drawbacks known

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

no applicable issues

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
