### PR TITLE
[bitnami/mysql] add commonAnnotations to initialization-configmap

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.8.14
+version: 8.8.15

--- a/bitnami/mysql/templates/primary/initialization-configmap.yaml
+++ b/bitnami/mysql/templates/primary/initialization-configmap.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: primary
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
 {{- include "common.tplvalues.render" (dict "value" .Values.initdbScripts "context" .) | nindent 2 }}
 {{ end }}


### PR DESCRIPTION
**Description of the change**
pass commonAnnotations variable to initialization-configmap

**Benefits**
enable configuring annotations to the initialization-configmap

use case: use mysql as subchart and install it during pre-install hook. to configure hook, annotations must be supplied to all mysql resources.

**Possible drawbacks**
none

**Applicable issues**
none

**Additional information**
how to test:
1. add mysql as subchart
2. set values.yaml
```
mysql:
  initdbScripts: <some mysql commands>
  primary:
    persistence:
      annotations:
        helm.sh/hook: pre-install
        helm.sh/hook-weight: "-10"
  commonAnnotations:
    helm.sh/hook: pre-install
    helm.sh/hook-weight: "-10"
```
3. helm install
before change: helm install failed with hook timeout; the mysql statefulset shows event error of mysql-init-scripts not found
after change: helm install success 

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
