### PR TITLE
[bitnami/airflow] Add ingressClassName parameter

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 11.2.0
+version: 11.3.0

--- a/bitnami/airflow/templates/web/ingress.yaml
+++ b/bitnami/airflow/templates/web/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{ $key }}: {{ include "common.tplvalues.render" (dict "value" $value "context" $) | quote }}
     {{- end }}
 spec:
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
     - host: {{ .name }}

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -913,6 +913,7 @@ ldap:
 ## @param ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
 ## @param ingress.hosts [array] The list of hostnames to be covered with this ingress record.
 ## @param ingress.secrets If you're providing your own certificates, use this to add the certificates as secrets
+## @param ingress.ingressClassName Set the ingerssClassName on the ingress record for k8s 1.18+
 ##
 ingress:
   enabled: false
@@ -933,6 +934,10 @@ ingress:
   ##   cert-manager.io/cluster-issuer: cluster-issuer-name
   ##
   annotations: {}
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName: ""
   ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
   ##
   hosts:


### PR DESCRIPTION
**Description of the change**
This PR adds support of ingressClassName for the airflow chart. This feature is required for k8s 1.18+ using more than one ingress controller.

**Benefits**
Supports the newest Kubernetes specification.

**Possible drawbacks**
None

**Applicable issues**
  - fixes partially https://github.com/bitnami/charts/issues/7364

**Additional information**
None

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the README.md
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
