### PR TITLE
[bitnami/cert-manager] Add clusterResourceNamespace value

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-cert-manager-webhook
   - https://github.com/bitnami/bitnami-docker-cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.1.29
+version: 0.2.0

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -57,18 +57,19 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                       | Description                                        | Value         |
-| -------------------------- | -------------------------------------------------- | ------------- |
-| `kubeVersion`              | Override Kubernetes version                        | `""`          |
-| `nameOverride`             | String to partially override common.names.fullname | `""`          |
-| `fullnameOverride`         | String to fully override common.names.fullname     | `""`          |
-| `commonLabels`             | Labels to add to all deployed objects              | `{}`          |
-| `commonAnnotations`        | Annotations to add to all deployed objects         | `{}`          |
-| `extraDeploy`              | Array of extra objects to deploy with the release  | `[]`          |
-| `logLevel`                 | Set up cert manager log level                      | `2`           |
-| `leaderElection.namespace` | Namespace which leaderElection works.              | `kube-system` |
-| `installCRDs`              | Flag to install Cert Manager CRDs                  | `false`       |
-| `replicaCount`             | Number of Cert Manager replicas                    | `1`           |
+| Name                       | Description                                                                                                                                       | Value         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `kubeVersion`              | Override Kubernetes version                                                                                                                       | `""`          |
+| `nameOverride`             | String to partially override common.names.fullname                                                                                                | `""`          |
+| `fullnameOverride`         | String to fully override common.names.fullname                                                                                                    | `""`          |
+| `commonLabels`             | Labels to add to all deployed objects                                                                                                             | `{}`          |
+| `commonAnnotations`        | Annotations to add to all deployed objects                                                                                                        | `{}`          |
+| `extraDeploy`              | Array of extra objects to deploy with the release                                                                                                 | `[]`          |
+| `logLevel`                 | Set up cert manager log level                                                                                                                     | `2`           |
+| `clusterResourceNamespace` | Namespace used to store DNS provider credentials etc. for ClusterIssuer resources. If empty, uses the namespace where the controller is deployed. | `""`          |
+| `leaderElection.namespace` | Namespace which leaderElection works.                                                                                                             | `kube-system` |
+| `installCRDs`              | Flag to install Cert Manager CRDs                                                                                                                 | `false`       |
+| `replicaCount`             | Number of Cert Manager replicas                                                                                                                   | `1`           |
 
 
 ### Controller deployment parameters
@@ -78,13 +79,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.replicaCount`                          | Number of Controller replicas                                                                        | `1`                    |
 | `controller.image.registry`                        | Controller image registry                                                                            | `docker.io`            |
 | `controller.image.repository`                      | Controller image repository                                                                          | `bitnami/cert-manager` |
-| `controller.image.tag`                             | Controller image tag (immutable tags are recommended)                                                | `1.6.1-debian-10-r25`  |
+| `controller.image.tag`                             | Controller image tag (immutable tags are recommended)                                                | `1.6.1-debian-10-r41`  |
 | `controller.image.pullPolicy`                      | Controller image pull policy                                                                         | `IfNotPresent`         |
 | `controller.image.pullSecrets`                     | Controller image pull secrets                                                                        | `[]`                   |
 | `controller.image.debug`                           | Controller image debug mode                                                                          | `false`                |
 | `controller.acmesolver.image.registry`             | Controller image registry                                                                            | `docker.io`            |
 | `controller.acmesolver.image.repository`           | Controller image repository                                                                          | `bitnami/acmesolver`   |
-| `controller.acmesolver.image.tag`                  | Controller image tag (immutable tags are recommended)                                                | `1.6.1-debian-10-r27`  |
+| `controller.acmesolver.image.tag`                  | Controller image tag (immutable tags are recommended)                                                | `1.6.1-debian-10-r43`  |
 | `controller.acmesolver.image.pullPolicy`           | Controller image pull policy                                                                         | `IfNotPresent`         |
 | `controller.acmesolver.image.pullSecrets`          | Controller image pull secrets                                                                        | `[]`                   |
 | `controller.acmesolver.image.debug`                | Controller image debug mode                                                                          | `false`                |
@@ -132,7 +133,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `webhook.replicaCount`                          | Number of Webhook replicas                                                                        | `1`                            |
 | `webhook.image.registry`                        | Webhook image registry                                                                            | `docker.io`                    |
 | `webhook.image.repository`                      | Webhook image repository                                                                          | `bitnami/cert-manager-webhook` |
-| `webhook.image.tag`                             | Webhook image tag (immutable tags are recommended)                                                | `1.6.1-debian-10-r27`          |
+| `webhook.image.tag`                             | Webhook image tag (immutable tags are recommended)                                                | `1.6.1-debian-10-r43`          |
 | `webhook.image.pullPolicy`                      | Webhook image pull policy                                                                         | `IfNotPresent`                 |
 | `webhook.image.pullSecrets`                     | Webhook image pull secrets                                                                        | `[]`                           |
 | `webhook.image.debug`                           | Webhook image debug mode                                                                          | `false`                        |
@@ -198,7 +199,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cainjector.replicaCount`                          | Number of CAInjector replicas                                                                        | `1`                   |
 | `cainjector.image.registry`                        | CAInjector image registry                                                                            | `docker.io`           |
 | `cainjector.image.repository`                      | CAInjector image repository                                                                          | `bitnami/cainjector`  |
-| `cainjector.image.tag`                             | CAInjector image tag (immutable tags are recommended)                                                | `1.6.1-debian-10-r26` |
+| `cainjector.image.tag`                             | CAInjector image tag (immutable tags are recommended)                                                | `1.6.1-debian-10-r42` |
 | `cainjector.image.pullPolicy`                      | CAInjector image pull policy                                                                         | `IfNotPresent`        |
 | `cainjector.image.pullSecrets`                     | CAInjector image pull secrets                                                                        | `[]`                  |
 | `cainjector.image.debug`                           | CAInjector image debug mode                                                                          | `false`               |

--- a/bitnami/cert-manager/templates/controller/deployment.yaml
+++ b/bitnami/cert-manager/templates/controller/deployment.yaml
@@ -78,7 +78,11 @@ spec:
           {{- else }}
           args:
             - --v={{ .Values.logLevel }}
+          {{- if .Values.clusterResourceNamespace }}
+            - --cluster-resource-namespace={{ .Values.clusterResourceNamespace }}
+          {{- else }}
             - --cluster-resource-namespace=$(POD_NAMESPACE)
+          {{- end }}
             - --leader-election-namespace={{ .Values.leaderElection.namespace }}
             - --acme-http01-solver-image={{ template "certmanager.acmesolver.image" . }}
           {{- end }}

--- a/bitnami/cert-manager/values.yaml
+++ b/bitnami/cert-manager/values.yaml
@@ -34,7 +34,9 @@ extraDeploy: []
 ## @param logLevel Set up cert manager log level
 ##
 logLevel: 2
-## Cert Manager leader Election
+## @param clusterResourceNamespace Namespace used to store DNS provider credentials etc. for ClusterIssuer resources. If empty, uses the namespace where the controller is deployed.
+##
+clusterResourceNamespace: ""
 ## @param leaderElection.namespace Namespace which leaderElection works.
 ##
 leaderElection:


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amorenoc@vmware.com>

**Description of the change**
Add the `clusterResourceNamespace` parameter to set the namespace where ClusterIssuer resources live.

**Applicable issues**
  - fixes #8559 

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
