### PR TITLE
[bitnami/mariadb-galera] change mariadb-galera bind-adrs to enable IPv6

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 6.0.8
+version: 6.0.9

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -319,7 +319,7 @@ mariadbConfiguration: |-
   tmpdir=/opt/bitnami/mariadb/tmp
   socket=/opt/bitnami/mariadb/tmp/mysql.sock
   pid_file=/opt/bitnami/mariadb/tmp/mysqld.pid
-  bind_address=0.0.0.0
+  bind_address=::
 
   ## Character set
   ##


### PR DESCRIPTION
Signed-off-by: Ioachim Lihor <ioachim.lihor@radcom.com>

**Description of the change**
Change bind-address from values.yaml from `0.0.0.0` to `::`

**Benefits**
With this change service could listen on IPv6

**Possible drawbacks**
No possible drawbacks

**Applicable issues**

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
