### PR TITLE
[bitnami/mariadb-galera] Improve peer discovering

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 6.0.6
+version: 6.0.7

--- a/bitnami/mariadb-galera/templates/headless-svc.yaml
+++ b/bitnami/mariadb-galera/templates/headless-svc.yaml
@@ -19,4 +19,5 @@ spec:
     - name: sst
       port: 4444
       targetPort: sst
+  publishNotReadyAddresses: true
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Improve peer discovering by publishing not-ready addresses in the headless service.

**Benefits**

Cluster stability

**Possible drawbacks**

None

**Applicable issues**

=  - fixes #8331

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
