### PR TITLE
[bitnami/thanos] Fix grpc.server.tls.autoGenerated doesn't work

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 8.1.2
+version: 8.1.3

--- a/bitnami/thanos/templates/query/grpc-client-tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/grpc-client-tls-secrets.yaml
@@ -18,9 +18,9 @@ data:
   {{- $ca := genCA "thanos-query-grpc-client-ca" 365 }}
   {{- $hostname := printf "%s-query-grpc-client" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls-cert: {{ $cert.Cert | b64enc | quote }}
+  tls-key: {{ $cert.Key | b64enc | quote }}
+  ca-crt: {{ $ca.Cert | b64enc | quote }}
   {{- else }}
   tls-cert: {{ .Values.query.grpc.client.tls.cert | b64enc | quote }}
   tls-key: {{ .Values.query.grpc.client.tls.key | b64enc | quote }}

--- a/bitnami/thanos/templates/query/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/grpc-server-tls-secrets.yaml
@@ -18,9 +18,9 @@ data:
   {{- $ca := genCA "thanos-query-grpc-server-ca" 365 }}
   {{- $hostname := printf "%s-query-grpc-server" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls-crt: {{ $cert.Cert | b64enc | quote }}
+  tls-key: {{ $cert.Key | b64enc | quote }}
+  ca-cert: {{ $ca.Cert | b64enc | quote }}
   {{- else }}
   tls-cert: {{ .Values.query.grpc.server.tls.cert | b64enc | quote }}
   tls-key: {{ .Values.query.grpc.server.tls.key | b64enc | quote }}

--- a/bitnami/thanos/templates/receive/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/receive/grpc-server-tls-secrets.yaml
@@ -19,9 +19,9 @@ data:
   {{- $ca := genCA "thanos-receive-grpc-server-ca" 365 }}
   {{- $hostname := printf "%s-receive-grpc-server" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls-crt: {{ $cert.Cert | b64enc | quote }}
+  tls-key: {{ $cert.Key | b64enc | quote }}
+  ca-cert: {{ $ca.Cert | b64enc | quote }}
   {{- else }}
   tls-cert: {{ .Values.receive.grpc.server.tls.cert | b64enc | quote }}
   tls-key: {{ .Values.receive.grpc.server.tls.key | b64enc | quote }}

--- a/bitnami/thanos/templates/storegateway/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/storegateway/grpc-server-tls-secrets.yaml
@@ -18,9 +18,9 @@ data:
   {{- $ca := genCA "thanos-store-grpc-server-ca" 365 }}
   {{- $hostname := printf "%s-store-grpc-server" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls-cert: {{ $cert.Cert | b64enc | quote }}
+  tls-key: {{ $cert.Key | b64enc | quote }}
+  ca-cert: {{ $ca.Cert | b64enc | quote }}
   {{- else }}
   tls-cert: {{ .Values.storegateway.grpc.server.tls.cert | b64enc | quote }}
   tls-key: {{ .Values.storegateway.grpc.server.tls.key | b64enc | quote }}


### PR DESCRIPTION
Resolves #8322

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

when set `grpc.server.tls.autoGenerated` components will start working again as intended.

**Applicable issues**

  - fixes #8322

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
