### PR TITLE
[bitnami/thanos] fix auto Generated certificate 

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 8.2.1
+version: 8.2.2

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 8.2.2
+version: 8.2.3

--- a/bitnami/thanos/templates/query/grpc-client-tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/grpc-client-tls-secrets.yaml
@@ -20,7 +20,7 @@ data:
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
   tls-cert: {{ $cert.Cert | b64enc | quote }}
   tls-key: {{ $cert.Key | b64enc | quote }}
-  ca-crt: {{ $ca.Cert | b64enc | quote }}
+  ca-cert: {{ $ca.Cert | b64enc | quote }}
   {{- else }}
   tls-cert: {{ .Values.query.grpc.client.tls.cert | b64enc | quote }}
   tls-key: {{ .Values.query.grpc.client.tls.key | b64enc | quote }}

--- a/bitnami/thanos/templates/query/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/grpc-server-tls-secrets.yaml
@@ -18,7 +18,7 @@ data:
   {{- $ca := genCA "thanos-query-grpc-server-ca" 365 }}
   {{- $hostname := printf "%s-query-grpc-server" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  tls-crt: {{ $cert.Cert | b64enc | quote }}
+  tls-cert: {{ $cert.Cert | b64enc | quote }}
   tls-key: {{ $cert.Key | b64enc | quote }}
   ca-cert: {{ $ca.Cert | b64enc | quote }}
   {{- else }}

--- a/bitnami/thanos/templates/receive/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/receive/grpc-server-tls-secrets.yaml
@@ -19,7 +19,7 @@ data:
   {{- $ca := genCA "thanos-receive-grpc-server-ca" 365 }}
   {{- $hostname := printf "%s-receive-grpc-server" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  tls-crt: {{ $cert.Cert | b64enc | quote }}
+  tls-cert: {{ $cert.Cert | b64enc | quote }}
   tls-key: {{ $cert.Key | b64enc | quote }}
   ca-cert: {{ $ca.Cert | b64enc | quote }}
   {{- else }}


### PR DESCRIPTION
when it creates the certificate its missing a E in the secret

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
