### PR TITLE
[bitnami/grafana-operator] add `grafana.ingress.pathType`

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 2.0.3
+version: 2.0.4

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -212,6 +212,7 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.ingress.ingressClassName`                          | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                 | `""`                  |
 | `grafana.ingress.hostname`                                  | The hostname under which the grafana instance should be reachable                             | `grafana.local`       |
 | `grafana.ingress.path`                                      | The path for the ingress instance to forward to the grafana app                               | `/`                   |
+| `grafana.ingress.pathType`                                      | The pathType for the ingress instance to forward to the grafana app                               | `Prefix`                   |
 | `grafana.ingress.labels`                                    | Additional Labels for the ingress resource                                                    | `{}`                  |
 | `grafana.ingress.annotations`                               | Additional Annotations for the ingress resource                                               | `{}`                  |
 | `grafana.ingress.tls`                                       | This enables tls support for the ingress resource                                             | `false`               |

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -212,7 +212,7 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.ingress.ingressClassName`                          | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                 | `""`                  |
 | `grafana.ingress.hostname`                                  | The hostname under which the grafana instance should be reachable                             | `grafana.local`       |
 | `grafana.ingress.path`                                      | The path for the ingress instance to forward to the grafana app                               | `/`                   |
-| `grafana.ingress.pathType`                                      | The pathType for the ingress instance to forward to the grafana app                               | `Prefix`                   |
+| `grafana.ingress.pathType`                                  | The pathType for the ingress instance to forward to the grafana app                           | `ImplementationSpecific`                   |
 | `grafana.ingress.labels`                                    | Additional Labels for the ingress resource                                                    | `{}`                  |
 | `grafana.ingress.annotations`                               | Additional Annotations for the ingress resource                                               | `{}`                  |
 | `grafana.ingress.tls`                                       | This enables tls support for the ingress resource                                             | `false`               |

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -160,6 +160,7 @@ spec:
       {{- end }}
     {{- end }}
     path: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.path "context" $) }}
+    pathType: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.pathType "context" $) }}
   config: {{- include "common.tplvalues.render" ( dict "value" .Values.grafana.config "context" $ ) | nindent 4 }}
   {{- if .Values.grafana.configMaps }}
   configMaps: {{ toYaml .Values.grafana.configMaps | nindent 4 }}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -127,7 +127,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/grafana-operator
-    tag: 4.1.1-debian-10-r16
+    tag: 4.1.1-debian-10-r18
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## Ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -386,7 +386,7 @@ grafana:
   image:
     registry: docker.io
     repository: bitnami/grafana
-    tag: 8.3.3-debian-10-r15
+    tag: 8.3.3-debian-10-r16
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -604,7 +604,7 @@ grafana:
     server:
       root_url: |-
         {{- if .Values.grafana.ingress.enabled }}
-        {{ if .Values.grafana.ingress.tls }}https{{ else }}http{{ end }}://{{ .Values.grafana.ingress.hostname }}
+        {{ if .Values.grafana.ingress.tls }}https{{ else }}http{{ end }}://{{ include "common.tplvalues.render" (dict "value" .Values.grafana.ingress.hostname "context" $) }}
         {{- else }}
         http://localhost:3000
         {{- end }}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -547,6 +547,9 @@ grafana:
     ## @param grafana.ingress.path The path for the ingress instance to forward to the grafana app
     ##
     path: /
+    ## @param grafana.ingress.pathType The pathType for the ingress instance to forward to the grafana app
+    ##
+    pathType: Prefix
     ## @param grafana.ingress.labels Additional Labels for the ingress resource
     ##
     labels: {}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -549,7 +549,7 @@ grafana:
     path: /
     ## @param grafana.ingress.pathType The pathType for the ingress instance to forward to the grafana app
     ##
-    pathType: Prefix
+    pathType: ImplementationSpecific
     ## @param grafana.ingress.labels Additional Labels for the ingress resource
     ##
     labels: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add `grafana.ingress.pathType` value with default value of `ImplementationSpecific`

**Benefits**

Fixes an issue where this chart `Grafana` resource could not be provisioned with an `Ingress` due to missing the `pathType` parameter required by the `networking.k8s.io/v1` API.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #8531
  - fixes #8540 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
