### PR TITLE
bitnami/spark: updated svc-master and master statefulset  to expose https port when ssl is enabled.

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -22,4 +22,4 @@ name: spark
 sources:
   - https://github.com/bitnami/bitnami-docker-spark
   - https://spark.apache.org/
-version: 5.8.0
+version: 5.8.1

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -142,7 +142,11 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- end }}
           ports:
+            {{- if .Values.security.ssl.enabled }}
+            - name: https
+            {{- else }}
             - name: http
+            {{- end }}
               containerPort: {{ .Values.master.webPort }}
               protocol: TCP
             - name: cluster

--- a/bitnami/spark/templates/svc-master.yaml
+++ b/bitnami/spark/templates/svc-master.yaml
@@ -28,8 +28,13 @@ spec:
       nodePort: null
       {{- end }}
     - port: {{ .Values.service.webPort }}
+      {{- if .Values.security.ssl.enabled }}
+      targetPort: https
+      name: https
+      {{- else }}
       targetPort: http
       name: http
+      {{- end }}
       protocol: TCP
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.web)) }}
       nodePort: {{ .Values.service.nodePorts.web }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**With current chart the https port is not exposed when ssl is enabled, because of this spark master webUI is not accessible, this change exposes the https port for master when ssl is enabled**



**Benefits**

We will be able to access master WebUI on https when ssl is enabled.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes # https://github.com/bitnami/charts/issues/8417

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
