### PR TITLE
[bitnami/grafana-operator] Add deployment.skipCreateAdminAccount to grafana.yaml

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 2.1.1
+version: 2.2.0

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -19,7 +19,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment
 
 ## Prerequisites
 
-- Kubernetes 1.16+
+- Kubernetes 1.19+
 - Helm 3.1.0
 
 ## Installing the Chart

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -194,6 +194,7 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.resources.limits`                                  | The resources limits for the container                                                        | `{}`                     |
 | `grafana.resources.requests`                                | The requested resources for the container                                                     | `{}`                     |
 | `grafana.replicaCount`                                      | Specify the amount of replicas running                                                        | `1`                      |
+| `grafana.skipCreateAdminAccount`                            | Prevent the operator from creating an admin secret                                            | `false`                  |
 | `grafana.podAffinityPreset`                                 | Pod affinity preset                                                                           | `""`                     |
 | `grafana.podAntiAffinityPreset`                             | Pod anti-affinity preset                                                                      | `soft`                   |
 | `grafana.nodeAffinityPreset.type`                           | Set nodeAffinity preset type                                                                  | `""`                     |

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -93,6 +93,7 @@ spec:
     envFrom: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.envFrom "context" $ ) | nindent 6 }}
     {{- end }}
     replicas: {{ .Values.grafana.replicaCount }}
+    skipCreateAdminAccount: {{ .Values.grafana.skipCreateAdminAccount }}
     {{- if .Values.grafana.podSecurityContext.enabled }}
     securityContext: {{- omit .Values.grafana.podSecurityContext "enabled" | toYaml | nindent 6 }}
     {{- end }}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -462,6 +462,11 @@ grafana:
   ## NOTE: Number of replicas. If more than one is selected, a shared database should be configured.
   ##
   replicaCount: 1
+  ## @param grafana.skipCreateAdminAccount Prevent the operator from creating an admin secret
+  ## Ref: https://github.com/grafana-operator/grafana-operator/blob/master/documentation/env_vars.md
+  ## Allowed values: true, false
+  ##
+  skipCreateAdminAccount: false
   ## @param grafana.podAffinityPreset Pod affinity preset
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ## Allowed values: soft, hard

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -127,7 +127,7 @@ operator:
   image:
     registry: docker.io
     repository: bitnami/grafana-operator
-    tag: 4.1.1-debian-10-r24
+    tag: 4.1.1-debian-10-r35
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## Ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -386,7 +386,7 @@ grafana:
   image:
     registry: docker.io
     repository: bitnami/grafana
-    tag: 8.3.3-debian-10-r22
+    tag: 8.3.3-debian-10-r32
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
**Description of the change**

Allow configuration of `deployment.skipCreateAdminAccount` in `grafana.yaml`.

**Benefits**

Users of this chart can now configure this parameter.

**Possible drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Fixes #8629
  - Fixes #8661 

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
