### PR TITLE
[bitnami/kafka] use resources for provisioning initContainer

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 14.5.0
+version: 14.5.1

--- a/bitnami/kafka/templates/kafka-provisioning.yaml
+++ b/bitnami/kafka/templates/kafka-provisioning.yaml
@@ -49,6 +49,9 @@ spec:
                 --timeout=120 \
                 {{ .Values.service.port | int64 }};
               echo "Kafka is available";
+          {{- if .Values.provisioning.resources }}
+          resources: {{- toYaml .Values.provisioning.resources | nindent 12 }}
+          {{- end }}
       containers:
         - name: kafka-provisioning
           image: {{ include "kafka.image" . }}


### PR DESCRIPTION
**Description of the change**
Use resources for provisioning initContainer

**Benefits**

The chart can be installed in more strict environments (requiring explicit resources being set on all containers).

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist**

- [x] Chart version bumped in Chart.yaml according to semver.

- [x] Variables are documented in the README.md

- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])