### PR TITLE
[bitnami/rabbitmq-cluster-operator] Specify default image pull secrets for the operator

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 1.10.0
+appVersion: 1.11.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 2.1.1
+version: 2.2.0

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 2.1.0
+version: 2.1.1

--- a/bitnami/rabbitmq-cluster-operator/templates/_helpers.tpl
+++ b/bitnami/rabbitmq-cluster-operator/templates/_helpers.tpl
@@ -82,6 +82,26 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+Return the proper Docker Image Registry Secret Names as a comma separated string
+*/}}
+{{- define "rmqco.imagePullSecrets.string" -}}
+{{- $pullSecrets := list }}
+{{- if .Values.global }}
+  {{- range .Values.global.imagePullSecrets -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- range (list .Values.clusterOperator.image .Values.rabbitmqImage) -}}
+  {{- range .pullSecrets -}}
+    {{- $pullSecrets = append $pullSecrets . -}}
+  {{- end -}}
+{{- end -}}
+{{- if (not (empty $pullSecrets)) }}
+  {{- printf "%s" (join "," $pullSecrets) -}}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use (Cluster Operator)
 */}}
 {{- define "rmqco.clusterOperator.serviceAccountName" -}}
@@ -101,28 +121,4 @@ Create the name of the service account to use (Messaging Topology Operator)
 {{- else -}}
     {{ default "default" .Values.msgTopologyOperator.serviceAccount.name }}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Return the proper Docker Image Registry Secret Names (deprecated: use common.images.renderPullSecrets instead)
-{{ include "common.images.pullSecrets" ( dict "images" (list path.to.the.image1, path.to.the.image2) "global" .Values.global) }}
-*/}}
-{{- define "rmqco.defaultPullSecrets" -}}
-  {{- $pullSecrets := list }}
-  {{- if .global }}
-    {{- range .global.imagePullSecrets -}}
-      {{- $pullSecrets = append $pullSecrets . -}}
-    {{- end -}}
-  {{- end -}}
-
-  {{- range .images -}}
-    {{- range .pullSecrets -}}
-      {{- $pullSecrets = append $pullSecrets . -}}
-    {{- end -}}
-  {{- end -}}
-{{- if (not (empty $pullSecrets)) }}
-{{- range $pullSecrets }}
-- name: {{ . }}
-{{- end }}
-{{- end }}
 {{- end -}}

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
@@ -92,9 +92,13 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: DEFAULT_RABBITMQ_IMAGE
-              value: {{ template "rmqco.rabbitmq.image" . }}
+              value: {{ include "rmqco.rabbitmq.image" . }}
             - name: DEFAULT_USER_UPDATER_IMAGE
-              value: {{ template "rmqco.defaultCredentialUpdater.image" . }}
+              value: {{ include "rmqco.defaultCredentialUpdater.image" . }}
+            {{- if (include "rmqco.imagePullSecrets.string" .) }}
+            - name: DEFAULT_IMAGE_PULL_SECRETS
+              value: {{ include "rmqco.imagePullSecrets.string" . | quote }}
+            {{- end }}
             {{- if .Values.clusterOperator.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -55,7 +55,7 @@ extraDeploy: []
 rabbitmqImage:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.26-debian-10-r26
+  tag: 3.8.27-debian-10-r6
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-rabbitmqImage-private-registry/
@@ -97,7 +97,7 @@ clusterOperator:
   image:
     registry: docker.io
     repository: bitnami/rabbitmq-cluster-operator
-    tag: 1.10.0-scratch-r5
+    tag: 1.11.0-scratch-r0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR ensure the default image pull secrets information is passed to the operator using the `DEFAULT_IMAGE_PULL_SECRETS` environment variable. 

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

Support for `DEFAULT_IMAGE_PULL_SECRETS` environment variable was recently added at https://github.com/rabbitmq/cluster-operator/pull/926

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
