### PR TITLE
[bitnami/solr] Fix indentation

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/bitnami-docker-solr
   - https://lucene.apache.org/solr/
-version: 2.4.1
+version: 2.4.2

--- a/bitnami/solr/templates/ingress.yaml
+++ b/bitnami/solr/templates/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 spec:
   {{- if .Values.ingress.ingressClassName }}
-    ingressClassName: {{ .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}


### PR DESCRIPTION
**Description of the change**

Fixes indentation issue on last PR to support `ingress.ingressClassName`

**Benefits**

Users can now correctly replace the deprecated `kubernetes.io/ingress.class` annotation to determine ingress class.

**Possible drawbacks**

None known.

**Applicable issues**

  - fixes error in https://github.com/bitnami/charts/pull/8601

**Additional information**

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
