### PR TITLE
[bitnami/phpbb] fix volumemount name for volumePermissions

### DIFF
--- a/bitnami/phpbb/Chart.yaml
+++ b/bitnami/phpbb/Chart.yaml
@@ -26,4 +26,4 @@ name: phpbb
 sources:
   - https://github.com/bitnami/bitnami-docker-phpbb
   - https://www.phpbb.com/
-version: 10.2.2
+version: 10.2.3

--- a/bitnami/phpbb/templates/deployment.yaml
+++ b/bitnami/phpbb/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: data
+            - name: phpbb-data
               mountPath: /bitnami/phpbb
         {{- end }}
         {{- if .Values.initContainers }}


### PR DESCRIPTION
**Description of the change**

The volume mount name is incorrect in the phpbb deployment template when using volumePermissions. It references a "data" mount instead of "phpbb-data". This causes the following error:

```
[...] is invalid: spec.template.spec.initContainers[0].volumeMounts[0].name: Not found: "data"
```
**Applicable issues**

- Fixes #5401

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
