### PR TITLE
[bitnami/postgresql-ha] Fix default value for pgpool.configuration

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 8.1.0
+version: 8.1.1

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -290,7 +290,7 @@ Additionally, if `persistence.resourcePolicy` is set to `keep`, you should manua
 | `pgpool.connectionLifeTime`                 | The time in seconds to terminate the cached connections to the PostgreSQL backend (PGPOOL_CONNECTION_LIFE_TIME)    | `""`                  |
 | `pgpool.useLoadBalancing`                   | Use Pgpool Load-Balancing                                                                                          | `true`                |
 | `pgpool.loadBalancingOnWrite`               | LoadBalancer on write actions behavior                                                                             | `transaction`         |
-| `pgpool.configuration`                      | Pgpool configuration                                                                                               | `{}`                  |
+| `pgpool.configuration`                      | Pgpool configuration                                                                                               | `""`                  |
 | `pgpool.configurationCM`                    | ConfigMap with Pgpool configuration                                                                                | `""`                  |
 | `pgpool.initdbScripts`                      | Dictionary of initdb scripts                                                                                       | `{}`                  |
 | `pgpool.initdbScriptsCM`                    | ConfigMap with scripts to be run every time Pgpool container is initialized                                        | `""`                  |

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -901,7 +901,7 @@ pgpool:
   ##   port = '5432'
   ##   ...
   ##
-  configuration: {}
+  configuration: ""
   ## @param pgpool.configurationCM ConfigMap with Pgpool configuration
   ## NOTE: This will override pgpool.configuration parameter
   ## The file used must be named `pgpool.conf`


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

The `pgpool.configuration` parameter expects a string instead of a map.

**Benefits**

README.md and default values are aligned with the expected format.

**Possible drawbacks**

None

**Applicable issues**

  - fixes #8375

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
