### PR TITLE
[bitnami/nginx] Fix ServiceMonitor relabling values

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 9.7.0
+version: 9.7.1

--- a/bitnami/nginx/templates/servicemonitor.yaml
+++ b/bitnami/nginx/templates/servicemonitor.yaml
@@ -29,11 +29,11 @@ spec:
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
-      {{- if .Values.metrics.podMonitor.relabelings }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
       relabelings:
       {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.metrics.podMonitor.relabelings }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings:
       {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 8 }}
       {{- end }} 


### PR DESCRIPTION
**Description of the change**

#8551 resolved some issues with the ServiceMonitor definition in the Nginx chart, but didn't correct the if statements that controlled the rendering of the relabelling options

**Benefits**

Resolves issues using the chart with metrics enabled.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

N/A

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
