### PR TITLE
[bitnami/nginx] Fix issue with ServiceMonitors

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 9.7.1
+version: 9.7.2

--- a/bitnami/nginx/templates/servicemonitor.yaml
+++ b/bitnami/nginx/templates/servicemonitor.yaml
@@ -10,7 +10,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}  


### PR DESCRIPTION
This fixes an issue with ServiceMonitors. If  `.Values.metrics.serviceMonitor.enabled` is true and `.Values.metrics.serviceMonitor.additionalLabels` is the empty object, no valid YAML is produced.