### PR TITLE
[bitnami/contour] Envoy sidecars in daemonset mode

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 7.2.0
+version: 7.3.0

--- a/bitnami/contour/templates/envoy/daemonset.yaml
+++ b/bitnami/contour/templates/envoy/daemonset.yaml
@@ -234,6 +234,9 @@ spec:
                 path: /shutdown
                 port: 8090
                 scheme: HTTP
+        {{- if .Values.envoy.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.envoy.sidecars "cotext" $ ) | nindent 8 }}
+        {{- end }}
       initContainers:
         - command:
             - contour


### PR DESCRIPTION
**Description of the change**
added envoy sidecars not only for deployment mode, but also for daemonset

**Benefits**
Run sidecars in Envoy pod in daemonset mode

**Additional information**
related to https://github.com/bitnami/charts/pull/8512

**Checklist** 
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
