### PR TITLE
[bitnami/mysql] lookup existing secrets

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.8.17
+version: 8.8.18

--- a/bitnami/mysql/templates/_helpers.tpl
+++ b/bitnami/mysql/templates/_helpers.tpl
@@ -127,6 +127,49 @@ Return true if a secret object should be created for MySQL
 {{- end -}}
 {{- end -}}
 
+{{/*
+Returns the available value for certain key in an existing secret (if it exists),
+otherwise it generates a random value.
+*/}}
+{{- define "getValueFromSecret" }}
+    {{- $len := (default 16 .Length) | int -}}
+    {{- $obj := (lookup "v1" "Secret" .Namespace .Name).data -}}
+    {{- if $obj }}
+        {{- index $obj .Key | b64dec -}}
+    {{- else -}}
+        {{- randAlphaNum $len -}}
+    {{- end -}}
+{{- end }}
+
+{{- define "mysql.password.root" -}}
+    {{- if not (empty .Values.auth.rootPassword) }}
+        {{- .Values.auth.rootPassword }}
+    {{- else if (not .Values.auth.forcePassword) }}
+        {{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (include "common.names.fullname" .) "Length" 10 "Key" "mysql-root-password") }}
+    {{- else }}
+        {{- required "A MySQL Root Password is required!" .Values.auth.rootPassword }}
+    {{- end }}
+{{- end -}}
+
+{{- define "mysql.password" -}}
+    {{- if and (not (empty .Values.auth.username)) (not (empty .Values.auth.password)) }}
+        {{ .Values.auth.password }}
+    {{- else if (not .Values.auth.forcePassword) }}
+        {{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (include "common.names.fullname" .) "Length" 10 "Key" "mysql-password") }}
+    {{- else }}
+        {{ required "A MySQL Database Password is required!" .Values.auth.password }}
+    {{- end }}
+{{- end -}}
+
+{{- define "mysql.password.replication" -}}
+    {{- if not (empty .Values.auth.replicationPassword) }}
+        {{ .Values.auth.replicationPassword }}
+    {{- else if (not .Values.auth.forcePassword) }}
+        {{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (include "common.names.fullname" .) "Length" 10 "Key" "mysql-replication-password") }}
+    {{- else }}
+        {{ required "A MySQL Replication Password is required!" .Values.auth.replicationPassword }}
+    {{- end }}
+{{- end -}}
 
 {{/* Check if there are rolling tags in the images */}}
 {{- define "mysql.checkRollingTags" -}}

--- a/bitnami/mysql/templates/_helpers.tpl
+++ b/bitnami/mysql/templates/_helpers.tpl
@@ -141,7 +141,7 @@ otherwise it generates a random value.
     {{- end -}}
 {{- end }}
 
-{{- define "mysql.password.root" -}}
+{{- define "mysql.root.password" -}}
     {{- if not (empty .Values.auth.rootPassword) }}
         {{- .Values.auth.rootPassword }}
     {{- else if (not .Values.auth.forcePassword) }}
@@ -161,7 +161,7 @@ otherwise it generates a random value.
     {{- end }}
 {{- end -}}
 
-{{- define "mysql.password.replication" -}}
+{{- define "mysql.replication.password" -}}
     {{- if not (empty .Values.auth.replicationPassword) }}
         {{ .Values.auth.replicationPassword }}
     {{- else if (not .Values.auth.forcePassword) }}

--- a/bitnami/mysql/templates/secrets.yaml
+++ b/bitnami/mysql/templates/secrets.yaml
@@ -13,9 +13,9 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  mysql-root-password: {{ include "mysql.password.root" . | b64enc | quote}}
+  mysql-root-password: {{ include "mysql.root.password" . | b64enc | quote}}
   mysql-password: {{ include "mysql.password" . | b64enc | quote }}
   {{- if eq .Values.architecture "replication" }}
-  mysql-replication-password: {{ include "mysql.password.replication" . | b64enc | quote }}
+  mysql-replication-password: {{ include "mysql.replication.password" . | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/bitnami/mysql/templates/secrets.yaml
+++ b/bitnami/mysql/templates/secrets.yaml
@@ -13,27 +13,9 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if not (empty .Values.auth.rootPassword) }}
-  mysql-root-password: {{ .Values.auth.rootPassword | b64enc | quote }}
-  {{- else if (not .Values.auth.forcePassword) }}
-  mysql-root-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{- else }}
-  mysql-root-password: {{ required "A MySQL Root Password is required!" .Values.auth.rootPassword }}
-  {{- end }}
-  {{- if and (not (empty .Values.auth.username)) (not (empty .Values.auth.password)) }}
-  mysql-password: {{ .Values.auth.password | b64enc | quote }}
-  {{- else if (not .Values.auth.forcePassword) }}
-  mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{- else }}
-  mysql-password: {{ required "A MySQL Database Password is required!" .Values.auth.password }}
-  {{- end }}
+  mysql-root-password: {{ include "mysql.password.root" . | b64enc | quote}}
+  mysql-password: {{ include "mysql.password" . | b64enc | quote }}
   {{- if eq .Values.architecture "replication" }}
-  {{- if not (empty .Values.auth.replicationPassword) }}
-  mysql-replication-password: {{ .Values.auth.replicationPassword | b64enc | quote }}
-  {{- else if (not .Values.auth.forcePassword) }}
-  mysql-replication-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{- else }}
-  mysql-replication-password: {{ required "A MySQL Replication Password is required!" .Values.auth.replicationPassword }}
-  {{- end }}
+  mysql-replication-password: {{ include "mysql.password.replication" . | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

Look up existing secrets before generating random secrets, and use the existing ones if they exist.

Related to: 
- #8320
- #8495
- #8499
- #8486
- #8504

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
