### PR TITLE
[bitnami/mariadb] change mariadb bind-address to enable IPv6

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 10.1.0
+version: 10.1.1

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -180,7 +180,7 @@ primary:
     socket=/opt/bitnami/mariadb/tmp/mysql.sock
     tmpdir=/opt/bitnami/mariadb/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=::
     pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
     log-error=/opt/bitnami/mariadb/logs/mysqld.log
     character-set-server=UTF8


### PR DESCRIPTION
Signed-off-by: Ioachim Lihor <ioachim.lihor@radcom.com>

**Description of the change**
Change `bind-address` from values.yaml from `0.0.0.0` to `::`

**Benefits**
With this change service could listen on IPv6

**Possible drawbacks**
No possible drawbacks

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
