### PR TITLE
[bitnami/rabbitmq-cluster-operator] Use consistent labeling and label selectors

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 2.0.7
+version: 2.0.8

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/servicemonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/servicemonitor.yaml
@@ -4,6 +4,8 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "rmqco.clusterOperator.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: rabbitmq-operator
+    app.kubernetes.io/part-of: rabbitmq
     {{- if .Values.clusterOperator.metrics.serviceMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
@@ -19,7 +21,6 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: rabbitmq-operator
-      app.kubernetes.io/part-of: rabbitmq
       {{- if .Values.clusterOperator.metrics.serviceMonitor.selector }}
       {{- include "common.tplvalues.render" ( dict "value" .Values.clusterOperator.metrics.serviceMonitor.selector "context" $ ) | nindent 6 }}
       {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -27,6 +27,7 @@ spec:
       {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: messaging-topology-operator
+        app.kubernetes.io/part-of: rabbitmq
         {{- if .Values.msgTopologyOperator.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
@@ -49,5 +49,4 @@ spec:
     {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: messaging-topology-operator
-    app.kubernetes.io/part-of: rabbitmq
 {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
@@ -4,6 +4,8 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "rmqco.msgTopologyOperator.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: messaging-topology-operator
+    app.kubernetes.io/part-of: rabbitmq
     {{- if .Values.msgTopologyOperator.metrics.serviceMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
@@ -19,7 +21,6 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: messaging-topology-operator
-      app.kubernetes.io/part-of: rabbitmq
       # We need an extra label for the ServiceMonitor to scrape it correctly
       type: metrics
       {{- if .Values.msgTopologyOperator.metrics.serviceMonitor.selector }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add `app.kubernetes.io/component` and `app.kubernetes.io/part-of` labels where they were missing and remove the `app.kubernetes.io/part-of` label from a few label selectors.

**Benefits**

Labels on all manifests are now consistent throughout the chart. The `app.kubernetes.io/part-of` label has no additional benefit or difference on label selectors, so I removed it to make them all consistent.

**Applicable issues**

Due to the inconsistencies of labeling and label selectors, the messaging topology operator metrics service and service monitor didn't match and no metrics were scraped for it.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name
