### PR TITLE
[bitnami/tomcat] Fix storageclass indentation

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/bitnami-docker-tomcat
   - http://tomcat.apache.org
-version: 10.1.1
+version: 10.1.2

--- a/bitnami/tomcat/templates/statefulset.yaml
+++ b/bitnami/tomcat/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
-        {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 6 }}
+        {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
         {{- with .Values.persistence.selectorLabels }}
         selector:
           matchLabels: {{- toYaml . | nindent 10 }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR fixes the indentation in Tomcat's statefulset when setting a custom StorageClass.

**Benefits**

Users can set a custom StorageClass

**Possible drawbacks**

None

**Applicable issues**

  - fixes #8664

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
