### PR TITLE
[bitnami/memcached] Chart standardized

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 5.15.14
+version: 6.0.0

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -58,115 +58,205 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                | Description                                                                                  | Value           |
-| ------------------- | -------------------------------------------------------------------------------------------- | --------------- |
-| `nameOverride`      | String to partially override common.names.fullname template (will maintain the release name) | `""`            |
-| `fullnameOverride`  | String to fully override common.names.fullname template                                      | `""`            |
-| `commonLabels`      | Labels to add to all deployed objects                                                        | `{}`            |
-| `commonAnnotations` | Annotations to add to all deployed objects                                                   | `{}`            |
-| `clusterDomain`     | Default Kubernetes cluster domain                                                            | `cluster.local` |
-| `extraDeploy`       | Array of extra objects to deploy with the release                                            | `[]`            |
+| Name                     | Description                                                                                  | Value           |
+| ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`            | Override Kubernetes version                                                                  | `""`            |
+| `nameOverride`           | String to partially override common.names.fullname template (will maintain the release name) | `""`            |
+| `fullnameOverride`       | String to fully override common.names.fullname template                                      | `""`            |
+| `clusterDomain`          | Kubernetes Cluster Domain                                                                    | `cluster.local` |
+| `extraDeploy`            | Extra objects to deploy (evaluated as a template)                                            | `[]`            |
+| `commonLabels`           | Add labels to all the deployed resources                                                     | `{}`            |
+| `commonAnnotations`      | Add annotations to all the deployed resources                                                | `{}`            |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)      | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the deployment/statefulset                             | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the deployment/statefulset                                | `["infinity"]`  |
 
 
 ### Memcached parameters
 
-| Name                                          | Description                                                                                     | Value                        |
-| --------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------- |
-| `image.registry`                              | Memcached image registry                                                                        | `docker.io`                  |
-| `image.repository`                            | Memcached image repository                                                                      | `bitnami/memcached`          |
-| `image.tag`                                   | Memcached image tag (immutable tags are recommended)                                            | `1.6.13-debian-10-r0`        |
-| `image.pullPolicy`                            | Memcached image pull policy                                                                     | `IfNotPresent`               |
-| `image.pullSecrets`                           | Specify docker-registry secret names as an array                                                | `[]`                         |
-| `image.debug`                                 | Enable image debug mode                                                                         | `false`                      |
-| `architecture`                                | Memcached architecture. Allowed values: standalone or high-availability                         | `standalone`                 |
-| `hostAliases`                                 | Add deployment host aliases                                                                     | `[]`                         |
-| `memcachedUsername`                           | Memcached admin user                                                                            | `""`                         |
-| `memcachedPassword`                           | Memcached admin password                                                                        | `""`                         |
-| `replicaCount`                                | Number of containers                                                                            | `1`                          |
-| `command`                                     | Default container command (useful when using custom images)                                     | `[]`                         |
-| `arguments`                                   | Default container args (useful when using custom images)                                        | `["/run.sh"]`                |
-| `extraEnv`                                    | Additional env vars to pass                                                                     | `[]`                         |
-| `podDisruptionBudget.create`                  | Specifies whether a Pod disruption budget should be created                                     | `false`                      |
-| `podDisruptionBudget.minAvailable`            | Minimum number of pods that need to be available                                                | `""`                         |
-| `podDisruptionBudget.maxUnavailable`          | Maximum number of pods that can be unavailable                                                  | `1`                          |
-| `service.type`                                | Kubernetes service type for Memcached                                                           | `ClusterIP`                  |
-| `service.port`                                | Memcached service port                                                                          | `11211`                      |
-| `service.nodePort`                            | Kubernetes Service nodePort                                                                     | `""`                         |
-| `service.loadBalancerIP`                      | `loadBalancerIP` if service type is `LoadBalancer`                                              | `""`                         |
-| `service.annotations`                         | Additional annotations for Memcached service                                                    | `{}`                         |
-| `autoscaling.enabled`                         | Enable memcached statefulset autoscaling (requires architecture: "high-availability")           | `false`                      |
-| `autoscaling.minReplicas`                     | memcached statefulset autoscaling minimum number of replicas                                    | `3`                          |
-| `autoscaling.maxReplicas`                     | memcached statefulset autoscaling maximum number of replicas                                    | `6`                          |
-| `autoscaling.targetCPU`                       | memcached statefulset autoscaling target CPU percentage                                         | `50`                         |
-| `autoscaling.targetMemory`                    | memcached statefulset autoscaling target CPU memory                                             | `50`                         |
-| `resources.limits`                            | CPU/Memory resource limits                                                                      | `{}`                         |
-| `resources.requests`                          | CPU/Memory resource requests                                                                    | `{}`                         |
-| `portName`                                    | Name of the main port exposed by memcached                                                      | `memcache`                   |
-| `securityContext.enabled`                     | Enable security context                                                                         | `true`                       |
-| `securityContext.fsGroup`                     | Group ID for the container                                                                      | `1001`                       |
-| `securityContext.runAsUser`                   | User ID for the container                                                                       | `1001`                       |
-| `securityContext.readOnlyRootFilesystem`      | Enable read-only filesystem                                                                     | `false`                      |
-| `podLabels`                                   | Pod extra labels                                                                                | `{}`                         |
-| `podAnnotations`                              | Pod annotations                                                                                 | `{}`                         |
-| `podAffinityPreset`                           | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`             | `""`                         |
-| `podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`        | `soft`                       |
-| `nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                         |
-| `nodeAffinityPreset.key`                      | Node label key to match. Ignored if `affinity` is set.                                          | `""`                         |
-| `nodeAffinityPreset.values`                   | Node label values to match. Ignored if `affinity` is set.                                       | `[]`                         |
-| `affinity`                                    | Affinity for pod assignment                                                                     | `{}`                         |
-| `nodeSelector`                                | Node labels for pod assignment                                                                  | `{}`                         |
-| `tolerations`                                 | Tolerations for pod assignment                                                                  | `[]`                         |
-| `topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains | `{}`                         |
-| `priorityClassName`                           | Pod priority                                                                                    | `""`                         |
-| `initContainers`                              | Add additional init containers to the Memcached pod                                             | `[]`                         |
-| `sidecars`                                    | Add additional sidecar containers to the Memcached pod                                          | `[]`                         |
-| `serviceAccount.create`                       | Enable creation of ServiceAccount for memcached pods                                            | `true`                       |
-| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                                          | `""`                         |
-| `serviceAccount.automountServiceAccountToken` | Enable/disable auto mounting of the service account token                                       | `true`                       |
-| `persistence.enabled`                         | Enable persistence using PVC (Requires architecture: "high-availability")                       | `false`                      |
-| `persistence.storageClass`                    | PVC Storage Class for Memcached volume                                                          | `""`                         |
-| `persistence.annotations`                     | Persistent Volume Claim annotations                                                             | `{}`                         |
-| `persistence.accessModes`                     | Persistent Volume Access Mode                                                                   | `["ReadWriteOnce"]`          |
-| `persistence.size`                            | PVC Storage Request for Memcached volume                                                        | `8Gi`                        |
-| `metrics.enabled`                             | Start a side-car prometheus exporter                                                            | `false`                      |
-| `metrics.image.registry`                      | Memcached exporter image registry                                                               | `docker.io`                  |
-| `metrics.image.repository`                    | Memcached exporter image repository                                                             | `bitnami/memcached-exporter` |
-| `metrics.image.tag`                           | Memcached exporter image tag (immutable tags are recommended)                                   | `0.9.0-debian-10-r268`       |
-| `metrics.image.pullPolicy`                    | Image pull policy                                                                               | `IfNotPresent`               |
-| `metrics.image.pullSecrets`                   | Specify docker-registry secret names as an array                                                | `[]`                         |
-| `metrics.podAnnotations`                      | Metrics exporter pod Annotation and Labels                                                      | `{}`                         |
-| `metrics.portName`                            | Memcached exporter port name                                                                    | `metrics`                    |
-| `metrics.resources.limits`                    | The resources limits for the container                                                          | `{}`                         |
-| `metrics.resources.requests`                  | The requested resources for the container                                                       | `{}`                         |
-| `metrics.livenessProbe.enabled`               | Enable livenessProbe                                                                            | `true`                       |
-| `metrics.livenessProbe.initialDelaySeconds`   | Initial delay seconds for livenessProbe                                                         | `15`                         |
-| `metrics.livenessProbe.periodSeconds`         | Period seconds for livenessProbe                                                                | `10`                         |
-| `metrics.livenessProbe.timeoutSeconds`        | Timeout seconds for livenessProbe                                                               | `5`                          |
-| `metrics.livenessProbe.failureThreshold`      | Failure threshold for livenessProbe                                                             | `3`                          |
-| `metrics.livenessProbe.successThreshold`      | Success threshold for livenessProbe                                                             | `1`                          |
-| `metrics.readinessProbe.enabled`              | Enable readinessProbe                                                                           | `true`                       |
-| `metrics.readinessProbe.initialDelaySeconds`  | Initial delay seconds for readinessProbe                                                        | `5`                          |
-| `metrics.readinessProbe.periodSeconds`        | Period seconds for readinessProbe                                                               | `10`                         |
-| `metrics.readinessProbe.timeoutSeconds`       | Timeout seconds for readinessProbe                                                              | `1`                          |
-| `metrics.readinessProbe.failureThreshold`     | Failure threshold for readinessProbe                                                            | `3`                          |
-| `metrics.readinessProbe.successThreshold`     | Success threshold for readinessProbe                                                            | `1`                          |
-| `metrics.service.type`                        | Kubernetes service type for Prometheus metrics                                                  | `ClusterIP`                  |
-| `metrics.service.port`                        | Prometheus metrics service port                                                                 | `9150`                       |
-| `metrics.service.annotations`                 | Annotations for the Prometheus metrics service                                                  | `{}`                         |
-| `metrics.serviceMonitor.enabled`              | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator                 | `false`                      |
-| `metrics.serviceMonitor.namespace`            | The namespace in which the ServiceMonitor will be created                                       | `""`                         |
-| `metrics.serviceMonitor.interval`             | The interval at which metrics should be scraped                                                 | `""`                         |
-| `metrics.serviceMonitor.scrapeTimeout`        | The timeout after which the scrape is ended                                                     | `""`                         |
-| `metrics.serviceMonitor.selector`             | Additional labels for ServiceMonitor resource                                                   | `{}`                         |
-| `metrics.serviceMonitor.metricRelabelings`    | MetricRelabelConfigs to apply to samples before ingestion                                       | `[]`                         |
-| `metrics.serviceMonitor.relabelings`          | Metrics relabelings to add to the scrape endpoint, applied before scraping                      | `[]`                         |
-| `volumePermissions.image.registry`            | Init container volume-permissions image registry                                                | `docker.io`                  |
-| `volumePermissions.image.repository`          | Init container volume-permissions image repository                                              | `bitnami/bitnami-shell`      |
-| `volumePermissions.image.tag`                 | Init container volume-permissions image tag (immutable tags are recommended)                    | `10-debian-10-r307`          |
-| `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy                                             | `IfNotPresent`               |
-| `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                                | `[]`                         |
-| `volumePermissions.resources.limits`          | Init container volume-permissions resource limits                                               | `{}`                         |
-| `volumePermissions.resources.requests`        | Init container volume-permissions resource requests                                             | `{}`                         |
+| Name                 | Description                                                              | Value                 |
+| -------------------- | ------------------------------------------------------------------------ | --------------------- |
+| `image.registry`     | Memcached image registry                                                 | `docker.io`           |
+| `image.repository`   | Memcached image repository                                               | `bitnami/memcached`   |
+| `image.tag`          | Memcached image tag (immutable tags are recommended)                     | `1.6.13-debian-10-r0` |
+| `image.pullPolicy`   | Memcached image pull policy                                              | `IfNotPresent`        |
+| `image.pullSecrets`  | Specify docker-registry secret names as an array                         | `[]`                  |
+| `image.debug`        | Specify if debug values should be set                                    | `false`               |
+| `architecture`       | Memcached architecture. Allowed values: standalone or high-availability  | `standalone`          |
+| `auth.enabled`       | Enable Memcached authentication                                          | `false`               |
+| `auth.username`      | Memcached admin user                                                     | `""`                  |
+| `auth.password`      | Memcached admin password                                                 | `""`                  |
+| `command`            | Override default container command (useful when using custom images)     | `[]`                  |
+| `args`               | Override default container args (useful when using custom images)        | `[]`                  |
+| `extraEnvVars`       | Array with extra environment variables to add to Memcached nodes         | `[]`                  |
+| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars for Memcached nodes | `""`                  |
+| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars for Memcached nodes    | `""`                  |
+
+
+### Deployment/Statefulset parameters
+
+| Name                                    | Description                                                                                                                                                                                       | Value           |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `replicaCount`                          | Number of Memcached nodes                                                                                                                                                                         | `1`             |
+| `containerPorts.memcached`              | Memcached container port                                                                                                                                                                          | `11211`         |
+| `livenessProbe.enabled`                 | Enable livenessProbe on Memcached containers                                                                                                                                                      | `true`          |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                                                                                           | `30`            |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                                                                                                  | `10`            |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                                                                                                 | `5`             |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                                                                                               | `6`             |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                                                                                               | `1`             |
+| `readinessProbe.enabled`                | Enable readinessProbe on Memcached containers                                                                                                                                                     | `true`          |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                                                                                          | `5`             |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                                                                                                 | `5`             |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                                                                                                | `3`             |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                                                                                              | `6`             |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                                                                                              | `1`             |
+| `startupProbe.enabled`                  | Enable startupProbe on Memcached containers                                                                                                                                                       | `false`         |
+| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                                                                                            | `30`            |
+| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                                                                                                   | `10`            |
+| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                                                                                                  | `1`             |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                                                                                                | `15`            |
+| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                                                                                                | `1`             |
+| `customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                                                                                                               | `{}`            |
+| `customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                                                                                                              | `{}`            |
+| `customStartupProbe`                    | Custom startupProbe that overrides the default one                                                                                                                                                | `{}`            |
+| `lifecycleHooks`                        | for the Memcached container(s) to automate configuration before or after startup                                                                                                                  | `{}`            |
+| `resources.limits`                      | The resources limits for the Memcached containers                                                                                                                                                 | `{}`            |
+| `resources.requests.memory`             | The requested memory for the Memcached containers                                                                                                                                                 | `256Mi`         |
+| `resources.requests.cpu`                | The requested cpu for the Memcached containers                                                                                                                                                    | `250m`          |
+| `podSecurityContext.enabled`            | Enabled Memcached pods' Security Context                                                                                                                                                          | `true`          |
+| `podSecurityContext.fsGroup`            | Set Memcached pod's Security Context fsGroup                                                                                                                                                      | `1001`          |
+| `containerSecurityContext.enabled`      | Enabled Memcached containers' Security Context                                                                                                                                                    | `true`          |
+| `containerSecurityContext.runAsUser`    | Set Memcached containers' Security Context runAsUser                                                                                                                                              | `1001`          |
+| `containerSecurityContext.runAsNonRoot` | Set Memcached containers' Security Context runAsNonRoot                                                                                                                                           | `true`          |
+| `hostAliases`                           | Add deployment host aliases                                                                                                                                                                       | `[]`            |
+| `podLabels`                             | Extra labels for Memcached pods                                                                                                                                                                   | `{}`            |
+| `podAnnotations`                        | Annotations for Memcached pods                                                                                                                                                                    | `{}`            |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                                                               | `""`            |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                                                          | `soft`          |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                                                         | `""`            |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                                                                                                             | `""`            |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                                                                                                         | `[]`            |
+| `affinity`                              | Affinity for pod assignment                                                                                                                                                                       | `{}`            |
+| `nodeSelector`                          | Node labels for pod assignment                                                                                                                                                                    | `{}`            |
+| `tolerations`                           | Tolerations for pod assignment                                                                                                                                                                    | `[]`            |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template                                                                          | `{}`            |
+| `podManagementPolicy`                   | StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: `OrderedReady` and `Parallel` | `Parallel`      |
+| `priorityClassName`                     | Name of the existing priority class to be used by Memcached pods, priority class needs to be created beforehand                                                                                   | `""`            |
+| `schedulerName`                         | Kubernetes pod scheduler registry                                                                                                                                                                 | `""`            |
+| `updateStrategy.type`                   | Memcached statefulset strategy type                                                                                                                                                               | `RollingUpdate` |
+| `updateStrategy.rollingUpdate`          | Memcached statefulset rolling update configuration parameters                                                                                                                                     | `{}`            |
+| `extraVolumes`                          | Optionally specify extra list of additional volumes for the Memcached pod(s)                                                                                                                      | `[]`            |
+| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Memcached container(s)                                                                                                           | `[]`            |
+| `sidecars`                              | Add additional sidecar containers to the Memcached pod(s)                                                                                                                                         | `[]`            |
+| `initContainers`                        | Add additional init containers to the Memcached pod(s)                                                                                                                                            | `[]`            |
+| `autoscaling.enabled`                   | Enable memcached statefulset autoscaling (requires architecture: "high-availability")                                                                                                             | `false`         |
+| `autoscaling.minReplicas`               | memcached statefulset autoscaling minimum number of replicas                                                                                                                                      | `3`             |
+| `autoscaling.maxReplicas`               | memcached statefulset autoscaling maximum number of replicas                                                                                                                                      | `6`             |
+| `autoscaling.targetCPU`                 | memcached statefulset autoscaling target CPU percentage                                                                                                                                           | `50`            |
+| `autoscaling.targetMemory`              | memcached statefulset autoscaling target CPU memory                                                                                                                                               | `50`            |
+| `pdb.create`                            | Deploy a pdb object for the Memcached pod                                                                                                                                                         | `false`         |
+| `pdb.minAvailable`                      | Minimum available Memcached replicas                                                                                                                                                              | `""`            |
+| `pdb.maxUnavailable`                    | Maximum unavailable Memcached replicas                                                                                                                                                            | `1`             |
+
+
+### Traffic Exposure parameters
+
+| Name                               | Description                                                                             | Value       |
+| ---------------------------------- | --------------------------------------------------------------------------------------- | ----------- |
+| `service.type`                     | Kubernetes Service type                                                                 | `ClusterIP` |
+| `service.ports.memcached`          | Memcached service port                                                                  | `11211`     |
+| `service.nodePorts.memcached`      | Node port for Memcached                                                                 | `""`        |
+| `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                        | `None`      |
+| `service.clusterIP`                | Memcached service Cluster IP                                                            | `""`        |
+| `service.loadBalancerIP`           | Memcached service Load Balancer IP                                                      | `""`        |
+| `service.loadBalancerSourceRanges` | Memcached service Load Balancer sources                                                 | `[]`        |
+| `service.externalTrafficPolicy`    | Memcached service external traffic policy                                               | `Cluster`   |
+| `service.annotations`              | Additional custom annotations for Memcached service                                     | `{}`        |
+| `service.extraPorts`               | Extra ports to expose in the Memcached service (normally used with the `sidecar` value) | `[]`        |
+
+
+### Other Parameters
+
+| Name                                          | Description                                                            | Value   |
+| --------------------------------------------- | ---------------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Enable creation of ServiceAccount for Memcached pod                    | `false` |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                 | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created | `true`  |
+| `serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                   | `{}`    |
+
+
+### Persistence parameters
+
+| Name                        | Description                                                              | Value               |
+| --------------------------- | ------------------------------------------------------------------------ | ------------------- |
+| `persistence.enabled`       | Enable Memcached data persistence using PVC. If false, use emptyDir      | `false`             |
+| `persistence.existingClaim` | Name of an existing PVC to use (only when deploying a single replica)    | `""`                |
+| `persistence.storageClass`  | PVC Storage Class for Memcached data volume                              | `""`                |
+| `persistence.accessModes`   | PVC Access modes                                                         | `["ReadWriteOnce"]` |
+| `persistence.size`          | PVC Storage Request for Memcached data volume                            | `8Gi`               |
+| `persistence.annotations`   | Annotations for the PVC                                                  | `{}`                |
+| `persistence.selector`      | Selector to match an existing Persistent Volume for Memcached's data PVC | `{}`                |
+
+
+### Volume Permissions parameters
+
+| Name                                                   | Description                                                                           | Value                        |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------- | ---------------------------- |
+| `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume       | `false`                      |
+| `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                      | `docker.io`                  |
+| `volumePermissions.image.repository`                   | Init container volume-permissions image repository                                    | `bitnami/bitnami-shell`      |
+| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)          | `10-debian-10-r304`          |
+| `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                                   | `IfNotPresent`               |
+| `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                                  | `[]`                         |
+| `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                                     | `{}`                         |
+| `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                                   | `{}`                         |
+| `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                        | `0`                          |
+| `metrics.enabled`                                      | Start a side-car prometheus exporter                                                  | `false`                      |
+| `metrics.image.registry`                               | Memcached exporter image registry                                                     | `docker.io`                  |
+| `metrics.image.repository`                             | Memcached exporter image repository                                                   | `bitnami/memcached-exporter` |
+| `metrics.image.tag`                                    | Memcached exporter image tag (immutable tags are recommended)                         | `0.9.0-debian-10-r268`       |
+| `metrics.image.pullPolicy`                             | Image pull policy                                                                     | `IfNotPresent`               |
+| `metrics.image.pullSecrets`                            | Specify docker-registry secret names as an array                                      | `[]`                         |
+| `metrics.containerPorts.metrics`                       | Memcached Prometheus Exporter container port                                          | `9150`                       |
+| `metrics.resources.limits`                             | Init container volume-permissions resource limits                                     | `{}`                         |
+| `metrics.resources.requests`                           | Init container volume-permissions resource requests                                   | `{}`                         |
+| `metrics.livenessProbe.enabled`                        | Enable livenessProbe on Memcached Prometheus exporter containers                      | `true`                       |
+| `metrics.livenessProbe.initialDelaySeconds`            | Initial delay seconds for livenessProbe                                               | `15`                         |
+| `metrics.livenessProbe.periodSeconds`                  | Period seconds for livenessProbe                                                      | `10`                         |
+| `metrics.livenessProbe.timeoutSeconds`                 | Timeout seconds for livenessProbe                                                     | `5`                          |
+| `metrics.livenessProbe.failureThreshold`               | Failure threshold for livenessProbe                                                   | `3`                          |
+| `metrics.livenessProbe.successThreshold`               | Success threshold for livenessProbe                                                   | `1`                          |
+| `metrics.readinessProbe.enabled`                       | Enable readinessProbe on Memcached Prometheus exporter containers                     | `true`                       |
+| `metrics.readinessProbe.initialDelaySeconds`           | Initial delay seconds for readinessProbe                                              | `5`                          |
+| `metrics.readinessProbe.periodSeconds`                 | Period seconds for readinessProbe                                                     | `10`                         |
+| `metrics.readinessProbe.timeoutSeconds`                | Timeout seconds for readinessProbe                                                    | `3`                          |
+| `metrics.readinessProbe.failureThreshold`              | Failure threshold for readinessProbe                                                  | `3`                          |
+| `metrics.readinessProbe.successThreshold`              | Success threshold for readinessProbe                                                  | `1`                          |
+| `metrics.startupProbe.enabled`                         | Enable startupProbe on Memcached Prometheus exporter containers                       | `false`                      |
+| `metrics.startupProbe.initialDelaySeconds`             | Initial delay seconds for startupProbe                                                | `10`                         |
+| `metrics.startupProbe.periodSeconds`                   | Period seconds for startupProbe                                                       | `10`                         |
+| `metrics.startupProbe.timeoutSeconds`                  | Timeout seconds for startupProbe                                                      | `1`                          |
+| `metrics.startupProbe.failureThreshold`                | Failure threshold for startupProbe                                                    | `15`                         |
+| `metrics.startupProbe.successThreshold`                | Success threshold for startupProbe                                                    | `1`                          |
+| `metrics.customLivenessProbe`                          | Custom livenessProbe that overrides the default one                                   | `{}`                         |
+| `metrics.customReadinessProbe`                         | Custom readinessProbe that overrides the default one                                  | `{}`                         |
+| `metrics.customStartupProbe`                           | Custom startupProbe that overrides the default one                                    | `{}`                         |
+| `metrics.podAnnotations`                               | Memcached Prometheus exporter pod Annotation and Labels                               | `{}`                         |
+| `metrics.service.ports.metrics`                        | Prometheus metrics service port                                                       | `9150`                       |
+| `metrics.service.clusterIP`                            | Static clusterIP or None for headless services                                        | `""`                         |
+| `metrics.service.sessionAffinity`                      | Control where client requests go, to the same pod or round-robin                      | `None`                       |
+| `metrics.service.annotations`                          | Annotations for the Prometheus metrics service                                        | `{}`                         |
+| `metrics.serviceMonitor.enabled`                       | Create ServiceMonitor Resource for scraping metrics using Prometheus Operator         | `false`                      |
+| `metrics.serviceMonitor.namespace`                     | Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)         | `""`                         |
+| `metrics.serviceMonitor.interval`                      | Interval at which metrics should be scraped.                                          | `""`                         |
+| `metrics.serviceMonitor.scrapeTimeout`                 | Timeout after which the scrape is ended                                               | `""`                         |
+| `metrics.serviceMonitor.additionalLabels`              | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`                         |
+| `metrics.serviceMonitor.selector`                      | Prometheus instance selector labels                                                   | `{}`                         |
+| `metrics.serviceMonitor.relabelings`                   | RelabelConfigs to apply to samples before scraping                                    | `[]`                         |
+| `metrics.serviceMonitor.metricRelabelings`             | MetricRelabelConfigs to apply to samples before ingestion                             | `[]`                         |
+| `metrics.serviceMonitor.honorLabels`                   | Specify honorLabels parameter to add the scrape endpoint                              | `false`                      |
+| `metrics.serviceMonitor.jobLabel`                      | The name of the label on the target service to use as the job name in prometheus.     | `""`                         |
 
 
 The above parameters map to the environment variables defined in the [bitnami/memcached](https://github.com/bitnami/bitnami-docker-memcached) container image. For more information please refer to the [bitnami/memcached](https://github.com/bitnami/bitnami-docker-memcached) container image documentation.
@@ -174,7 +264,7 @@ The above parameters map to the environment variables defined in the [bitnami/me
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install my-release --set memcachedUsername=user,memcachedPassword=password bitnami/memcached
+$ helm install my-release --set auth.username=user,auth.password=password bitnami/memcached
 ```
 
 The above command sets the Memcached admin account username and password to `user` and `password` respectively.
@@ -223,23 +313,21 @@ If you encounter errors when working with persistent volumes, refer to our [trou
 
 Find more information about how to deal with common errors related to Bitnami’s Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
-## Notable changes
-
-### 4.0.0
-
-Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
-Use the workaround below to upgrade from versions previous to 4.0.0. The following example assumes that the release name is memcached:
-
-```console
-$ kubectl delete deployment  memcached --cascade=false
-$ helm upgrade memcached bitnami/memcached
-```
-
-### 3.0.0
-
-This release uses the new bash based `bitnami/memcached` container which uses bash scripts for the start up logic of the container and is smaller in size.
-
 ## Upgrading
+
+### To 5.0.0
+
+This major release renames several values in this chart and adds missing features, in order to be inline with the rest of assets in the Bitnami charts repository.
+
+Some affected values are:
+
+- `memcachedUsername` and `memcachedPassword` have regrouped under the `auth` map.
+- `arguments` has been renamed to `args`.
+- `extraEnv` has been renamed to `extraEnvVars`.
+- `service.port`, `service.internalPort` and `service.externalPort` have been regrouped under the `service.ports` map.
+- `metrics.kafka.service.port` has been regrouped under the `metrics.kafka.service.ports` map.
+- `metrics.jmx.service.port` has been regrouped under the `metrics.jmx.service.ports` map.
+- `updateStrategy` (string) and `rollingUpdatePartition` are regrouped under the `updateStrategy` map.
 
 ### To 5.3.0
 
@@ -250,6 +338,20 @@ This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs
 [On November 13, 2020, Helm v2 support formally ended](https://github.com/helm/charts#status-of-the-project). This major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
 
 [Learn more about this change and related upgrade considerations](https://docs.bitnami.com/kubernetes/infrastructure/memcached/administration/upgrade-helm3/).
+
+### To 4.0.0
+
+Backwards compatibility is not guaranteed unless you modify the labels used on the chart's deployments.
+Use the workaround below to upgrade from versions previous to 4.0.0. The following example assumes that the release name is memcached:
+
+```console
+$ kubectl delete deployment  memcached --cascade=false
+$ helm upgrade memcached bitnami/memcached
+```
+
+### To 3.0.0
+
+This release uses the new bash based `bitnami/memcached` container which uses bash scripts for the start up logic of the container and is smaller in size.
 
 ### To 1.0.0
 

--- a/bitnami/memcached/ci/values-production.yaml
+++ b/bitnami/memcached/ci/values-production.yaml
@@ -1,5 +1,0 @@
-# Test values file for generating all of the yaml and check that
-# the rendering is correct
-
-metrics:
-  enabled: true

--- a/bitnami/memcached/ci/values-with-persistence-and-metrics.yaml
+++ b/bitnami/memcached/ci/values-with-persistence-and-metrics.yaml
@@ -1,0 +1,10 @@
+# Test values file for generating hidden section of the yaml
+# and check that the rendering is correct
+architecture: high-availability
+replicaCount: 3
+persistence:
+  enabled: true
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true

--- a/bitnami/memcached/templates/NOTES.txt
+++ b/bitnami/memcached/templates/NOTES.txt
@@ -2,28 +2,40 @@ CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
+{{- if and (not .Values.auth.enabled) (contains .Values.service.type "LoadBalancer") }}
+-------------------------------------------------------------------------------
+ WARNING
+
+    By specifying "serviceType=LoadBalancer" and not specifying "auth.enabled=true"
+    you have most likely exposed the Memcached service externally without any
+    authentication mechanism.
+
+    For security reasons, we strongly suggest that you switch to "ClusterIP" or
+    "NodePort". As alternative, you can also specify valid credentials using the
+    "auth.username" and "auth.password" parameters.
+
+-------------------------------------------------------------------------------
+{{- end }}
+
 ** Please be patient while the chart is being deployed **
 
-{{- if eq .Values.architecture "standalone" }}
-Memcached can be accessed on port 11211 on the following DNS name from within your cluster: {{ template "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
-{{- else if eq .Values.architecture "high-availability" }}
-Memcached endpoints are exposed on the headless service named: {{ template "common.names.fullname" . }}.
+Memcached can be accessed via port {{ .Values.service.ports.memcached }} on the following DNS name from within your cluster:
+
+    {{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+
+{{- if eq .Values.architecture "high-availability" }}
+
 Please see https://github.com/memcached/memcached/wiki/ConfiguringClient to understand the Memcached model and need for client-based consistent hashing.
 You might also want to consider more advanced routing/replication approaches with mcrouter: https://github.com/facebook/mcrouter/wiki/Replicated-pools-setup
-{{- end }}
-
-{{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
-
-WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/
 
 {{- end }}
+
 {{- if .Values.metrics.enabled }}
 
 To access the Memcached Prometheus metrics from outside the cluster execute the following commands:
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }}-metrics {{ .Values.metrics.service.port }}:{{ .Values.metrics.service.port }} &
-    curl http://127.0.0.1:{{ .Values.metrics.service.port }}/metrics
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ printf "%s-metrics" (include "common.names.fullname" .) }} {{ .Values.metrics.service.ports.metrics }}:{{ .Values.metrics.service.ports.metrics }} &
+    curl http://127.0.0.1:{{ .Values.metrics.service.ports.metrics }}/metrics
 
 {{- end }}
 

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
@@ -144,6 +147,9 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "memcached.metrics.image" . }}
@@ -185,4 +191,7 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -21,15 +21,16 @@ spec:
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
-      {{- if or .Values.podAnnotations (and .Values.metrics.enabled .Values.metrics.podAnnotations) }}
       annotations:
+        {{- if .Values.auth.enabled }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
         {{- if and .Values.metrics.enabled .Values.metrics.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
-      {{- end }}
     spec:
       {{- include "memcached.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.hostAliases }}
@@ -53,12 +54,13 @@ spec:
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName | quote }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "memcached.serviceAccountName" . }}
       {{- if .Values.initContainers }}
@@ -68,73 +70,111 @@ spec:
         - name: memcached
           image: {{ template "memcached.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          {{- if .Values.command }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.arguments }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.arguments "context" $) | nindent 12 }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
           {{- end }}
           env:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
-            {{- if .Values.memcachedUsername }}
+            {{- if .Values.auth.enabled }}
             - name: MEMCACHED_USERNAME
-              value: {{ .Values.memcachedUsername | quote }}
-            {{- end }}
-            {{- if .Values.memcachedPassword }}
+              value: {{ .Values.auth.username | quote }}
             - name: MEMCACHED_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "common.names.fullname" . }}
+                  name: {{ include "common.names.fullname" . }}
                   key: memcached-password
             {{- end }}
-            {{- if .Values.extraEnv }}
-            {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- end }}
           ports:
-            - name: {{ .Values.portName }}
-              containerPort: 11211
-          livenessProbe:
+            - name: memcache
+              containerPort: {{ .Values.containerPorts.memcached }}
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
-              port: {{ .Values.portName }}
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 6
-          readinessProbe:
+              port: memcache
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
-              port: {{ .Values.portName }}
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-            periodSeconds: 5
+              port: memcache
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: memcache
+          {{- else if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: tmp
               mountPath: /tmp
-          {{- if .Values.securityContext.enabled }}
-          securityContext:
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
-          {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "memcached.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           ports:
-            - name: {{ .Values.metrics.portName }}
-              containerPort: 9150
-          livenessProbe:
+            - name: metrics
+              containerPort: {{ .Values.metrics.containerPorts.metrics }}
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.metrics.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
-              port: {{ .Values.metrics.portName }}
-            initialDelaySeconds: 15
-            timeoutSeconds: 5
-          readinessProbe:
+              port: {{ .Values.metrics.containerPorts.metrics }}
+          {{- else if .Values.metrics.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.metrics.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
-              port: {{ .Values.metrics.portName }}
-            initialDelaySeconds: 5
-            timeoutSeconds: 1
+              port: {{ .Values.metrics.containerPorts.metrics }}
+          {{- else if .Values.metrics.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.metrics.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.startupProbe "enabled") "context" $) | nindent 12 }}
+            port: memcache
+          {{- else if .Values.metrics.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/memcached/templates/metrics-svc.yaml
+++ b/bitnami/memcached/templates/metrics-svc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "common.names.fullname" . }}-metrics
+  name: {{ printf "%s-metrics" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: metrics
@@ -17,10 +17,14 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-  type: {{ .Values.metrics.service.type }}
+  type: ClusterIP
+  sessionAffinity: {{ .Values.metrics.service.sessionAffinity }}
+  {{- if .Values.metrics.service.clusterIP }}
+  clusterIP: {{ .Values.metrics.service.clusterIP }}
+  {{- end }}
   ports:
     - name: metrics
-      port: {{ .Values.metrics.service.port }}
-      targetPort: {{ .Values.metrics.portName }}
+      port: {{ .Values.metrics.service.ports.metrics }}
+      targetPort: metrics
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
 {{- end }}

--- a/bitnami/memcached/templates/pdb.yaml
+++ b/bitnami/memcached/templates/pdb.yaml
@@ -1,16 +1,16 @@
-{{- if and .Values.podDisruptionBudget.create (eq .Values.architecture "high-availability") }}
-apiVersion: policy/v1beta1
+{{- if and .Values.pdb.create (eq .Values.architecture "high-availability") }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
-  {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
   {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}

--- a/bitnami/memcached/templates/secrets.yaml
+++ b/bitnami/memcached/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.memcachedPassword }}
+{{- if .Values.auth.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,5 +13,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  memcached-password: {{ .Values.memcachedPassword | b64enc | quote }}
+  memcached-password: {{ default (randAlphaNum 10) .Values.auth.password | b64enc | quote }}
 {{- end }}

--- a/bitnami/memcached/templates/service.yaml
+++ b/bitnami/memcached/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -16,19 +16,29 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if and (eq .Values.architecture "high-availability") (eq .Values.service.type "ClusterIP") }}
-  clusterIP: None
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
-  {{- if and (not (empty .Values.service.loadBalancerIP)) (eq .Values.service.type "LoadBalancer") }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{ end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   ports:
     - name: memcache
-      port: {{ .Values.service.port }}
-      targetPort: {{ .Values.portName }}
-      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePort)) }}
-      nodePort: {{ .Values.service.nodePort }}
+      port: {{ .Values.service.ports.memcached }}
+      targetPort: memcache
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.memcached)) }}
+      nodePort: {{ .Values.service.nodePorts.memcached }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/memcached/templates/serviceaccount.yaml
+++ b/bitnami/memcached/templates/serviceaccount.yaml
@@ -9,7 +9,11 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/bitnami/memcached/templates/servicemonitor.yaml
+++ b/bitnami/memcached/templates/servicemonitor.yaml
@@ -16,6 +16,9 @@ metadata:
   annotations:
   {{- end }}
 spec:
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       {{- if .Values.metrics.serviceMonitor.selector }}
@@ -23,13 +26,16 @@ spec:
       {{- end }}
       app.kubernetes.io/component: metrics
   endpoints:
-    - port: {{ .Values.metrics.portName }}
+    - port: metrics
       path: /metrics
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}

--- a/bitnami/memcached/templates/servicemonitor.yaml
+++ b/bitnami/memcached/templates/servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations:
   {{- end }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -22,15 +22,16 @@ spec:
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
-      {{- if or .Values.podAnnotations (and .Values.metrics.enabled .Values.metrics.podAnnotations) }}
       annotations:
+        {{- if .Values.auth.enabled }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
         {{- if and .Values.metrics.enabled .Values.metrics.podAnnotations }}
         {{- include "common.tplvalues.render" (dict "value" .Values.metrics.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
-      {{- end }}
     spec:
       {{- include "memcached.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.hostAliases }}
@@ -54,12 +55,13 @@ spec:
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" .) | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName | quote }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "memcached.serviceAccountName" . }}
       {{- if or .Values.persistence.enabled .Values.initContainers }}
@@ -70,10 +72,12 @@ spec:
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
           command:
             - /bin/bash
+          args:
             - -ec
             - |
+              mkdir -p /cache-state
               touch /cache-state/memory_file
-              chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.fsGroup }} /cache-state
+              find /cache-state -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
           securityContext:
             runAsUser: 0
           {{- if .Values.volumePermissions.resources }}
@@ -89,7 +93,80 @@ spec:
       {{- end }}
       containers:
         - name: memcached
-          {{- if .Values.persistence.enabled }}
+          image: {{ template "memcached.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- else if .Values.persistence.enabled }}
+          args:
+            - /run.sh
+            - --memory-file=/cache-state/memory_file
+          {{- end }}
+          env:
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            {{- if .Values.auth.enabled }}
+            - name: MEMCACHED_USERNAME
+              value: {{ .Values.auth.username | quote }}
+            - name: MEMCACHED_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "common.names.fullname" . }}
+                  key: memcached-password
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: memcache
+              containerPort: {{ .Values.containerPorts.memcached }}
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: memcache
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: memcache
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: memcache
+          {{- else if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- else if .Values.persistence.enabled }}
           lifecycle:
             preStop:
               exec:
@@ -100,55 +177,8 @@ spec:
                     /usr/bin/pkill -10 memcached
                     sleep 60s
           {{- end }}
-          image: {{ template "memcached.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          {{- if .Values.command }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
-          {{- end }}
-          {{- if .Values.arguments }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.arguments "context" $) | nindent 12 }}
-          {{- end }}
-          {{- if .Values.persistence.enabled }}
-            - --memory-file=/cache-state/memory_file
-          {{- end }}
-          {{- if or .Values.extraEnv .Values.memcachedUsername .Values.memcachedPassword }}
-          env:
-            {{- if .Values.memcachedUsername }}
-            - name: MEMCACHED_USERNAME
-              value: {{ .Values.memcachedUsername | quote }}
-            {{- end }}
-            {{- if .Values.memcachedPassword }}
-            - name: MEMCACHED_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "common.names.fullname" . }}
-                  key: memcached-password
-            {{- end }}
-            {{- if .Values.extraEnv }}
-            {{- toYaml .Values.extraEnv | nindent 12 }}
-            {{- end }}
-          {{- end }}
-          ports:
-            - name: {{ .Values.portName }}
-              containerPort: 11211
-          livenessProbe:
-            tcpSocket:
-              port: {{ .Values.portName }}
-            initialDelaySeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 6
-          readinessProbe:
-            tcpSocket:
-              port: {{ .Values.portName }}
-            initialDelaySeconds: 5
-            timeoutSeconds: 3
-            periodSeconds: 5
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
-          {{- end }}
-          {{- if .Values.securityContext.enabled }}
-          securityContext:
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
           {{- end }}
           volumeMounts:
           {{- if .Values.persistence.enabled }}
@@ -162,29 +192,32 @@ spec:
           image: {{ template "memcached.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           ports:
-            - name: {{ .Values.metrics.portName }}
-              containerPort: 9150
+            - name: metrics
+              containerPort: {{ .Values.metrics.containerPorts.metrics }}
+          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.metrics.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
-              port: {{ .Values.metrics.portName }}
-            initialDelaySeconds: {{ .Values.metrics.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.metrics.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.metrics.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.metrics.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.metrics.livenessProbe.failureThreshold }}
+              port: {{ .Values.metrics.containerPorts.metrics }}
+          {{- else if .Values.metrics.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.metrics.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
-              port: {{ .Values.metrics.portName }}
-            initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
+              port: {{ .Values.metrics.containerPorts.metrics }}
+          {{- else if .Values.metrics.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.metrics.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: metrics
+          {{- else if .Values.metrics.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
@@ -196,16 +229,20 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
-{{- if .Values.persistence.enabled }}
+  {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data
-      {{- with .Values.persistence.annotations }}
         annotations:
-        {{- range $key, $value := . }}
-          {{ $key }}: {{ $value }}
+          {{- if .Values.persistence.annotations }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+          {{- end }}
+          {{- if .Values.commonAnnotations }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
+          {{- end }}
+        {{- if .Values.commonLabels }}
+        labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
         {{- end }}
-      {{- end }}
       spec:
         accessModes:
         {{- range .Values.persistence.accessModes }}
@@ -214,6 +251,9 @@ spec:
         resources:
           requests:
             storage: {{ .Values.persistence.size | quote }}
+        {{- if .Values.persistence.selector }}
+        selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 10 }}
+        {{- end }}
         {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -16,6 +16,9 @@ spec:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.replicaCount }}
   serviceName: {{ template "common.names.fullname" . }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
@@ -181,12 +184,15 @@ spec:
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-          {{- if .Values.persistence.enabled }}
+            {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: /cache-state
-          {{- end }}
+            {{- end }}
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.extraVolumeMounts "context" $ ) | nindent 12 }}
+            {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           image: {{ template "memcached.metrics.image" . }}
@@ -224,11 +230,14 @@ spec:
           {{- end }}
         {{- end }}
         {{- if .Values.sidecars }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $ ) | nindent 8 }}
         {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -447,9 +447,6 @@ persistence:
   ## @param persistence.enabled Enable Memcached data persistence using PVC. If false, use emptyDir
   ##
   enabled: false
-  ## @param persistence.existingClaim Name of an existing PVC to use (only when deploying a single replica)
-  ##
-  existingClaim: ""
   ## @param persistence.storageClass PVC Storage Class for Memcached data volume
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -658,9 +655,9 @@ metrics:
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     scrapeTimeout: ""
-    ## @param metrics.serviceMonitor.additionalLabels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+    ## @param metrics.serviceMonitor.labels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
     ##
-    additionalLabels: {}
+    labels: {}
     ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
     ##

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -18,24 +18,42 @@ global:
 
 ## @section Common parameters
 
+## @param kubeVersion Override Kubernetes version
+##
+kubeVersion: ""
 ## @param nameOverride String to partially override common.names.fullname template (will maintain the release name)
 ##
 nameOverride: ""
 ## @param fullnameOverride String to fully override common.names.fullname template
 ##
 fullnameOverride: ""
-## @param commonLabels Labels to add to all deployed objects
-##
-commonLabels: {}
-## @param commonAnnotations Annotations to add to all deployed objects
-##
-commonAnnotations: {}
-## @param clusterDomain Default Kubernetes cluster domain
+## @param clusterDomain Kubernetes Cluster Domain
 ##
 clusterDomain: cluster.local
-## @param extraDeploy Array of extra objects to deploy with the release
+## @param extraDeploy Extra objects to deploy (evaluated as a template)
 ##
 extraDeploy: []
+## @param commonLabels Add labels to all the deployed resources
+##
+commonLabels: {}
+## @param commonAnnotations Add annotations to all the deployed resources
+##
+commonAnnotations: {}
+
+## Enable diagnostic mode in the deployment/statefulset
+##
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ##
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the deployment/statefulset
+  ##
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the deployment/statefulset
+  ##
+  args:
+    - infinity
 
 ## @section Memcached parameters
 
@@ -46,7 +64,7 @@ extraDeploy: []
 ## @param image.tag Memcached image tag (immutable tags are recommended)
 ## @param image.pullPolicy Memcached image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
-## @param image.debug Enable image debug mode
+## @param image.debug Specify if debug values should be set
 ##
 image:
   registry: docker.io
@@ -71,25 +89,23 @@ image:
 ## @param architecture Memcached architecture. Allowed values: standalone or high-availability
 ##
 architecture: standalone
-## @param hostAliases Add deployment host aliases
-## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
-##
-hostAliases: []
-## @param memcachedUsername Memcached admin user
+## Authentication parameters
 ## ref: https://github.com/bitnami/bitnami-docker-memcached#creating-the-memcached-admin-user
 ##
-memcachedUsername: ""
-## @param memcachedPassword Memcached admin password
-## ref: https://github.com/bitnami/bitnami-docker-memcached#creating-the-memcached-admin-user
-##
-memcachedPassword: ""
-## @param replicaCount Number of containers
-##
-replicaCount: 1
-## @param command Default container command (useful when using custom images)
+auth:
+  ## @param auth.enabled Enable Memcached authentication
+  ##
+  enabled: false
+  ## @param auth.username Memcached admin user
+  ##
+  username: ""
+  ## @param auth.password Memcached admin password
+  ##
+  password: ""
+## @param command Override default container command (useful when using custom images)
 ##
 command: []
-## @param arguments Default container args (useful when using custom images)
+## @param args Override default container args (useful when using custom images)
 ## e.g:
 ## arguments:
 ##   - /run.sh
@@ -97,100 +113,124 @@ command: []
 ##   - -I <maxItemSize>
 ##   - -vv
 ##
-arguments:
-  - /run.sh
-## @param extraEnv Additional env vars to pass
-## ref: https://github.com/bitnami/bitnami-docker-memcached#configuration
+args: []
+## @param extraEnvVars Array with extra environment variables to add to Memcached nodes
+## e.g:
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
 ##
-extraEnv: []
-## Pod disruption budget configuration
-## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+extraEnvVars: []
+## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars for Memcached nodes
 ##
-podDisruptionBudget:
-  ## @param podDisruptionBudget.create Specifies whether a Pod disruption budget should be created
-  ##
-  create: false
-  ## @param podDisruptionBudget.minAvailable Minimum number of pods that need to be available
-  ##
-  minAvailable: ""
-  ## @param podDisruptionBudget.maxUnavailable Maximum number of pods that can be unavailable
-  ##
-  maxUnavailable: 1
-## Service parameters
+extraEnvVarsCM: ""
+## @param extraEnvVarsSecret Name of existing Secret containing extra env vars for Memcached nodes
 ##
-service:
-  ## @param service.type Kubernetes service type for Memcached
-  ##
-  type: ClusterIP
-  ## @param service.port Memcached service port
-  ##
-  port: 11211
-  ## @param service.nodePort Kubernetes Service nodePort
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
-  ##
-  nodePort: ""
-  ## @param service.loadBalancerIP `loadBalancerIP` if service type is `LoadBalancer`
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
-  ##
-  loadBalancerIP: ""
-  ## @param service.annotations Additional annotations for Memcached service
-  ##
-  annotations: {}
+extraEnvVarsSecret: ""
 
-## Memcached Autoscaling
-## @param autoscaling.enabled Enable memcached statefulset autoscaling (requires architecture: "high-availability")
-## @param autoscaling.minReplicas memcached statefulset autoscaling minimum number of replicas
-## @param autoscaling.maxReplicas memcached statefulset autoscaling maximum number of replicas
-## @param autoscaling.targetCPU memcached statefulset autoscaling target CPU percentage
-## @param autoscaling.targetMemory memcached statefulset autoscaling target CPU memory
+## @section Deployment/Statefulset parameters
+
+## @param replicaCount Number of Memcached nodes
 ##
-autoscaling:
+replicaCount: 1
+## @param containerPorts.memcached Memcached container port
+##
+containerPorts:
+  memcached: 11211
+## Configure extra options for Memcached containers' liveness, readiness and startup probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe on Memcached containers
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+## @param readinessProbe.enabled Enable readinessProbe on Memcached containers
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 6
+  successThreshold: 1
+## @param startupProbe.enabled Enable startupProbe on Memcached containers
+## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+## @param startupProbe.periodSeconds Period seconds for startupProbe
+## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.successThreshold Success threshold for startupProbe
+##
+startupProbe:
   enabled: false
-  minReplicas: 3
-  maxReplicas: 6
-  targetCPU: 50
-  targetMemory: 50
-
-## Memcached containers' resource requests and limits
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 1
+  failureThreshold: 15
+  successThreshold: 1
+## @param customLivenessProbe Custom livenessProbe that overrides the default one
+##
+customLivenessProbe: {}
+## @param customReadinessProbe Custom readinessProbe that overrides the default one
+##
+customReadinessProbe: {}
+## @param customStartupProbe Custom startupProbe that overrides the default one
+##
+customStartupProbe: {}
+## @param lifecycleHooks for the Memcached container(s) to automate configuration before or after startup
+##
+lifecycleHooks: {}
+## Memcached resource requests and limits
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-## We usually recommend not to specify default resources and to leave this as a conscious
-## choice for the user. This also increases chances charts run on environments with little
-## resources, such as Minikube. If you do want to specify resources, uncomment the following
-## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-## @param resources.limits CPU/Memory resource limits
-## @param resources.requests [object] CPU/Memory resource requests
+## @param resources.limits The resources limits for the Memcached containers
+## @param resources.requests.memory The requested memory for the Memcached containers
+## @param resources.requests.cpu The requested cpu for the Memcached containers
 ##
 resources:
-  ## Example:
-  ## limits:
-  ##    cpu: 100m
-  ##    memory: 128Mi
   limits: {}
   requests:
     memory: 256Mi
     cpu: 250m
-## @param portName Name of the main port exposed by memcached
-## If you want to override the port name (can be usefull when using a service mesh)
-## ref for istio: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/
+## Configure Pods Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param podSecurityContext.enabled Enabled Memcached pods' Security Context
+## @param podSecurityContext.fsGroup Set Memcached pod's Security Context fsGroup
 ##
-portName: memcache
-## Pod Security Context
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-## @param securityContext.enabled Enable security context
-## @param securityContext.fsGroup Group ID for the container
-## @param securityContext.runAsUser User ID for the container
-## @param securityContext.readOnlyRootFilesystem Enable read-only filesystem
-##
-securityContext:
+podSecurityContext:
   enabled: true
   fsGroup: 1001
+## Configure Container Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## @param containerSecurityContext.enabled Enabled Memcached containers' Security Context
+## @param containerSecurityContext.runAsUser Set Memcached containers' Security Context runAsUser
+## @param containerSecurityContext.runAsNonRoot Set Memcached containers' Security Context runAsNonRoot
+##
+containerSecurityContext:
+  enabled: true
   runAsUser: 1001
-  readOnlyRootFilesystem: false
-## @param podLabels Pod extra labels
+  runAsNonRoot: true
+## @param hostAliases Add deployment host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+## @param podLabels Extra labels for Memcached pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
 podLabels: {}
-## @param podAnnotations Pod annotations
+## @param podAnnotations Annotations for Memcached pods
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
 podAnnotations: {}
@@ -209,7 +249,7 @@ nodeAffinityPreset:
   ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
   ##
   type: ""
-  ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set.
+  ## @param nodeAffinityPreset.key Node label key to match Ignored if `affinity` is set.
   ## E.g.
   ## key: "kubernetes.io/e2e-az-name"
   ##
@@ -227,22 +267,74 @@ nodeAffinityPreset:
 ##
 affinity: {}
 ## @param nodeSelector Node labels for pod assignment
-## ref: https://kubernetes.io/docs/user-guide/node-selection/
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
 nodeSelector: {}
 ## @param tolerations Tolerations for pod assignment
-## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
-## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 ##
 topologySpreadConstraints: {}
-## @param priorityClassName Pod priority
-## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+## @param podManagementPolicy StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: `OrderedReady` and `Parallel`
+## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
+##
+podManagementPolicy: Parallel
+## @param priorityClassName Name of the existing priority class to be used by Memcached pods, priority class needs to be created beforehand
+## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 ##
 priorityClassName: ""
-## @param initContainers Add additional init containers to the Memcached pod
+## @param schedulerName Kubernetes pod scheduler registry
+## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+schedulerName: ""
+## @param updateStrategy.type Memcached statefulset strategy type
+## @param updateStrategy.rollingUpdate Memcached statefulset rolling update configuration parameters
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+##
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate: {}
+## @param extraVolumes Optionally specify extra list of additional volumes for the Memcached pod(s)
+## Example Use Case: mount certificates to enable TLS
+## e.g:
+## extraVolumes:
+## - name: zookeeper-keystore
+##   secret:
+##     defaultMode: 288
+##     secretName: zookeeper-keystore
+## - name: zookeeper-truststore
+##   secret:
+##     defaultMode: 288
+##     secretName: zookeeper-truststore
+##
+extraVolumes: []
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Memcached container(s)
+## Example Use Case: mount certificates to enable TLS
+## e.g:
+## extraVolumeMounts:
+## - name: zookeeper-keystore
+##   mountPath: /certs/keystore
+##   readOnly: true
+## - name: zookeeper-truststore
+##   mountPath: /certs/truststore
+##   readOnly: true
+##
+extraVolumeMounts: []
+## @param sidecars Add additional sidecar containers to the Memcached pod(s)
+## e.g:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: []
+## @param initContainers Add additional init containers to the Memcached pod(s)
 ## Example:
 ## initContainers:
 ##   - name: your-image-name
@@ -253,56 +345,183 @@ priorityClassName: ""
 ##         containerPort: 1234
 ##
 initContainers: []
-## @param sidecars Add additional sidecar containers to the Memcached pod
-## Example:
-## sidecars:
-##   - name: your-image-name
-##     image: your-image
-##     imagePullPolicy: Always
-##     ports:
-##       - name: portname
-##         containerPort: 1234
+## Memcached Autoscaling
+## @param autoscaling.enabled Enable memcached statefulset autoscaling (requires architecture: "high-availability")
+## @param autoscaling.minReplicas memcached statefulset autoscaling minimum number of replicas
+## @param autoscaling.maxReplicas memcached statefulset autoscaling maximum number of replicas
+## @param autoscaling.targetCPU memcached statefulset autoscaling target CPU percentage
+## @param autoscaling.targetMemory memcached statefulset autoscaling target CPU memory
 ##
-sidecars: []
-## memcached pods ServiceAccount
+autoscaling:
+  enabled: false
+  minReplicas: 3
+  maxReplicas: 6
+  targetCPU: 50
+  targetMemory: 50
+## Memcached Pod Disruption Budget
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+## @param pdb.create Deploy a pdb object for the Memcached pod
+## @param pdb.minAvailable Minimum available Memcached replicas
+## @param pdb.maxUnavailable Maximum unavailable Memcached replicas
+##
+pdb:
+  create: false
+  minAvailable: ""
+  maxUnavailable: 1
+
+## @section Traffic Exposure parameters
+
+service:
+  ## @param service.type Kubernetes Service type
+  ##
+  type: ClusterIP
+  ## @param service.ports.memcached Memcached service port
+  ##
+  ports:
+    memcached: 11211
+  ## Node ports to expose
+  ## NOTE: choose port between <30000-32767>
+  ## @param service.nodePorts.memcached Node port for Memcached
+  ##
+  nodePorts:
+    memcached: ""
+  ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
+  ## Values: ClientIP or None
+  ## ref: https://kubernetes.io/docs/user-guide/services/
+  ##
+  sessionAffinity: None
+  ## @param service.clusterIP Memcached service Cluster IP
+  ## e.g.:
+  ## clusterIP: None
+  ##
+  clusterIP: ""
+  ## @param service.loadBalancerIP Memcached service Load Balancer IP
+  ## ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer
+  ##
+  loadBalancerIP: ""
+  ## @param service.loadBalancerSourceRanges Memcached service Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## @param service.externalTrafficPolicy Memcached service external traffic policy
+  ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+  ## @param service.annotations Additional custom annotations for Memcached service
+  ##
+  annotations: {}
+  ## @param service.extraPorts Extra ports to expose in the Memcached service (normally used with the `sidecar` value)
+  ##
+  extraPorts: []
+
+## @section Other Parameters
+
+## Service account for Memcached to use.
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## @param serviceAccount.create Enable creation of ServiceAccount for memcached pods
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Memcached pod
   ##
-  create: true
+  create: false
   ## @param serviceAccount.name The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the memcached.serviceAccountName template
+  ## If not set and create is true, a name is generated using the common.names.fullname template
   ##
   name: ""
-  ## @param serviceAccount.automountServiceAccountToken Enable/disable auto mounting of the service account token
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
   ##
   automountServiceAccountToken: true
-## Persistence - used for dumping and restoring states between recreations
-## Ref: https://github.com/memcached/memcached/wiki/WarmRestart
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
+
+## @section Persistence parameters
+
+## Enable persistence using Persistent Volume Claims
+## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
-  ## @param persistence.enabled Enable persistence using PVC (Requires architecture: "high-availability")
+  ## @param persistence.enabled Enable Memcached data persistence using PVC. If false, use emptyDir
   ##
   enabled: false
-  ## @param persistence.storageClass PVC Storage Class for Memcached volume
+  ## @param persistence.existingClaim Name of an existing PVC to use (only when deploying a single replica)
+  ##
+  existingClaim: ""
+  ## @param persistence.storageClass PVC Storage Class for Memcached data volume
   ## If defined, storageClassName: <storageClass>
   ## If set to "-", storageClassName: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
-  ##  set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##  GKE, AWS & OpenStack)
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
   ##
   storageClass: ""
-  ## @param persistence.annotations Persistent Volume Claim annotations
-  ##
-  annotations: {}
-  ## @param persistence.accessModes Persistent Volume Access Mode
+  ## @param persistence.accessModes PVC Access modes
   ##
   accessModes:
     - ReadWriteOnce
-  ## @param persistence.size PVC Storage Request for Memcached volume
+  ## @param persistence.size PVC Storage Request for Memcached data volume
   ##
   size: 8Gi
+  ## @param persistence.annotations Annotations for the PVC
+  ##
+  annotations: {}
+  ## @param persistence.selector Selector to match an existing Persistent Volume for Memcached's data PVC
+  ## If set, the PVC can't have a PV dynamically provisioned for it
+  ## E.g.
+  ## selector:
+  ##   matchLabels:
+  ##     app: my-app
+  ##
+  selector: {}
+
+## @section Volume Permissions parameters
+##
+
+## Init containers parameters:
+## volumePermissions: Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each node
+##
+volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes the owner and group of the persistent volume
+  ##
+  enabled: false
+  ## @param volumePermissions.image.registry Init container volume-permissions image registry
+  ## @param volumePermissions.image.repository Init container volume-permissions image repository
+  ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+  ## @param volumePermissions.image.pullSecrets Init container volume-permissions image pull secrets
+  ##
+  image:
+    registry: docker.io
+    repository: bitnami/bitnami-shell
+    tag: 10-debian-10-r304
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## Init container resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param volumePermissions.resources.limits Init container volume-permissions resource limits
+  ## @param volumePermissions.resources.requests Init container volume-permissions resource requests
+  ##
+  resources:
+    limits: {}
+    requests: {}
+  ## Init container' Security Context
+  ## Note: the chown of the data folder is done to containerSecurityContext.runAsUser
+  ## and not the below volumePermissions.containerSecurityContext.runAsUser
+  ## @param volumePermissions.containerSecurityContext.runAsUser User ID for the init container
+  ##
+  containerSecurityContext:
+    runAsUser: 0
+
 ## Prometheus Exporter / Metrics
 ##
 metrics:
@@ -330,40 +549,21 @@ metrics:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-  ## @param metrics.podAnnotations [object] Metrics exporter pod Annotation and Labels
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ## @param metrics.containerPorts.metrics Memcached Prometheus Exporter container port
   ##
-  podAnnotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "9150"
-  ## @param metrics.portName Memcached exporter port name
-  ## If you want to override the port name (can be usefull when using a service mesh)
-  ## ref for istio: https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/
-  ##
-  portName: metrics
-  ## Memcached Prometheus exporter resource requests and limits
+  containerPorts:
+    metrics: 9150
+  ## Memcached Prometheus exporter container resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param metrics.resources.limits The resources limits for the container
-  ## @param metrics.resources.requests The requested resources for the container
+  ## @param metrics.resources.limits Init container volume-permissions resource limits
+  ## @param metrics.resources.requests Init container volume-permissions resource requests
   ##
   resources:
-    ## Example:
-    ## limits:
-    ##    cpu: 100m
-    ##    memory: 128Mi
     limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 100m
-    ##    memory: 128Mi
     requests: {}
-  ## Configure extra options for liveness probe
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param metrics.livenessProbe.enabled Enable livenessProbe
+  ## Configure extra options for Memcached Prometheus exporter containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param metrics.livenessProbe.enabled Enable livenessProbe on Memcached Prometheus exporter containers
   ## @param metrics.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param metrics.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param metrics.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -377,9 +577,7 @@ metrics:
     timeoutSeconds: 5
     failureThreshold: 3
     successThreshold: 1
-  ## Configure extra options for readiness probe
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param metrics.readinessProbe.enabled Enable readinessProbe
+  ## @param metrics.readinessProbe.enabled Enable readinessProbe on Memcached Prometheus exporter containers
   ## @param metrics.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param metrics.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param metrics.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -390,119 +588,92 @@ metrics:
     enabled: true
     initialDelaySeconds: 5
     periodSeconds: 10
-    timeoutSeconds: 1
+    timeoutSeconds: 3
     failureThreshold: 3
     successThreshold: 1
+  ## @param metrics.startupProbe.enabled Enable startupProbe on Memcached Prometheus exporter containers
+  ## @param metrics.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param metrics.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param metrics.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param metrics.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param metrics.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+  ## @param metrics.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param metrics.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param metrics.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## @param metrics.podAnnotations [object] Memcached Prometheus exporter pod Annotation and Labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.metrics.containerPorts.metrics }}"
+  ## Service configuration
+  ##
   service:
-    ## @param metrics.service.type Kubernetes service type for Prometheus metrics
+    ## @param metrics.service.ports.metrics Prometheus metrics service port
     ##
-    type: ClusterIP
-    ## @param metrics.service.port Prometheus metrics service port
+    ports:
+      metrics: 9150
+    ## @param metrics.service.clusterIP Static clusterIP or None for headless services
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#choosing-your-own-ip-address
     ##
-    port: 9150
+    clusterIP: ""
+    ## @param metrics.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
     ## @param metrics.service.annotations [object] Annotations for the Prometheus metrics service
     ##
     annotations:
       prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ .Values.metrics.service.port }}"
+      prometheus.io/port: "{{ .Values.metrics.service.ports.metrics }}"
   ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using Prometheus Operator
     ##
     enabled: false
-    ## @param metrics.serviceMonitor.namespace The namespace in which the ServiceMonitor will be created
-    ## e.g:
-    ## namespace: monitoring
+    ## @param metrics.serviceMonitor.namespace Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)
     ##
     namespace: ""
-    ## @param metrics.serviceMonitor.interval The interval at which metrics should be scraped
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
-    ## e.g:
-    ## interval: 10s
     ##
     interval: ""
-    ## @param metrics.serviceMonitor.scrapeTimeout The timeout after which the scrape is ended
+    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
-    ## e.g:
-    ## scrapeTimeout: 10s
     ##
     scrapeTimeout: ""
-    ## @param metrics.serviceMonitor.selector Additional labels for ServiceMonitor resource
+    ## @param metrics.serviceMonitor.additionalLabels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+    ##
+    additionalLabels: {}
+    ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
-    ## e.g:
-    ## selector:
-    ##   prometheus: my-prometheus
     ##
     selector: {}
-    ## @param metrics.serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
-    ## ref: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
-    ## e.g:
-    ## metricRelabelings:
-    ## - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
-    ##   separator: ;
-    ##   regex: ^(.*)$
-    ##   targetLabel: pod_name
-    ##   replacement: $1
-    ##   action: replace
-    ##
-    metricRelabelings: []
-    ## @param metrics.serviceMonitor.relabelings Metrics relabelings to add to the scrape endpoint, applied before scraping
-    ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
-    ## e.g:
-    ## relabelings:
-    ## - sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
-    ##   separator: ;
-    ##   regex: ^(.*)$
-    ##   targetLabel: pod_name
-    ##   replacement: $1
-    ##   action: replace
+    ## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
     ##
     relabelings: []
-## Init Container parameters
-## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component
-## values from the securityContext section of the component
-##
-volumePermissions:
-  ## @param volumePermissions.image.registry Init container volume-permissions image registry
-  ## @param volumePermissions.image.repository Init container volume-permissions image repository
-  ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
-  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
-  ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
-  ##
-  image:
-    registry: docker.io
-    repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r307
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ## @param metrics.serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
     ##
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## Example:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
     ##
-    pullSecrets: []
-  ## Init Container resource requests and limits
-  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param volumePermissions.resources.limits Init container volume-permissions resource limits
-  ## @param volumePermissions.resources.requests Init container volume-permissions resource requests
-  ##
-  resources:
-    ## Example:
-    ## limits:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    requests: {}
+    honorLabels: false
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+    ##
+    jobLabel: ""

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -69,7 +69,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/memcached
-  tag: 1.6.13-debian-10-r0
+  tag: 1.6.13-debian-10-r7
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -493,7 +493,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r304
+    tag: 10-debian-10-r313
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -536,7 +536,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/memcached-exporter
-    tag: 0.9.0-debian-10-r268
+    tag: 0.9.0-debian-10-r274
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR standardizes the `bitnami/memcached` chart to be in line with the rest of the catalog.

**Benefits**

Standardization

**Possible drawbacks**

Changes the values structure forcing a major bump, check the README.md for more information.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist** 

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])