### PR TITLE
[bitnami/spring-cloud-dataflow] Allow multiple external kafka nodes

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 4.2.2
+version: 4.2.3

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -242,7 +242,7 @@ helm uninstall my-release
 | `deployer.tolerations`                        | Streaming applications tolerations                                                          | `{}`   |
 | `deployer.volumeMounts`                       | Streaming applications extra volume mounts                                                  | `{}`   |
 | `deployer.volumes`                            | Streaming applications extra volumes                                                        | `{}`   |
-| `deployer.environmentVariables`               | Streaming applications environment variables                                                | `""`   |
+| `deployer.environmentVariables`               | Streaming applications environment variables. List of strings                               | `[]`   |
 | `deployer.podSecurityContext.runAsUser`       | Set Dataflow Streams container's Security Context runAsUser                                 | `1001` |
 
 

--- a/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
+++ b/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
@@ -384,7 +384,11 @@ Return Deployer Environment Variables. Empty string or variables started with co
 */}}
 {{- define "scdf.deployer.environmentVariables" -}}
   {{- if .Values.deployer.environmentVariables -}}
-    {{- printf ",%s" .Values.deployer.environmentVariables | trim -}}
+    {{- if kindIs "string" .Values.deployer.environmentVariables -}}
+      {{- printf "- %s" .Values.deployer.environmentVariables | trim -}}
+    {{- else -}}
+      {{- toYaml .Values.deployer.environmentVariables -}}
+    {{- end -}}
   {{- else -}}
     {{- printf "" -}}
   {{- end -}}

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -36,8 +36,9 @@ data:
               kubernetes:
                 accounts:
                   {{ .Values.server.configuration.accountName }}:
-                    {{- if .Values.deployer.environmentVariables }}
-                    environmentVariables: '{{ .Values.deployer.environmentVariables | trim }}'
+                    {{- $environmentVariables := include "scdf.deployer.environmentVariables" . }}
+                    {{- if $environmentVariables }}
+                    environmentVariables: {{- $environmentVariables | trim | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.resources.limits }}
                     limits: {{- toYaml .Values.deployer.resources.limits | trim | nindent 22 }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -41,14 +41,32 @@ data:
                     {{- $rabbitmqPort := include "scdf.rabbitmq.port" . }}
                     {{- $rabbitmqUser := include "scdf.rabbitmq.user" . }}
                     {{- $rabbitmqVhost := include "scdf.rabbitmq.vhost" . }}
-                    environmentVariables: 'SPRING_RABBITMQ_HOST={{ $rabbitmqHost }},SPRING_RABBITMQ_PORT={{ $rabbitmqPort }},SPRING_RABBITMQ_USERNAME={{ $rabbitmqUser }},SPRING_RABBITMQ_PASSWORD=${rabbitmq-password},SPRING_RABBITMQ_VIRTUAL_HOST={{ $rabbitmqVhost }}{{ $environmentVariables }}'
+                    environmentVariables:
+                      - SPRING_RABBITMQ_HOST={{ $rabbitmqHost }}
+                      - SPRING_RABBITMQ_PORT={{ $rabbitmqPort }}
+                      - SPRING_RABBITMQ_USERNAME={{ $rabbitmqUser }}
+                      - SPRING_RABBITMQ_PASSWORD=${rabbitmq-password}
+                      - SPRING_RABBITMQ_VIRTUAL_HOST={{ $rabbitmqVhost }}
+                      {{- if $environmentVariables }}
+                      {{- $environmentVariables | nindent 22 }}
+                      {{- end }}
                     {{- else if .Values.kafka.enabled }}
-                    environmentVariables: 'SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=${{ printf "{" }}{{ .Release.Name }}_KAFKA_SERVICE_HOST}:${{ printf "{" }}{{ .Release.Name }}_KAFKA_SERVICE_PORT},SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=${{ printf "{" }}{{ .Release.Name }}_ZOOKEEPER_SERVICE_HOST}:${{ printf "{" }}{{ .Release.Name }}_ZOOKEEPER_SERVICE_PORT}{{ $environmentVariables }}'
+                    environmentVariables:
+                      - SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=${{ printf "{" }}{{ .Release.Name }}_KAFKA_SERVICE_HOST}:${{ printf "{" }}{{ .Release.Name }}_KAFKA_SERVICE_PORT}
+                      - SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=${{ printf "{" }}{{ .Release.Name }}_ZOOKEEPER_SERVICE_HOST}:${{ printf "{" }}{{ .Release.Name }}_ZOOKEEPER_SERVICE_PORT}
+                      {{- if $environmentVariables }}
+                      {{- $environmentVariables | nindent 22 }}
+                      {{- end }}
                     {{- else if .Values.externalKafka.enabled }}
-                    environmentVariables: 'SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS={{ .Values.externalKafka.brokers }},SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES={{ .Values.externalKafka.zkNodes }}{{ $environmentVariables }}'
+                    environmentVariables:
+                      - SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS={{ .Values.externalKafka.brokers }}
+                      - SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES={{ .Values.externalKafka.zkNodes }}
+                      {{- if $environmentVariables }}
+                      {{- $environmentVariables | nindent 22 }}
+                      {{- end }}
                     {{- else }}
-                    {{- if .Values.deployer.environmentVariables }}
-                    environmentVariables: '{{ .Values.deployer.environmentVariables | trim }}'
+                    {{- if $environmentVariables }}
+                    environmentVariables: {{- $environmentVariables  | trim | nindent 22 }}
                     {{- end }}
                     {{- end }}
                     {{- if .Values.deployer.resources.limits }}

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -814,9 +814,9 @@ deployer:
   ##
   volumes: {}
   ## @param deployer.environmentVariables Streaming applications environment variables
-  ## RabbitMQ/Kafka envs. Multiple values are comma separated.
+  ## RabbitMQ/Kafka envs.
   ##
-  environmentVariables: ""
+  environmentVariables: []
   ## Streams containers' Security Context. This security context will be use in every deployed stream.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param deployer.podSecurityContext.runAsUser Set Dataflow Streams container's Security Context runAsUser

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -814,7 +814,12 @@ deployer:
   ##
   volumes: {}
   ## @param deployer.environmentVariables Streaming applications environment variables
-  ## RabbitMQ/Kafka envs.
+  ## RabbitMQ/Kafka envs. 
+  ## Example:
+  ## environmentVariables:
+  ##   - JAVA_TOOL_OPTIONS=-Xmx1024m
+  ##   - SPRING_REDIS_HOST=redis
+  ##   - SPRING_REDIS_PORT=6379
   ##
   environmentVariables: []
   ## Streams containers' Security Context. This security context will be use in every deployed stream.

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -814,7 +814,7 @@ deployer:
   ##
   volumes: {}
   ## @param deployer.environmentVariables Streaming applications environment variables
-  ## RabbitMQ/Kafka envs. 
+  ## RabbitMQ/Kafka envs.
   ## Example:
   ## environmentVariables:
   ##   - JAVA_TOOL_OPTIONS=-Xmx1024m


### PR DESCRIPTION
**Description of the change**

Now we can define the environment variables for the Spring Cloud Deployer (`deployer.environmentVariables`) with a list of strings instead of a single string splitted by commas (this method is still allowed).

**Benefits**

 - Clearer values.yml files
 - Amend issues with multivalued environment variables

**Possible drawbacks**

None

**Applicable issues**

  - fixes #7639

**Additional information**

 - https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#configuration-kubernetes-deployer


**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
