### PR TITLE
[bitnami/mongodb] Add medium option for non-persisted.

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.29.4
+version: 10.29.5

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.29.5
+version: 10.30.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -243,6 +243,7 @@ Refer to the [chart documentation for more information on each of these architec
 | Name                                          | Description                                                                        | Value               |
 | --------------------------------------------- | ---------------------------------------------------------------------------------- | ------------------- |
 | `persistence.enabled`                         | Enable MongoDB&reg; data persistence using PVC                                     | `true`              |
+| `persistence.medium`                          | Provide a medium for `emptyDir` volumes.                                           | `""`                |
 | `persistence.existingClaim`                   | Provide an existing `PersistentVolumeClaim` (only when `architecture=standalone`)  | `""`                |
 | `persistence.storageClass`                    | PVC Storage Class for MongoDB&reg; data volume                                     | `""`                |
 | `persistence.accessModes`                     | PV Access Mode                                                                     | `["ReadWriteOnce"]` |
@@ -398,6 +399,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `hidden.pdb.minAvailable`                            | Minimum number/percentage of hidden node pods that should remain scheduled                           | `1`                 |
 | `hidden.pdb.maxUnavailable`                          | Maximum number/percentage of hidden node pods that may be made unavailable                           | `""`                |
 | `hidden.persistence.enabled`                         | Enable hidden node data persistence using PVC                                                        | `true`              |
+| `hidden.persistence.medium`                          | Provide a medium for `emptyDir` volumes.                                                             | `""`                |
 | `hidden.persistence.storageClass`                    | PVC Storage Class for hidden node data volume                                                        | `""`                |
 | `hidden.persistence.accessModes`                     | PV Access Mode                                                                                       | `["ReadWriteOnce"]` |
 | `hidden.persistence.size`                            | PVC Storage Request for hidden node data volume                                                      | `8Gi`               |

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -511,7 +511,13 @@ spec:
         {{- end }}
   {{- if not .Values.hidden.persistence.enabled }}
         - name: datadir
+          {{- if .Values.hidden.persistence.medium }}
+          emptyDir: {
+            medium: {{ .Values.hidden.persistence.medium | quote }}
+          }
+          {{- else }}
           emptyDir: {}
+          {{- end }}
   {{- else }}
   volumeClaimTemplates:
     - metadata:

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -512,9 +512,8 @@ spec:
   {{- if not .Values.hidden.persistence.enabled }}
         - name: datadir
           {{- if .Values.hidden.persistence.medium }}
-          emptyDir: {
+          emptyDir:
             medium: {{ .Values.hidden.persistence.medium | quote }}
-          }
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -545,7 +545,13 @@ spec:
         {{- end }}
   {{- if not .Values.persistence.enabled }}
         - name: datadir
+          {{- if .Values.persistence.medium }}
+          emptyDir: {
+            medium: {{ .Values.persistence.medium | quote }}
+          }
+          {{- else }}
           emptyDir: {}
+          {{- end }}
   {{- else }}
   volumeClaimTemplates:
     - metadata:

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -546,9 +546,8 @@ spec:
   {{- if not .Values.persistence.enabled }}
         - name: datadir
           {{- if .Values.persistence.medium }}
-          emptyDir: {
+          emptyDir:
             medium: {{ .Values.persistence.medium | quote }}
-          }
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -480,7 +480,13 @@ spec:
         {{- end }}
   {{- if not .Values.persistence.enabled }}
         - name: datadir
+          {{- if .Values.persistence.medium }}
+          emptyDir: {
+            medium: {{ .Values.persistence.medium | quote }}
+          }
+          {{- else }}
           emptyDir: {}
+          {{- end }}
   {{- else if .Values.persistence.existingClaim }}
         - name: datadir
           persistentVolumeClaim:

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -481,9 +481,8 @@ spec:
   {{- if not .Values.persistence.enabled }}
         - name: datadir
           {{- if .Values.persistence.medium }}
-          emptyDir: {
+          emptyDir:
             medium: {{ .Values.persistence.medium | quote }}
-          }
           {{- else }}
           emptyDir: {}
           {{- end }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -772,6 +772,10 @@ persistence:
   ## @param persistence.enabled Enable MongoDB&reg; data persistence using PVC
   ##
   enabled: true
+  ## @param persistence.medium Provide a medium for `emptyDir` volumes.
+  ## Requires persistence.enabled: false
+  ##
+  medium: ""
   ## @param persistence.existingClaim Provide an existing `PersistentVolumeClaim` (only when `architecture=standalone`)
   ## Requires persistence.enabled: true
   ## If defined, PVC must be created manually before volume will be bound
@@ -1465,6 +1469,10 @@ hidden:
     ## @param hidden.persistence.enabled Enable hidden node data persistence using PVC
     ##
     enabled: true
+    ## @param hidden.persistence.medium Provide a medium for `emptyDir` volumes.
+    ## Requires hidden.persistence.enabled: false
+    ##
+    medium: ""
     ## @param hidden.persistence.storageClass PVC Storage Class for hidden node data volume
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Adds `persistence.medium` and `hidden.persistence.medium` options.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
With the added medium option, it is now possible to set medium to `Memory`, as opposed to defaulting to local fs.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
None come to mind, as this is completely optional and will keep the default if not set.
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - closes #7382 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
