### PR TITLE
bitnami/postgresql Render template values inside initDbScripts, resolves #8366

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 10.13.13
+version: 10.13.14

--- a/bitnami/postgresql/templates/initialization-configmap.yaml
+++ b/bitnami/postgresql/templates/initialization-configmap.yaml
@@ -22,7 +22,5 @@ data:
 {{- with .Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql}" }}
 {{ .AsConfig | indent 2 }}
 {{- end }}
-{{- with .Values.initdbScripts }}
-{{ toYaml . | indent 2 }}
-{{- end }}
+{{- include "common.tplvalues.render" (dict "value" .Values.initdbScripts "context" .) | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
**Description of the change**

- fixes #8366

Instead of using toYaml, use common.tplrender helper in order to have option to render chart variables into initDbScripts, like in mongoDb chart
**Benefits**

When implementing initDbScript, user has an option to render chart values if needed

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
