### PR TITLE
[bitnami/mongodb] Fix deprecated 'IP Address in the DNS Name field on certificate' when using tls

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.30.6
+version: 10.30.7

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -153,7 +153,6 @@ spec:
               DNS.2 = $my_hostname
               DNS.3 = $my_hostname.$svc.$MY_POD_NAMESPACE.svc.{{ .Values.clusterDomain }}
               DNS.4 = localhost
-              DNS.5 = 127.0.0.1
               {{- if .Values.tls.extraDnsNames }}
               {{- range $key, $dnsName := .Values.tls.extraDnsNames }}
               {{ $key }} = {{ $dnsName }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -193,8 +193,8 @@ tls:
     pullPolicy: IfNotPresent
   ## e.g:
   ## extraDnsNames
-  ##   "DNS.6": "$my_host"
-  ##   "DNS.7": "$test"
+  ##   "DNS.5": "$my_host"
+  ##   "DNS.6": "$test"
   ##
   extraDnsNames: []
   ## @param tls.mode Allows to set the tls mode which should be used when tls is enabled (options: `allowTLS`, `preferTLS`, `requireTLS`)


### PR DESCRIPTION
**Description of the change**

Using MongoDB shell version v5.0.5 and MongoDB shell version v4.4.10, a warning is issued when you try to connect to a cluster using TLS autogenerated certs.

`{"t":{"$date":"2021-12-14T17:21:50.482Z"},"s":"W",  "c":"NETWORK",  "id":23237,   "ctx":"js","msg":"You have an IP Address in the DNS Name field on your certificate. This formulation is deprecated."}`

This is painfull when you use mongoshell for scripting as we can't disable this warning (even with `--quiet` option).

**Benefits**

Removing `127.0.0.1` in default generation `alt_names` seems to resolve this 'un-mutable' warning.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
