### PR TITLE
[bitnami/postgresql-ha] Startup probe enabled by default

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 8.2.2
+version: 8.3.0

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -263,7 +263,7 @@ Additionally, if `persistence.resourcePolicy` is set to `keep`, you should manua
 | `pgpool.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                                       | `5`                   |
 | `pgpool.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                                     | `5`                   |
 | `pgpool.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                                     | `1`                   |
-| `pgpool.startupProbe.enabled`               | Enable startupProbe                                                                                                                      | `false`               |
+| `pgpool.startupProbe.enabled`               | Enable startupProbe                                                                                                                      | `true`                |
 | `pgpool.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                                                   | `5`                   |
 | `pgpool.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                                                          | `10`                  |
 | `pgpool.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                                                         | `5`                   |

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -803,7 +803,7 @@ pgpool:
   ## @param pgpool.startupProbe.successThreshold Success threshold for startupProbe
   ##
   startupProbe:
-    enabled: false
+    enabled: true
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 5


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This enables by default the startup probes.
This will make that the pgpool not to restart when  postgresql take a while to start.

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

Now some pgpool's errors on the missing nodes are shown in the log until the nodes are available.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  This will help with #8257, but a new pgpool image is needed where the initial waiting is removed.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
