### PR TITLE
[bitnami/grafana] add podAntiAffinity support for image-renderer

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 7.2.12
+version: 7.3.0

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -158,7 +158,7 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | ---------------------------------- | --------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`                   | Grafana image registry                                                            | `docker.io`          |
 | `image.repository`                 | Grafana image repository                                                          | `bitnami/grafana`    |
-| `image.tag`                        | Grafana image tag (immutable tags are recommended)                                | `8.3.0-debian-10-r0` |
+| `image.tag`                        | Grafana image tag (immutable tags are recommended)                                | `8.3.3-debian-10-r0` |
 | `image.pullPolicy`                 | Grafana image pull policy                                                         | `IfNotPresent`       |
 | `image.pullSecrets`                | Grafana image pull secrets                                                        | `[]`                 |
 | `hostAliases`                      | Add deployment host aliases                                                       | `[]`                 |
@@ -336,7 +336,7 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | `imageRenderer.enabled`                              | Enable using a remote rendering service to render PNG images                                            | `false`                          |
 | `imageRenderer.image.registry`                       | Grafana Image Renderer image registry                                                                   | `docker.io`                      |
 | `imageRenderer.image.repository`                     | Grafana Image Renderer image repository                                                                 | `bitnami/grafana-image-renderer` |
-| `imageRenderer.image.tag`                            | Grafana Image Renderer image tag (immutable tags are recommended)                                       | `3.3.0-debian-10-r11`            |
+| `imageRenderer.image.tag`                            | Grafana Image Renderer image tag (immutable tags are recommended)                                       | `3.3.0-debian-10-r24`            |
 | `imageRenderer.image.pullPolicy`                     | Grafana Image Renderer image pull policy                                                                | `IfNotPresent`                   |
 | `imageRenderer.image.pullSecrets`                    | Grafana image Renderer pull secrets                                                                     | `[]`                             |
 | `imageRenderer.replicaCount`                         | Number of Grafana Image Renderer Pod replicas                                                           | `1`                              |
@@ -344,6 +344,11 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | `imageRenderer.nodeSelector`                         | Node labels for pod assignment                                                                          | `{}`                             |
 | `imageRenderer.tolerations`                          | Tolerations for pod assignment                                                                          | `[]`                             |
 | `imageRenderer.topologySpreadConstraints`            | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in | `[]`                             |
+| `imageRenderer.podAffinityPreset`                    | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`                             |
+| `imageRenderer.podAntiAffinityPreset`                | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `soft`                           |
+| `imageRenderer.nodeAffinityPreset.type`              | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`                             |
+| `imageRenderer.nodeAffinityPreset.key`               | Node label key to match Ignored if `affinity` is set.                                                   | `""`                             |
+| `imageRenderer.nodeAffinityPreset.values`            | Node label values to match. Ignored if `affinity` is set.                                               | `[]`                             |
 | `imageRenderer.affinity`                             | Affinity for pod assignment                                                                             | `{}`                             |
 | `imageRenderer.resources.limits`                     | The resources limits for Grafana containers                                                             | `{}`                             |
 | `imageRenderer.resources.requests`                   | The requested resources for Grafana containers                                                          | `{}`                             |
@@ -382,7 +387,7 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                    | `docker.io`             |
 | `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r266`     |
+| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r279`     |
 | `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                | `[]`                    |
 | `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                    |

--- a/bitnami/grafana/templates/image-renderer-deployment.yaml
+++ b/bitnami/grafana/templates/image-renderer-deployment.yaml
@@ -32,6 +32,11 @@ spec:
       {{- end }}
       {{- if .Values.imageRenderer.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.imageRenderer.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.imageRenderer.podAffinityPreset "component" "image-renderer" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.imageRenderer.podAntiAffinityPreset "component" "image-renderer" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.imageRenderer.nodeAffinityPreset.type "key" .Values.imageRenderer.nodeAffinityPreset.key "values" .Values.imageRenderer.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       {{- if .Values.imageRenderer.nodeSelector }}
       nodeSelector: {{- include "common.tplvalues.render" (dict "value" .Values.imageRenderer.nodeSelector "context" $) | nindent 8 }}

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -741,8 +741,35 @@ imageRenderer:
   ##     whenUnsatisfiable: DoNotSchedule
   ##
   topologySpreadConstraints: []
+  ## @param imageRenderer.podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAffinityPreset: ""
+  ## @param imageRenderer.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+  podAntiAffinityPreset: soft
+  ## Node affinity preset
+  ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+  ## @param imageRenderer.nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## @param imageRenderer.nodeAffinityPreset.key Node label key to match Ignored if `affinity` is set.
+  ## @param imageRenderer.nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set.
+  ##
+  nodeAffinityPreset:
+    type: ""
+    ## E.g.
+    ## key: "kubernetes.io/e2e-az-name"
+    ##
+    key: ""
+    ## E.g.
+    ## values:
+    ##   - e2e-az1
+    ##   - e2e-az2
+    ##
+    values: []
   ## @param imageRenderer.affinity Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
   ##
   affinity: {}
   ## Grafana Image Renderer containers' resource requests and limits


### PR DESCRIPTION
Signed-off-by: Ioachim Lihor <ioachim.lihor@radcom.com>

**Description of the change**
Add support for PodAntiAffinity for image-renderer

**Benefits**
Spread the containers over nodes instead a possible single one (if it's use `hard` option)

**Possible drawbacks**
No possible knows limitations

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
