### PR TITLE
[bitnami/grafana] add extraEnvVars for image-renderer

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 7.3.0
+version: 7.4.0

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -349,6 +349,7 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | `imageRenderer.nodeAffinityPreset.type`              | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`                             |
 | `imageRenderer.nodeAffinityPreset.key`               | Node label key to match Ignored if `affinity` is set.                                                   | `""`                             |
 | `imageRenderer.nodeAffinityPreset.values`            | Node label values to match. Ignored if `affinity` is set.                                               | `[]`                             |
+| `imageRenderer.extraEnvVars`                         | Array containing extra env vars to configure Grafana                                                    | `{}`                             |
 | `imageRenderer.affinity`                             | Affinity for pod assignment                                                                             | `{}`                             |
 | `imageRenderer.resources.limits`                     | The resources limits for Grafana containers                                                             | `{}`                             |
 | `imageRenderer.resources.requests`                   | The requested resources for Grafana containers                                                          | `{}`                             |

--- a/bitnami/grafana/templates/image-renderer-deployment.yaml
+++ b/bitnami/grafana/templates/image-renderer-deployment.yaml
@@ -90,6 +90,9 @@ spec:
               value: "0.0.0.0"
             - name: ENABLE_METRICS
               value: {{ ternary "true" "false" .Values.imageRenderer.metrics.enabled | quote }}
+            {{- if .Values.imageRenderer.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.imageRenderer.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -767,6 +767,13 @@ imageRenderer:
     ##   - e2e-az2
     ##
     values: []
+  ## @param imageRenderer.extraEnvVars Array containing extra env vars to configure Grafana
+  ## For example:
+  ## extraEnvVars:
+  ##  - name: GF_DEFAULT_INSTANCE_NAME
+  ##    value: my-instance
+  ##
+  extraEnvVars: {}
   ## @param imageRenderer.affinity Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set


### PR DESCRIPTION
Signed-off-by: Ioachim Lihor <ioachim.lihor@radcom.com>

**Description of the change**
In order to use image-renderer configuration environment variables it's needed to use extraEnvVars to chart.
re. [Image Renderer Configuration](https://grafana.com/docs/grafana/latest/image-rendering/#configuration) 
For this I added extraEnvVars support

**Benefits**
Support for extraEnvVars for Grafana Image Renderer

**Possible drawbacks**
No possible knows limitations

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
