### PR TITLE
[bitnami/minio] Fix minio discovery

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 9.2.10
+version: 9.2.11

--- a/bitnami/minio/templates/distributed/statefulset.yaml
+++ b/bitnami/minio/templates/distributed/statefulset.yaml
@@ -3,6 +3,7 @@
 {{- $headlessService := printf "%s-headless" (include "common.names.fullname" .) | trunc 63 }}
 {{- $releaseNamespace := .Release.Namespace }}
 {{- $clusterDomain := .Values.clusterDomain }}
+{{- $apiPort := toString .Values.containerPorts.api }}
 {{- $replicaCount := int .Values.statefulset.replicaCount }}
 {{- $zoneCount := int .Values.statefulset.zones }}
 {{- $drivesPerNode := int .Values.statefulset.drivesPerNode }}
@@ -134,7 +135,7 @@ spec:
                   {{- $endIndex := sub (add $factor $replicaCount) 1 }}
                   {{- $beginIndex := mul $i $replicaCount }}
                   {{- $bucket := ternary (printf "%s-{0...%d}" $mountPath (sub $drivesPerNode 1)) $mountPath (gt $drivesPerNode 1) }}
-                  {{- $clusters = append $clusters (printf "%s-{%d...%d}.%s.%s.svc.%s%s" $fullname $beginIndex $endIndex $headlessService $releaseNamespace $clusterDomain $bucket) }}
+                  {{- $clusters = append $clusters (printf "%s-{%d...%d}.%s.%s.svc.%s:%s%s" $fullname $beginIndex $endIndex $headlessService $releaseNamespace $clusterDomain $apiPort $bucket) }}
               {{- end }}
               value: {{ join "," $clusters | quote }}
             - name: MINIO_SCHEME


### PR DESCRIPTION
**Description of the change**

With new version of Minio, it requires to have the API port in the discovery URLs passed to Minio nodes.

**Benefits**

Fix Minio not starting in distributed mode.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
