### PR TITLE
[bitnami/mongodb] Fixed tls.extraDnsNames example

### DIFF
--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -193,8 +193,8 @@ tls:
     pullPolicy: IfNotPresent
   ## e.g:
   ## extraDnsNames
-  ##   - "DNS.6": "$my_host"
-  ##   - "DNS.7": "$test"
+  ##   "DNS.6": "$my_host"
+  ##   "DNS.7": "$test"
   ##
   extraDnsNames: []
   ## @param tls.mode Allows to set the tls mode which should be used when tls is enabled (options: `allowTLS`, `preferTLS`, `requireTLS`)


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

I fixed the example of tls.extraDnsNames of the mongoDB chart as it led me in error.
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

Before, using the example, the alt_names were looking like this (using kubectl describe pod)
```
      [alt_names]
      DNS.1 = $svc
      DNS.2 = $my_hostname
      DNS.3 = $my_hostname.$svc.$MY_POD_NAMESPACE.svc.cluster.local
      DNS.4 = localhost
      DNS.5 = 127.0.0.1
      0 = map[DNS.6:mongo.domain.com]
      EOL
```
With the corrected example :
```
      [alt_names]
      DNS.1 = $svc
      DNS.2 = $my_hostname
      DNS.3 = $my_hostname.$svc.$MY_POD_NAMESPACE.svc.cluster.local
      DNS.4 = localhost
      DNS.5 = 127.0.0.1
      DNS.6 = mongo.domain.com
      EOL
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])

Edit:
**Impact**
This generates this warning now : 
`coalesce.go:202: warning: destination for extraDnsNames is a table. Ignoring non-table value []`