### PR TITLE
[bitnami/mariadb-galera] Add password validations during upgrades

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 6.0.10
+version: 6.0.11

--- a/bitnami/mariadb-galera/templates/NOTES.txt
+++ b/bitnami/mariadb-galera/templates/NOTES.txt
@@ -85,3 +85,17 @@ To upgrade this helm chart:
 
 {{ include "mariadb-galera.validateValues" . }}
 {{ include "mariadb-galera.checkRollingTags" . }}
+{{- $requiredPasswords := list -}}
+{{- $secretName := include "mariadb-galera.secretName" . -}}
+{{- if not .Values.existingSecret -}}
+  {{- $requiredRootPassword := dict "valueKey" "rootUser.password" "secret" $secretName "field" "mariadb-root-password" -}}
+  {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
+  {{- $requiredMariaBackupPassword := dict "valueKey" "galera.mariabackup.password" "secret" $secretName "field" "mariadb-galera-mariabackup-password" -}}
+  {{- $requiredPasswords = append $requiredPasswords $requiredMariaBackupPassword -}}
+  {{- if .Values.db.user }}
+    {{- $requiredUserPassword := dict "valueKey" "db.password" "secret" $secretName "field" "mariadb-password" -}}
+    {{- $requiredPasswords = append $requiredPasswords $requiredUserPassword -}}
+  {{- end -}}
+{{- end -}}
+{{- $requiredRedisPasswordErrors := include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" $) -}}
+{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" (list $requiredRedisPasswordErrors) "context" $) -}}

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -64,7 +64,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/mariadb-galera
-  tag: 10.6.5-debian-10-r29
+  tag: 10.6.5-debian-10-r35
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -699,7 +699,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mysqld-exporter
-    tag: 0.13.0-debian-10-r185
+    tag: 0.13.0-debian-10-r191
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR includes password validations to ensure that every expected password is provided during chart upgrades so users avoid the [Credentials error known issue](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues/#credential-errors-while-upgrading-chart-releases). 

**Benefits**

Reduce the % of making a bad use of the chart during upgrades.

**Possible drawbacks**

None

**Applicable issues**

  - fixes #8256

**Additional information**

N/A

**Checklist** 

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
