### PR TITLE
[bitnami/redis] add timeout to redis container for sentinel

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -25,4 +25,4 @@ name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 15.7.2
+version: 15.7.3

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -80,9 +80,9 @@ data:
 
     get_sentinel_master_info() {
         if is_boolean_yes "$REDIS_TLS_ENABLED"; then
-            sentinel_info_command="{{- if and .Values.auth.enabled .Values.auth.sentinel }}REDISCLI_AUTH="\$REDIS_PASSWORD" {{ end }}redis-cli -h $REDIS_SERVICE -p $SENTINEL_SERVICE_PORT --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+            sentinel_info_command="{{- if and .Values.auth.enabled .Values.auth.sentinel }}REDISCLI_AUTH="\$REDIS_PASSWORD" {{ end }}timeout 5 redis-cli -h $REDIS_SERVICE -p $SENTINEL_SERVICE_PORT --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
         else
-            sentinel_info_command="{{- if and .Values.auth.enabled .Values.auth.sentinel }}REDISCLI_AUTH="\$REDIS_PASSWORD" {{ end }}redis-cli -h $REDIS_SERVICE -p $SENTINEL_SERVICE_PORT sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
+            sentinel_info_command="{{- if and .Values.auth.enabled .Values.auth.sentinel }}REDISCLI_AUTH="\$REDIS_PASSWORD" {{ end }}timeout 5 redis-cli -h $REDIS_SERVICE -p $SENTINEL_SERVICE_PORT sentinel get-master-addr-by-name {{ .Values.sentinel.masterSet }}"
         fi
 
         info "about to run the command: $sentinel_info_command"


### PR DESCRIPTION
**Description of the change**

When starting the current Redis chart with Sentinel, one of the containers (the `redis` container) does not start. It gets killed by the liveliness probe:
```
Events:
  Type     Reason                  Age                From                     Message
  ----     ------                  ----               ----                     -------
  Warning  FailedScheduling        13m                default-scheduler        0/1 nodes are available: 1 pod has unbound immediate PersistentVolumeClaims.
  Normal   Scheduled               13m                default-scheduler        Successfully assigned api-engine/engine-redis-node-0 to scw-x-x-x-pg-2fe6e7bd09064
  Normal   SuccessfulAttachVolume  13m                attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-9f6ace55-c360-4bd2-9514-4ae8492d0c7c"
  Normal   Pulled                  13m                kubelet                  Container image "docker.io/bitnami/redis:6.2.6-debian-10-r94" already present on machine
  Normal   Started                 13m                kubelet                  Started container redis
  Normal   Pulled                  13m                kubelet                  Container image "docker.io/bitnami/redis-sentinel:6.2.6-debian-10-r93" already present on machine
  Normal   Created                 13m                kubelet                  Created container sentinel
  Normal   Started                 13m                kubelet                  Started container sentinel
  Warning  Unhealthy               12m (x5 over 13m)  kubelet                  Liveness probe failed: 
Could not connect to Redis at localhost:6379: Connection refused
  Normal   Killing    12m                   kubelet  Container redis failed liveness probe, will be restarted
  Normal   Created    8m34s (x5 over 13m)   kubelet  Created container redis
  Warning  Unhealthy  3m31s (x84 over 13m)  kubelet  Readiness probe failed: 
Could not connect to Redis at localhost:6379: Connection refused
```

The only output of the `redis` container was:
```
❯ k logs engine-redis-node-0 -c redis
 16:00:54.51 INFO  ==> about to run the command: REDISCLI_AUTH=$REDIS_PASSWORD redis-cli -h engine-redis.api-engine.svc.cluster.local -p 26379 sentinel get-master-addr-by-name mymaster
```

Just like the `sentinel` container has a `timeout 5`, I also added this to the `redis` container - making it boot properly as well.

**Benefits**

A working Redis Sentinel.

**Possible drawbacks**

When the `redis-cli -h engine-redis.api-engine.svc.cluster.local -p 26379 sentinel get-master-addr-by-name mymaster` call hangs for a longer period of 5 seconds for a different reason then anticipated. But, this is the same for the workaround that is already in place by #8476.

**Applicable issues**

See above.

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
