### PR TITLE
[bitnami/kafka] Fixed existingsecrets issues for auth configuration

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 14.9.0
+version: 14.9.1

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -118,7 +118,7 @@ data:
     {{- if (include "kafka.tlsEncryption" .) }}
     mkdir -p /opt/bitnami/kafka/config/certs
     {{- if eq .Values.auth.tls.type "jks" }}
-    {{- if not (empty .Values.auth.tls.existingSecrets) }}
+    {{- if (empty .Values.auth.tls.existingSecrets) }}
     JKS_TRUSTSTORE={{ printf "/%s/%s" (ternary "certs-${ID}" "truststore" (empty $jksTruststoreSecret)) (default "kafka.truststore.jks" $jksTruststore) | quote }}
     JKS_KEYSTORE="/certs-${ID}/kafka-keystore.jks"
     {{- else }}


### PR DESCRIPTION
**Description of the change**

Fixes `.Values.auth.tls.existingSecrets` parameter for auth configuration.

**Benefits**

- Fixes installation for cluster when existing secrets is setted.

**Possible drawbacks**

N/A.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- Fixes #8593

**Additional information**

N/A.

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
