### PR TITLE
[bitnami/ghost] Add secret password key parameter

### DIFF
--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - https://www.ghost.org/
-version: 15.2.0
+version: 15.2.1

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -76,7 +76,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------- | ------------------------------------------------ | --------------------- |
 | `image.registry`    | Ghost image registry                             | `docker.io`           |
 | `image.repository`  | Ghost image repository                           | `bitnami/ghost`       |
-| `image.tag`         | Ghost image tag (immutable tags are recommended) | `4.24.0-debian-10-r2` |
+| `image.tag`         | Ghost image tag (immutable tags are recommended) | `4.32.0-debian-10-r0` |
 | `image.pullPolicy`  | Ghost image pull policy                          | `IfNotPresent`        |
 | `image.pullSecrets` | Ghost image pull secrets                         | `[]`                  |
 | `image.debug`       | Enable image debug mode                          | `false`               |
@@ -210,7 +210,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                   | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`            | Bitnami Shell image registry                                                                    | `docker.io`             |
 | `volumePermissions.image.repository`          | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r265`     |
+| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r282`     |
 | `volumePermissions.image.pullPolicy`          | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`         | Bitnami Shell image pull secrets                                                                | `[]`                    |
 | `volumePermissions.resources.limits`          | The resources limits for the init container                                                     | `{}`                    |
@@ -220,25 +220,27 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Database Parameters
 
-| Name                                       | Description                                                               | Value           |
-| ------------------------------------------ | ------------------------------------------------------------------------- | --------------- |
-| `mariadb.enabled`                          | Deploy a MariaDB server to satisfy the applications database requirements | `true`          |
-| `mariadb.architecture`                     | MariaDB architecture. Allowed values: `standalone` or `replication`       | `standalone`    |
-| `mariadb.auth.rootPassword`                | MariaDB root password                                                     | `""`            |
-| `mariadb.auth.database`                    | MariaDB custom database                                                   | `bitnami_ghost` |
-| `mariadb.auth.username`                    | MariaDB custom user name                                                  | `bn_ghost`      |
-| `mariadb.auth.password`                    | MariaDB custom user password                                              | `""`            |
-| `mariadb.auth.existingSecret`              | Existing secret with MariaDB credentials                                  | `""`            |
-| `mariadb.primary.persistence.enabled`      | Enable persistence on MariaDB using PVC(s)                                | `true`          |
-| `mariadb.primary.persistence.storageClass` | Persistent Volume storage class                                           | `""`            |
-| `mariadb.primary.persistence.accessModes`  | Persistent Volume access modes                                            | `[]`            |
-| `mariadb.primary.persistence.size`         | Persistent Volume size                                                    | `8Gi`           |
-| `externalDatabase.host`                    | External Database server host                                             | `localhost`     |
-| `externalDatabase.port`                    | External Database server port                                             | `3306`          |
-| `externalDatabase.user`                    | External Database username                                                | `bn_ghost`      |
-| `externalDatabase.password`                | External Database user password                                           | `""`            |
-| `externalDatabase.database`                | External Database database name                                           | `bitnami_ghost` |
-| `externalDatabase.existingSecret`          | The name of an existing secret with database credentials                  | `""`            |
+| Name                                         | Description                                                               | Value              |
+| -------------------------------------------- | ------------------------------------------------------------------------- | ------------------ |
+| `mariadb.enabled`                            | Deploy a MariaDB server to satisfy the applications database requirements | `true`             |
+| `mariadb.architecture`                       | MariaDB architecture. Allowed values: `standalone` or `replication`       | `standalone`       |
+| `mariadb.auth.rootPassword`                  | MariaDB root password                                                     | `""`               |
+| `mariadb.auth.database`                      | MariaDB custom database                                                   | `bitnami_ghost`    |
+| `mariadb.auth.username`                      | MariaDB custom user name                                                  | `bn_ghost`         |
+| `mariadb.auth.password`                      | MariaDB custom user password                                              | `""`               |
+| `mariadb.auth.existingSecret`                | Existing secret with MariaDB credentials                                  | `""`               |
+| `mariadb.auth.existingSecretPasswordKey`     | Password key to be retrieved from existing secret                         | `mariadb-password` |
+| `mariadb.primary.persistence.enabled`        | Enable persistence on MariaDB using PVC(s)                                | `true`             |
+| `mariadb.primary.persistence.storageClass`   | Persistent Volume storage class                                           | `""`               |
+| `mariadb.primary.persistence.accessModes`    | Persistent Volume access modes                                            | `[]`               |
+| `mariadb.primary.persistence.size`           | Persistent Volume size                                                    | `8Gi`              |
+| `externalDatabase.host`                      | External Database server host                                             | `localhost`        |
+| `externalDatabase.port`                      | External Database server port                                             | `3306`             |
+| `externalDatabase.user`                      | External Database username                                                | `bn_ghost`         |
+| `externalDatabase.password`                  | External Database user password                                           | `""`               |
+| `externalDatabase.database`                  | External Database database name                                           | `bitnami_ghost`    |
+| `externalDatabase.existingSecret`            | The name of an existing secret with database credentials                  | `""`               |
+| `externalDatabase.existingSecretPasswordKey` | Password key to be retrieved from existing secret                         | `mariadb-password` |
 
 
 ### NetworkPolicy parameters
@@ -406,9 +408,9 @@ Please read the update notes carefully.
 **What changes were introduced in this major version?**
 
 - Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
-- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
-- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
-- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+- Move dependency information from the _requirements.yaml_ to the _Chart.yaml_
+- After running `helm dependency update`, a _Chart.lock_ file is generated containing the same structure used in the previous _requirements.lock_
+- The different fields present in the _Chart.yaml_ file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
 
 **Considerations when upgrading to this version**
 
@@ -442,11 +444,11 @@ $ export MARIADB_PVC=$(kubectl get pvc -l app=mariadb,component=master,release=g
 
 Delete the Ghost deployment and delete the MariaDB statefulset. Notice the option `--cascade=false` in the latter.
 
-  ```console
-  $ kubectl delete deployments.apps ghost
+```console
+$ kubectl delete deployments.apps ghost
 
-  $ kubectl delete statefulsets.apps ghost-mariadb --cascade=false
-  ```
+$ kubectl delete statefulsets.apps ghost-mariadb --cascade=false
+```
 
 Upgrade you release to 11.0.0 reusing the existing PVC, and enabling back MariaDB:
 

--- a/bitnami/ghost/templates/_helpers.tpl
+++ b/bitnami/ghost/templates/_helpers.tpl
@@ -120,6 +120,18 @@ Return the MariaDB Secret Name
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Return the MariaDB Secret Password Key
+*/}}
+{{- define "ghost.databaseSecretPasswordKey" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" .Values.mariadb.auth.existingSecretPasswordKey -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalDatabase.existingSecretPasswordKey -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Compile all warnings into a single message.
 */}}

--- a/bitnami/ghost/templates/deployment.yaml
+++ b/bitnami/ghost/templates/deployment.yaml
@@ -124,7 +124,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "ghost.databaseSecretName" . }}
-                  key: mariadb-password
+                  key: {{ include "ghost.databaseSecretPasswordKey" . }}
             - name: GHOST_HOST
               value: {{ include "ghost.host" . | quote }}
             - name: GHOST_PORT_NUMBER

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -592,6 +592,7 @@ mariadb:
   ## @param mariadb.auth.username MariaDB custom user name
   ## @param mariadb.auth.password MariaDB custom user password
   ## @param mariadb.auth.existingSecret Existing secret with MariaDB credentials
+  ## @param mariadb.auth.existingSecretPasswordKey Password key to be retrieved from existing secret
   ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
   ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
   ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
@@ -601,6 +602,7 @@ mariadb:
     username: bn_ghost
     password: ""
     existingSecret: ""
+    existingSecretPasswordKey: "mariadb-password"
   ## MariaDB Primary configuration
   ##
   primary:
@@ -637,10 +639,12 @@ externalDatabase:
   ##
   database: bitnami_ghost
   ## @param externalDatabase.existingSecret The name of an existing secret with database credentials
-  ## NOTE: Must contain key `mariadb-password`
   ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
   ##
   existingSecret: ""
+  ## @param externalDatabase.existingSecretPasswordKey Password key to be retrieved from existing secret
+  ##
+  existingSecretPasswordKey: "mariadb-password"
 
 ## @section NetworkPolicy parameters
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add secret password key parameter

**Benefits**

We will be able to use secret keys other than `mariadb-password`

**Possible drawbacks**

None

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
