### PR TITLE
[bitnami/contour] Added ability to use sidecars in Envoy pods

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 7.0.8
+version: 7.1.0

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -258,6 +258,7 @@ $ helm uninstall my-release
 | `envoy.containerPorts.http`                         | Sets http port inside Envoy pod  (change this to >1024 to run envoy as a non-root user)                               | `8080`                 |
 | `envoy.containerPorts.https`                        | Sets https port inside Envoy pod  (change this to >1024 to run envoy as a non-root user)                              | `8443`                 |
 | `envoy.initContainers`                              | Attach additional init containers to Envoy pods                                                                       | `[]`                   |
+| `envoy.sidecars`                                    | Add additional sidecar containers to the Envoy pods                                                                   | `[]`                   |
 | `envoy.extraVolumes`                                | Array to add extra volumes                                                                                            | `[]`                   |
 | `envoy.extraVolumeMounts`                           | Array to add extra mounts (normally used with extraVolumes)                                                           | `[]`                   |
 | `envoy.extraEnvVars`                                | Array containing extra env vars to be added to all Envoy containers                                                   | `[]`                   |

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -245,6 +245,9 @@ spec:
                 path: /shutdown
                 port: 8090
                 scheme: HTTP
+        {{- if .Values.envoy.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.envoy.sidecars "cotext" $ ) | nindent 8 }}
+        {{- end }}
       initContainers:
         - command:
             - contour

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -740,6 +740,17 @@ envoy:
   ##     imagePullPolicy: Always
   ##
   initContainers: []
+  ## @param envoy.sidecars [array] Add additional sidecar containers to the Envoy pods
+  ## Example:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
   ## @param envoy.extraVolumes [array] Array to add extra volumes
   ##
   extraVolumes: []

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -740,7 +740,7 @@ envoy:
   ##     imagePullPolicy: Always
   ##
   initContainers: []
-  ## @param envoy.sidecars [array] Add additional sidecar containers to the Envoy pods
+  ## @param envoy.sidecars Add additional sidecar containers to the Envoy pods
   ## Example:
   ## sidecars:
   ##   - name: your-image-name


### PR DESCRIPTION
**Description of the change**
Added additional parameter to values.yaml which allows to configure sidecars for Envoy pods

**Benefits**
Run sidecars in Envoy pod

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
