### PR TITLE
bitnami/wavefront Add Log4j workaround to proxy

### DIFF
--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 3.1.18
+version: 3.1.19

--- a/bitnami/wavefront/templates/proxy-deployment.yaml
+++ b/bitnami/wavefront/templates/proxy-deployment.yaml
@@ -71,6 +71,8 @@ spec:
             runAsNonRoot: {{ .Values.proxy.containerSecurityContext.runAsNonRoot }}
           {{- end }}
           env:
+            - name: JAVA_ARGS
+              value: "-Dlog4j2.formatMsgNoLookups=true"
             - name: WAVEFRONT_URL
               value: {{ .Values.wavefront.url }}/api
             - name: WAVEFRONT_TOKEN


### PR DESCRIPTION
Signed-off-by: Helen Shao <shaoh@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Just the wavefront `proxy-deployment.yaml` template file for `bitnami/wavefront`

**Benefits**

Address Log4j vulnerability https://community.pivotal.io/s/article/Workaround-instructions-to-address-CVE-2021-44228-in-Tanzu-Observability-Proxy?language=en_US

**Possible drawbacks**

Just a workaround until a new proxy image is released

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md - N/A
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
