### PR TITLE
[bitnami/rabbitmq-cluster-operator] Fix messaging-topology-operator pod affinities

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 2.0.6
+version: 2.0.7

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -46,8 +46,8 @@ spec:
       affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.msgTopologyOperator.affinity "context" $) | nindent 8 }}
       {{- else }}
       affinity:
-        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.msgTopologyOperator.podAffinityPreset "component" "rabbitmq-operator" "context" $) | nindent 10 }}
-        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.msgTopologyOperator.podAntiAffinityPreset "component" "rabbitmq-operator" "context" $) | nindent 10 }}
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.msgTopologyOperator.podAffinityPreset "component" "messaging-topology-operator" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.msgTopologyOperator.podAntiAffinityPreset "component" "messaging-topology-operator" "context" $) | nindent 10 }}
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.msgTopologyOperator.nodeAffinityPreset.type "key" .Values.msgTopologyOperator.nodeAffinityPreset.key "values" .Values.msgTopologyOperator.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.msgTopologyOperator.nodeSelector }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Use the correct component name for pod affinities on the `message-topology-operator` deployment.

**Benefits**

When deploying the operators in HA, the `message-topology-operator` will now spread over different nodes to each other instead of having and anti-affinity by default to the `rabbitmq-cluster-operator`.

**Possible drawbacks**

This change will update the default pod anti-affinity of the `messaging-topology-operator` deployment. If anyone has adapted the affinities due to this bug, they can remove their changes.

If anyone is using the pod affinity preset to co-locate the `messaging-topology-operator` with the `rabbitmq-cluster-operator` pods, this will not be possible anymore. But IMHO it's not the intended case.

**Additional information**

RFC: Should the component name of the affinity/anti-affinity presets be configurable in the case of having multiple components in one chart?

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name
