### PR TITLE
[bitnami/magento] Correct protocol and port number with https

### DIFF
--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -35,4 +35,4 @@ name: magento
 sources:
   - https://github.com/bitnami/bitnami-docker-magento
   - https://magento.com/
-version: 19.1.1
+version: 19.1.2

--- a/bitnami/magento/templates/NOTES.txt
+++ b/bitnami/magento/templates/NOTES.txt
@@ -51,16 +51,17 @@ host. To configure Magento with the URL of your service:
 
 {{- if eq .Values.service.type "ClusterIP" }}
 
-  echo "Store URL: http://127.0.0.1:8080/"
-  echo "Admin URL: http://127.0.0.1:8080/{{ .Values.magentoAdminUri }}"
+  echo "Store URL: http{{ if .Values.magentoUseHttps }}s{{ end }}://127.0.0.1:8080/"
+  echo "Admin URL: http{{ if .Values.magentoUseSecureAdmin }}s{{ end }}://127.0.0.1:8080/{{ .Values.magentoAdminUri }}"
   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} 8080:{{ .Values.service.port }}
 
 {{- else }}
 
 {{- $port:=.Values.service.port | toString }}
+{{- $httpsPort:=.Values.service.httpsPort | toString }}
 
-  echo "Store URL: http://{{ include "magento.host" . }}{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/"
-  echo "Admin URL: http://{{ include "magento.host" . }}{{- if ne $port "80" }}:{{ .Values.service.port }}{{ end }}/{{ .Values.magentoAdminUri }}"
+  echo "Store URL: http{{ if .Values.magentoUseHttps }}s{{ end }}://{{ include "magento.host" . }}{{ if not (or (and (eq $port "80") (not .Values.magentoUseHttps)) (and (eq $httpsPort "443") (.Values.magentoUseHttps))) }}:{{ if .Values.magentoUseHttps }}{{ .Values.service.httpsPort }}{{ else }}{{ .Values.service.port }}{{ end }}{{ end }}/"
+  echo "Admin URL: http{{ if .Values.magentoUseSecureAdmin }}s{{ end }}://{{ include "magento.host" . }}{{ if not (or (and (eq $port "80") (not .Values.magentoUseSecureAdmin)) (and (eq $httpsPort "443") (.Values.magentoUseSecureAdmin))) }}:{{ if .Values.magentoUseSecureAdmin }}{{ .Values.service.httpsPort }}{{ else }}{{ .Values.service.port }}{{ end }}{{ end }}/{{ .Values.magentoAdminUri }}"
 
 {{- end }}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Print `https` and corresponding `httpsPort` number when `magentoUseHttps` or `magentoUseSecureAdmin` are set to `true`.

**Benefits**

Prints correct values after installing the Helm chart.

Otherwise, user is mislead when using security to point to an incorrect protocol or port number.

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #8279

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
