### PR TITLE
[bitnami/postgresql-ha] Add network egress policy rules

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 8.0.5
+version: 8.1.0

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -404,20 +404,22 @@ Additionally, if `persistence.resourcePolicy` is set to `keep`, you should manua
 
 ### Traffic Exposure parameters
 
-| Name                               | Description                                                         | Value       |
-| ---------------------------------- | ------------------------------------------------------------------- | ----------- |
-| `service.type`                     | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`) | `ClusterIP` |
-| `service.port`                     | PostgreSQL port                                                     | `5432`      |
-| `service.nodePort`                 | Kubernetes service nodePort                                         | `""`        |
-| `service.loadBalancerIP`           | Load balancer IP if service type is `LoadBalancer`                  | `""`        |
-| `service.loadBalancerSourceRanges` | Addresses that are allowed when service is LoadBalancer             | `[]`        |
-| `service.clusterIP`                | Set the Cluster IP to use                                           | `""`        |
-| `service.externalTrafficPolicy`    | Enable client source IP preservation                                | `Cluster`   |
-| `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin    | `None`      |
-| `service.annotations`              | Provide any additional annotations for PostgreSQL service           | `{}`        |
-| `service.serviceLabels`            | Labels for PostgreSQL service                                       | `{}`        |
-| `networkPolicy.enabled`            | Enable NetworkPolicy                                                | `false`     |
-| `networkPolicy.allowExternal`      | Don't require client label for connections                          | `true`      |
+| Name                                                  | Description                                                                                   | Value       |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------- | ----------- |
+| `service.type`                                        | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                           | `ClusterIP` |
+| `service.port`                                        | PostgreSQL port                                                                               | `5432`      |
+| `service.nodePort`                                    | Kubernetes service nodePort                                                                   | `""`        |
+| `service.loadBalancerIP`                              | Load balancer IP if service type is `LoadBalancer`                                            | `""`        |
+| `service.loadBalancerSourceRanges`                    | Addresses that are allowed when service is LoadBalancer                                       | `[]`        |
+| `service.clusterIP`                                   | Set the Cluster IP to use                                                                     | `""`        |
+| `service.externalTrafficPolicy`                       | Enable client source IP preservation                                                          | `Cluster`   |
+| `service.sessionAffinity`                             | Control where client requests go, to the same pod or round-robin                              | `None`      |
+| `service.annotations`                                 | Provide any additional annotations for PostgreSQL service                                     | `{}`        |
+| `service.serviceLabels`                               | Labels for PostgreSQL service                                                                 | `{}`        |
+| `networkPolicy.enabled`                               | Enable NetworkPolicy                                                                          | `false`     |
+| `networkPolicy.allowExternal`                         | Don't require client label for connections                                                    | `true`      |
+| `networkPolicy.egressRules.denyConnectionsToExternal` | Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53) | `false`     |
+| `networkPolicy.egressRules.customRules`               | Custom network policy rule                                                                    | `{}`        |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/postgresql-ha/templates/networkpolicy-egress.yaml
+++ b/bitnami/postgresql-ha/templates/networkpolicy-egress.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.networkPolicy.enabled (or .Values.networkPolicy.egressRules.denyConnectionsToExternal .Values.networkPolicy.egressRules.customRules) }}
+kind: NetworkPolicy
+apiVersion: {{ template "postgresql-ha.networkPolicy.apiVersion" . }}
+metadata:
+  name: {{ printf "%s-egress" (include "common.names.fullname" .) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgresql
+  policyTypes:
+    - Egress
+  egress:
+    {{- if .Values.networkPolicy.egressRules.denyConnectionsToExternal }}
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - namespaceSelector: {}
+    {{- end }}
+    {{- if .Values.networkPolicy.egressRules.customRules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.egressRules.customRules "context" $) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/postgresql-ha/templates/networkpolicy-ingress.yaml
+++ b/bitnami/postgresql-ha/templates/networkpolicy-ingress.yaml
@@ -2,7 +2,7 @@
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ printf "%s-ingress" (include "common.names.fullname" .) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -14,6 +14,8 @@ spec:
   podSelector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: postgresql
+  policyTypes:
+    - Ingress
   ingress:
     # Allow inbound connections
     - ports:

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -1359,3 +1359,17 @@ networkPolicy:
   ## (with the correct destination port).
   ##
   allowExternal: true
+  ## @param networkPolicy.egressRules.denyConnectionsToExternal Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53)
+  ## @param networkPolicy.egressRules.customRules [object] Custom network policy rule
+  ##
+  egressRules:
+    # Deny connections to external. This is not compatible with an external database.
+    denyConnectionsToExternal: false
+    ## Additional custom egress rules
+    ## e.g:
+    ## customRules:
+    ##   - to:
+    ##       - namespaceSelector:
+    ##           matchLabels:
+    ##             label: example
+    customRules: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Add network Egress policy rules as it's done in other bitnami charts (ex. MariaDB).

**Benefits**

<!-- What benefits will be realized by the code change? -->
The extension makes it possible to configurer Egress rules in the values with no need to patch the original chart.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
No drawbacks known because by default these extra Egress rules are disabled.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
None

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
