### PR TITLE
[bitnami/sonarqube] Removed extra quotes from externalDatabase variables

### DIFF
--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -28,4 +28,4 @@ name: sonarqube
 sources:
   - https://github.com/bitnami/bitnami-docker-sonarqube
   - https://github.com/SonarSource/sonarqube
-version: 0.2.0
+version: 0.2.1

--- a/bitnami/sonarqube/templates/_helpers.tpl
+++ b/bitnami/sonarqube/templates/_helpers.tpl
@@ -59,7 +59,7 @@ Return the Database Hostname
 {{- if .Values.postgresql.enabled }}
     {{- printf "%s" (include "sonarqube.postgresql.fullname" .) -}}
 {{- else -}}
-    {{- .Values.externalDatabase.host | quote -}}
+    {{- .Values.externalDatabase.host  -}}
 {{- end -}}
 {{- end -}}
 
@@ -81,7 +81,7 @@ Return the Database Name
 {{- if .Values.postgresql.enabled }}
     {{- printf "%s" .Values.postgresql.postgresqlDatabase -}}
 {{- else -}}
-    {{- .Values.externalDatabase.database | quote -}}
+    {{- .Values.externalDatabase.database -}}
 {{- end -}}
 {{- end -}}
 
@@ -92,7 +92,7 @@ Return the Database User
 {{- if .Values.postgresql.enabled }}
     {{- printf "%s" .Values.postgresql.postgresqlUsername -}}
 {{- else -}}
-    {{- .Values.externalDatabase.user | quote -}}
+    {{- .Values.externalDatabase.user -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
If external database is used the enviroment variables are quoted twice and sonarqube is not able to connect to db

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
With this external db can be used

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #8437

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
