### PR TITLE
[bitnami/thanos] Update Thanos Readme for minio configuration.

### DIFF
--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -1199,10 +1199,9 @@ metrics:
     enabled: true
 minio:
   enabled: true
-  accessKey:
-    password: "minio"
-  secretKey:
-    password: "minio123"
+  auth:
+    rootUser: "admin"
+    rootPassword: "minio123"
   defaultBuckets: "thanos"
 ```
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

The example minio configuration is no longer correct for the newest
chart version.

The `accessKey` and `secretKey` fields were removed and only and `auth`
dictionary is now available.

<!-- Describe the scope of your change - i.e. what the change does. -->

Deploying Thanos with the configuration in the Readme works again.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
