### PR TITLE
[bitnami/contour] Fix applying default ingress label even if not default #8450

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 7.0.7
+version: 7.0.8

--- a/bitnami/contour/templates/contour/ingressclass.yaml
+++ b/bitnami/contour/templates/contour/ingressclass.yaml
@@ -7,7 +7,9 @@ kind: IngressClass
 metadata:
   name: {{ include "contour.ingressClassName" . }}
   annotations:
-    ingressclass.kubernetes.io/is-default-class: {{ default true $ingressClass.default | quote }}
+{{- if $ingressClass.default }}
+    ingressclass.kubernetes.io/is-default-class: "true"
+{{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: contour
 spec:


### PR DESCRIPTION
Even if `ingressClass.default` is set to false, the actual label will be applied and make the ingress be a default ingress. See #8450

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])

Credits go all to @javsalgar !