### PR TITLE
[bitnami/spring-cloud-dataflow] Remove dollar prompt from command examples in README

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 5.0.1
+version: 5.0.2

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -718,7 +718,7 @@ To upgrade to `1.0.0`, you will need to reuse the PVC used to hold the MariaDB d
 
 Obtain the credentials and the name of the PVC used to hold the MariaDB data on your current release:
 
-```console
+```bash
 export MARIADB_ROOT_PASSWORD=$(kubectl get secret --namespace default dataflow-mariadb -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)
 export MARIADB_PASSWORD=$(kubectl get secret --namespace default dataflow-mariadb -o jsonpath="{.data.mariadb-password}" | base64 --decode)
 export MARIADB_PVC=$(kubectl get pvc -l app=mariadb,component=master,release=dataflow -o jsonpath="{.items[0].metadata.name}")
@@ -728,7 +728,7 @@ export RABBITMQ_ERLANG_COOKIE=$(kubectl get secret --namespace default dataflow-
 
 Upgrade your release (maintaining the version) disabling MariaDB and scaling Data Flow replicas to 0:
 
-```console
+```bash
 helm upgrade dataflow bitnami/spring-cloud-dataflow --version 0.7.4 \
   --set server.replicaCount=0 \
   --set skipper.replicaCount=0 \
@@ -739,7 +739,7 @@ helm upgrade dataflow bitnami/spring-cloud-dataflow --version 0.7.4 \
 
 Finally, upgrade you release to 1.0.0 reusing the existing PVC, and enabling back MariaDB:
 
-```console
+```bash
 helm upgrade dataflow bitnami/spring-cloud-dataflow \
   --set mariadb.primary.persistence.existingClaim=$MARIADB_PVC \
   --set mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD \
@@ -750,7 +750,7 @@ helm upgrade dataflow bitnami/spring-cloud-dataflow \
 
 You should see the lines below in MariaDB container logs:
 
-```console
+```bash
 kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=dataflow,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
 ...
 mariadb 12:13:24.98 INFO  ==> Using persisted data

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -750,8 +750,8 @@ helm upgrade dataflow bitnami/spring-cloud-dataflow \
 
 You should see the lines below in MariaDB container logs:
 
-```bash
-kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=dataflow,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
+```console
+$ kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=dataflow,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
 ...
 mariadb 12:13:24.98 INFO  ==> Using persisted data
 mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -729,7 +729,7 @@ export RABBITMQ_ERLANG_COOKIE=$(kubectl get secret --namespace default dataflow-
 Upgrade your release (maintaining the version) disabling MariaDB and scaling Data Flow replicas to 0:
 
 ```console
-$ helm upgrade dataflow bitnami/spring-cloud-dataflow --version 0.7.4 \
+helm upgrade dataflow bitnami/spring-cloud-dataflow --version 0.7.4 \
   --set server.replicaCount=0 \
   --set skipper.replicaCount=0 \
   --set mariadb.enabled=false \
@@ -740,7 +740,7 @@ $ helm upgrade dataflow bitnami/spring-cloud-dataflow --version 0.7.4 \
 Finally, upgrade you release to 1.0.0 reusing the existing PVC, and enabling back MariaDB:
 
 ```console
-$ helm upgrade dataflow bitnami/spring-cloud-dataflow \
+helm upgrade dataflow bitnami/spring-cloud-dataflow \
   --set mariadb.primary.persistence.existingClaim=$MARIADB_PVC \
   --set mariadb.auth.rootPassword=$MARIADB_ROOT_PASSWORD \
   --set mariadb.auth.password=$MARIADB_PASSWORD \
@@ -751,7 +751,7 @@ $ helm upgrade dataflow bitnami/spring-cloud-dataflow \
 You should see the lines below in MariaDB container logs:
 
 ```console
-$ kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=dataflow,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
+kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=dataflow,app.kubernetes.io/name=mariadb,app.kubernetes.io/component=primary -o jsonpath="{.items[0].metadata.name}")
 ...
 mariadb 12:13:24.98 INFO  ==> Using persisted data
 mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade


### PR DESCRIPTION

**Description**
This removes the `$` (dollar prompt) from several copyable command examples in the `bitnami/spring-cloud-dataflow` README to allow the user to copy and used them directly without editing them to remove the `$`. This is part of an improvement effort on the Spring Cloud Dataflow Microsite to make these copyable commands easier to use. The coupling between the 2 repos is due to the fact that the microsite [includes the bitnami README](https://github.com/spring-io/dataflow.spring.io/blob/main/content/documentation/pages/1-installation/3-kubernetes/2-helm.md?plain=1#L42) via 
```
<!--TEMPLATE:https://raw.githubusercontent.com/bitnami/charts/master/bitnami/spring-cloud-dataflow/README.md-->
```

**Benefits**
Without this change, the microsite will have 4 (out of ~50) inconsistent command examples.

**Possible drawbacks**
Since this only changes the `bitnami/spring-cloud-dataflow` README, it leaves the other charts inconsistent in this area (they still have the `$ ` on the copyable command examples). 

**Applicable issues**
Supports https://github.com/spring-io/dataflow.spring.io/issues/280

>  ℹ️ ❓ I just referenced the existing dataflow.spring.io ticket via its full path. I was not sure if I should create another bitnami/charts specific issue. Please let me know if that is the case and I will amend. 

**Checklist** 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
