### PR TITLE
[bitnami/influxdb] Fix probes

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 2.4.2
+version: 2.4.3

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Database
 apiVersion: v2
-appVersion: 2.0.9
+appVersion: 2.1.1
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/influxdb/templates/influxdb/deployment-standalone.yaml
+++ b/bitnami/influxdb/templates/influxdb/deployment-standalone.yaml
@@ -217,7 +217,7 @@ spec:
                   branch=$(influxdb_branch)
 
                   if [[ "$branch" = "2" ]]; then
-                      timeout {{ $livenessTimeout }}s influx --host http://$POD_IP:{{ .Values.influxdb.containerPorts.http }} ping
+                      timeout {{ $livenessTimeout }}s influx ping --host http://$POD_IP:{{ .Values.influxdb.containerPorts.http }}
                   else
                       timeout {{ $livenessTimeout }}s influx -host $POD_IP -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
                   fi
@@ -244,7 +244,7 @@ spec:
                   branch=$(influxdb_branch)
 
                   if [[ "$branch" = "2" ]]; then
-                      timeout {{ $readinessTimeout }}s influx --host http://$POD_IP:{{ .Values.influxdb.containerPorts.http }} ping
+                      timeout {{ $readinessTimeout }}s influx ping --host http://$POD_IP:{{ .Values.influxdb.containerPorts.http }}
                   else
                       timeout {{ $readinessTimeout }}s influx -host $POD_IP -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
                   fi

--- a/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
+++ b/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
@@ -215,7 +215,7 @@ spec:
                   branch=$(influxdb_branch)
 
                   if [[ "$branch" = "2" ]]; then
-                      timeout {{ $livenessTimeout }}s influx --host http://$POD_IP:{{ .Values.influxdb.containerPorts.http }} ping
+                      timeout {{ $livenessTimeout }}s influx ping --host http://$POD_IP:{{ .Values.influxdb.containerPorts.http }}
                   else
                       timeout {{ $livenessTimeout }}s influx -host $POD_IP -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
                   fi
@@ -242,7 +242,7 @@ spec:
                   branch=$(influxdb_branch)
 
                   if [[ "$branch" = "2" ]]; then
-                      timeout {{ $readinessTimeout }}s influx --host http://$POD_IP:{{ .Values.influxdb.containerPorts.http }} ping
+                      timeout {{ $readinessTimeout }}s influx ping --host http://$POD_IP:{{ .Values.influxdb.containerPorts.http }}
                   else
                       timeout {{ $readinessTimeout }}s influx -host $POD_IP -port {{ .Values.influxdb.containerPorts.http }} -execute "SHOW DATABASES"
                   fi

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -69,7 +69,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/influxdb
-  tag: 2.0.9-debian-10-r45
+  tag: 2.1.1-debian-10-r0
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -382,7 +382,7 @@ relay:
   image:
     registry: docker.io
     repository: bitnami/influxdb-relay
-    tag: 0.20200717.0-scratch-r13
+    tag: 0.20200717.0-scratch-r14
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -855,7 +855,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r254
+    tag: 10-debian-10-r264
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -984,7 +984,7 @@ backup:
       image:
         registry: docker.io
         repository: bitnami/google-cloud-sdk
-        tag: 0.365.0-debian-10-r0
+        tag: 0.365.0-debian-10-r11
         ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
         ##
@@ -1021,7 +1021,7 @@ backup:
       image:
         registry: docker.io
         repository: bitnami/azure-cli
-        tag: 2.30.0-debian-10-r15
+        tag: 2.30.0-debian-10-r25
         ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
         ##


### PR DESCRIPTION
**Description of the change**

The new CLI version shows an error when running `influx --host X.X.X.X ping`:

```
Incorrect Usage. flag provided but not defined: -host
```

But it works if you switch the order and the command is the 1st argument: `influx ping --host X.X.X.X`.

**Benefits**

Adapt the chart for the new CLI version.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
