### PR TITLE
[bitnami/mongodb] Support tls.extraDnsNames in "replicaset" architecture

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.30.2
+version: 10.30.3

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -151,6 +151,11 @@ spec:
               DNS.3 = $my_hostname.$svc.$MY_POD_NAMESPACE.svc.{{ .Values.clusterDomain }}
               DNS.4 = localhost
               DNS.5 = 127.0.0.1
+              {{- if .Values.tls.extraDnsNames }}
+              {{- range $key, $dnsName := .Values.tls.extraDnsNames }}
+              {{ $key }} = {{ $dnsName }}
+              {{- end }}
+              {{- end }}
               {{- if .Values.externalAccess.service.loadBalancerIPs }}
               {{- range $key, $val := .Values.externalAccess.service.loadBalancerIPs }}
               IP.{{ $key }} = {{ $val | quote }}


### PR DESCRIPTION
**Description of the change**

Add handling of `tls.extraDnsNames` paramater to "replicaset" cluster architecture. Currently `tls.extraDnsNames` works only in "standalone" mode, but it can be useful in "replicaset" as well. 

**Benefits**

`tls.extraDnsNames` will work in both "standalone" and "replicaset" modes.

**Possible drawbacks**

Not know

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
