### PR TITLE
bitnami/rabbitmq: README copywriting updates

### DIFF
--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -1,6 +1,6 @@
 # RabbitMQ
 
-[RabbitMQ](https://www.rabbitmq.com/) is an open source message broker software that implements the Advanced Message Queuing Protocol (AMQP).
+[RabbitMQ](https://www.rabbitmq.com/) is an open source multi-protocol message broker.
 
 ## TL;DR
 


### PR DESCRIPTION
RabbitMQ has been multi-protocol since 2010 or so (when STOMP support was introduced).
The core team would strongly prefer to use this language as "AMQP" these days refers to more
than one protocol for historical reasons.
