### PR TITLE
[bitnami/kafka] Improved compatibility with Kubernetes 1.21+ and Openshift

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 14.7.1
+version: 14.7.2

--- a/bitnami/kafka/templates/poddisruptionbudget.yaml
+++ b/bitnami/kafka/templates/poddisruptionbudget.yaml
@@ -1,6 +1,10 @@
 {{- $replicaCount := int .Values.replicaCount }}
 {{- if and .Values.pdb.create (gt $replicaCount 1) }}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kafka.fullname" . }}

--- a/bitnami/kafka/templates/poddisruptionbudget.yaml
+++ b/bitnami/kafka/templates/poddisruptionbudget.yaml
@@ -1,10 +1,6 @@
 {{- $replicaCount := int .Values.replicaCount }}
 {{- if and .Values.pdb.create (gt $replicaCount 1) }}
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
-apiVersion: policy/v1
-{{- else }}
-apiVersion: policy/v1beta1
-{{- end }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kafka.fullname" . }}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -111,7 +111,11 @@ spec:
             - |
               chown -R "{{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}" "{{ .Values.persistence.mountPath }}"
               chown -R "{{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}" "{{ .Values.logPersistence.mountPath }}"
+          {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
+          securityContext: {{- omit .Values.volumePermissions.securityContext "runAsUser" | toYaml | nindent 12 }}
+          {{- else }}
           securityContext: {{- .Values.volumePermissions.securityContext | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.volumePermissions.resources }}
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -902,7 +902,8 @@ volumePermissions:
   ##
   enabled: false
   ## The security context for the volumePermissions init container
-  ## @param volumePermissions.securityContext.runAsUser User ID for the container. Can be set to "auto". "auto" is especially useful for OpenShift which has scc with dynamic userids (and 0 is not allowed).
+  ## @param volumePermissions.securityContext.runAsUser User ID for the container.
+  ## Can be set to "auto". "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed).
   ##
   securityContext:
     runAsUser: 0

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -902,7 +902,7 @@ volumePermissions:
   ##
   enabled: false
   ## The security context for the volumePermissions init container
-  ## @param volumePermissions.securityContext.runAsUser User ID for the container
+  ## @param volumePermissions.securityContext.runAsUser User ID for the container. Can be set to "auto". "auto" is especially useful for OpenShift which has scc with dynamic userids (and 0 is not allowed).
   ##
   securityContext:
     runAsUser: 0


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
There are 2 changes to the kafka chart:
- Ensure that the chart is Kubernetes 1.21+ compatible by making sure that the PodDisruptionBudget uses the `policy/v1` apiVersion if it is available.
- Can set a special `auto` value to the `volumePermissions.securityContext.runAsUser` to make it OpenShift compatible as that does not like the `0` (root) user.

**Benefits**
Compatibility with newer Kubernetes versions and OpenShift deployments

**Possible drawbacks**
Fully backwards compatible so no drawbacks expected.>

**Applicable issues**
N/A

**Additional information**
N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
