### PR TITLE
[bitnami/phpmyadmin] Add support for ingressClassName

### DIFF
--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -29,4 +29,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/bitnami-docker-phpmyadmin
   - https://www.phpmyadmin.net/
-version: 8.4.0
+version: 8.4.1

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -29,4 +29,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/bitnami-docker-phpmyadmin
   - https://www.phpmyadmin.net/
-version: 8.4.1
+version: 8.5.0

--- a/bitnami/phpmyadmin/README.md
+++ b/bitnami/phpmyadmin/README.md
@@ -144,6 +144,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.externalTrafficPolicy`    | Enable client source IP preservation                                                                                             | `Cluster`                |
 | `service.annotations`              | Provide any additional annotations that may be required for the PhpMyAdmin service                                               | `{}`                     |
 | `ingress.enabled`                  | Set to true to enable ingress record generation                                                                                  | `false`                  |
+| `ingress.ingressClassName`         | Name of the ingress class (Kubernetes 1.18+)                                                                                     | `""`                     |
 | `ingress.hostname`                 | When the ingress is enabled, a host pointing to this will be created                                                             | `phpmyadmin.local`       |
 | `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |

--- a/bitnami/phpmyadmin/templates/ingress.yaml
+++ b/bitnami/phpmyadmin/templates/ingress.yaml
@@ -20,6 +20,9 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+    ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
     - host: {{ .Values.ingress.hostname }}

--- a/bitnami/phpmyadmin/values.yaml
+++ b/bitnami/phpmyadmin/values.yaml
@@ -323,7 +323,11 @@ ingress:
   ## DEPRECATED: Use ingress.annotations instead of ingress.certManager
   ## certManager: false
   ##
-
+  ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName: ""
   ## @param ingress.hostname When the ingress is enabled, a host pointing to this will be created
   ##
   hostname: phpmyadmin.local


### PR DESCRIPTION
**Description of the change**

Adds support for `ingress.ingressClassName`

**Benefits**

Replaces a deprecated feature of using `kubernetes.io/ingress.class` annotation to determine ingress class.

**Possible drawbacks**

None known.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
