### PR TITLE
[bitnami/fluentd] fix host label in prometheus metrics

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/bitnami-docker-fluentd
   - https://www.fluentd.org/
-version: 4.4.4
+version: 4.4.5

--- a/bitnami/fluentd/values.yaml
+++ b/bitnami/fluentd/values.yaml
@@ -235,21 +235,21 @@ forwarder:
       <source>
         @type prometheus_monitor
         <labels>
-          host #{hostname}
+          host ${hostname}
         </labels>
       </source>
       # input plugin that collects metrics for output plugin
       <source>
         @type prometheus_output_monitor
         <labels>
-          host #{hostname}
+          host ${hostname}
         </labels>
       </source>
       # input plugin that collects metrics for in_tail plugin
       <source>
         @type prometheus_tail_monitor
         <labels>
-          host #{hostname}
+          host ${hostname}
         </labels>
       </source>
   ## @param forwarder.extraArgs Extra arguments for the Fluentd command line
@@ -647,7 +647,7 @@ aggregator:
       <source>
         @type prometheus_monitor
         <labels>
-          host #{hostname}
+          host ${hostname}
         </labels>
       </source>
 
@@ -655,7 +655,7 @@ aggregator:
       <source>
         @type prometheus_output_monitor
         <labels>
-          host #{hostname}
+          host ${hostname}
         </labels>
       </source>
 


### PR DESCRIPTION
**Description of the change**

Fix the host label in prometheus metrics for fluentd.

**Benefits**

correct hostname in prometheus metrics

**Possible drawbacks**

nothing

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
