### PR TITLE
[bitnami/cert-manager] Add dnsPolicy and dnsConfig settings to controller

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-cert-manager-webhook
   - https://github.com/bitnami/bitnami-docker-cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.2.1
+version: 0.3.0

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-cert-manager-webhook
   - https://github.com/bitnami/bitnami-docker-cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.2.0
+version: 0.2.1

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -111,9 +111,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.tolerations`                           | Tolerations for pod assignment                                                                       | `[]`                   |
 | `controller.podLabels`                             | Extra labels for Controller pods                                                                     | `{}`                   |
 | `controller.podAnnotations`                        | Annotations for Controller pods                                                                      | `{}`                   |
+| `controller.dnsPolicy`                             | Controller pod DNS policy                                                                            | `""`                   |
+| `controller.dnsConfig`                             | Controller pod DNS config. Required if `controller.dnsPolicy` is set to `None`                       | `{}`                   |
 | `controller.lifecycleHooks`                        | Add lifecycle hooks to the Controller deployment                                                     | `{}`                   |
-| `controller.dnsPolicy`                             | Controller DNS policy                                                                                | `ClusterFirst`         |
-| `controller.dnsConfig`                             | Controller DNS config. Required if `controller.dnsPolicy` is set to `None`                           | `[]`                   |
 | `controller.updateStrategy.type`                   | Controller deployment update strategy                                                                | `RollingUpdate`        |
 | `controller.updateStrategy.rollingUpdate`          | Controller deployment rolling update configuration parameters                                        | `{}`                   |
 | `controller.extraEnvVars`                          | Add extra environment variables to the Controller container                                          | `[]`                   |

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -112,6 +112,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.podLabels`                             | Extra labels for Controller pods                                                                     | `{}`                   |
 | `controller.podAnnotations`                        | Annotations for Controller pods                                                                      | `{}`                   |
 | `controller.lifecycleHooks`                        | Add lifecycle hooks to the Controller deployment                                                     | `{}`                   |
+| `controller.dnsPolicy`                             | Controller DNS policy                                                                                | `ClusterFirst`         |
+| `controller.dnsConfig`                             | Controller DNS config. Required if `controller.dnsPolicy` is set to `None`                           | `[]`                   |
 | `controller.updateStrategy.type`                   | Controller deployment update strategy                                                                | `RollingUpdate`        |
 | `controller.updateStrategy.rollingUpdate`          | Controller deployment rolling update configuration parameters                                        | `{}`                   |
 | `controller.extraEnvVars`                          | Add extra environment variables to the Controller container                                          | `[]`                   |

--- a/bitnami/cert-manager/templates/controller/deployment.yaml
+++ b/bitnami/cert-manager/templates/controller/deployment.yaml
@@ -128,7 +128,9 @@ spec:
         {{- if .Values.controller.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.controller.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
+      {{- if .Values.controller.dnsPolicy }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}
+      {{- end }}
       {{- if .Values.controller.dnsConfig }}
       dnsConfig: {{- include "common.tplvalues.render" (dict "value" .Values.controller.dnsConfig "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/cert-manager/templates/controller/deployment.yaml
+++ b/bitnami/cert-manager/templates/controller/deployment.yaml
@@ -129,7 +129,6 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.controller.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
       dnsPolicy: {{ .Values.controller.dnsPolicy }}
-      {{- with .Values.controller.dnsConfig }}
-      dnsConfig:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.controller.dnsConfig }}
+      dnsConfig: {{- include "common.tplvalues.render" (dict "value" .Values.controller.dnsConfig "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/cert-manager/templates/controller/deployment.yaml
+++ b/bitnami/cert-manager/templates/controller/deployment.yaml
@@ -128,3 +128,8 @@ spec:
         {{- if .Values.controller.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.controller.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
+      dnsPolicy: {{ .Values.controller.dnsPolicy }}
+      {{- with .Values.controller.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/bitnami/cert-manager/values.yaml
+++ b/bitnami/cert-manager/values.yaml
@@ -212,7 +212,7 @@ controller:
   ##   nameservers:
   ##     - "1.1.1.1"
   ##
-  dnsConfig: []
+  dnsConfig: {}
   ## @param controller.lifecycleHooks Add lifecycle hooks to the Controller deployment
   ##
   lifecycleHooks: {}

--- a/bitnami/cert-manager/values.yaml
+++ b/bitnami/cert-manager/values.yaml
@@ -201,11 +201,11 @@ controller:
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
-  ## @param controller.dnsPolicy Pod DNS policy
+  ## @param controller.dnsPolicy Controller pod DNS policy
   ## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
   ##
-  dnsPolicy: ClusterFirst
-  ## @param controller.dnsConfig Pod DNS config
+  dnsPolicy: ""
+  ## @param controller.dnsConfig Controller pod DNS config. Required if `controller.dnsPolicy` is set to `None`
   ## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
   ## E.g:
   ## dnsConfig:

--- a/bitnami/cert-manager/values.yaml
+++ b/bitnami/cert-manager/values.yaml
@@ -201,6 +201,18 @@ controller:
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
+  ## @param controller.dnsPolicy Pod DNS policy
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+  ##
+  dnsPolicy: ClusterFirst
+  ## @param controller.dnsConfig Pod DNS config
+  ## Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  ## E.g:
+  ## dnsConfig:
+  ##   nameservers:
+  ##     - "1.1.1.1"
+  ##
+  dnsConfig: []
   ## @param controller.lifecycleHooks Add lifecycle hooks to the Controller deployment
   ##
   lifecycleHooks: {}


### PR DESCRIPTION
**Description of the change**

Add dnsPolicy and dnsConfig settings to controller

**Benefits**

Optional DNS settings, useful if you have a public and private DNS zone for the same domain on Route 53.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

None

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
