### PR TITLE
[bitnami/solr] Add support for ingressClassName

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/bitnami-docker-solr
   - https://lucene.apache.org/solr/
-version: 2.3.0
+version: 2.3.1

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -194,6 +194,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.nodePorts.http`  | Node ports for the HTTP service                                                                                                  | `""`                     |
 | `service.nodePorts.https` | Node ports for the HTTPS service                                                                                                 | `""`                     |
 | `ingress.enabled`         | Enable ingress controller resource                                                                                               | `false`                  |
+| `ingress.ingressClassName`| Name of the ingress class (Kubernetes 1.18+)                                                                                     | `""`                     |
 | `ingress.pathType`        | Path type for the ingress resource                                                                                               | `ImplementationSpecific` |
 | `ingress.apiVersion`      | Override API Version (automatically detected if not set)                                                                         | `""`                     |
 | `ingress.hostname`        | Default host for the ingress resource                                                                                            | `solr.local`             |

--- a/bitnami/solr/templates/ingress.yaml
+++ b/bitnami/solr/templates/ingress.yaml
@@ -21,6 +21,9 @@ metadata:
     {{- end }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  {{- if .Values.ingress.ingressClassName }}
+    ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
     - host: {{ .Values.ingress.hostname | quote }}

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -502,7 +502,11 @@ ingress:
   ## DEPRECATED: Use ingress.annotations instead of ingress.certManager
   ## certManager: false
   ##
-
+  ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName: ""
   ## @param ingress.pathType Path type for the ingress resource
   ##
   pathType: ImplementationSpecific


### PR DESCRIPTION
**Description of the change**

Adds support for `ingress.ingressClassName`

**Benefits**

Replaces a deprecated feature of using `kubernetes.io/ingress.class` annotation to determine ingress class.

**Possible drawbacks**

None known.

**Additional information**

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
