### PR TITLE
[bitnami/influxdb] Changed ownership of /bitnami/influxdb to prevent custom init script initialization error.

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 2.4.4
+version: 2.4.5

--- a/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
+++ b/bitnami/influxdb/templates/influxdb/statefulset-high-availability.yaml
@@ -65,9 +65,9 @@ spec:
               mkdir -p /bitnami/influxdb/{data,meta,wal}
               chmod 700 /bitnami/influxdb/{data,meta,wal}
               {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
-                chown -R `id -u`:`id -G` /bitnami/influxdb/{data,meta,wal}
+                chown -R `id -u`:`id -G` /bitnami/influxdb
               {{- else }}
-                chown -R {{ .Values.influxdb.securityContext.runAsUser }}:{{ .Values.influxdb.securityContext.fsGroup }} /bitnami/influxdb/{data,meta,wal}
+                chown -R {{ .Values.influxdb.securityContext.runAsUser }}:{{ .Values.influxdb.securityContext.fsGroup }} /bitnami/influxdb
               {{- end }}
           {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
           securityContext:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Changed the ownership of /bitnami/influxdb path mounted in influxdb pod initialized in high-availability setup to prevent error relating to custom script initialization problem. 

**Benefits**

<!-- What benefits will be realized by the code change? -->
Providing user-defined initialization scripts no longer causes error in initialization of influxdb pods. 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

When script is inserted using the `influxdb.initdbScripts` parameter, the deployed pod will run the scripts provided and attempted to touch a file `.user_scripts_initialized` to prevent rerun of the provided initialization scripts in the future. 

We are using microk8s on Centos 7. Thus the persistent volume mounted is on the filesystem of the machine. Initially this worked fine with kernel version 3.10.0-957.21.3.el7.x86_64. However it no longer work when kernel was upgraded to 3.10.0-1160.49.1.el7.x86_64, as the pod is attempting to touch a file in a folder not owned by the running user. 

Following is the output for the occurence of such error:

```
influxdb 01:41:11.46
influxdb 01:41:11.47 Welcome to the Bitnami influxdb container
influxdb 01:41:11.47 Subscribe to project updates by watching https://github.com/bitnami/bitnami-docker-influxdb
influxdb 01:41:11.47 Submit issues and feature requests at https://github.com/bitnami/bitnami-docker-influxdb/issues
influxdb 01:41:11.47
influxdb 01:41:11.47 INFO  ==> ** Starting InfluxDB setup **
influxdb 01:41:11.49 WARN  ==> Authentication is disabled over HTTP and HTTPS. For safety reasons, enable it in a production environment.
influxdb 01:41:11.49 WARN  ==> The INFLUXDB_ADMIN_USER environment variable will be ignored since authentication is disabled.
influxdb 01:41:11.49 WARN  ==> The INFLUXDB_USER environment variable will be ignored since authentication is disabled.
influxdb 01:41:11.50 INFO  ==> Initializing InfluxDB...
influxdb 01:41:11.50 INFO  ==> No injected configuration files found. Creating default config files...
influxdb 01:41:11.51 INFO  ==> Deploying InfluxDB from scratch
influxdb 01:41:11.51 INFO  ==> Loading user's custom files from /docker-entrypoint-initdb.d ... 
influxdb 01:41:11.52 INFO  ==> Starting InfluxDB in background...
Hello world (echo-ed from initialization scripts provided)
touch: cannot touch '/bitnami/influxdb/.user_scripts_initialized': Permission denied
influxdb 01:41:12.04 INFO  ==> Stopping InfluxDB...
```
Thus, the /bitnami/influxdb path in the pods must be owned by the running user for the initialization to work. 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
