### PR TITLE
[bitnami/postgresql]: fix unique services template render

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 10.15.0
+version: 10.15.1

--- a/bitnami/postgresql/templates/svc-read-set.yaml
+++ b/bitnami/postgresql/templates/svc-read-set.yaml
@@ -15,8 +15,8 @@ metadata:
   labels:
     pod: {{ $targetPod }}
   {{- include "common.labels.standard" $root | nindent 4 }}
-  {{- if .Values.commonLabels }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if $root.Values.commonLabels }}
+  {{- include "common.tplvalues.render" ( dict "value" $root.Values.commonLabels "context" $ ) | nindent 4 }}
   {{- end }}
   annotations:
 


### PR DESCRIPTION
Fixes the following templating error when setting `replication.uniqueServices` to `true`:

```
Error: template: postgresql/templates/svc-read-set.yaml:18:16: executing "postgresql/templates/svc-read-set.yaml" at <.Values.commonLabels>: can't evaluate field Values in type int
```

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
