### PR TITLE
[bitnami/elasticsearch] coordinating-hpa kind to StatefulSet

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.5.2
+version: 17.5.3

--- a/bitnami/elasticsearch/templates/coordinating-hpa.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-hpa.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
-    kind: Deployment
+    kind: StatefulSet
     name: {{ include "elasticsearch.coordinating.fullname" . }}
   minReplicas: {{ .Values.coordinating.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.coordinating.autoscaling.maxReplicas }}


### PR DESCRIPTION
**Description of the change**
Coordinating pods are of type `StatefulSet` but the corresponding hpa has type `Deployment`. So setting `coordinating.autoscaling.enabled: true` causes pods to not be fully deployed.

**Benefits**
HPA will work for coordinating type es nodes

**Possible drawbacks**
None


<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Variables are documented in the README.md
- [ X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
