### PR TITLE
[bitnami/postgresql-ha] Default pgpool reserved_connections to 1

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 8.1.2
+version: 8.1.3

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 8.1.1
+version: 8.1.2

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -204,104 +204,105 @@ Additionally, if `persistence.resourcePolicy` is set to `keep`, you should manua
 
 ### Pgpool parameters
 
-| Name                                        | Description                                                                                                        | Value                 |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------- |
-| `pgpoolImage.registry`                      | Pgpool image registry                                                                                              | `docker.io`           |
-| `pgpoolImage.repository`                    | Pgpool image repository                                                                                            | `bitnami/pgpool`      |
-| `pgpoolImage.tag`                           | Pgpool image tag                                                                                                   | `4.2.6-debian-10-r11` |
-| `pgpoolImage.pullPolicy`                    | Pgpool image pull policy                                                                                           | `IfNotPresent`        |
-| `pgpoolImage.pullSecrets`                   | Specify docker-registry secret names as an array                                                                   | `[]`                  |
-| `pgpoolImage.debug`                         | Specify if debug logs should be enabled                                                                            | `false`               |
-| `pgpool.customUsers`                        | Additional users that will be performing connections to the database using                                         | `{}`                  |
-| `pgpool.usernames`                          | Comma or semicolon separated list of postgres usernames                                                            | `""`                  |
-| `pgpool.passwords`                          | Comma or semicolon separated list of the associated passwords for the users above                                  | `""`                  |
-| `pgpool.hostAliases`                        | Deployment pod host aliases                                                                                        | `[]`                  |
-| `pgpool.customUsersSecret`                  | Name of a secret containing the usernames and passwords of accounts that will be added to pgpool_passwd            | `""`                  |
-| `pgpool.srCheckDatabase`                    | Name of the database to perform streaming replication checks                                                       | `postgres`            |
-| `pgpool.labels`                             | Labels to add to the Deployment. Evaluated as template                                                             | `{}`                  |
-| `pgpool.podLabels`                          | Labels to add to the pods. Evaluated as template                                                                   | `{}`                  |
-| `pgpool.serviceLabels`                      | Labels to add to the service. Evaluated as template                                                                | `{}`                  |
-| `pgpool.customLivenessProbe`                | Override default liveness probe                                                                                    | `{}`                  |
-| `pgpool.customReadinessProbe`               | Override default readiness probe                                                                                   | `{}`                  |
-| `pgpool.customStartupProbe`                 | Override default startup probe                                                                                     | `{}`                  |
-| `pgpool.command`                            | Override default container command (useful when using custom images)                                               | `[]`                  |
-| `pgpool.args`                               | Override default container args (useful when using custom images)                                                  | `[]`                  |
-| `pgpool.lifecycleHooks`                     | LifecycleHook to set additional configuration at startup, e.g. LDAP settings via REST API. Evaluated as a template | `{}`                  |
-| `pgpool.extraEnvVars`                       | Array containing extra environment variables                                                                       | `[]`                  |
-| `pgpool.extraEnvVarsCM`                     | ConfigMap with extra environment variables                                                                         | `""`                  |
-| `pgpool.extraEnvVarsSecret`                 | Secret with extra environment variables                                                                            | `""`                  |
-| `pgpool.extraVolumes`                       | Extra volumes to add to the deployment                                                                             | `[]`                  |
-| `pgpool.extraVolumeMounts`                  | Extra volume mounts to add to the container. Normally used with `extraVolumes`                                     | `[]`                  |
-| `pgpool.initContainers`                     | Extra init containers to add to the deployment                                                                     | `[]`                  |
-| `pgpool.sidecars`                           | Extra sidecar containers to add to the deployment                                                                  | `[]`                  |
-| `pgpool.replicaCount`                       | The number of replicas to deploy                                                                                   | `1`                   |
-| `pgpool.podAnnotations`                     | Additional pod annotations                                                                                         | `{}`                  |
-| `pgpool.priorityClassName`                  | Pod priority class                                                                                                 | `""`                  |
-| `pgpool.podAffinityPreset`                  | Pgpool pod affinity preset. Ignored if `pgpool.affinity` is set. Allowed values: `soft` or `hard`                  | `""`                  |
-| `pgpool.podAntiAffinityPreset`              | Pgpool pod anti-affinity preset. Ignored if `pgpool.affinity` is set. Allowed values: `soft` or `hard`             | `soft`                |
-| `pgpool.nodeAffinityPreset.type`            | Pgpool node affinity preset type. Ignored if `pgpool.affinity` is set. Allowed values: `soft` or `hard`            | `""`                  |
-| `pgpool.nodeAffinityPreset.key`             | Pgpool node label key to match Ignored if `pgpool.affinity` is set.                                                | `""`                  |
-| `pgpool.nodeAffinityPreset.values`          | Pgpool node label values to match. Ignored if `pgpool.affinity` is set.                                            | `[]`                  |
-| `pgpool.affinity`                           | Affinity for Pgpool pods assignment                                                                                | `{}`                  |
-| `pgpool.nodeSelector`                       | Node labels for Pgpool pods assignment                                                                             | `{}`                  |
-| `pgpool.tolerations`                        | Tolerations for Pgpool pods assignment                                                                             | `[]`                  |
-| `pgpool.securityContext.enabled`            | Enable security context for Pgpool                                                                                 | `true`                |
-| `pgpool.securityContext.fsGroup`            | Group ID for the Pgpool filesystem                                                                                 | `1001`                |
-| `pgpool.containerSecurityContext.enabled`   | Enable container security context                                                                                  | `true`                |
-| `pgpool.containerSecurityContext.runAsUser` | User ID for the Pgpool container                                                                                   | `1001`                |
-| `pgpool.resources.limits`                   | The resources limits for the container                                                                             | `{}`                  |
-| `pgpool.resources.requests`                 | The requested resources for the container                                                                          | `{}`                  |
-| `pgpool.livenessProbe.enabled`              | Enable livenessProbe                                                                                               | `true`                |
-| `pgpool.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                            | `30`                  |
-| `pgpool.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                   | `10`                  |
-| `pgpool.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                  | `5`                   |
-| `pgpool.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                | `5`                   |
-| `pgpool.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                | `1`                   |
-| `pgpool.readinessProbe.enabled`             | Enable readinessProbe                                                                                              | `true`                |
-| `pgpool.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                           | `5`                   |
-| `pgpool.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                  | `5`                   |
-| `pgpool.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                 | `5`                   |
-| `pgpool.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                               | `5`                   |
-| `pgpool.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                               | `1`                   |
-| `pgpool.startupProbe.enabled`               | Enable startupProbe                                                                                                | `false`               |
-| `pgpool.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                             | `5`                   |
-| `pgpool.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                                    | `10`                  |
-| `pgpool.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                                   | `5`                   |
-| `pgpool.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                                 | `10`                  |
-| `pgpool.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                                 | `1`                   |
-| `pgpool.pdb.create`                         | Specifies whether a Pod disruption budget should be created for Pgpool pods                                        | `false`               |
-| `pgpool.pdb.minAvailable`                   | Minimum number / percentage of pods that should remain scheduled                                                   | `1`                   |
-| `pgpool.pdb.maxUnavailable`                 | Maximum number / percentage of pods that may be made unavailable                                                   | `""`                  |
-| `pgpool.updateStrategy`                     | Strategy used to replace old Pods by new ones                                                                      | `{}`                  |
-| `pgpool.containerPort`                      | Pgpool port                                                                                                        | `5432`                |
-| `pgpool.minReadySeconds`                    | How many seconds a pod needs to be ready before killing the next, during update                                    | `""`                  |
-| `pgpool.adminUsername`                      | Pgpool Admin username                                                                                              | `admin`               |
-| `pgpool.adminPassword`                      | Pgpool Admin password                                                                                              | `""`                  |
-| `pgpool.logConnections`                     | Log all client connections (PGPOOL_ENABLE_LOG_CONNECTIONS)                                                         | `false`               |
-| `pgpool.logHostname`                        | Log the client hostname instead of IP address (PGPOOL_ENABLE_LOG_HOSTNAME)                                         | `true`                |
-| `pgpool.logPerNodeStatement`                | Log every SQL statement for each DB node separately (PGPOOL_ENABLE_LOG_PER_NODE_STATEMENT)                         | `false`               |
-| `pgpool.logLinePrefix`                      | Format of the log entry lines (PGPOOL_LOG_LINE_PREFIX)                                                             | `""`                  |
-| `pgpool.clientMinMessages`                  | Log level for clients                                                                                              | `error`               |
-| `pgpool.numInitChildren`                    | The number of preforked Pgpool-II server processes. It is also the concurrent                                      | `""`                  |
-| `pgpool.maxPool`                            | The maximum number of cached connections in each child process (PGPOOL_MAX_POOL)                                   | `""`                  |
-| `pgpool.childMaxConnections`                | The maximum number of client connections in each child process (PGPOOL_CHILD_MAX_CONNECTIONS)                      | `""`                  |
-| `pgpool.childLifeTime`                      | The time in seconds to terminate a Pgpool-II child process if it remains idle (PGPOOL_CHILD_LIFE_TIME)             | `""`                  |
-| `pgpool.clientIdleLimit`                    | The time in seconds to disconnect a client if it remains idle since the last query (PGPOOL_CLIENT_IDLE_LIMIT)      | `""`                  |
-| `pgpool.connectionLifeTime`                 | The time in seconds to terminate the cached connections to the PostgreSQL backend (PGPOOL_CONNECTION_LIFE_TIME)    | `""`                  |
-| `pgpool.useLoadBalancing`                   | Use Pgpool Load-Balancing                                                                                          | `true`                |
-| `pgpool.loadBalancingOnWrite`               | LoadBalancer on write actions behavior                                                                             | `transaction`         |
-| `pgpool.configuration`                      | Pgpool configuration                                                                                               | `""`                  |
-| `pgpool.configurationCM`                    | ConfigMap with Pgpool configuration                                                                                | `""`                  |
-| `pgpool.initdbScripts`                      | Dictionary of initdb scripts                                                                                       | `{}`                  |
-| `pgpool.initdbScriptsCM`                    | ConfigMap with scripts to be run every time Pgpool container is initialized                                        | `""`                  |
-| `pgpool.initdbScriptsSecret`                | Secret with scripts to be run every time Pgpool container is initialized                                           | `""`                  |
-| `pgpool.tls.enabled`                        | Enable TLS traffic support for end-client connections                                                              | `false`               |
-| `pgpool.tls.autoGenerated`                  | Create self-signed TLS certificates. Currently only supports PEM certificates                                      | `false`               |
-| `pgpool.tls.preferServerCiphers`            | Whether to use the server's TLS cipher preferences rather than the client's                                        | `true`                |
-| `pgpool.tls.certificatesSecret`             | Name of an existing secret that contains the certificates                                                          | `""`                  |
-| `pgpool.tls.certFilename`                   | Certificate filename                                                                                               | `""`                  |
-| `pgpool.tls.certKeyFilename`                | Certificate key filename                                                                                           | `""`                  |
-| `pgpool.tls.certCAFilename`                 | CA Certificate filename                                                                                            | `""`                  |
+| Name                                        | Description                                                                                                                              | Value                 |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `pgpoolImage.registry`                      | Pgpool image registry                                                                                                                    | `docker.io`           |
+| `pgpoolImage.repository`                    | Pgpool image repository                                                                                                                  | `bitnami/pgpool`      |
+| `pgpoolImage.tag`                           | Pgpool image tag                                                                                                                         | `4.2.6-debian-10-r11` |
+| `pgpoolImage.pullPolicy`                    | Pgpool image pull policy                                                                                                                 | `IfNotPresent`        |
+| `pgpoolImage.pullSecrets`                   | Specify docker-registry secret names as an array                                                                                         | `[]`                  |
+| `pgpoolImage.debug`                         | Specify if debug logs should be enabled                                                                                                  | `false`               |
+| `pgpool.customUsers`                        | Additional users that will be performing connections to the database using                                                               | `{}`                  |
+| `pgpool.usernames`                          | Comma or semicolon separated list of postgres usernames                                                                                  | `""`                  |
+| `pgpool.passwords`                          | Comma or semicolon separated list of the associated passwords for the users above                                                        | `""`                  |
+| `pgpool.hostAliases`                        | Deployment pod host aliases                                                                                                              | `[]`                  |
+| `pgpool.customUsersSecret`                  | Name of a secret containing the usernames and passwords of accounts that will be added to pgpool_passwd                                  | `""`                  |
+| `pgpool.srCheckDatabase`                    | Name of the database to perform streaming replication checks                                                                             | `postgres`            |
+| `pgpool.labels`                             | Labels to add to the Deployment. Evaluated as template                                                                                   | `{}`                  |
+| `pgpool.podLabels`                          | Labels to add to the pods. Evaluated as template                                                                                         | `{}`                  |
+| `pgpool.serviceLabels`                      | Labels to add to the service. Evaluated as template                                                                                      | `{}`                  |
+| `pgpool.customLivenessProbe`                | Override default liveness probe                                                                                                          | `{}`                  |
+| `pgpool.customReadinessProbe`               | Override default readiness probe                                                                                                         | `{}`                  |
+| `pgpool.customStartupProbe`                 | Override default startup probe                                                                                                           | `{}`                  |
+| `pgpool.command`                            | Override default container command (useful when using custom images)                                                                     | `[]`                  |
+| `pgpool.args`                               | Override default container args (useful when using custom images)                                                                        | `[]`                  |
+| `pgpool.lifecycleHooks`                     | LifecycleHook to set additional configuration at startup, e.g. LDAP settings via REST API. Evaluated as a template                       | `{}`                  |
+| `pgpool.extraEnvVars`                       | Array containing extra environment variables                                                                                             | `[]`                  |
+| `pgpool.extraEnvVarsCM`                     | ConfigMap with extra environment variables                                                                                               | `""`                  |
+| `pgpool.extraEnvVarsSecret`                 | Secret with extra environment variables                                                                                                  | `""`                  |
+| `pgpool.extraVolumes`                       | Extra volumes to add to the deployment                                                                                                   | `[]`                  |
+| `pgpool.extraVolumeMounts`                  | Extra volume mounts to add to the container. Normally used with `extraVolumes`                                                           | `[]`                  |
+| `pgpool.initContainers`                     | Extra init containers to add to the deployment                                                                                           | `[]`                  |
+| `pgpool.sidecars`                           | Extra sidecar containers to add to the deployment                                                                                        | `[]`                  |
+| `pgpool.replicaCount`                       | The number of replicas to deploy                                                                                                         | `1`                   |
+| `pgpool.podAnnotations`                     | Additional pod annotations                                                                                                               | `{}`                  |
+| `pgpool.priorityClassName`                  | Pod priority class                                                                                                                       | `""`                  |
+| `pgpool.podAffinityPreset`                  | Pgpool pod affinity preset. Ignored if `pgpool.affinity` is set. Allowed values: `soft` or `hard`                                        | `""`                  |
+| `pgpool.podAntiAffinityPreset`              | Pgpool pod anti-affinity preset. Ignored if `pgpool.affinity` is set. Allowed values: `soft` or `hard`                                   | `soft`                |
+| `pgpool.nodeAffinityPreset.type`            | Pgpool node affinity preset type. Ignored if `pgpool.affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                  |
+| `pgpool.nodeAffinityPreset.key`             | Pgpool node label key to match Ignored if `pgpool.affinity` is set.                                                                      | `""`                  |
+| `pgpool.nodeAffinityPreset.values`          | Pgpool node label values to match. Ignored if `pgpool.affinity` is set.                                                                  | `[]`                  |
+| `pgpool.affinity`                           | Affinity for Pgpool pods assignment                                                                                                      | `{}`                  |
+| `pgpool.nodeSelector`                       | Node labels for Pgpool pods assignment                                                                                                   | `{}`                  |
+| `pgpool.tolerations`                        | Tolerations for Pgpool pods assignment                                                                                                   | `[]`                  |
+| `pgpool.securityContext.enabled`            | Enable security context for Pgpool                                                                                                       | `true`                |
+| `pgpool.securityContext.fsGroup`            | Group ID for the Pgpool filesystem                                                                                                       | `1001`                |
+| `pgpool.containerSecurityContext.enabled`   | Enable container security context                                                                                                        | `true`                |
+| `pgpool.containerSecurityContext.runAsUser` | User ID for the Pgpool container                                                                                                         | `1001`                |
+| `pgpool.resources.limits`                   | The resources limits for the container                                                                                                   | `{}`                  |
+| `pgpool.resources.requests`                 | The requested resources for the container                                                                                                | `{}`                  |
+| `pgpool.livenessProbe.enabled`              | Enable livenessProbe                                                                                                                     | `true`                |
+| `pgpool.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                                  | `30`                  |
+| `pgpool.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                                         | `10`                  |
+| `pgpool.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                                        | `5`                   |
+| `pgpool.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                                      | `5`                   |
+| `pgpool.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                                      | `1`                   |
+| `pgpool.readinessProbe.enabled`             | Enable readinessProbe                                                                                                                    | `true`                |
+| `pgpool.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                                 | `5`                   |
+| `pgpool.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                                        | `5`                   |
+| `pgpool.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                                       | `5`                   |
+| `pgpool.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                                     | `5`                   |
+| `pgpool.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                                     | `1`                   |
+| `pgpool.startupProbe.enabled`               | Enable startupProbe                                                                                                                      | `false`               |
+| `pgpool.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                                                   | `5`                   |
+| `pgpool.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                                                          | `10`                  |
+| `pgpool.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                                                         | `5`                   |
+| `pgpool.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                                                       | `10`                  |
+| `pgpool.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                                                       | `1`                   |
+| `pgpool.pdb.create`                         | Specifies whether a Pod disruption budget should be created for Pgpool pods                                                              | `false`               |
+| `pgpool.pdb.minAvailable`                   | Minimum number / percentage of pods that should remain scheduled                                                                         | `1`                   |
+| `pgpool.pdb.maxUnavailable`                 | Maximum number / percentage of pods that may be made unavailable                                                                         | `""`                  |
+| `pgpool.updateStrategy`                     | Strategy used to replace old Pods by new ones                                                                                            | `{}`                  |
+| `pgpool.containerPort`                      | Pgpool port                                                                                                                              | `5432`                |
+| `pgpool.minReadySeconds`                    | How many seconds a pod needs to be ready before killing the next, during update                                                          | `""`                  |
+| `pgpool.adminUsername`                      | Pgpool Admin username                                                                                                                    | `admin`               |
+| `pgpool.adminPassword`                      | Pgpool Admin password                                                                                                                    | `""`                  |
+| `pgpool.logConnections`                     | Log all client connections (PGPOOL_ENABLE_LOG_CONNECTIONS)                                                                               | `false`               |
+| `pgpool.logHostname`                        | Log the client hostname instead of IP address (PGPOOL_ENABLE_LOG_HOSTNAME)                                                               | `true`                |
+| `pgpool.logPerNodeStatement`                | Log every SQL statement for each DB node separately (PGPOOL_ENABLE_LOG_PER_NODE_STATEMENT)                                               | `false`               |
+| `pgpool.logLinePrefix`                      | Format of the log entry lines (PGPOOL_LOG_LINE_PREFIX)                                                                                   | `""`                  |
+| `pgpool.clientMinMessages`                  | Log level for clients                                                                                                                    | `error`               |
+| `pgpool.numInitChildren`                    | The number of preforked Pgpool-II server processes. It is also the concurrent                                                            | `""`                  |
+| `pgpool.reservedConnections`                | Number of reserved connections. When zero, excess connection block. When non-zero, excess connections are refused with an error message. | `1`                   |
+| `pgpool.maxPool`                            | The maximum number of cached connections in each child process (PGPOOL_MAX_POOL)                                                         | `""`                  |
+| `pgpool.childMaxConnections`                | The maximum number of client connections in each child process (PGPOOL_CHILD_MAX_CONNECTIONS)                                            | `""`                  |
+| `pgpool.childLifeTime`                      | The time in seconds to terminate a Pgpool-II child process if it remains idle (PGPOOL_CHILD_LIFE_TIME)                                   | `""`                  |
+| `pgpool.clientIdleLimit`                    | The time in seconds to disconnect a client if it remains idle since the last query (PGPOOL_CLIENT_IDLE_LIMIT)                            | `""`                  |
+| `pgpool.connectionLifeTime`                 | The time in seconds to terminate the cached connections to the PostgreSQL backend (PGPOOL_CONNECTION_LIFE_TIME)                          | `""`                  |
+| `pgpool.useLoadBalancing`                   | Use Pgpool Load-Balancing                                                                                                                | `true`                |
+| `pgpool.loadBalancingOnWrite`               | LoadBalancer on write actions behavior                                                                                                   | `transaction`         |
+| `pgpool.configuration`                      | Pgpool configuration                                                                                                                     | `""`                  |
+| `pgpool.configurationCM`                    | ConfigMap with Pgpool configuration                                                                                                      | `""`                  |
+| `pgpool.initdbScripts`                      | Dictionary of initdb scripts                                                                                                             | `{}`                  |
+| `pgpool.initdbScriptsCM`                    | ConfigMap with scripts to be run every time Pgpool container is initialized                                                              | `""`                  |
+| `pgpool.initdbScriptsSecret`                | Secret with scripts to be run every time Pgpool container is initialized                                                                 | `""`                  |
+| `pgpool.tls.enabled`                        | Enable TLS traffic support for end-client connections                                                                                    | `false`               |
+| `pgpool.tls.autoGenerated`                  | Create self-signed TLS certificates. Currently only supports PEM certificates                                                            | `false`               |
+| `pgpool.tls.preferServerCiphers`            | Whether to use the server's TLS cipher preferences rather than the client's                                                              | `true`                |
+| `pgpool.tls.certificatesSecret`             | Name of an existing secret that contains the certificates                                                                                | `""`                  |
+| `pgpool.tls.certFilename`                   | Certificate filename                                                                                                                     | `""`                  |
+| `pgpool.tls.certKeyFilename`                | Certificate key filename                                                                                                                 | `""`                  |
+| `pgpool.tls.certCAFilename`                 | CA Certificate filename                                                                                                                  | `""`                  |
 
 
 ### LDAP parameters

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -223,7 +223,6 @@ spec:
             - name: PGPOOL_NUM_INIT_CHILDREN
               value: {{ .Values.pgpool.numInitChildren | quote }}
             {{- end }}
-            # .Values.pgpool.reservedConnections: {{ .Values.pgpool.reservedConnections }}
             {{- if .Values.pgpool.reservedConnections }}
             - name: PGPOOL_RESERVED_CONNECTIONS
               value: '{{ .Values.pgpool.reservedConnections }}'

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -223,6 +223,11 @@ spec:
             - name: PGPOOL_NUM_INIT_CHILDREN
               value: {{ .Values.pgpool.numInitChildren | quote }}
             {{- end }}
+            # .Values.pgpool.reservedConnections: {{ .Values.pgpool.reservedConnections }}
+            {{- if .Values.pgpool.reservedConnections }}
+            - name: PGPOOL_RESERVED_CONNECTIONS
+              value: '{{ .Values.pgpool.reservedConnections }}'
+            {{- end }}
             {{- if .Values.pgpool.maxPool }}
             - name: PGPOOL_MAX_POOL
               value: {{ .Values.pgpool.maxPool | quote }}

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -863,10 +863,12 @@ pgpool:
   ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
   ##
   numInitChildren: ""
-  ## @param pgpool.reservedConnections When this parameter is set to 1 or greater, incoming connections from clients
-  ## are not accepted with error message "Sorry, too many clients already", rather than blocked if the number of current
-  ## connections from clients is more than (num_init_children - reserved_connections).
+  ## @param pgpool.reservedConnections Number of reserved connections. When zero, excess connection block. When non-zero, excess connections are refused with an error message.
+  ## When this parameter is set to 1 or greater, incoming connections from clients are not accepted with error message
+  ## "Sorry, too many clients already", rather than blocked if the number of current connections from clients is more than
+  ## (num_init_children - reserved_connections).
   ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ##
   reservedConnections: 1
 
   ## @param pgpool.maxPool The maximum number of cached connections in each child process (PGPOOL_MAX_POOL)

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -863,6 +863,12 @@ pgpool:
   ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
   ##
   numInitChildren: ""
+  ## @param pgpool.reservedConnections When this parameter is set to 1 or greater, incoming connections from clients
+  ## are not accepted with error message "Sorry, too many clients already", rather than blocked if the number of current
+  ## connections from clients is more than (num_init_children - reserved_connections).
+  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  reservedConnections: 1
+
   ## @param pgpool.maxPool The maximum number of cached connections in each child process (PGPOOL_MAX_POOL)
   ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Default to setting reserved_connections to 1 in pgpool.conf.

See [here](https://www.pgpool.net/docs/latest/en/html/runtime-config-connection.html#GUC-RESERVED-CONNECTIONS) for documentation on this property.

**Benefits**

When this property is set to 0 (as is default), pgpool blocks excess connections. This results in the readiness/liveness probes for pgpool failing with a timeout and no errors in the logs. When this property is set to 1, pgpool instead rejects the connection with an informative error message in the pod events, as well as the logs. This makes the problem much more obvious, as well as allows for log monitoring to scan for this message and alert if found.

**Possible drawbacks**

As the name implies, one fewer connection is allowed, but users can increase numInitChildren by 1 to compensate.

**Applicable issues**

See [This comment](https://github.com/bitnami/charts/issues/6094#issuecomment-991395399) for context

**Additional information**

This depends on [This PR](https://github.com/bitnami/bitnami-docker-pgpool/pull/73)

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
