### PR TITLE
[bitnami/ghost] Fix Health probes when HTTPS is enabled (#8201)

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - https://www.ghost.org/
-version: 15.1.5
+version: 15.1.6

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -200,7 +200,12 @@ spec:
             httpGet:
               path: /
               port: {{ ternary "https" "http" .Values.ghostEnableHttps | quote }}
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.ghostEnableHttps | quote }}
+              scheme: HTTP
+              {{- if .Values.ghostEnableHttps }}
+              httpHeaders:
+                - name: x-forwarded-proto
+                  value: https
+              {{- end }}
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
@@ -214,7 +219,12 @@ spec:
             httpGet:
               path: /
               port: {{ ternary "https" "http" .Values.ghostEnableHttps | quote }}
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.ghostEnableHttps | quote }}
+              scheme: HTTP
+              {{- if .Values.ghostEnableHttps }}
+              httpHeaders:
+                - name: x-forwarded-proto
+                  value: https
+              {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -228,7 +238,12 @@ spec:
             httpGet:
               path: /
               port: {{ ternary "https" "http" .Values.ghostEnableHttps | quote }}
-              scheme: {{ ternary "HTTPS" "HTTP" .Values.ghostEnableHttps | quote }}
+              scheme: HTTP
+              {{- if .Values.ghostEnableHttps }}
+              httpHeaders:
+                - name: x-forwarded-proto
+                  value: https
+              {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Patch health probes for Ghost chart when HTTPS is enabled
<!-- Describe the scope of your change - i.e. what the change does. -->


**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #8201 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
