### PR TITLE
[bitnami/apache] Adds a switch to enable/disable the git-repo-syncer sidecar container…

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -26,4 +26,4 @@ name: apache
 sources:
   - https://github.com/bitnami/bitnami-docker-apache
   - https://httpd.apache.org
-version: 8.9.7
+version: 8.10.0

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -98,6 +98,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cloneHtdocsFromGit.enabled`           | Get the server static content from a git repository                                                                      | `false`                |
 | `cloneHtdocsFromGit.repository`        | Repository to clone static content from                                                                                  | `""`                   |
 | `cloneHtdocsFromGit.branch`            | Branch inside the git repository                                                                                         | `""`                   |
+| `cloneHtdocsFromGit.enableAutoRefresh` | Enables an automatic git pull with a sidecar container                                                                   | `true`                 |
 | `cloneHtdocsFromGit.interval`          | Interval for sidecar container pull from the repository                                                                  | `60`                   |
 | `cloneHtdocsFromGit.resources`         | Init container git resource requests                                                                                     | `{}`                   |
 | `cloneHtdocsFromGit.extraVolumeMounts` | Add extra volume mounts for the GIT containers                                                                           | `[]`                   |

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
         {{- end }}
       {{- end }}
       containers:
-        {{- if .Values.cloneHtdocsFromGit.enabled && .Values.cloneHtdocsFromGit.enableAutoRefresh }}
+        {{- if and .Values.cloneHtdocsFromGit.enabled .Values.cloneHtdocsFromGit.enableAutoRefresh }}
         - name: git-repo-syncer
           image: {{ include "git.image" . }}
           imagePullPolicy: {{ .Values.git.pullPolicy | quote }}

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
         {{- end }}
       {{- end }}
       containers:
-        {{- if .Values.cloneHtdocsFromGit.enabled }}
+        {{- if .Values.cloneHtdocsFromGit.enabled && .Values.cloneHtdocsFromGit.enableAutoRefresh }}
         - name: git-repo-syncer
           image: {{ include "git.image" . }}
           imagePullPolicy: {{ .Values.git.pullPolicy | quote }}

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -139,6 +139,7 @@ extraPodSpec: {}
 ## @param cloneHtdocsFromGit.enabled Get the server static content from a git repository
 ## @param cloneHtdocsFromGit.repository Repository to clone static content from
 ## @param cloneHtdocsFromGit.branch Branch inside the git repository
+## @param cloneHtdocsFromGit.enableAutoRefresh Enables an automatic git pull with a sidecar container
 ## @param cloneHtdocsFromGit.interval Interval for sidecar container pull from the repository
 ## @param cloneHtdocsFromGit.resources Init container git resource requests
 ## @param cloneHtdocsFromGit.extraVolumeMounts Add extra volume mounts for the GIT containers
@@ -147,6 +148,7 @@ cloneHtdocsFromGit:
   enabled: false
   repository: ""
   branch: ""
+  enableAutoRefresh: true
   interval: 60
   resources: {}
   ## Useful to mount keys to connect through ssh. (normally used with extraVolumes)


### PR DESCRIPTION
… to save resources on a deployment with no regular updates from the repo.


**Description of the change**

Simple adds an option to disable the sidecar container responsible for the subsequent git pulls within the lifetime of the apache pods. 

**Benefits**

If the deployment is *not* required to update regularly we don't need to start the extra container. Saves Resources on the Cluster.

**Possible drawbacks**

None that I know of.

**Additional information**

If the option is unused the default value is true, so no changes to existing deployments are required. 



**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
