### PR TITLE
[bitnami/rabbitmq-cluster-operator] Remove namespace from cluster-scoped resources

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 2.0.9
+version: 2.0.10

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/clusterrole.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/clusterrole.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.clusterOperator.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/clusterrolebinding.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/clusterrolebinding.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.clusterOperator.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.msgTopologyOperator.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrolebinding.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrolebinding.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.msgTopologyOperator.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Remove the namespace from non-namespaced cluster-scoped resources.

**Applicable issues**

Most of the tooling ignores the namespace on cluster-scoped resources. But the [GitLab Kubernetes Agent](https://docs.gitlab.com/ee/user/clusters/agent/) where I use `helm template` to render the chart and use it within the GitOps workflow of the agent is very strict and fails with namespaces defined on cluster-scoped resources.

```
{"level":"error","time":"2021-12-14T13:39:32.245Z","msg":"Failed to decode GitOps objects","mod_name":"gitops","project_id":"<redacted>/manifests","agent_id":<redacted>,"error":"resource is cluster-scoped but has a non-empty namespace \"rabbitmq-operator\"","commit_id":"<redacted>"}
```

Meta issue: #8414

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name
