### PR TITLE
[bitnami/ghost] Fix host when using ingress with external TLS termination

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - http://www.ghost.org/
-version: 15.2.1
+version: 15.1.3

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - http://www.ghost.org/
-version: 15.1.2
+version: 15.2.1

--- a/bitnami/ghost/templates/_helpers.tpl
+++ b/bitnami/ghost/templates/_helpers.tpl
@@ -46,10 +46,10 @@ Gets the host to be used for this application.
 If not using ClusterIP, or if a host or LoadBalancerIP is not defined, the value will be empty.
 */}}
 {{- define "ghost.host" -}}
-{{- if .Values.ingress.enabled }}
-    {{- printf "%s%s" .Values.ingress.hostname .Values.ingress.path | default "" -}}
-{{- else if .Values.ghostHost -}}
+{{- if .Values.ghostHost -}}
     {{- printf "%s%s" .Values.ghostHost .Values.ghostPath | default "" -}}
+{{- else if .Values.ingress.enabled }}
+    {{- printf "%s%s" .Values.ingress.hostname .Values.ingress.path | default "" -}}
 {{- else -}}
     {{- include "ghost.serviceIP" . -}}
 {{- end -}}


### PR DESCRIPTION
**Description of the change**

Gives `ghostHost` precedence over `ingress.hostname` when defining the `ghost.host` variable helper.

**Benefits**

This way, the host can be set independently / override the hostname from ingress. 
This is necessary when using external TLS termination. In this case, we need to provide a `https://`-prefix for the host which is not possible through an ingress hostname.

**Possible drawbacks**

none

**Applicable issues**

none

**Additional information**

none

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
