### PR TITLE
[bitnami/thanos] Fix Thanos Receiver service port name

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 8.2.0
+version: 8.2.1

--- a/bitnami/thanos/templates/receive/service.yaml
+++ b/bitnami/thanos/templates/receive/service.yaml
@@ -52,7 +52,7 @@ spec:
     - port: {{ if .Values.receive.service.remoteWrite }}{{ coalesce .Values.receive.service.ports.remote .Values.receive.service.remoteWrite.port }}{{ else }}{{ .Values.receive.service.ports.remote }}{{ end }}
       targetPort: remote-write
       protocol: TCP
-      name: remote
+      name: remote-write
       {{- if and (or (eq .Values.receive.service.type "NodePort") (eq .Values.receive.service.type "LoadBalancer")) .Values.receive.service.nodePorts.remote }}
       nodePort: {{ .Values.receive.service.nodePorts.remote }}
       {{- else if eq .Values.receive.service.type "ClusterIP" }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
<!-- Describe the scope of your change - i.e. what the change does. -->

Currently the Thanos receiver Ingress points to a service port `remote-write` and the actual port name is called `remote`. 
Of course this introduces issues and traffic is not received corretly.


**Benefits**
Tha thanos receiver getting the traffic destined to it.

**Possible drawbacks**

None
**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
