### PR TITLE
[bitnami/keycloak] Disable http(s) service mapping

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 5.2.3
+version: 5.3.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -213,8 +213,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                               | Description                                                                                                                      | Value                    |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | `service.type`                     | Kubernetes service type                                                                                                          | `LoadBalancer`           |
-| `service.port`                     | Service HTTP port                                                                                                                | `80`                     |
-| `service.httpsPort`                | HTTPS Port                                                                                                                       | `443`                    |
+| `service.port`                     | Service HTTP port. 0 will disable http mapping.                                                                                  | `80`                     |
+| `service.httpsPort`                | HTTPS Port. 0 will disable https mapping.                                                                                        | `443`                    |
 | `service.nodePorts`                | Specify the nodePort values for the LoadBalancer and NodePort service types.                                                     | `{}`                     |
 | `service.clusterIP`                | Keycloak service clusterIP IP                                                                                                    | `""`                     |
 | `service.loadBalancerIP`           | loadBalancerIP for the SuiteCRM Service (optional, cloud specific)                                                               | `""`                     |

--- a/bitnami/keycloak/templates/service.yaml
+++ b/bitnami/keycloak/templates/service.yaml
@@ -32,6 +32,7 @@ spec:
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
+    {{- if .Values.service.port }}
     - name: http
       port: {{ .Values.service.port }}
       protocol: TCP
@@ -41,6 +42,8 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- end }}
+    {{- if .Values.service.httpsPort }}
     - name: https
       port: {{ .Values.service.httpsPort }}
       protocol: TCP
@@ -50,5 +53,6 @@ spec:
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -630,9 +630,11 @@ service:
   ##
   type: LoadBalancer
   ## @param service.port Service HTTP port
+  ## 0 will disable http-mapping
   ##
   port: 80
   ## @param service.httpsPort HTTPS Port
+  ## 0 will disable http-mapping
   ##
   httpsPort: 443
   ## @param service.nodePorts [object] Specify the nodePort values for the LoadBalancer and NodePort service types.


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Added possibility to disable http(s) mapping by setting service.port / service.httpsPort to 0.
The default value 80 and 443 will remain.


**Benefits**

This change is necessary if you like to use the exposed service with nginx-ingress-controller.
Nginx-Ingress will only work, if just one port is set inside the service.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
