### PR TITLE
[bitnami/grafana] from grafana to imageRenderer in configmap

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 7.2.9
+version: 7.2.10

--- a/bitnami/grafana/templates/configmap.yaml
+++ b/bitnami/grafana/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
   {{- if .Values.imageRenderer.enabled }}
   {{- $domain := .Values.clusterDomain }}
   {{- $namespace := .Release.Namespace }}
-  GF_RENDERING_SERVER_URL: "http://{{ include "common.names.fullname" . }}-image-renderer.{{ $namespace }}.svc.{{ $domain }}:{{ .Values.imageRenderer.service.ports.grafana }}/render"
+  GF_RENDERING_SERVER_URL: "http://{{ include "common.names.fullname" . }}-image-renderer.{{ $namespace }}.svc.{{ $domain }}:{{ .Values.imageRenderer.service.ports.imageRenderer }}/render"
   GF_RENDERING_CALLBACK_URL: "http://{{ include "common.names.fullname" . }}.{{ $namespace }}.svc.{{ $domain }}:{{ .Values.service.ports.grafana }}/"
   {{- end }}
   {{- if .Values.plugins }}


### PR DESCRIPTION
Signed-off-by: Ioachim Lihor <ioachim.lihor@radcom.com>

**Description of the change**

For grafana virtual environment `GF_RENDERING_SERVER_URL` I changed the address template from `.Values.imageRenderer.service.ports.grafana` to `.Values.imageRenderer.service.ports.imageRenderer`.


**Benefits**

The changes made will allow grafana to bind to Image Renderer service.

**Possible drawbacks**

There will be no known limitations.

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
