### PR TITLE
* [bitnami/redis] Fix env variable name

### DIFF
--- a/bitnami/redis/templates/NOTES.txt
+++ b/bitnami/redis/templates/NOTES.txt
@@ -90,7 +90,7 @@ To connect to your Redis&trade; server:
 
 1. Run a Redis&trade; pod that you can use as a client:
 
-   kubectl run --namespace {{ .Release.Namespace }} redis-client --restart='Never' {{ if .Values.auth.enabled }} --env REDISCLI_AUTH=$REDIS_PASSWORD {{ end }} --image {{ template "redis.image" . }} --command -- sleep infinity
+   kubectl run --namespace {{ .Release.Namespace }} redis-client --restart='Never' {{ if .Values.auth.enabled }} --env REDIS_PASSWORD=$REDIS_PASSWORD {{ end }} --image {{ template "redis.image" . }} --command -- sleep infinity
 
 {{- if .Values.tls.enabled }}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

The REDISCLI_AUTH variable settings in redis-client pod are `REDISCLI_AUTH="$REDIS_PASSWORD"`.
Thus, the `kubectl run` should set the env `REDIS_PASSWORD=$REDIS_PASSWORD` instead of `REDISCLI_AUTH=$REDIS_PASSWORD`.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
