### PR TITLE
[bitnami/grafana] prometheusrules supp for grafana and image-renderer

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 7.4.1
+version: 7.5.0

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -154,42 +154,42 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 
 ### Grafana parameters
 
-| Name                               | Description                                                                       | Value                |
-| ---------------------------------- | --------------------------------------------------------------------------------- | -------------------- |
-| `image.registry`                   | Grafana image registry                                                            | `docker.io`          |
-| `image.repository`                 | Grafana image repository                                                          | `bitnami/grafana`    |
-| `image.tag`                        | Grafana image tag (immutable tags are recommended)                                | `8.3.3-debian-10-r0` |
-| `image.pullPolicy`                 | Grafana image pull policy                                                         | `IfNotPresent`       |
-| `image.pullSecrets`                | Grafana image pull secrets                                                        | `[]`                 |
-| `hostAliases`                      | Add deployment host aliases                                                       | `[]`                 |
-| `admin.user`                       | Grafana admin username                                                            | `admin`              |
-| `admin.password`                   | Admin password. If a password is not provided a random password will be generated | `""`                 |
-| `admin.existingSecret`             | Name of the existing secret containing admin password                             | `""`                 |
-| `admin.existingSecretPasswordKey`  | Password key on the existing secret                                               | `password`           |
-| `smtp.enabled`                     | Enable SMTP configuration                                                         | `false`              |
-| `smtp.user`                        | SMTP user                                                                         | `user`               |
-| `smtp.password`                    | SMTP password                                                                     | `password`           |
-| `smtp.host`                        | Custom host for the smtp server                                                   | `""`                 |
-| `smtp.fromAddress`                 | From address                                                                      | `""`                 |
-| `smtp.fromName`                    | From name                                                                         | `""`                 |
-| `smtp.skipVerify`                  | Enable skip verify                                                                | `false`              |
-| `smtp.existingSecret`              | Name of existing secret containing SMTP credentials (user and password)           | `""`                 |
-| `smtp.existingSecretUserKey`       | User key on the existing secret                                                   | `user`               |
-| `smtp.existingSecretPasswordKey`   | Password key on the existing secret                                               | `password`           |
-| `plugins`                          | Grafana plugins to be installed in deployment time separated by commas            | `""`                 |
-| `ldap.enabled`                     | Enable LDAP for Grafana                                                           | `false`              |
-| `ldap.allowSignUp`                 | Allows LDAP sign up for Grafana                                                   | `false`              |
-| `ldap.configuration`               | Specify content for ldap.toml configuration file                                  | `""`                 |
-| `ldap.configMapName`               | Name of the ConfigMap with the ldap.toml configuration file for Grafana           | `""`                 |
-| `ldap.secretName`                  | Name of the Secret with the ldap.toml configuration file for Grafana              | `""`                 |
-| `config.useGrafanaIniFile`         | Allows to load a `grafana.ini` file                                               | `false`              |
-| `config.grafanaIniConfigMap`       | Name of the ConfigMap containing the `grafana.ini` file                           | `""`                 |
-| `config.grafanaIniSecret`          | Name of the Secret containing the `grafana.ini` file                              | `""`                 |
-| `dashboardsProvider.enabled`       | Enable the use of a Grafana dashboard provider                                    | `false`              |
-| `dashboardsProvider.configMapName` | Name of a ConfigMap containing a custom dashboard provider                        | `""`                 |
-| `dashboardsConfigMaps`             | Array with the names of a series of ConfigMaps containing dashboards files        | `[]`                 |
-| `datasources.secretName`           | Secret name containing custom datasource files                                    | `""`                 |
-| `notifiers.configMapName`          | Name of a ConfigMap containing Grafana notifiers configuration                    | `""`                 |
+| Name                               | Description                                                                       | Value                 |
+| ---------------------------------- | --------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`                   | Grafana image registry                                                            | `docker.io`           |
+| `image.repository`                 | Grafana image repository                                                          | `bitnami/grafana`     |
+| `image.tag`                        | Grafana image tag (immutable tags are recommended)                                | `8.3.3-debian-10-r13` |
+| `image.pullPolicy`                 | Grafana image pull policy                                                         | `IfNotPresent`        |
+| `image.pullSecrets`                | Grafana image pull secrets                                                        | `[]`                  |
+| `hostAliases`                      | Add deployment host aliases                                                       | `[]`                  |
+| `admin.user`                       | Grafana admin username                                                            | `admin`               |
+| `admin.password`                   | Admin password. If a password is not provided a random password will be generated | `""`                  |
+| `admin.existingSecret`             | Name of the existing secret containing admin password                             | `""`                  |
+| `admin.existingSecretPasswordKey`  | Password key on the existing secret                                               | `password`            |
+| `smtp.enabled`                     | Enable SMTP configuration                                                         | `false`               |
+| `smtp.user`                        | SMTP user                                                                         | `user`                |
+| `smtp.password`                    | SMTP password                                                                     | `password`            |
+| `smtp.host`                        | Custom host for the smtp server                                                   | `""`                  |
+| `smtp.fromAddress`                 | From address                                                                      | `""`                  |
+| `smtp.fromName`                    | From name                                                                         | `""`                  |
+| `smtp.skipVerify`                  | Enable skip verify                                                                | `false`               |
+| `smtp.existingSecret`              | Name of existing secret containing SMTP credentials (user and password)           | `""`                  |
+| `smtp.existingSecretUserKey`       | User key on the existing secret                                                   | `user`                |
+| `smtp.existingSecretPasswordKey`   | Password key on the existing secret                                               | `password`            |
+| `plugins`                          | Grafana plugins to be installed in deployment time separated by commas            | `""`                  |
+| `ldap.enabled`                     | Enable LDAP for Grafana                                                           | `false`               |
+| `ldap.allowSignUp`                 | Allows LDAP sign up for Grafana                                                   | `false`               |
+| `ldap.configuration`               | Specify content for ldap.toml configuration file                                  | `""`                  |
+| `ldap.configMapName`               | Name of the ConfigMap with the ldap.toml configuration file for Grafana           | `""`                  |
+| `ldap.secretName`                  | Name of the Secret with the ldap.toml configuration file for Grafana              | `""`                  |
+| `config.useGrafanaIniFile`         | Allows to load a `grafana.ini` file                                               | `false`               |
+| `config.grafanaIniConfigMap`       | Name of the ConfigMap containing the `grafana.ini` file                           | `""`                  |
+| `config.grafanaIniSecret`          | Name of the Secret containing the `grafana.ini` file                              | `""`                  |
+| `dashboardsProvider.enabled`       | Enable the use of a Grafana dashboard provider                                    | `false`               |
+| `dashboardsProvider.configMapName` | Name of a ConfigMap containing a custom dashboard provider                        | `""`                  |
+| `dashboardsConfigMaps`             | Array with the names of a series of ConfigMaps containing dashboards files        | `[]`                  |
+| `datasources.secretName`           | Secret name containing custom datasource files                                    | `""`                  |
+| `notifiers.configMapName`          | Name of a ConfigMap containing Grafana notifiers configuration                    | `""`                  |
 
 
 ### Grafana Deployment parameters
@@ -314,71 +314,79 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 
 ### Metrics parameters
 
-| Name                                       | Description                                                                                            | Value   |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------ | ------- |
-| `metrics.enabled`                          | Enable the export of Prometheus metrics                                                                | `false` |
-| `metrics.service.annotations`              | Annotations for Prometheus metrics service                                                             | `{}`    |
-| `metrics.serviceMonitor.enabled`           | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false` |
-| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                               | `""`    |
-| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                           | `""`    |
-| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                | `""`    |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                    | `{}`    |
-| `metrics.serviceMonitor.metricRelabelings` | Specify Metric Relabellings to add to the scrape endpoint                                              | `[]`    |
-| `metrics.serviceMonitor.honorLabels`       | Labels to honor to add to the scrape endpoint                                                          | `false` |
-| `metrics.serviceMonitor.additionalLabels`  | Additional custom labels for the ServiceMonitor                                                        | `{}`    |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                      | `""`    |
+| Name                                       | Description                                                                                                                               | Value   |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `metrics.enabled`                          | Enable the export of Prometheus metrics                                                                                                   | `false` |
+| `metrics.service.annotations`              | Annotations for Prometheus metrics service                                                                                                | `{}`    |
+| `metrics.serviceMonitor.enabled`           | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                                    | `false` |
+| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                                                                  | `""`    |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                                                              | `""`    |
+| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                                                   | `""`    |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                                                       | `{}`    |
+| `metrics.serviceMonitor.metricRelabelings` | Specify Metric Relabellings to add to the scrape endpoint                                                                                 | `[]`    |
+| `metrics.serviceMonitor.honorLabels`       | Labels to honor to add to the scrape endpoint                                                                                             | `false` |
+| `metrics.serviceMonitor.additionalLabels`  | Additional custom labels for the ServiceMonitor                                                                                           | `{}`    |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                                                         | `""`    |
+| `metrics.prometheusRule.enabled`           | if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`) | `false` |
+| `metrics.prometheusRule.namespace`         | Namespace for the PrometheusRule Resource (defaults to the Release Namespace)                                                             | `""`    |
+| `metrics.prometheusRule.additionalLabels`  | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                                     | `{}`    |
+| `metrics.prometheusRule.rules`             | PrometheusRule rules to configure                                                                                                         | `[]`    |
 
 
 ### Grafana Image Renderer parameters
 
-| Name                                                 | Description                                                                                             | Value                            |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `imageRenderer.enabled`                              | Enable using a remote rendering service to render PNG images                                            | `false`                          |
-| `imageRenderer.image.registry`                       | Grafana Image Renderer image registry                                                                   | `docker.io`                      |
-| `imageRenderer.image.repository`                     | Grafana Image Renderer image repository                                                                 | `bitnami/grafana-image-renderer` |
-| `imageRenderer.image.tag`                            | Grafana Image Renderer image tag (immutable tags are recommended)                                       | `3.3.0-debian-10-r24`            |
-| `imageRenderer.image.pullPolicy`                     | Grafana Image Renderer image pull policy                                                                | `IfNotPresent`                   |
-| `imageRenderer.image.pullSecrets`                    | Grafana image Renderer pull secrets                                                                     | `[]`                             |
-| `imageRenderer.replicaCount`                         | Number of Grafana Image Renderer Pod replicas                                                           | `1`                              |
-| `imageRenderer.podAnnotations`                       | Grafana Image Renderer Pod annotations                                                                  | `{}`                             |
-| `imageRenderer.nodeSelector`                         | Node labels for pod assignment                                                                          | `{}`                             |
-| `imageRenderer.tolerations`                          | Tolerations for pod assignment                                                                          | `[]`                             |
-| `imageRenderer.topologySpreadConstraints`            | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in | `[]`                             |
-| `imageRenderer.podAffinityPreset`                    | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`                             |
-| `imageRenderer.podAntiAffinityPreset`                | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `soft`                           |
-| `imageRenderer.nodeAffinityPreset.type`              | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`                             |
-| `imageRenderer.nodeAffinityPreset.key`               | Node label key to match Ignored if `affinity` is set.                                                   | `""`                             |
-| `imageRenderer.nodeAffinityPreset.values`            | Node label values to match. Ignored if `affinity` is set.                                               | `[]`                             |
-| `imageRenderer.extraEnvVars`                         | Array containing extra env vars to configure Grafana                                                    | `{}`                             |
-| `imageRenderer.affinity`                             | Affinity for pod assignment                                                                             | `{}`                             |
-| `imageRenderer.resources.limits`                     | The resources limits for Grafana containers                                                             | `{}`                             |
-| `imageRenderer.resources.requests`                   | The requested resources for Grafana containers                                                          | `{}`                             |
-| `imageRenderer.podSecurityContext.enabled`           | Enable securityContext on for Grafana Image Renderer deployment                                         | `true`                           |
-| `imageRenderer.podSecurityContext.fsGroup`           | Group to configure permissions for volumes                                                              | `1001`                           |
-| `imageRenderer.podSecurityContext.runAsUser`         | User for the security context                                                                           | `1001`                           |
-| `imageRenderer.podSecurityContext.runAsNonRoot`      | Run containers as non-root users                                                                        | `true`                           |
-| `imageRenderer.containerSecurityContext.enabled`     | Enabled Grafana Image Renderer containers' Security Context                                             | `true`                           |
-| `imageRenderer.containerSecurityContext.runAsUser`   | Set Grafana Image Renderer containers' Security Context runAsUser                                       | `1001`                           |
-| `imageRenderer.service.type`                         | Kubernetes Service type                                                                                 | `ClusterIP`                      |
-| `imageRenderer.service.clusterIP`                    | Grafana service Cluster IP                                                                              | `""`                             |
-| `imageRenderer.service.ports.imageRenderer`          | Grafana Image Renderer metrics port                                                                     | `8080`                           |
-| `imageRenderer.service.nodePorts.grafana`            | Specify the nodePort value for the LoadBalancer and NodePort service types                              | `""`                             |
-| `imageRenderer.service.loadBalancerIP`               | loadBalancerIP if Grafana service type is `LoadBalancer` (optional, cloud specific)                     | `""`                             |
-| `imageRenderer.service.loadBalancerSourceRanges`     | loadBalancerSourceRanges if Grafana service type is `LoadBalancer` (optional, cloud specific)           | `[]`                             |
-| `imageRenderer.service.annotations`                  | Provide any additional annotations which may be required.                                               | `{}`                             |
-| `imageRenderer.service.externalTrafficPolicy`        | Grafana service external traffic policy                                                                 | `Cluster`                        |
-| `imageRenderer.service.extraPorts`                   | Extra port to expose on Redmine service                                                                 | `[]`                             |
-| `imageRenderer.metrics.enabled`                      | Enable the export of Prometheus metrics                                                                 | `false`                          |
-| `imageRenderer.metrics.annotations`                  | Prometheus annotations                                                                                  | `{}`                             |
-| `imageRenderer.metrics.serviceMonitor.enabled`       | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)  | `false`                          |
-| `imageRenderer.metrics.serviceMonitor.namespace`     | Namespace in which Prometheus is running                                                                | `""`                             |
-| `imageRenderer.metrics.serviceMonitor.interval`      | Interval at which metrics should be scraped.                                                            | `""`                             |
-| `imageRenderer.metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                                                 | `""`                             |
-| `imageRenderer.initContainers`                       | Add additional init containers to the Grafana Image Renderer pod(s)                                     | `{}`                             |
-| `imageRenderer.extraEnvVarsCM`                       | Name of existing ConfigMap containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes                  | `""`                             |
-| `imageRenderer.extraEnvVarsSecret`                   | Name of existing Secret containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes                     | `""`                             |
-| `imageRenderer.command`                              | Override default container command (useful when using custom images)                                    | `[]`                             |
-| `imageRenderer.args`                                 | Override default container args (useful when using custom images)                                       | `[]`                             |
+| Name                                                    | Description                                                                                                                               | Value                            |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `imageRenderer.enabled`                                 | Enable using a remote rendering service to render PNG images                                                                              | `false`                          |
+| `imageRenderer.image.registry`                          | Grafana Image Renderer image registry                                                                                                     | `docker.io`                      |
+| `imageRenderer.image.repository`                        | Grafana Image Renderer image repository                                                                                                   | `bitnami/grafana-image-renderer` |
+| `imageRenderer.image.tag`                               | Grafana Image Renderer image tag (immutable tags are recommended)                                                                         | `3.3.0-debian-10-r36`            |
+| `imageRenderer.image.pullPolicy`                        | Grafana Image Renderer image pull policy                                                                                                  | `IfNotPresent`                   |
+| `imageRenderer.image.pullSecrets`                       | Grafana image Renderer pull secrets                                                                                                       | `[]`                             |
+| `imageRenderer.replicaCount`                            | Number of Grafana Image Renderer Pod replicas                                                                                             | `1`                              |
+| `imageRenderer.podAnnotations`                          | Grafana Image Renderer Pod annotations                                                                                                    | `{}`                             |
+| `imageRenderer.nodeSelector`                            | Node labels for pod assignment                                                                                                            | `{}`                             |
+| `imageRenderer.tolerations`                             | Tolerations for pod assignment                                                                                                            | `[]`                             |
+| `imageRenderer.topologySpreadConstraints`               | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in                                   | `[]`                             |
+| `imageRenderer.podAffinityPreset`                       | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                       | `""`                             |
+| `imageRenderer.podAntiAffinityPreset`                   | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                  | `soft`                           |
+| `imageRenderer.nodeAffinityPreset.type`                 | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                 | `""`                             |
+| `imageRenderer.nodeAffinityPreset.key`                  | Node label key to match Ignored if `affinity` is set.                                                                                     | `""`                             |
+| `imageRenderer.nodeAffinityPreset.values`               | Node label values to match. Ignored if `affinity` is set.                                                                                 | `[]`                             |
+| `imageRenderer.extraEnvVars`                            | Array containing extra env vars to configure Grafana                                                                                      | `{}`                             |
+| `imageRenderer.affinity`                                | Affinity for pod assignment                                                                                                               | `{}`                             |
+| `imageRenderer.resources.limits`                        | The resources limits for Grafana containers                                                                                               | `{}`                             |
+| `imageRenderer.resources.requests`                      | The requested resources for Grafana containers                                                                                            | `{}`                             |
+| `imageRenderer.podSecurityContext.enabled`              | Enable securityContext on for Grafana Image Renderer deployment                                                                           | `true`                           |
+| `imageRenderer.podSecurityContext.fsGroup`              | Group to configure permissions for volumes                                                                                                | `1001`                           |
+| `imageRenderer.podSecurityContext.runAsUser`            | User for the security context                                                                                                             | `1001`                           |
+| `imageRenderer.podSecurityContext.runAsNonRoot`         | Run containers as non-root users                                                                                                          | `true`                           |
+| `imageRenderer.containerSecurityContext.enabled`        | Enabled Grafana Image Renderer containers' Security Context                                                                               | `true`                           |
+| `imageRenderer.containerSecurityContext.runAsUser`      | Set Grafana Image Renderer containers' Security Context runAsUser                                                                         | `1001`                           |
+| `imageRenderer.service.type`                            | Kubernetes Service type                                                                                                                   | `ClusterIP`                      |
+| `imageRenderer.service.clusterIP`                       | Grafana service Cluster IP                                                                                                                | `""`                             |
+| `imageRenderer.service.ports.imageRenderer`             | Grafana Image Renderer metrics port                                                                                                       | `8080`                           |
+| `imageRenderer.service.nodePorts.grafana`               | Specify the nodePort value for the LoadBalancer and NodePort service types                                                                | `""`                             |
+| `imageRenderer.service.loadBalancerIP`                  | loadBalancerIP if Grafana service type is `LoadBalancer` (optional, cloud specific)                                                       | `""`                             |
+| `imageRenderer.service.loadBalancerSourceRanges`        | loadBalancerSourceRanges if Grafana service type is `LoadBalancer` (optional, cloud specific)                                             | `[]`                             |
+| `imageRenderer.service.annotations`                     | Provide any additional annotations which may be required.                                                                                 | `{}`                             |
+| `imageRenderer.service.externalTrafficPolicy`           | Grafana service external traffic policy                                                                                                   | `Cluster`                        |
+| `imageRenderer.service.extraPorts`                      | Extra port to expose on Redmine service                                                                                                   | `[]`                             |
+| `imageRenderer.metrics.enabled`                         | Enable the export of Prometheus metrics                                                                                                   | `false`                          |
+| `imageRenderer.metrics.annotations`                     | Prometheus annotations                                                                                                                    | `{}`                             |
+| `imageRenderer.metrics.serviceMonitor.enabled`          | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                                    | `false`                          |
+| `imageRenderer.metrics.serviceMonitor.namespace`        | Namespace in which Prometheus is running                                                                                                  | `""`                             |
+| `imageRenderer.metrics.serviceMonitor.interval`         | Interval at which metrics should be scraped.                                                                                              | `""`                             |
+| `imageRenderer.metrics.serviceMonitor.scrapeTimeout`    | Timeout after which the scrape is ended                                                                                                   | `""`                             |
+| `imageRenderer.metrics.prometheusRule.enabled`          | if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`) | `false`                          |
+| `imageRenderer.metrics.prometheusRule.namespace`        | Namespace for the PrometheusRule Resource (defaults to the Release Namespace)                                                             | `""`                             |
+| `imageRenderer.metrics.prometheusRule.additionalLabels` | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                                     | `{}`                             |
+| `imageRenderer.metrics.prometheusRule.rules`            | Prometheus Rule definitions                                                                                                               | `[]`                             |
+| `imageRenderer.initContainers`                          | Add additional init containers to the Grafana Image Renderer pod(s)                                                                       | `{}`                             |
+| `imageRenderer.extraEnvVarsCM`                          | Name of existing ConfigMap containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes                                                    | `""`                             |
+| `imageRenderer.extraEnvVarsSecret`                      | Name of existing Secret containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes                                                       | `""`                             |
+| `imageRenderer.command`                                 | Override default container command (useful when using custom images)                                                                      | `[]`                             |
+| `imageRenderer.args`                                    | Override default container args (useful when using custom images)                                                                         | `[]`                             |
 
 
 ### Volume permissions init Container Parameters
@@ -388,7 +396,7 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                    | `docker.io`             |
 | `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r279`     |
+| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r291`     |
 | `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                | `[]`                    |
 | `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                    |

--- a/bitnami/grafana/templates/image-renderer-prometheusrules.yaml
+++ b/bitnami/grafana/templates/image-renderer-prometheusrules.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.imageRenderer.metrics.enabled .Values.imageRenderer.metrics.prometheusRule.enabled  }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "common.names.fullname" . }}-image-renderer
+  {{- if .Values.imageRenderer.metrics.prometheusRule.namespace }}
+  namespace: {{ .Values.imageRenderer.metrics.prometheusRule.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.imageRenderer.metrics.prometheusRule.additionalLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+  - name: {{ include "common.names.fullname" . }}-image-renderer
+    rules: {{- include "common.tplvalues.render" ( dict "value" .Values.imageRenderer.metrics.prometheusRule.rules "context" $ ) | nindent 6 }}
+{{- end }}

--- a/bitnami/grafana/templates/prometheusrules.yaml
+++ b/bitnami/grafana/templates/prometheusrules.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.metrics.enabled .Values.metrics.prometheusRule.enabled  }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  {{- if .Values.metrics.prometheusRule.namespace }}
+  namespace: {{ .Values.metrics.prometheusRule.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+  - name: {{ include "common.names.fullname" . }}
+    rules: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.rules "context" $ ) | nindent 6 }}
+{{- end }}

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -686,7 +686,31 @@ metrics:
     ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
     ##
     jobLabel: ""
-
+  ## Prometheus Operator PrometheusRule configuration
+  ##
+  prometheusRule:
+    ## @param metrics.prometheusRule.enabled if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)
+    ##
+    enabled: false
+    ## @param metrics.prometheusRule.namespace Namespace for the PrometheusRule Resource (defaults to the Release Namespace)
+    ##
+    namespace: ""
+    ## @param metrics.prometheusRule.additionalLabels Additional labels that can be used so PrometheusRule will be discovered by Prometheus
+    ##
+    additionalLabels: {}
+    ## @param metrics.prometheusRule.rules PrometheusRule rules to configure
+    ## e.g:
+    ##  - alert: Grafana-Down
+    ##    annotations:
+    ##      message: 'Grafana instance is down'
+    ##      summary: Grafana instance is down
+    ##    expr: absent(up{job="grafana"} == 1)
+    ##    labels:
+    ##      severity: warning
+    ##      service: grafana
+    ##    for: 5m
+    ##
+    rules: []
 ## @section Grafana Image Renderer parameters
 
 imageRenderer:
@@ -892,6 +916,29 @@ imageRenderer:
       ## scrapeTimeout: 10s
       ##
       scrapeTimeout: ""
+    ## Prometheus Operator PrometheusRule configuration
+    ##
+    prometheusRule:
+      ## @param imageRenderer.metrics.prometheusRule.enabled if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`)
+      ##
+      enabled: false
+      ## @param imageRenderer.metrics.prometheusRule.namespace Namespace for the PrometheusRule Resource (defaults to the Release Namespace)
+      ##
+      namespace: ""
+      ## @param imageRenderer.metrics.prometheusRule.additionalLabels Additional labels that can be used so PrometheusRule will be discovered by Prometheus
+      ##
+      additionalLabels: {}
+      ## @param imageRenderer.metrics.prometheusRule.rules Prometheus Rule definitions
+      ##      - alert: Grafana-Image-Renderer-Down
+      ##        expr: absent(up{job="grafana-image-renderer"} == 1)
+      ##        for: 1s
+      ##        labels:
+      ##          severity: critical
+      ##        annotations:
+      ##          summary: Grafana Image Renderer Down
+      ##          description: "Grafana Image Renderer is down. There are no values coming from grafana-image-renderer."
+      ##
+      rules: []
   ## @param imageRenderer.initContainers Add additional init containers to the Grafana Image Renderer pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
   ## e.g:


### PR DESCRIPTION

Signed-off-by: Ioachim Lihor <ioachim.lihor@radcom.com>

**Description of the change**
Add image-renderer-prometheusrule and prometheusrule files to enable support for PrometheusRules

**Benefits**
Write prometheus rules to alert the state of grafana and grafana-image-renderer services

**Possible drawbacks**
No possible known drawbacks.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
