### PR TITLE
[bitnami/airflow] Ensure LDAP related env. vars values are quoted

### DIFF
--- a/bitnami/airflow/Chart.lock
+++ b/bitnami/airflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.10.1
+  version: 1.10.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.13.8
+  version: 10.13.12
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 15.5.5
-digest: sha256:fa3da4a96677028b43c5982557899d473970bc4697da2f6e81927f44c550d3fb
-generated: "2021-11-15T23:02:45.439894929Z"
+  version: 15.6.4
+digest: sha256:dcd9e5afc889a4226f92af9433d9ff10bfffc629b6ce6b3dc8129db0bbbbced4
+generated: "2021-12-09T16:37:54.13337035Z"

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 11.1.10
+version: 11.1.11

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -105,13 +105,13 @@ spec:
               value: {{ ternary "yes" "no" .Values.ldap.enabled | quote }}
             {{- if .Values.ldap.enabled }}
             - name: AIRFLOW_LDAP_URI
-              value: {{ .Values.ldap.uri }}
+              value: {{ .Values.ldap.uri | quote }}
             - name: AIRFLOW_LDAP_SEARCH
-              value: {{ .Values.ldap.base }}
+              value: {{ .Values.ldap.base | quote }}
             - name: AIRFLOW_LDAP_UID_FIELD
-              value: {{ .Values.ldap.uidField }}
+              value: {{ .Values.ldap.uidField | quote }}
             - name: AIRFLOW_LDAP_BIND_USER
-              value: {{ .Values.ldap.binddn }}
+              value: {{ .Values.ldap.binddn | quote }}
             - name: AIRFLOW_LDAP_BIND_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -120,7 +120,7 @@ spec:
             - name: AIRFLOW_LDAP_USER_REGISTRATION
               value: {{ .Values.ldap.userRegistration | quote }}
             - name: AIRFLOW_LDAP_USER_REGISTRATION_ROLE
-              value: {{ .Values.ldap.userRegistrationRole }}
+              value: {{ .Values.ldap.userRegistrationRole | quote }}
             - name: AIRFLOW_LDAP_ROLES_MAPPING
               value: {{ .Values.ldap.rolesMapping | quote }}
             - name: AIRFLOW_LDAP_ROLES_SYNC_AT_LOGIN

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -205,7 +205,7 @@ dags:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r252
+    tag: 10-debian-10-r274
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -229,7 +229,7 @@ web:
   image:
     registry: docker.io
     repository: bitnami/airflow
-    tag: 2.2.2-debian-10-r0
+    tag: 2.2.2-debian-10-r9
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -418,7 +418,7 @@ scheduler:
   image:
     registry: docker.io
     repository: bitnami/airflow-scheduler
-    tag: 2.2.1-debian-10-r15
+    tag: 2.2.2-debian-10-r21
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -550,7 +550,7 @@ worker:
   image:
     registry: docker.io
     repository: bitnami/airflow-worker
-    tag: 2.2.1-debian-10-r15
+    tag: 2.2.2-debian-10-r21
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -759,7 +759,7 @@ git:
   image:
     registry: docker.io
     repository: bitnami/git
-    tag: 2.33.0-debian-10-r87
+    tag: 2.34.1-debian-10-r13
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1057,7 +1057,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/airflow-exporter
-    tag: 0.20210126.0-debian-10-r277
+    tag: 0.20210126.0-debian-10-r300
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

There are several env. vars values that aren't properly quoted resulting on "invalid syntax" errors when you try to enable LDAP.

**Benefits**

Users can properly define LDAP properties in the values.yaml without facing syntax errors.

**Possible drawbacks**

None

**Applicable issues**

  - reported at https://github.com/bitnami/charts/issues/8345

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
