### PR TITLE
[bitnami/rabbitmq-cluster-operator] Fix reference to metrics ports in values.yaml and metrics service

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 2.0.1
+version: 2.0.2

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
@@ -36,7 +36,7 @@ spec:
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.msgTopologyOperator.metrics.service.port }}
+      port: {{ .Values.msgTopologyOperator.metrics.service.ports.http }}
       targetPort: http-metrics
       protocol: TCP
       {{- if (and (or (eq .Values.msgTopologyOperator.metrics.service.type "NodePort") (eq .Values.msgTopologyOperator.metrics.service.type "LoadBalancer")) (not (empty .Values.msgTopologyOperator.metrics.service.nodePorts.http))) }}

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -396,7 +396,7 @@ clusterOperator:
       ##
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.metrics.service.port }}"
+        prometheus.io/port: "{{ .Values.clusterOperator.metrics.service.ports.http }}"
     serviceMonitor:
       ## @param clusterOperator.metrics.serviceMonitor.enabled Specify if a servicemonitor will be deployed for prometheus-operator
       ##
@@ -799,7 +799,7 @@ msgTopologyOperator:
       ##
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "{{ .Values.metrics.service.port }}"
+        prometheus.io/port: "{{ .Values.msgTopologyOperator.metrics.service.ports.http }}"
     serviceMonitor:
       ## @param msgTopologyOperator.metrics.serviceMonitor.enabled Specify if a servicemonitor will be deployed for prometheus-operator
       ##


### PR DESCRIPTION
**Description of the change**

With the addition of the messaging-topology-operator the path to the metrics
ports changed. This change was still missing in the values.yaml, causing a
"nil pointer evaluating interface" error when rendering the chart with enabled
metrics.

One of the metrics services was also still using the old path.

**Benefits**

The chart renders correctly when enabling metrics.

**Possible drawbacks**

If the user uses a different name for the port instead of the default `http` or a `nodePort`, they will also have to adjust the annotation. They have to to that anyway though, as for example a hardcoded value would also need manual adjustment by the user.

**Applicable issues**

None.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
