### PR TITLE
bitnami/grafana-operator fix default value for accessModes

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 2.0.4
+version: 2.0.5

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 2.0.5
+version: 2.1.0

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -219,7 +219,7 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.ingress.tlsSecret`                                 | The name for the secret to use for the tls termination                                        | `grafana.local-tls`   |
 | `grafana.persistence.enabled`                               | Enable persistent storage for the grafana deployment                                          | `false`               |
 | `grafana.persistence.storageClass`                          | Define the storageClass for the persistent storage if not defined default is used             | `""`                  |
-| `grafana.persistence.accessModes`                           | Define the accessModes for the persistent storage                                             | `ReadWriteOnce`       |
+| `grafana.persistence.accessModes`                           | Define the accessModes for the persistent storage                                             | `[ReadWriteOnce]`       |
 | `grafana.persistence.annotations`                           | Add annotations to the persistent volume                                                      | `{}`                  |
 | `grafana.persistence.size`                                  | Define the size of the PersistentVolumeClaim to request for                                   | `10Gi`                |
 | `grafana.config`                                            | grafana.ini configuration for the instance for this to configure please look at upstream docs | `{}`                  |

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -589,7 +589,8 @@ grafana:
     storageClass: ""
     ## @param grafana.persistence.accessModes Define the accessModes for the persistent storage
     ##
-    accessModes: ReadWriteOnce
+    accessModes:
+      - ReadWriteOnce
     ## @param grafana.persistence.annotations Add annotations to the persistent volume
     ##
     annotations: {}


### PR DESCRIPTION
**Description of the change**
After recent [changes](https://github.com/bitnami/charts/commit/d87dec202858e218f08470a8a28d5397426b6a6c) to the grafana-operator chart Values.grafana.persistence.accessModes is expected to be a list:
https://github.com/bitnami/charts/blob/master/bitnami/grafana-operator/templates/grafana.yaml#L33

Change Values.grafana.persistence.accessModes to be a list.

**Benefits**

Fixes: Error: UPGRADE FAILED: template: grafana-operator/templates/grafana.yaml:34:23: executing "grafana-operator/templates/grafana.yaml" at <.Values.grafana.persistence.accessModes>: range can't iterate over ReadWriteOnce

**Possible drawbacks**

None



**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
