### PR TITLE
[bitnami/RabbitMQ] Allow to set nodePort when type is LoadBalancer for all ports

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.24.11
+version: 8.24.12

--- a/bitnami/rabbitmq/templates/svc.yaml
+++ b/bitnami/rabbitmq/templates/svc.yaml
@@ -75,7 +75,7 @@ spec:
       targetPort: stats
       {{- if eq .Values.service.type "ClusterIP" }}
       nodePort: null
-            {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.managerNodePort)) }}
+      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.managerNodePort)) }}
       nodePort: {{ .Values.service.managerNodePort }}
       {{- end }}
     {{- end }}

--- a/bitnami/rabbitmq/templates/svc.yaml
+++ b/bitnami/rabbitmq/templates/svc.yaml
@@ -58,7 +58,7 @@ spec:
       targetPort: epmd
       {{- if (eq .Values.service.type "ClusterIP") }}
       nodePort: null
-      {{- else if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.epmdNodePort))) }}
+      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.epmdNodePort)) }}
       nodePort: {{ .Values.service.epmdNodePort }}
       {{- end }}
     - name: {{ .Values.service.distPortName }}
@@ -66,7 +66,7 @@ spec:
       targetPort: dist
       {{- if eq .Values.service.type "ClusterIP" }}
       nodePort: null
-      {{- else if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.distNodePort))) }}
+      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.distNodePort)) }}
       nodePort: {{ .Values.service.distNodePort }}
       {{- end }}
     {{- if .Values.service.managerPortEnabled }}
@@ -75,7 +75,7 @@ spec:
       targetPort: stats
       {{- if eq .Values.service.type "ClusterIP" }}
       nodePort: null
-      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.managerNodePort)) }}
+            {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.managerNodePort)) }}
       nodePort: {{ .Values.service.managerNodePort }}
       {{- end }}
     {{- end }}
@@ -85,7 +85,7 @@ spec:
       targetPort: metrics
       {{- if eq .Values.service.type "ClusterIP" }}
       nodePort: null
-      {{- else if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.metricsNodePort))) }}
+      {{- else if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.metricsNodePort)) }}
       nodePort: {{ .Values.service.metricsNodePort }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Allow to set nodePort when type is LoadBalancer for all ports. Fixes issue: #8363

**Benefits**

Fixes issue: #8363

**Possible drawbacks**

None that I know of.

**Applicable issues**

  - fixes #8363

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
