### PR TITLE
[bitnami/mongodb] Add metrics active wait

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 10.30.10
+version: 10.30.11

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -387,10 +387,44 @@ spec:
           {{- end }}
           command:
             - /bin/bash
-            - -ec
           args:
+            - -ec
             - |
-              /bin/mongodb_exporter --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
+                #!/bin/bash
+
+                set -o errexit
+                set -o nounset
+                set -o pipefail
+
+                retry_while() {
+                    local cmd="${1:?cmd is missing}"
+                    local retries="${2:-12}"
+                    local sleep_time="${3:-5}"
+                    local return_value=1
+
+                    read -r -a command <<< "$cmd"
+                    for ((i = 1 ; i <= retries ; i+=1 )); do
+                        "${command[@]}" && return_value=0 && break
+                        sleep "$sleep_time"
+                    done
+                    return $return_value
+                }
+
+                check_mongodb_connection() {
+                  /bin/mongodb_exporter --test --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }} >/dev/null 2>&1
+                  ret=$?
+                  if [ $ret -ne 0 ]; then
+                    false
+                  fi
+                }
+
+                echo "Checking MongoDB connection..."
+                if ! retry_while "check_mongodb_connection"; then
+                    echo "Could not connect to the MongoDB server"
+                    return 1
+                else
+                    /bin/mongodb_exporter --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
+                fi
           env:
           {{- if .Values.auth.enabled }}
           {{- if not .Values.metrics.username }}


### PR DESCRIPTION
**Description of the change**

Adds an active wait to prevent the exporter from initializing before MongoDB credentials have been set.

**Applicable issues**

  - fixes #7592

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
