### PR TITLE
[bitnami/contour] Remove ttlSecondsAfterFinished from Job

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 7.0.4
+version: 7.0.5

--- a/bitnami/contour/templates/certgen/job.yaml
+++ b/bitnami/contour/templates/certgen/job.yaml
@@ -18,7 +18,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
-  ttlSecondsAfterFinished: 0
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}


### PR DESCRIPTION
**Description of the change**
Remove ttlSecondsAfterFinished from a `contour-certgen` Job. `"helm.sh/hook-delete-policy": hook-succeeded` is responsible for the Job deletion.

I was trying to deploy `bitnami/contour` chart with Argo CD but it was stuck almost every time with `waiting for completion of hook...`. I found out that job is launching and closing normally and creates secrets successfully. But for some reason Argo CD was not picking up on job completion (maybe issue is needed to be open as well there). 

I though that something was wrong with `helm.sh/hook-weight` and spent a lot of time there, but in the end I finally saw 
```
As an alternative to hook deletion policies, both Jobs and Argo Workflows support 
the ttlSecondsAfterFinished field in the spec, which let their respective controllers 
delete the Job/Workflow after it completes.
```
and figured out that `helm.sh/hook-delete-policy` and `ttlSecondsAfterFinished` are mutually exclusive for some reason (or not thought through) (at least with small value like 0 in this chart).

Also I checked and found out that there is no other chart in this repo that uses ttlSecondsAfterFinished for Jobs. (There are only 6 Jobs elsewhere, but still)

As soon as I removed this field and tested CD again it successfully finished.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
N/A

**Possible drawbacks**
N/A

**Applicable issues**
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
