### PR TITLE
[bitnami/several] Fix issue with quote when followed by }}

### DIFF
--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -30,4 +30,4 @@ name: concourse
 sources:
   - https://github.com/bitnami/bitnami-docker-concourse
   - https://github.com/concourse/concourse
-version: 0.1.17
+version: 0.1.18

--- a/bitnami/concourse/templates/web/deployment.yaml
+++ b/bitnami/concourse/templates/web/deployment.yaml
@@ -115,7 +115,7 @@ spec:
             - name: POSTGRESQL_CLIENT_DATABASE_NAME
               value: {{ ternary .Values.postgresql.postgresqlDatabase .Values.externalDatabase.port .Values.postgresql.enabled }}
             - name: POSTGRESQL_CLIENT_DATABASE_PORT_NUMBER
-              value: {{ ternary "5432" .Values.externalDatabase.port .Values.postgresql.enabled | quote}}
+              value: {{ ternary "5432" .Values.externalDatabase.port .Values.postgresql.enabled | quote }}
             - name: POSTGRESQL_CLIENT_CREATE_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.5.6
+version: 17.5.7

--- a/bitnami/elasticsearch/templates/cronjob.yaml
+++ b/bitnami/elasticsearch/templates/cronjob.yaml
@@ -108,17 +108,17 @@ spec:
               env:
                 {{- if .Values.curator.env }}
                 {{- range $key,$value := .Values.curator.env }}
-                - name: {{ $key | upper | quote}}
-                  value: {{ $value | quote}}
+                - name: {{ $key | upper | quote }}
+                  value: {{ $value | quote }}
                 {{- end }}
                 {{- end }}
                 {{- if .Values.curator.envFromSecrets }}
                 {{- range $key,$value := .Values.curator.envFromSecrets }}
-                - name: {{ $key | upper | quote}}
+                - name: {{ $key | upper | quote }}
                   valueFrom:
                     secretKeyRef:
-                      name: {{ $value.from.secret | quote}}
-                      key: {{ $value.from.key | quote}}
+                      name: {{ $value.from.secret | quote }}
+                      key: {{ $value.from.key | quote }}
                 {{- end }}
                 {{- end }}
               {{- if .Values.curator.resources }}

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -24,4 +24,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 6.10.7
+version: 6.10.8

--- a/bitnami/etcd/templates/statefulset.yaml
+++ b/bitnami/etcd/templates/statefulset.yaml
@@ -150,7 +150,7 @@ spec:
             {{- end }}
             - name: ETCD_AUTH_TOKEN
               {{- if eq .Values.auth.token.type "jwt" }}
-              value: {{ printf "jwt,priv-key=/opt/bitnami/etcd/certs/token/%s,sign-method=%s,ttl=%s" .Values.auth.token.privateKey.filename .Values.auth.token.signMethod .Values.auth.token.ttl | quote}}
+              value: {{ printf "jwt,priv-key=/opt/bitnami/etcd/certs/token/%s,sign-method=%s,ttl=%s" .Values.auth.token.privateKey.filename .Values.auth.token.signMethod .Values.auth.token.ttl | quote }}
               {{- else if eq .Values.auth.token.type "simple" }}
               value: "simple"
               {{- end }}

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -26,4 +26,4 @@ name: jupyterhub
 sources:
   - https://github.com/bitnami/bitnami-docker-jupyterhub
   - https://github.com/jupyterhub/jupyterhub
-version: 0.3.6
+version: 0.3.7

--- a/bitnami/jupyterhub/templates/hub/deployment.yaml
+++ b/bitnami/jupyterhub/templates/hub/deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - name: POSTGRESQL_CLIENT_DATABASE_NAME
               value: {{ ternary .Values.postgresql.postgresqlDatabase .Values.externalDatabase.port .Values.postgresql.enabled }}
             - name: POSTGRESQL_CLIENT_DATABASE_PORT_NUMBER
-              value: {{ ternary "5432" .Values.externalDatabase.port .Values.postgresql.enabled | quote}}
+              value: {{ ternary "5432" .Values.externalDatabase.port .Values.postgresql.enabled | quote }}
             - name: POSTGRESQL_CLIENT_CREATE_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 9.2.9
+version: 9.2.10

--- a/bitnami/minio/templates/gateway/deployment.yaml
+++ b/bitnami/minio/templates/gateway/deployment.yaml
@@ -70,7 +70,7 @@ spec:
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.gateway.priorityClassName }}
-      priorityClassName: {{ .Values.gateway.priorityClassName | quote}}
+      priorityClassName: {{ .Values.gateway.priorityClassName | quote }}
       {{- end }}
       {{- if .Values.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 3.10.1
+version: 3.10.2

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -98,7 +98,7 @@ spec:
               name: mongodb
           env:
             - name: MONGODB_ENABLE_NUMACTL
-              value: {{ ternary "yes" "no" $.Values.common.mongodbEnableNumactl | quote}}
+              value: {{ ternary "yes" "no" $.Values.common.mongodbEnableNumactl | quote }}
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" (or $.Values.image.debug $.Values.diagnosticMode.enabled) | quote }}
             - name: MONGODB_SYSTEM_LOG_VERBOSITY

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.8.19
+version: 8.8.20

--- a/bitnami/mysql/templates/secrets.yaml
+++ b/bitnami/mysql/templates/secrets.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  mysql-root-password: {{ include "mysql.root.password" . | b64enc | quote}}
+  mysql-root-password: {{ include "mysql.root.password" . | b64enc | quote }}
   mysql-password: {{ include "mysql.password" . | b64enc | quote }}
   {{- if eq .Values.architecture "replication" }}
   mysql-replication-password: {{ include "mysql.replication.password" . | b64enc | quote }}

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 9.6.1
+version: 9.6.2

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -218,7 +218,7 @@ spec:
           imagePullPolicy: {{ .Values.ldapDaemon.image.pullPolicy | quote }}
           env:
             - name: NGINXLDAP_PORT_NUMBER
-              value: {{ .Values.ldapDaemon.port | quote}}
+              value: {{ .Values.ldapDaemon.port | quote }}
             - name: NGINXLDAP_LDAP_URI
               value: {{ .Values.ldapDaemon.ldapConfig.uri | quote }}
             - name: NGINXLDAP_LDAP_BASE_DN

--- a/bitnami/nginx/templates/ldap-daemon-secrets.yaml
+++ b/bitnami/nginx/templates/ldap-daemon-secrets.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  ldap-daemon-ldap-bind-password: {{ .Values.ldapDaemon.ldapConfig.bindPassword | b64enc | quote}}
+  ldap-daemon-ldap-bind-password: {{ .Values.ldapDaemon.ldapConfig.bindPassword | b64enc | quote }}
 {{- if (not .Values.ldapDaemon.existingNginxServerBlockSecret) }}
   ldap_nginx.conf: |-
 {{ tpl .Values.ldapDaemon.nginxServerBlock . | b64enc | indent 4 }}


### PR DESCRIPTION
**Description of the change**

Replace all occurrences of `| quote}}` with `| quote }}` in order to solve some issues.
 
**Benefits**

Originally created to solve the issue described for MySQL at #8557 (probably introduced at #8504), but it can be also applied to all occurrences. For this specific issue:

- With `| quote}}`:

```yaml
data:   
  mysql-root-password: {{ include "mysql.root.password" . | b64enc | quote}}
  mysql-password: {{ include "mysql.password" . | b64enc | quote }}
```
```console
$ kubectl get secret --namespace mymysql7 mysql7 -o jsonpath="{.data.mysql-root-password}" | base64 --decode
myRootPassword%
$ kubectl get secret  mysql -o jsonpath="{.data.mysql-password}" | base64 --decode

        myregularpassword%
```

- With `| quote }}`
```yaml
data:   
  mysql-root-password: {{ include "mysql.root.password" . | b64enc | quote }}
  mysql-password: {{ include "mysql.password" . | b64enc | quote }}
```
```
$ kubectl get secret --namespace mymysql7 mysql7 -o jsonpath="{.data.mysql-root-password}" | base64 --decode
myRootPassword%
$ kubectl get secret  mysql -o jsonpath="{.data.mysql-password}" | base64 --decode
myregularpassword%
```

Note how the password stored in the secret contains some undesired characters (tabs, spaces, newlines, etc) when using `| quote}}`. Space is required, see https://helm.sh/docs/chart_best_practices/templates/#formatting-templates

**Applicable issues**

  - fixes #8557

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
