### PR TITLE
[bitnami/rabbitmq] Error on network policy definition

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.24.12
+version: 8.24.13

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -971,13 +971,18 @@ networkPolicy:
   ## @param networkPolicy.additionalRules Additional NetworkPolicy Ingress "from" rules to set. Note that all rules are OR-ed.
   ## e.g:
   ## additionalRules:
-  ##  - matchLabels:
-  ##    - role: frontend
-  ##  - matchExpressions:
-  ##    - key: role
-  ##      operator: In
-  ##      values:
-  ##        - frontend
+  ##   - podSelector:
+  ##       matchLabels:
+  ##         role: frontend
+  ##     namespaceSelector:
+  ##       matchLabels:
+  ##         namespace: frontend
+  ##   - podSelector:
+  ##       matchExpressions:
+  ##         - key: role
+  ##           operator: In
+  ##           values:
+  ##             - frontend
   ##
   additionalRules: []
 


### PR DESCRIPTION
**Description of the change**

Change network policy definition in values.yaml to make it works

**Benefits**

Applying network policies works.

**Possible drawbacks**

N/A

**Applicable issues**

**Additional information**

No code is changed, only commented network policy definition. I have dump version, but I don't know if it is necessary if I haven't changed the code.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
