### PR TITLE
[bitnami/airflow] fix airflow worker init container

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 11.1.9
+version: 11.1.10

--- a/bitnami/airflow/templates/_git_helpers.tpl
+++ b/bitnami/airflow/templates/_git_helpers.tpl
@@ -98,12 +98,12 @@ Returns the init container that will clone repositories files from a given list 
       [[ -f "/opt/bitnami/scripts/git/entrypoint.sh" ]] && . /opt/bitnami/scripts/git/entrypoint.sh
     {{- if .Values.git.dags.enabled }}
       {{- range .Values.git.dags.repositories }}
-      is_mounted_dir_empty "/dags_{{ include "airflow.git.repository.name" . }}" && git clone {{ .repository }} --branch {{ .branch }} /dags_{{ include "airflow.git.repository.name" . }} || true
+      is_mounted_dir_empty "/dags_{{ include "airflow.git.repository.name" . }}" && git clone {{ .repository }} --branch {{ .branch }} /dags_{{ include "airflow.git.repository.name" . }}
       {{- end }}
     {{- end }}
     {{- if .Values.git.plugins.enabled }}
       {{- range .Values.git.plugins.repositories }}
-      is_mounted_dir_empty "/plugins_{{ include "airflow.git.repository.name" . }}" && git clone {{ .repository }} --branch {{ .branch }} /plugins_{{ include "airflow.git.repository.name" . }} || true
+      is_mounted_dir_empty "/plugins_{{ include "airflow.git.repository.name" . }}" && git clone {{ .repository }} --branch {{ .branch }} /plugins_{{ include "airflow.git.repository.name" . }}
       {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**
Fix #8207 
In airflow chart, make the init container of airflow worker fails when it fails to clone dags or plugins repository

**Benefits**
Airflow worker will not be ready if it fails to loads dags or plugins. So it will not receive tasks that will automatically fails as dags or plugins are not loaded.
