### PR TITLE
[bitnami/keycloak] fix keycloak add values if is external db

### DIFF
--- a/bitnami/keycloak/Chart.lock
+++ b/bitnami/keycloak/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.8.0
+  version: 1.10.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.9.5
-digest: sha256:8bd7414347de5ca50108cb48c76ab4b2b3ba37103aa7863d7d3d6144a94393b8
-generated: "2021-09-10T16:53:34.527900169Z"
+  version: 10.13.11
+digest: sha256:b8753330b5c641cf86de7e24f5f4069b1989e04dfbe8e11f9639cc894bd58bad
+generated: "2021-12-07T10:56:14.326957+03:00"

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -24,6 +24,12 @@ data:
   KEYCLOAK_DATABASE_NAME: {{ include "keycloak.databaseName" . | quote }}
   KEYCLOAK_DATABASE_USER: {{ include "keycloak.databaseUser" . | quote }}
   {{- end }}
+  {{- if (not .Values.postgresql.enabled) }}
+  KEYCLOAK_DATABASE_HOST: {{ .Values.externalDatabase.host | quote }}
+  KEYCLOAK_DATABASE_PORT: {{ .Values.externalDatabase.port | quote }}
+  KEYCLOAK_DATABASE_NAME: {{ .Values.externalDatabase.database | quote }}
+  KEYCLOAK_DATABASE_USER: {{ .Values.externalDatabase.user | quote }}
+  {{- end }}
   {{- if .Values.serviceDiscovery.enabled }}
   KEYCLOAK_JGROUPS_DISCOVERY_PROTOCOL: {{ .Values.serviceDiscovery.protocol | quote }}
   KEYCLOAK_JGROUPS_DISCOVERY_PROPERTIES: {{ (tpl (join "," .Values.serviceDiscovery.properties) $) | quote }}


### PR DESCRIPTION
**Description of the change**

This adds environment variables when using an external database. Part of my values file:
```yaml
postgresql:
  enabled: False
externalDatabase:
  host: external-database.example.io
  port: 5432
```
When I use it, I see that it does not set values for the external database. Part of pod logs:
```log
keycloak 06:19:07.75 INFO  ==> Trying to connect to PostgreSQL server postgresql...
cannot resolve host "postgresql": lookup postgresql on 172.20.0.10:53: no such host
cannot resolve host "postgresql": lookup postgresql on 172.20.0.10:53: no such host
cannot resolve host "postgresql": lookup postgresql on 172.20.0.10:53: no such host
```
**Benefits**
This makes it possible to use an external database

**Possible drawbacks**
Knowing the logic of the chart in more detail, you can make the changes better

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
