### PR TITLE
[bitnami/tomcat] Fix extraVolumes parameter

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/bitnami-docker-tomcat
   - http://tomcat.apache.org
-version: 10.1.2
+version: 10.1.3

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -181,9 +181,6 @@ volumes:
   {{- if .Values.extraVolumes }}
   {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 2 }}
   {{- end }}
-{{- if .Values.extraVolumes }}
-{{ include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) }}
-{{- end }}
 {{- if .Values.extraPodSpec }}
 {{- include "common.tplvalues.render" (dict "value" .Values.extraPodSpec "context" $) }}
 {{- end }}

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -133,7 +133,7 @@ containers:
       - name: data
         mountPath: /bitnami/tomcat
       {{- if .Values.extraVolumeMounts }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 4 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 6 }}
       {{- end }}
 {{- if .Values.sidecars }}
 {{ include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) }}


### PR DESCRIPTION
**Description of the change**

Removes duplicated `extraVolumes` in Tomcat's pod.

**Benefits**

Fixes bug.

**Possible drawbacks**

None known.

**Applicable issues**

  - fixes #8681
  - fixes #8690

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)