### PR TITLE
[bitnami/mysql] Prevent introduction of leading newline character in predefined password and replicationPassword

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.8.18
+version: 8.8.19

--- a/bitnami/mysql/templates/_helpers.tpl
+++ b/bitnami/mysql/templates/_helpers.tpl
@@ -153,21 +153,21 @@ otherwise it generates a random value.
 
 {{- define "mysql.password" -}}
     {{- if and (not (empty .Values.auth.username)) (not (empty .Values.auth.password)) }}
-        {{ .Values.auth.password }}
+        {{- .Values.auth.password }}
     {{- else if (not .Values.auth.forcePassword) }}
         {{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (include "common.names.fullname" .) "Length" 10 "Key" "mysql-password") }}
     {{- else }}
-        {{ required "A MySQL Database Password is required!" .Values.auth.password }}
+        {{- required "A MySQL Database Password is required!" .Values.auth.password }}
     {{- end }}
 {{- end -}}
 
 {{- define "mysql.replication.password" -}}
     {{- if not (empty .Values.auth.replicationPassword) }}
-        {{ .Values.auth.replicationPassword }}
+        {{- .Values.auth.replicationPassword }}
     {{- else if (not .Values.auth.forcePassword) }}
         {{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (include "common.names.fullname" .) "Length" 10 "Key" "mysql-replication-password") }}
     {{- else }}
-        {{ required "A MySQL Replication Password is required!" .Values.auth.replicationPassword }}
+        {{- required "A MySQL Replication Password is required!" .Values.auth.replicationPassword }}
     {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Leading newline character added to predefined `auth.password` and `auth.replicationPassword` by bitnami/mysql chart.
Introducing change: https://github.com/bitnami/charts/commit/7238fbe13877943f861c03229a72dad35c0d81b9

**Benefits**

Permit use of predefined `auth.password` and `auth.replicationPassword` parameters in bitnami/mysql chart.

**Possible drawbacks**

n/a

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #8504

**Additional information**

Reproduced by predefined values for `auth.password` and `auth.replicationPassword` and visible in container logs with `image.debug: true`:

`helm install my-release bitnami/mysql --set auth.password=9fXymk61OT,auth.replicationPassword=E6dMqifzrh,auth.username=my_user,image.debug=true`

Log file:
```
mysql 01:31:24.36 DEBUG ==> Configuring root user credentials
mysql 01:31:24.37 DEBUG ==> Executing SQL command:
-- create admin user
create user 'root'@'%' identified by "wf3vWj0zlO";
grant all on *.* to 'root'@'%' with grant option;
flush privileges;
mysql 01:31:24.53 DEBUG ==> removing the unknown user
mysql 01:31:24.54 DEBUG ==> Executing SQL command:
select Host from user where User='';
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql 01:31:24.56 DEBUG ==> creating database user \'my_user\'
mysql 01:31:24.57 DEBUG ==> Executing SQL command:
create user if not exists 'my_user'@'%' identified by "
9fXymk61OT";
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql 01:31:24.65 DEBUG ==> Removing all other hosts for the user
mysql 01:31:24.68 DEBUG ==> Executing SQL command:
select Host from user where User='my_user' and Host!='%';
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql 01:31:24.71 DEBUG ==> Creating database my_user
mysql 01:31:24.72 DEBUG ==> Executing SQL command:
create database if not exists `my_database` ;
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql 01:31:24.86 DEBUG ==> Providing privileges to username my_user on database my_database
mysql 01:31:24.90 DEBUG ==> Executing SQL command:
grant all on `my_database`.* to 'my_user'@'%';
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql 01:31:25.08 INFO  ==> Configuring replication in master node
mysql 01:31:25.11 DEBUG ==> Configure replication user credentials
mysql 01:31:25.20 DEBUG ==> Executing SQL command:
create user 'replicator'@'%' identified with 'mysql_native_password' by "
E6dMqifzrh";
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql 01:31:25.43 DEBUG ==> Executing SQL command:
grant REPLICATION SLAVE on *.* to 'replicator'@'%' with grant option;
flush privileges;
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
