### PR TITLE
[bitnami/spring-cloud-dataflow] Add deployer.imagePullSecrets property

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 5.0.0
+version: 5.0.1

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -285,6 +285,7 @@ helm uninstall my-release
 | `deployer.volumes`                            | Streaming applications extra volumes                                                        | `{}`   |
 | `deployer.environmentVariables`               | Streaming applications environment variables                                                | `[]`   |
 | `deployer.podSecurityContext.runAsUser`       | Set Dataflow Streams container's Security Context runAsUser                                 | `1001` |
+| `deployer.imagePullSecrets`                   | Streaming applications imagePullSecrets                                                     | `[]`   |
 
 
 ### RBAC parameters

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -67,6 +67,9 @@ data:
                     {{- if .Values.deployer.podSecurityContext }}
                     podSecurityContext: {{- toYaml .Values.deployer.podSecurityContext | nindent 22 }}
                     {{- end }}
+                    {{- if .Values.deployer.imagePullSecrets }}
+                    imagePullSecrets: {{- toYaml .Values.deployer.imagePullSecrets | nindent 22 }}
+                    {{- end }}
           {{- end }}
           {{- if .Values.server.configuration.containerRegistries }}
           container:

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -96,6 +96,9 @@ data:
                     {{- if .Values.deployer.podSecurityContext }}
                     podSecurityContext: {{- toYaml .Values.deployer.podSecurityContext | nindent 22 }}
                     {{- end }}
+                    {{- if .Values.deployer.imagePullSecrets }}
+                    imagePullSecrets: {{- toYaml .Values.deployer.imagePullSecrets | nindent 22 }}
+                    {{- end }}
       {{- $hibernateDialect := include "scdf.database.hibernate.dialect" .  }}
       {{- if $hibernateDialect }}
       jpa:

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -984,6 +984,7 @@ deployer:
   podSecurityContext:
     runAsUser: 1001
   ## @param deployer.imagePullSecrets Streaming applications imagePullSecrets
+  ##
   imagePullSecrets: []
 
 ## @section RBAC parameters

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -984,7 +984,7 @@ deployer:
   podSecurityContext:
     runAsUser: 1001
   ## @param deployer.imagePullSecrets Streaming applications imagePullSecrets
-  imagePullSecrets : []
+  imagePullSecrets: []
 
 ## @section RBAC parameters
 

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -983,6 +983,8 @@ deployer:
   ##
   podSecurityContext:
     runAsUser: 1001
+  ## @param deployer.imagePullSecrets Streaming applications imagePullSecrets
+  imagePullSecrets : []
 
 ## @section RBAC parameters
 


### PR DESCRIPTION
**Description of the change**
Adding deployer imagePullSecrets property in skipper and SCDF server configmap

**Benefits**
Add imagePullSecrets to pod deployment of stream and tasks apps when using a private registry

**Applicable issues**
  - fixes #7902

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
