### PR TITLE
[bitnami/phpmyadmin] Fix indentation

### DIFF
--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -29,4 +29,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/bitnami-docker-phpmyadmin
   - https://www.phpmyadmin.net/
-version: 8.5.0
+version: 8.5.1

--- a/bitnami/phpmyadmin/templates/ingress.yaml
+++ b/bitnami/phpmyadmin/templates/ingress.yaml
@@ -21,7 +21,7 @@ metadata:
   {{- end }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
-    ingressClassName: {{ .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}


### PR DESCRIPTION
**Description of the change**

Fixes indentation issue on last PR to support `ingress.ingressClassName`

**Benefits**

Users can now correctly replace the deprecated `kubernetes.io/ingress.class` annotation to determine ingress class

**Possible drawbacks**

None known.

**Applicable issues**

  - fixes error in https://github.com/bitnami/charts/pull/8600

**Additional information**

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
