### PR TITLE
[bitnami/mariadb-galera] Revert enabling of IPv6

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 6.0.9
+version: 6.0.10

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -64,7 +64,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/mariadb-galera
-  tag: 10.6.5-debian-10-r26
+  tag: 10.6.5-debian-10-r29
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -699,7 +699,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.13.0-debian-10-r181
+    tag: 0.13.0-debian-10-r185
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -319,7 +319,7 @@ mariadbConfiguration: |-
   tmpdir=/opt/bitnami/mariadb/tmp
   socket=/opt/bitnami/mariadb/tmp/mysql.sock
   pid_file=/opt/bitnami/mariadb/tmp/mysqld.pid
-  bind_address=::
+  bind_address=0.0.0.0
 
   ## Character set
   ##


### PR DESCRIPTION
Reverts #8395, because it is failing in the internal CI/CD:
```
                1) MariaDB remote authentication
                     Password authentication is required through 10.49.49.5:
                   Expected "Access denied for user 'root'@'10.49.49.5'" but got "'ERROR 2002 (HY000): Can't connect to server on '10.49.49.5' (115)'"
                2) MariaDB remote authentication
                     Password authentication is required through 127.0.0.1:
                   Expected "Access denied for user 'root'@'127.0.0.1'" but got "'ERROR 2002 (HY000): Can't connect to server on '127.0.0.1' (115)'"
```
