### PR TITLE
Redis - removed unnecessary sentinel metrics config entry

### DIFF
--- a/bitnami/redis/ci/sentinel-values.yaml
+++ b/bitnami/redis/ci/sentinel-values.yaml
@@ -2,5 +2,3 @@ sentinel:
   enabled: true
 metrics:
   enabled: true
-  sentinel:
-    enabled: true


### PR DESCRIPTION
According to version 14.8.0 of the helm chart the sentinel metrics config entry was removed. This should be reflected in ci folder.

https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1480