### PR TITLE
[bitnami/grafana-tempo] Chart standardized

### DIFF
--- a/bitnami/grafana-tempo/Chart.lock
+++ b/bitnami/grafana-tempo/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.10.3
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 5.15.14
-digest: sha256:649187759d21e3fce44086320c891ed34e323e8ad37c361c052f3691aa6537c9
-generated: "2022-01-15T19:31:30.144603187Z"
+  version: 6.0.0
+digest: sha256:58641f6cbcaed1dcee5dec9013e9594adac4e9c0bec302f050a0f8ae490da87b
+generated: "2022-01-19T16:53:23.258095+01:00"

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -8,9 +8,10 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-  - name: memcached
+  - condition: memcached.enabled
+    name: memcached
     repository: https://charts.bitnami.com/bitnami
-    version: 5.x.x
+    version: 6.x.x
 description: Grafana Tempo is an open source, easy-to-use and high-scale distributed tracing backend.
 engine: gotpl
 home: https://github.com/grafana/tempo/
@@ -27,4 +28,4 @@ name: grafana-tempo
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana-tempo
   - https://github.com/grafana/tempo/
-version: 0.2.18
+version: 1.0.0

--- a/bitnami/grafana-tempo/README.md
+++ b/bitnami/grafana-tempo/README.md
@@ -72,487 +72,574 @@ The command removes all the Kubernetes components associated with the chart and 
 | `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
-| `diagnosticMode.command` | Command to override all containers in the deployment                                    | `["sleep"]`     |
-| `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `["infinity"]`  |
+| `diagnosticMode.command` | Command to override all containers in the deployments/statefulsets                      | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the deployments/statefulsets                         | `["infinity"]`  |
 
 
 ### Common Grafana Tempo Parameters
 
-| Name                                   | Description                                                | Value                         |
-| -------------------------------------- | ---------------------------------------------------------- | ----------------------------- |
-| `tempo.image.registry`                 | Grafana Tempo image registry                               | `docker.io`                   |
-| `tempo.image.repository`               | Grafana Tempo image repository                             | `bitnami/grafana-tempo`       |
-| `tempo.image.tag`                      | Grafana Tempo image tag (immutable tags are recommended)   | `1.2.1-debian-10-r47`         |
-| `tempo.image.pullPolicy`               | Grafana Tempo image pull policy                            | `IfNotPresent`                |
-| `tempo.image.pullSecrets`              | Grafana Tempo image pull secrets                           | `[]`                          |
-| `tempo.containerPort`                  | Tempo components web port                                  | `3100`                        |
-| `tempo.grpcContainerPort`              | Tempo components GRPC port                                 | `9095`                        |
-| `tempo.memBallastSizeMbs`              | Tempo components memory ballast size in MB                 | `1024`                        |
-| `tempo.dataDir`                        | Tempo components data directory                            | `/bitnami/grafana-tempo/data` |
-| `tempo.traces.jaeger.grpc`             | Enable Tempo to ingest Jaeger GRPC traces                  | `true`                        |
-| `tempo.traces.jaeger.thriftBinary`     | Enable Tempo to ingest Jaeger Thrift Binary traces         | `false`                       |
-| `tempo.traces.jaeger.thriftCompact`    | Enable Tempo to ingest Jaeger Thrift Compact traces        | `false`                       |
-| `tempo.traces.jaeger.thriftHttp`       | Enable Tempo to ingest Jaeger Thrift HTTP traces           | `true`                        |
-| `tempo.traces.zipkin`                  | Enable Tempo to ingest Zipkin traces                       | `false`                       |
-| `tempo.traces.otlp.http`               | Enable Tempo to ingest Open Telementry HTTP traces         | `false`                       |
-| `tempo.traces.otlp.grpc`               | Enable Tempo to ingest Open Telementry GRPC traces         | `false`                       |
-| `tempo.traces.opencensus`              | Enable Tempo to ingest Open Census traces                  | `false`                       |
-| `tempo.gossipRing.containerPort`       | gossip service HTTP port                                   | `7946`                        |
-| `tempo.gossipRing.service.port`        | gossip headless service HTTP port                          | `7946`                        |
-| `tempo.gossipRing.service.annotations` | Additional custom annotations for gossip headless service  | `{}`                          |
-| `tempo.configuration`                  | Tempo components configuration                             | `""`                          |
-| `tempo.existingConfigmap`              | Name of a ConfigMap with the tempo configuration           | `""`                          |
-| `tempo.overridesConfiguration`         | Tempo components overrides configuration settings          | `""`                          |
-| `tempo.existingOverridesConfigmap`     | Name of a ConfigMap with the tempo overrides configuration | `""`                          |
+| Name                                   | Description                                                    | Value                         |
+| -------------------------------------- | -------------------------------------------------------------- | ----------------------------- |
+| `tempo.image.registry`                 | Grafana Tempo image registry                                   | `docker.io`                   |
+| `tempo.image.repository`               | Grafana Tempo image repository                                 | `bitnami/grafana-tempo`       |
+| `tempo.image.tag`                      | Grafana Tempo image tag (immutable tags are recommended)       | `1.2.1-debian-10-r47`         |
+| `tempo.image.pullPolicy`               | Grafana Tempo image pull policy                                | `IfNotPresent`                |
+| `tempo.image.pullSecrets`              | Grafana Tempo image pull secrets                               | `[]`                          |
+| `tempo.memBallastSizeMbs`              | Tempo components memory ballast size in MB                     | `1024`                        |
+| `tempo.dataDir`                        | Tempo components data directory                                | `/bitnami/grafana-tempo/data` |
+| `tempo.traces.jaeger.grpc`             | Enable Tempo to ingest Jaeger GRPC traces                      | `true`                        |
+| `tempo.traces.jaeger.thriftBinary`     | Enable Tempo to ingest Jaeger Thrift Binary traces             | `false`                       |
+| `tempo.traces.jaeger.thriftCompact`    | Enable Tempo to ingest Jaeger Thrift Compact traces            | `false`                       |
+| `tempo.traces.jaeger.thriftHttp`       | Enable Tempo to ingest Jaeger Thrift HTTP traces               | `true`                        |
+| `tempo.traces.otlp.http`               | Enable Tempo to ingest Open Telemetry HTTP traces              | `false`                       |
+| `tempo.traces.otlp.grpc`               | Enable Tempo to ingest Open Telemetry GRPC traces              | `false`                       |
+| `tempo.traces.opencensus`              | Enable Tempo to ingest Open Census traces                      | `false`                       |
+| `tempo.traces.zipkin`                  | Enable Tempo to ingest Zipkin traces                           | `false`                       |
+| `tempo.configuration`                  | Tempo components configuration                                 | `""`                          |
+| `tempo.existingConfigmap`              | Name of a ConfigMap with the Tempo configuration               | `""`                          |
+| `tempo.overridesConfiguration`         | Tempo components overrides configuration settings              | `""`                          |
+| `tempo.existingOverridesConfigmap`     | Name of a ConfigMap with the tempo overrides configuration     | `""`                          |
+| `tempo.containerPorts.web`             | Tempo components web container port                            | `3100`                        |
+| `tempo.containerPorts.grpc`            | Tempo components GRPC container port                           | `9095`                        |
+| `tempo.containerPorts.gossipRing`      | Tempo components Gossip Ring container port                    | `7946`                        |
+| `tempo.gossipRing.service.ports.http`  | Gossip Ring HTTP headless service port                         | `7946`                        |
+| `tempo.gossipRing.service.annotations` | Additional custom annotations for Gossip Ring headless service | `{}`                          |
 
 
 ### Compactor Deployment Parameters
 
-| Name                                           | Description                                                                                         | Value           |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------- |
-| `compactor.enabled`                            | Enable compactor deployment                                                                         | `true`          |
-| `compactor.replicaCount`                       | Number of compactor replicas to deploy                                                              | `1`             |
-| `compactor.livenessProbe.enabled`              | Enable livenessProbe on compactor nodes                                                             | `true`          |
-| `compactor.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                             | `10`            |
-| `compactor.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                    | `10`            |
-| `compactor.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                   | `1`             |
-| `compactor.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                 | `3`             |
-| `compactor.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                 | `1`             |
-| `compactor.readinessProbe.enabled`             | Enable readinessProbe on compactor nodes                                                            | `true`          |
-| `compactor.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                            | `10`            |
-| `compactor.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                   | `10`            |
-| `compactor.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                  | `1`             |
-| `compactor.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                | `3`             |
-| `compactor.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                | `1`             |
-| `compactor.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                 | `{}`            |
-| `compactor.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                | `{}`            |
-| `compactor.resources.limits`                   | The resources limits for the compactor containers                                                   | `{}`            |
-| `compactor.resources.requests`                 | The requested resources for the compactor containers                                                | `{}`            |
-| `compactor.podSecurityContext.enabled`         | Enabled compactor pods' Security Context                                                            | `true`          |
-| `compactor.podSecurityContext.fsGroup`         | Set compactor pod's Security Context fsGroup                                                        | `1001`          |
-| `compactor.containerSecurityContext.enabled`   | Enabled compactor containers' Security Context                                                      | `true`          |
-| `compactor.containerSecurityContext.runAsUser` | Set compactor containers' Security Context runAsUser                                                | `1001`          |
-| `compactor.command`                            | Override default container command (useful when using custom images)                                | `[]`            |
-| `compactor.args`                               | Override default container args (useful when using custom images)                                   | `[]`            |
-| `compactor.hostAliases`                        | compactor pods host aliases                                                                         | `[]`            |
-| `compactor.podLabels`                          | Extra labels for compactor pods                                                                     | `{}`            |
-| `compactor.podAnnotations`                     | Annotations for compactor pods                                                                      | `{}`            |
-| `compactor.podAffinityPreset`                  | Pod affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
-| `compactor.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
-| `compactor.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
-| `compactor.nodeAffinityPreset.key`             | Node label key to match. Ignored if `compactor.affinity` is set                                     | `""`            |
-| `compactor.nodeAffinityPreset.values`          | Node label values to match. Ignored if `compactor.affinity` is set                                  | `[]`            |
-| `compactor.affinity`                           | Affinity for compactor pods assignment                                                              | `{}`            |
-| `compactor.nodeSelector`                       | Node labels for compactor pods assignment                                                           | `{}`            |
-| `compactor.tolerations`                        | Tolerations for compactor pods assignment                                                           | `[]`            |
-| `compactor.updateStrategy.type`                | compactor statefulset strategy type                                                                 | `RollingUpdate` |
-| `compactor.priorityClassName`                  | compactor pods' priorityClassName                                                                   | `""`            |
-| `compactor.lifecycleHooks`                     | for the compactor container(s) to automate configuration before or after startup                    | `{}`            |
-| `compactor.extraEnvVars`                       | Array with extra environment variables to add to compactor nodes                                    | `[]`            |
-| `compactor.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for compactor nodes                            | `""`            |
-| `compactor.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for compactor nodes                               | `""`            |
-| `compactor.extraVolumes`                       | Optionally specify extra list of additional volumes for the compactor pod(s)                        | `[]`            |
-| `compactor.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the compactor container(s)             | `[]`            |
-| `compactor.sidecars`                           | Add additional sidecar containers to the compactor pod(s)                                           | `[]`            |
-| `compactor.initContainers`                     | Add additional init containers to the compactor pod(s)                                              | `[]`            |
+| Name                                              | Description                                                                                         | Value           |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------- |
+| `compactor.enabled`                               | Enable Compactor deployment                                                                         | `true`          |
+| `compactor.extraEnvVars`                          | Array with extra environment variables to add to compactor nodes                                    | `[]`            |
+| `compactor.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for compactor nodes                            | `""`            |
+| `compactor.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for compactor nodes                               | `""`            |
+| `compactor.command`                               | Override default container command (useful when using custom images)                                | `[]`            |
+| `compactor.args`                                  | Override default container args (useful when using custom images)                                   | `[]`            |
+| `compactor.replicaCount`                          | Number of Compactor replicas to deploy                                                              | `1`             |
+| `compactor.livenessProbe.enabled`                 | Enable livenessProbe on Compactor nodes                                                             | `true`          |
+| `compactor.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                             | `10`            |
+| `compactor.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                    | `10`            |
+| `compactor.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                   | `1`             |
+| `compactor.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                 | `3`             |
+| `compactor.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                 | `1`             |
+| `compactor.readinessProbe.enabled`                | Enable readinessProbe on Compactor nodes                                                            | `true`          |
+| `compactor.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                            | `10`            |
+| `compactor.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                   | `10`            |
+| `compactor.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                  | `1`             |
+| `compactor.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                | `3`             |
+| `compactor.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                | `1`             |
+| `compactor.startupProbe.enabled`                  | Enable startupProbe on Compactor containers                                                         | `false`         |
+| `compactor.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                              | `30`            |
+| `compactor.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                     | `10`            |
+| `compactor.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                    | `1`             |
+| `compactor.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                  | `15`            |
+| `compactor.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                  | `1`             |
+| `compactor.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                 | `{}`            |
+| `compactor.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                | `{}`            |
+| `compactor.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                  | `{}`            |
+| `compactor.resources.limits`                      | The resources limits for the compactor containers                                                   | `{}`            |
+| `compactor.resources.requests`                    | The requested resources for the compactor containers                                                | `{}`            |
+| `compactor.podSecurityContext.enabled`            | Enabled Compactor pods' Security Context                                                            | `true`          |
+| `compactor.podSecurityContext.fsGroup`            | Set Compactor pod's Security Context fsGroup                                                        | `1001`          |
+| `compactor.containerSecurityContext.enabled`      | Enabled Compactor containers' Security Context                                                      | `true`          |
+| `compactor.containerSecurityContext.runAsUser`    | Set Compactor containers' Security Context runAsUser                                                | `1001`          |
+| `compactor.containerSecurityContext.runAsNonRoot` | Set Compactor containers' Security Context runAsNonRoot                                             | `true`          |
+| `compactor.lifecycleHooks`                        | for the compactor container(s) to automate configuration before or after startup                    | `{}`            |
+| `compactor.hostAliases`                           | compactor pods host aliases                                                                         | `[]`            |
+| `compactor.podLabels`                             | Extra labels for compactor pods                                                                     | `{}`            |
+| `compactor.podAnnotations`                        | Annotations for compactor pods                                                                      | `{}`            |
+| `compactor.podAffinityPreset`                     | Pod affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
+| `compactor.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `compactor.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `compactor.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
+| `compactor.nodeAffinityPreset.key`                | Node label key to match. Ignored if `compactor.affinity` is set                                     | `""`            |
+| `compactor.nodeAffinityPreset.values`             | Node label values to match. Ignored if `compactor.affinity` is set                                  | `[]`            |
+| `compactor.affinity`                              | Affinity for Compactor pods assignment                                                              | `{}`            |
+| `compactor.nodeSelector`                          | Node labels for Compactor pods assignment                                                           | `{}`            |
+| `compactor.tolerations`                           | Tolerations for Compactor pods assignment                                                           | `[]`            |
+| `compactor.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains     | `{}`            |
+| `compactor.priorityClassName`                     | Compactor pods' priorityClassName                                                                   | `""`            |
+| `compactor.schedulerName`                         | Kubernetes pod scheduler registry                                                                   | `""`            |
+| `compactor.updateStrategy.type`                   | Compactor statefulset strategy type                                                                 | `RollingUpdate` |
+| `compactor.updateStrategy.rollingUpdate`          | Compactor statefulset rolling update configuration parameters                                       | `{}`            |
+| `compactor.extraVolumes`                          | Optionally specify extra list of additional volumes for the Compactor pod(s)                        | `[]`            |
+| `compactor.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Compactor container(s)             | `[]`            |
+| `compactor.sidecars`                              | Add additional sidecar containers to the Compactor pod(s)                                           | `[]`            |
+| `compactor.initContainers`                        | Add additional init containers to the Compactor pod(s)                                              | `[]`            |
 
 
 ### Compactor Traffic Exposure Parameters
 
-| Name                                         | Description                                         | Value       |
-| -------------------------------------------- | --------------------------------------------------- | ----------- |
-| `compactor.service.type`                     | compactor service type                              | `ClusterIP` |
-| `compactor.service.port`                     | compactor service HTTP port                         | `3100`      |
-| `compactor.service.nodePorts.http`           | Node port for HTTP                                  | `""`        |
-| `compactor.service.clusterIP`                | compactor service Cluster IP                        | `""`        |
-| `compactor.service.loadBalancerIP`           | compactor service Load Balancer IP                  | `""`        |
-| `compactor.service.loadBalancerSourceRanges` | compactor service Load Balancer sources             | `[]`        |
-| `compactor.service.externalTrafficPolicy`    | compactor service external traffic policy           | `Cluster`   |
-| `compactor.service.annotations`              | Additional custom annotations for compactor service | `{}`        |
+| Name                                         | Description                                                      | Value       |
+| -------------------------------------------- | ---------------------------------------------------------------- | ----------- |
+| `compactor.service.type`                     | Compactor service type                                           | `ClusterIP` |
+| `compactor.service.ports.http`               | Compactor HTTP service port                                      | `3100`      |
+| `compactor.service.nodePorts.http`           | Node port for HTTP                                               | `""`        |
+| `compactor.service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin | `None`      |
+| `compactor.service.clusterIP`                | Compactor service Cluster IP                                     | `""`        |
+| `compactor.service.loadBalancerIP`           | Compactor service Load Balancer IP                               | `""`        |
+| `compactor.service.loadBalancerSourceRanges` | Compactor service Load Balancer sources                          | `[]`        |
+| `compactor.service.externalTrafficPolicy`    | Compactor service external traffic policy                        | `Cluster`   |
+| `compactor.service.annotations`              | Additional custom annotations for Compactor service              | `{}`        |
+| `compactor.service.extraPorts`               | Extra ports to expose in the Compactor service                   | `[]`        |
 
 
 ### Distributor Deployment Parameters
 
-| Name                                             | Description                                                                                           | Value           |
-| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | --------------- |
-| `distributor.replicaCount`                       | Number of distributor replicas to deploy                                                              | `1`             |
-| `distributor.livenessProbe.enabled`              | Enable livenessProbe on distributor nodes                                                             | `true`          |
-| `distributor.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                               | `10`            |
-| `distributor.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                      | `10`            |
-| `distributor.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                     | `1`             |
-| `distributor.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                   | `3`             |
-| `distributor.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                   | `1`             |
-| `distributor.readinessProbe.enabled`             | Enable readinessProbe on distributor nodes                                                            | `true`          |
-| `distributor.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                              | `10`            |
-| `distributor.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                     | `10`            |
-| `distributor.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                    | `1`             |
-| `distributor.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                  | `3`             |
-| `distributor.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                  | `1`             |
-| `distributor.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                   | `{}`            |
-| `distributor.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                  | `{}`            |
-| `distributor.resources.limits`                   | The resources limits for the distributor containers                                                   | `{}`            |
-| `distributor.resources.requests`                 | The requested resources for the distributor containers                                                | `{}`            |
-| `distributor.podSecurityContext.enabled`         | Enabled distributor pods' Security Context                                                            | `true`          |
-| `distributor.podSecurityContext.fsGroup`         | Set distributor pod's Security Context fsGroup                                                        | `1001`          |
-| `distributor.containerSecurityContext.enabled`   | Enabled distributor containers' Security Context                                                      | `true`          |
-| `distributor.containerSecurityContext.runAsUser` | Set distributor containers' Security Context runAsUser                                                | `1001`          |
-| `distributor.command`                            | Override default container command (useful when using custom images)                                  | `[]`            |
-| `distributor.args`                               | Override default container args (useful when using custom images)                                     | `[]`            |
-| `distributor.hostAliases`                        | distributor pods host aliases                                                                         | `[]`            |
-| `distributor.podLabels`                          | Extra labels for distributor pods                                                                     | `{}`            |
-| `distributor.podAnnotations`                     | Annotations for distributor pods                                                                      | `{}`            |
-| `distributor.podAffinityPreset`                  | Pod affinity preset. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
-| `distributor.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
-| `distributor.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
-| `distributor.nodeAffinityPreset.key`             | Node label key to match. Ignored if `distributor.affinity` is set                                     | `""`            |
-| `distributor.nodeAffinityPreset.values`          | Node label values to match. Ignored if `distributor.affinity` is set                                  | `[]`            |
-| `distributor.affinity`                           | Affinity for distributor pods assignment                                                              | `{}`            |
-| `distributor.nodeSelector`                       | Node labels for distributor pods assignment                                                           | `{}`            |
-| `distributor.tolerations`                        | Tolerations for distributor pods assignment                                                           | `[]`            |
-| `distributor.updateStrategy.type`                | distributor statefulset strategy type                                                                 | `RollingUpdate` |
-| `distributor.priorityClassName`                  | distributor pods' priorityClassName                                                                   | `""`            |
-| `distributor.lifecycleHooks`                     | for the distributor container(s) to automate configuration before or after startup                    | `{}`            |
-| `distributor.extraEnvVars`                       | Array with extra environment variables to add to distributor nodes                                    | `[]`            |
-| `distributor.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for distributor nodes                            | `""`            |
-| `distributor.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for distributor nodes                               | `""`            |
-| `distributor.extraVolumes`                       | Optionally specify extra list of additional volumes for the distributor pod(s)                        | `[]`            |
-| `distributor.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the distributor container(s)             | `[]`            |
-| `distributor.sidecars`                           | Add additional sidecar containers to the distributor pod(s)                                           | `[]`            |
-| `distributor.initContainers`                     | Add additional init containers to the distributor pod(s)                                              | `[]`            |
+| Name                                                | Description                                                                                           | Value           |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | --------------- |
+| `distributor.extraEnvVars`                          | Array with extra environment variables to add to distributor nodes                                    | `[]`            |
+| `distributor.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for distributor nodes                            | `""`            |
+| `distributor.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for distributor nodes                               | `""`            |
+| `distributor.command`                               | Override default container command (useful when using custom images)                                  | `[]`            |
+| `distributor.args`                                  | Override default container args (useful when using custom images)                                     | `[]`            |
+| `distributor.replicaCount`                          | Number of Distributor replicas to deploy                                                              | `1`             |
+| `distributor.livenessProbe.enabled`                 | Enable livenessProbe on Distributor nodes                                                             | `true`          |
+| `distributor.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                               | `10`            |
+| `distributor.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                      | `10`            |
+| `distributor.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                     | `1`             |
+| `distributor.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                   | `3`             |
+| `distributor.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                   | `1`             |
+| `distributor.readinessProbe.enabled`                | Enable readinessProbe on Distributor nodes                                                            | `true`          |
+| `distributor.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                              | `10`            |
+| `distributor.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                     | `10`            |
+| `distributor.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                    | `1`             |
+| `distributor.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                  | `3`             |
+| `distributor.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                  | `1`             |
+| `distributor.startupProbe.enabled`                  | Enable startupProbe on Distributor containers                                                         | `false`         |
+| `distributor.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                | `30`            |
+| `distributor.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                       | `10`            |
+| `distributor.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                      | `1`             |
+| `distributor.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                    | `15`            |
+| `distributor.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                    | `1`             |
+| `distributor.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                   | `{}`            |
+| `distributor.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                  | `{}`            |
+| `distributor.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                    | `{}`            |
+| `distributor.resources.limits`                      | The resources limits for the distributor containers                                                   | `{}`            |
+| `distributor.resources.requests`                    | The requested resources for the distributor containers                                                | `{}`            |
+| `distributor.podSecurityContext.enabled`            | Enabled Distributor pods' Security Context                                                            | `true`          |
+| `distributor.podSecurityContext.fsGroup`            | Set Distributor pod's Security Context fsGroup                                                        | `1001`          |
+| `distributor.containerSecurityContext.enabled`      | Enabled Distributor containers' Security Context                                                      | `true`          |
+| `distributor.containerSecurityContext.runAsUser`    | Set Distributor containers' Security Context runAsUser                                                | `1001`          |
+| `distributor.containerSecurityContext.runAsNonRoot` | Set Distributor containers' Security Context runAsNonRoot                                             | `true`          |
+| `distributor.lifecycleHooks`                        | for the distributor container(s) to automate configuration before or after startup                    | `{}`            |
+| `distributor.hostAliases`                           | distributor pods host aliases                                                                         | `[]`            |
+| `distributor.podLabels`                             | Extra labels for distributor pods                                                                     | `{}`            |
+| `distributor.podAnnotations`                        | Annotations for distributor pods                                                                      | `{}`            |
+| `distributor.podAffinityPreset`                     | Pod affinity preset. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
+| `distributor.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `distributor.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `distributor.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
+| `distributor.nodeAffinityPreset.key`                | Node label key to match. Ignored if `distributor.affinity` is set                                     | `""`            |
+| `distributor.nodeAffinityPreset.values`             | Node label values to match. Ignored if `distributor.affinity` is set                                  | `[]`            |
+| `distributor.affinity`                              | Affinity for Distributor pods assignment                                                              | `{}`            |
+| `distributor.nodeSelector`                          | Node labels for Distributor pods assignment                                                           | `{}`            |
+| `distributor.tolerations`                           | Tolerations for Distributor pods assignment                                                           | `[]`            |
+| `distributor.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains       | `{}`            |
+| `distributor.priorityClassName`                     | Distributor pods' priorityClassName                                                                   | `""`            |
+| `distributor.schedulerName`                         | Kubernetes pod scheduler registry                                                                     | `""`            |
+| `distributor.updateStrategy.type`                   | Distributor statefulset strategy type                                                                 | `RollingUpdate` |
+| `distributor.updateStrategy.rollingUpdate`          | Distributor statefulset rolling update configuration parameters                                       | `{}`            |
+| `distributor.extraVolumes`                          | Optionally specify extra list of additional volumes for the Distributor pod(s)                        | `[]`            |
+| `distributor.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Distributor container(s)             | `[]`            |
+| `distributor.sidecars`                              | Add additional sidecar containers to the Distributor pod(s)                                           | `[]`            |
+| `distributor.initContainers`                        | Add additional init containers to the Distributor pod(s)                                              | `[]`            |
 
 
 ### Distributor Traffic Exposure Parameters
 
-| Name                                           | Description                                           | Value       |
-| ---------------------------------------------- | ----------------------------------------------------- | ----------- |
-| `distributor.service.type`                     | distributor service type                              | `ClusterIP` |
-| `distributor.service.port`                     | distributor service HTTP port                         | `3100`      |
-| `distributor.service.grpcPort`                 | distributor service HTTP port                         | `9095`      |
-| `distributor.service.nodePorts.http`           | Node port for HTTP                                    | `""`        |
-| `distributor.service.nodePorts.grpc`           | Node port for GRPC                                    | `""`        |
-| `distributor.service.clusterIP`                | distributor service Cluster IP                        | `""`        |
-| `distributor.service.loadBalancerIP`           | distributor service Load Balancer IP                  | `""`        |
-| `distributor.service.loadBalancerSourceRanges` | distributor service Load Balancer sources             | `[]`        |
-| `distributor.service.externalTrafficPolicy`    | distributor service external traffic policy           | `Cluster`   |
-| `distributor.service.annotations`              | Additional custom annotations for distributor service | `{}`        |
+| Name                                           | Description                                                      | Value       |
+| ---------------------------------------------- | ---------------------------------------------------------------- | ----------- |
+| `distributor.service.type`                     | Distributor service type                                         | `ClusterIP` |
+| `distributor.service.ports.http`               | Distributor HTTP service port                                    | `3100`      |
+| `distributor.service.ports.grpc`               | Distributor GRPC service port                                    | `9095`      |
+| `distributor.service.nodePorts.http`           | Node port for HTTP                                               | `""`        |
+| `distributor.service.nodePorts.grpc`           | Node port for GRPC                                               | `""`        |
+| `distributor.service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin | `None`      |
+| `distributor.service.clusterIP`                | Distributor service Cluster IP                                   | `""`        |
+| `distributor.service.loadBalancerIP`           | Distributor service Load Balancer IP                             | `""`        |
+| `distributor.service.loadBalancerSourceRanges` | Distributor service Load Balancer sources                        | `[]`        |
+| `distributor.service.externalTrafficPolicy`    | Distributor service external traffic policy                      | `Cluster`   |
+| `distributor.service.annotations`              | Additional custom annotations for Distributor service            | `{}`        |
+| `distributor.service.extraPorts`               | Extra ports to expose in the Distributor service                 | `[]`        |
 
 
 ### Ingester Deployment Parameters
 
-| Name                                          | Description                                                                                        | Value           |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------- |
-| `ingester.replicaCount`                       | Number of ingester replicas to deploy                                                              | `1`             |
-| `ingester.livenessProbe.enabled`              | Enable livenessProbe on ingester nodes                                                             | `true`          |
-| `ingester.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                            | `10`            |
-| `ingester.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                   | `10`            |
-| `ingester.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                  | `1`             |
-| `ingester.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                | `3`             |
-| `ingester.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                | `1`             |
-| `ingester.readinessProbe.enabled`             | Enable readinessProbe on ingester nodes                                                            | `true`          |
-| `ingester.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                           | `10`            |
-| `ingester.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                  | `10`            |
-| `ingester.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                 | `1`             |
-| `ingester.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                               | `3`             |
-| `ingester.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                               | `1`             |
-| `ingester.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                | `{}`            |
-| `ingester.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                               | `{}`            |
-| `ingester.resources.limits`                   | The resources limits for the ingester containers                                                   | `{}`            |
-| `ingester.resources.requests`                 | The requested resources for the ingester containers                                                | `{}`            |
-| `ingester.podSecurityContext.enabled`         | Enabled ingester pods' Security Context                                                            | `true`          |
-| `ingester.podSecurityContext.fsGroup`         | Set ingester pod's Security Context fsGroup                                                        | `1001`          |
-| `ingester.containerSecurityContext.enabled`   | Enabled ingester containers' Security Context                                                      | `true`          |
-| `ingester.containerSecurityContext.runAsUser` | Set ingester containers' Security Context runAsUser                                                | `1001`          |
-| `ingester.command`                            | Override default container command (useful when using custom images)                               | `[]`            |
-| `ingester.args`                               | Override default container args (useful when using custom images)                                  | `[]`            |
-| `ingester.hostAliases`                        | ingester pods host aliases                                                                         | `[]`            |
-| `ingester.podLabels`                          | Extra labels for ingester pods                                                                     | `{}`            |
-| `ingester.podAnnotations`                     | Annotations for ingester pods                                                                      | `{}`            |
-| `ingester.podAffinityPreset`                  | Pod affinity preset. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
-| `ingester.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
-| `ingester.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
-| `ingester.nodeAffinityPreset.key`             | Node label key to match. Ignored if `ingester.affinity` is set                                     | `""`            |
-| `ingester.nodeAffinityPreset.values`          | Node label values to match. Ignored if `ingester.affinity` is set                                  | `[]`            |
-| `ingester.affinity`                           | Affinity for ingester pods assignment                                                              | `{}`            |
-| `ingester.nodeSelector`                       | Node labels for ingester pods assignment                                                           | `{}`            |
-| `ingester.tolerations`                        | Tolerations for ingester pods assignment                                                           | `[]`            |
-| `ingester.updateStrategy.type`                | ingester statefulset strategy type                                                                 | `RollingUpdate` |
-| `ingester.priorityClassName`                  | ingester pods' priorityClassName                                                                   | `""`            |
-| `ingester.lifecycleHooks`                     | for the ingester container(s) to automate configuration before or after startup                    | `{}`            |
-| `ingester.extraEnvVars`                       | Array with extra environment variables to add to ingester nodes                                    | `[]`            |
-| `ingester.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for ingester nodes                            | `""`            |
-| `ingester.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for ingester nodes                               | `""`            |
-| `ingester.extraVolumes`                       | Optionally specify extra list of additional volumes for the ingester pod(s)                        | `[]`            |
-| `ingester.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the ingester container(s)             | `[]`            |
-| `ingester.sidecars`                           | Add additional sidecar containers to the ingester pod(s)                                           | `[]`            |
-| `ingester.initContainers`                     | Add additional init containers to the ingester pod(s)                                              | `[]`            |
+| Name                                             | Description                                                                                        | Value           |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------- | --------------- |
+| `ingester.extraEnvVars`                          | Array with extra environment variables to add to ingester nodes                                    | `[]`            |
+| `ingester.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for ingester nodes                            | `""`            |
+| `ingester.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for ingester nodes                               | `""`            |
+| `ingester.command`                               | Override default container command (useful when using custom images)                               | `[]`            |
+| `ingester.args`                                  | Override default container args (useful when using custom images)                                  | `[]`            |
+| `ingester.replicaCount`                          | Number of Ingester replicas to deploy                                                              | `1`             |
+| `ingester.livenessProbe.enabled`                 | Enable livenessProbe on Ingester nodes                                                             | `true`          |
+| `ingester.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                            | `10`            |
+| `ingester.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                   | `10`            |
+| `ingester.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                  | `1`             |
+| `ingester.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                | `3`             |
+| `ingester.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                | `1`             |
+| `ingester.readinessProbe.enabled`                | Enable readinessProbe on Ingester nodes                                                            | `true`          |
+| `ingester.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                           | `10`            |
+| `ingester.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                  | `10`            |
+| `ingester.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                 | `1`             |
+| `ingester.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                               | `3`             |
+| `ingester.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                               | `1`             |
+| `ingester.startupProbe.enabled`                  | Enable startupProbe on Ingester containers                                                         | `false`         |
+| `ingester.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                             | `30`            |
+| `ingester.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                    | `10`            |
+| `ingester.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                   | `1`             |
+| `ingester.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                 | `15`            |
+| `ingester.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                 | `1`             |
+| `ingester.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                | `{}`            |
+| `ingester.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                               | `{}`            |
+| `ingester.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                 | `{}`            |
+| `ingester.lifecycleHooks`                        | for the ingester container(s) to automate configuration before or after startup                    | `{}`            |
+| `ingester.resources.limits`                      | The resources limits for the Ingester containers                                                   | `{}`            |
+| `ingester.resources.requests`                    | The requested resources for the Ingester containers                                                | `{}`            |
+| `ingester.podSecurityContext.enabled`            | Enabled Ingester pods' Security Context                                                            | `true`          |
+| `ingester.podSecurityContext.fsGroup`            | Set Ingester pod's Security Context fsGroup                                                        | `1001`          |
+| `ingester.containerSecurityContext.enabled`      | Enabled Ingester containers' Security Context                                                      | `true`          |
+| `ingester.containerSecurityContext.runAsUser`    | Set Ingester containers' Security Context runAsUser                                                | `1001`          |
+| `ingester.containerSecurityContext.runAsNonRoot` | Set Ingester containers' Security Context runAsNonRoot                                             | `true`          |
+| `ingester.hostAliases`                           | ingester pods host aliases                                                                         | `[]`            |
+| `ingester.podLabels`                             | Extra labels for ingester pods                                                                     | `{}`            |
+| `ingester.podAnnotations`                        | Annotations for ingester pods                                                                      | `{}`            |
+| `ingester.podAffinityPreset`                     | Pod affinity preset. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
+| `ingester.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `ingester.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `ingester.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
+| `ingester.nodeAffinityPreset.key`                | Node label key to match. Ignored if `ingester.affinity` is set                                     | `""`            |
+| `ingester.nodeAffinityPreset.values`             | Node label values to match. Ignored if `ingester.affinity` is set                                  | `[]`            |
+| `ingester.affinity`                              | Affinity for ingester pods assignment                                                              | `{}`            |
+| `ingester.nodeSelector`                          | Node labels for Ingester pods assignment                                                           | `{}`            |
+| `ingester.tolerations`                           | Tolerations for Ingester pods assignment                                                           | `[]`            |
+| `ingester.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains    | `{}`            |
+| `ingester.priorityClassName`                     | Ingester pods' priorityClassName                                                                   | `""`            |
+| `ingester.schedulerName`                         | Kubernetes pod scheduler registry                                                                  | `""`            |
+| `ingester.updateStrategy.type`                   | Ingester statefulset strategy type                                                                 | `RollingUpdate` |
+| `ingester.updateStrategy.rollingUpdate`          | Ingester statefulset rolling update configuration parameters                                       | `{}`            |
+| `ingester.extraVolumes`                          | Optionally specify extra list of additional volumes for the Ingester pod(s)                        | `[]`            |
+| `ingester.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the ingester container(s)             | `[]`            |
+| `ingester.sidecars`                              | Add additional sidecar containers to the Ingester pod(s)                                           | `[]`            |
+| `ingester.initContainers`                        | Add additional init containers to the Ingester pod(s)                                              | `[]`            |
 
 
 ### Ingester Persistence Parameters
 
-| Name                                                   | Description                                | Value  |
-| ------------------------------------------------------ | ------------------------------------------ | ------ |
-| `ingester.persistence.enabled`                         | Enable persistence in ingester instances   | `true` |
-| `ingester.persistence.storageClass`                    | Persistent Volumes storage class           | `""`   |
-| `ingester.persistence.subPath`                         | The subdirectory of the volume to mount to | `""`   |
-| `ingester.persistence.accessModes`                     | Persistent Volumes access modes            | `[]`   |
-| `ingester.persistence.size`                            | Persistent Volumes size                    | `8Gi`  |
-| `ingester.persistence.annotations`                     | Persistent Volumes annotations             | `{}`   |
-| `ingester.persistence.volumeClaimTemplates.selector`   | Persistent Volumes selector                | `{}`   |
-| `ingester.persistence.volumeClaimTemplates.requests`   | Persistent Volumes requests                | `{}`   |
-| `ingester.persistence.volumeClaimTemplates.dataSource` | Persistent Volumes data source             | `{}`   |
+| Name                                 | Description                                                             | Value               |
+| ------------------------------------ | ----------------------------------------------------------------------- | ------------------- |
+| `ingester.persistence.enabled`       | Enable persistence in Ingester instances                                | `true`              |
+| `ingester.persistence.existingClaim` | Name of an existing PVC to use                                          | `""`                |
+| `ingester.persistence.storageClass`  | PVC Storage Class for Memcached data volume                             | `""`                |
+| `ingester.persistence.subPath`       | The subdirectory of the volume to mount to                              | `""`                |
+| `ingester.persistence.accessModes`   | PVC Access modes                                                        | `["ReadWriteOnce"]` |
+| `ingester.persistence.size`          | PVC Storage Request for Memcached data volume                           | `8Gi`               |
+| `ingester.persistence.annotations`   | Additional PVC annotations                                              | `{}`                |
+| `ingester.persistence.selector`      | Selector to match an existing Persistent Volume for Ingester's data PVC | `{}`                |
 
 
 ### Ingester Traffic Exposure Parameters
 
-| Name                                        | Description                                        | Value       |
-| ------------------------------------------- | -------------------------------------------------- | ----------- |
-| `ingester.service.type`                     | ingester service type                              | `ClusterIP` |
-| `ingester.service.port`                     | ingester service HTTP port                         | `3100`      |
-| `ingester.service.grpcPort`                 | ingester service HTTP port                         | `9095`      |
-| `ingester.service.nodePorts.http`           | Node port for HTTP                                 | `""`        |
-| `ingester.service.nodePorts.grpc`           | Node port for GRPC                                 | `""`        |
-| `ingester.service.clusterIP`                | ingester service Cluster IP                        | `""`        |
-| `ingester.service.loadBalancerIP`           | ingester service Load Balancer IP                  | `""`        |
-| `ingester.service.loadBalancerSourceRanges` | ingester service Load Balancer sources             | `[]`        |
-| `ingester.service.externalTrafficPolicy`    | ingester service external traffic policy           | `Cluster`   |
-| `ingester.service.annotations`              | Additional custom annotations for ingester service | `{}`        |
+| Name                                        | Description                                                      | Value       |
+| ------------------------------------------- | ---------------------------------------------------------------- | ----------- |
+| `ingester.service.type`                     | Ingester service type                                            | `ClusterIP` |
+| `ingester.service.ports.http`               | Ingester HTTP service port                                       | `3100`      |
+| `ingester.service.ports.grpc`               | Ingester GRPC service port                                       | `9095`      |
+| `ingester.service.nodePorts.http`           | Node port for HTTP                                               | `""`        |
+| `ingester.service.nodePorts.grpc`           | Node port for GRPC                                               | `""`        |
+| `ingester.service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin | `None`      |
+| `ingester.service.clusterIP`                | Ingester service Cluster IP                                      | `""`        |
+| `ingester.service.loadBalancerIP`           | Ingester service Load Balancer IP                                | `""`        |
+| `ingester.service.loadBalancerSourceRanges` | Ingester service Load Balancer sources                           | `[]`        |
+| `ingester.service.externalTrafficPolicy`    | Ingester service external traffic policy                         | `Cluster`   |
+| `ingester.service.annotations`              | Additional custom annotations for Ingester service               | `{}`        |
+| `ingester.service.extraPorts`               | Extra ports to expose in the Ingester service                    | `[]`        |
 
 
 ### Querier Deployment Parameters
 
-| Name                                         | Description                                                                                       | Value           |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------- | --------------- |
-| `querier.replicaCount`                       | Number of querier replicas to deploy                                                              | `1`             |
-| `querier.livenessProbe.enabled`              | Enable livenessProbe on querier nodes                                                             | `true`          |
-| `querier.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                           | `10`            |
-| `querier.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                  | `10`            |
-| `querier.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                 | `1`             |
-| `querier.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                               | `3`             |
-| `querier.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                               | `1`             |
-| `querier.readinessProbe.enabled`             | Enable readinessProbe on querier nodes                                                            | `true`          |
-| `querier.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                          | `10`            |
-| `querier.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                 | `10`            |
-| `querier.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                | `1`             |
-| `querier.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                              | `3`             |
-| `querier.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                              | `1`             |
-| `querier.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                               | `{}`            |
-| `querier.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                              | `{}`            |
-| `querier.resources.limits`                   | The resources limits for the querier containers                                                   | `{}`            |
-| `querier.resources.requests`                 | The requested resources for the querier containers                                                | `{}`            |
-| `querier.podSecurityContext.enabled`         | Enabled querier pods' Security Context                                                            | `true`          |
-| `querier.podSecurityContext.fsGroup`         | Set querier pod's Security Context fsGroup                                                        | `1001`          |
-| `querier.containerSecurityContext.enabled`   | Enabled querier containers' Security Context                                                      | `true`          |
-| `querier.containerSecurityContext.runAsUser` | Set querier containers' Security Context runAsUser                                                | `1001`          |
-| `querier.command`                            | Override default container command (useful when using custom images)                              | `[]`            |
-| `querier.args`                               | Override default container args (useful when using custom images)                                 | `[]`            |
-| `querier.hostAliases`                        | querier pods host aliases                                                                         | `[]`            |
-| `querier.podLabels`                          | Extra labels for querier pods                                                                     | `{}`            |
-| `querier.podAnnotations`                     | Annotations for querier pods                                                                      | `{}`            |
-| `querier.podAffinityPreset`                  | Pod affinity preset. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
-| `querier.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
-| `querier.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
-| `querier.nodeAffinityPreset.key`             | Node label key to match. Ignored if `querier.affinity` is set                                     | `""`            |
-| `querier.nodeAffinityPreset.values`          | Node label values to match. Ignored if `querier.affinity` is set                                  | `[]`            |
-| `querier.affinity`                           | Affinity for querier pods assignment                                                              | `{}`            |
-| `querier.nodeSelector`                       | Node labels for querier pods assignment                                                           | `{}`            |
-| `querier.tolerations`                        | Tolerations for querier pods assignment                                                           | `[]`            |
-| `querier.updateStrategy.type`                | querier statefulset strategy type                                                                 | `RollingUpdate` |
-| `querier.priorityClassName`                  | querier pods' priorityClassName                                                                   | `""`            |
-| `querier.lifecycleHooks`                     | for the querier container(s) to automate configuration before or after startup                    | `{}`            |
-| `querier.extraEnvVars`                       | Array with extra environment variables to add to querier nodes                                    | `[]`            |
-| `querier.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for querier nodes                            | `""`            |
-| `querier.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for querier nodes                               | `""`            |
-| `querier.extraVolumes`                       | Optionally specify extra list of additional volumes for the querier pod(s)                        | `[]`            |
-| `querier.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the querier container(s)             | `[]`            |
-| `querier.sidecars`                           | Add additional sidecar containers to the querier pod(s)                                           | `[]`            |
-| `querier.initContainers`                     | Add additional init containers to the querier pod(s)                                              | `[]`            |
+| Name                                            | Description                                                                                       | Value           |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------- | --------------- |
+| `querier.replicaCount`                          | Number of Querier replicas to deploy                                                              | `1`             |
+| `querier.extraEnvVars`                          | Array with extra environment variables to add to Querier nodes                                    | `[]`            |
+| `querier.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for Querier nodes                            | `""`            |
+| `querier.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for Querier nodes                               | `""`            |
+| `querier.command`                               | Override default container command (useful when using custom images)                              | `[]`            |
+| `querier.args`                                  | Override default container args (useful when using custom images)                                 | `[]`            |
+| `querier.livenessProbe.enabled`                 | Enable livenessProbe on Querier nodes                                                             | `true`          |
+| `querier.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                           | `10`            |
+| `querier.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                  | `10`            |
+| `querier.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                 | `1`             |
+| `querier.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                               | `3`             |
+| `querier.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                               | `1`             |
+| `querier.readinessProbe.enabled`                | Enable readinessProbe on Querier nodes                                                            | `true`          |
+| `querier.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                          | `10`            |
+| `querier.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                 | `10`            |
+| `querier.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                | `1`             |
+| `querier.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                              | `3`             |
+| `querier.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                              | `1`             |
+| `querier.startupProbe.enabled`                  | Enable startupProbe on Querier containers                                                         | `false`         |
+| `querier.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                            | `30`            |
+| `querier.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                   | `10`            |
+| `querier.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                  | `1`             |
+| `querier.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                | `15`            |
+| `querier.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                | `1`             |
+| `querier.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                               | `{}`            |
+| `querier.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                              | `{}`            |
+| `querier.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                | `{}`            |
+| `querier.resources.limits`                      | The resources limits for the Querier containers                                                   | `{}`            |
+| `querier.resources.requests`                    | The requested resources for the Querier containers                                                | `{}`            |
+| `querier.podSecurityContext.enabled`            | Enabled Querier pods' Security Context                                                            | `true`          |
+| `querier.podSecurityContext.fsGroup`            | Set Querier pod's Security Context fsGroup                                                        | `1001`          |
+| `querier.containerSecurityContext.enabled`      | Enabled Querier containers' Security Context                                                      | `true`          |
+| `querier.containerSecurityContext.runAsUser`    | Set Querier containers' Security Context runAsUser                                                | `1001`          |
+| `querier.containerSecurityContext.runAsNonRoot` | Set Querier containers' Security Context runAsNonRoot                                             | `true`          |
+| `querier.lifecycleHooks`                        | for the Querier container(s) to automate configuration before or after startup                    | `{}`            |
+| `querier.hostAliases`                           | querier pods host aliases                                                                         | `[]`            |
+| `querier.podLabels`                             | Extra labels for querier pods                                                                     | `{}`            |
+| `querier.podAnnotations`                        | Annotations for querier pods                                                                      | `{}`            |
+| `querier.podAffinityPreset`                     | Pod affinity preset. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
+| `querier.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `querier.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `querier.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
+| `querier.nodeAffinityPreset.key`                | Node label key to match. Ignored if `querier.affinity` is set                                     | `""`            |
+| `querier.nodeAffinityPreset.values`             | Node label values to match. Ignored if `querier.affinity` is set                                  | `[]`            |
+| `querier.affinity`                              | Affinity for Querier pods assignment                                                              | `{}`            |
+| `querier.nodeSelector`                          | Node labels for Querier pods assignment                                                           | `{}`            |
+| `querier.tolerations`                           | Tolerations for Querier pods assignment                                                           | `[]`            |
+| `querier.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains   | `{}`            |
+| `querier.priorityClassName`                     | Querier pods' priorityClassName                                                                   | `""`            |
+| `querier.schedulerName`                         | Kubernetes pod scheduler registry                                                                 | `""`            |
+| `querier.updateStrategy.type`                   | Querier statefulset strategy type                                                                 | `RollingUpdate` |
+| `querier.updateStrategy.rollingUpdate`          | Querier statefulset rolling update configuration parameters                                       | `{}`            |
+| `querier.extraVolumes`                          | Optionally specify extra list of additional volumes for the Querier pod(s)                        | `[]`            |
+| `querier.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the querier container(s)             | `[]`            |
+| `querier.sidecars`                              | Add additional sidecar containers to the Querier pod(s)                                           | `[]`            |
+| `querier.initContainers`                        | Add additional init containers to the Querier pod(s)                                              | `[]`            |
 
 
 ### Querier Traffic Exposure Parameters
 
-| Name                                       | Description                                       | Value       |
-| ------------------------------------------ | ------------------------------------------------- | ----------- |
-| `querier.service.type`                     | querier service type                              | `ClusterIP` |
-| `querier.service.port`                     | querier service HTTP port                         | `3100`      |
-| `querier.service.grpcPort`                 | querier service HTTP port                         | `9095`      |
-| `querier.service.nodePorts.http`           | Node port for HTTP                                | `""`        |
-| `querier.service.nodePorts.grpc`           | Node port for GRPC                                | `""`        |
-| `querier.service.clusterIP`                | querier service Cluster IP                        | `""`        |
-| `querier.service.loadBalancerIP`           | querier service Load Balancer IP                  | `""`        |
-| `querier.service.loadBalancerSourceRanges` | querier service Load Balancer sources             | `[]`        |
-| `querier.service.externalTrafficPolicy`    | querier service external traffic policy           | `Cluster`   |
-| `querier.service.annotations`              | Additional custom annotations for querier service | `{}`        |
+| Name                                       | Description                                                      | Value       |
+| ------------------------------------------ | ---------------------------------------------------------------- | ----------- |
+| `querier.service.type`                     | Querier service type                                             | `ClusterIP` |
+| `querier.service.ports.http`               | Querier HTTP service port                                        | `3100`      |
+| `querier.service.ports.grpc`               | Querier GRPC service port                                        | `9095`      |
+| `querier.service.nodePorts.http`           | Node port for HTTP                                               | `""`        |
+| `querier.service.nodePorts.grpc`           | Node port for GRPC                                               | `""`        |
+| `querier.service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin | `None`      |
+| `querier.service.clusterIP`                | Querier service Cluster IP                                       | `""`        |
+| `querier.service.loadBalancerIP`           | Querier service Load Balancer IP                                 | `""`        |
+| `querier.service.loadBalancerSourceRanges` | Querier service Load Balancer sources                            | `[]`        |
+| `querier.service.externalTrafficPolicy`    | Querier service external traffic policy                          | `Cluster`   |
+| `querier.service.annotations`              | Additional custom annotations for Querier service                | `{}`        |
+| `querier.service.extraPorts`               | Extra ports to expose in the Querier service                     | `[]`        |
 
 
 ### Query Frontend Deployment Parameters
 
-| Name                                                     | Description                                                                                             | Value                         |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `queryFrontend.replicaCount`                             | Number of queryFrontend replicas to deploy                                                              | `1`                           |
-| `queryFrontend.livenessProbe.enabled`                    | Enable livenessProbe on queryFrontend nodes                                                             | `true`                        |
-| `queryFrontend.livenessProbe.initialDelaySeconds`        | Initial delay seconds for livenessProbe                                                                 | `10`                          |
-| `queryFrontend.livenessProbe.periodSeconds`              | Period seconds for livenessProbe                                                                        | `10`                          |
-| `queryFrontend.livenessProbe.timeoutSeconds`             | Timeout seconds for livenessProbe                                                                       | `1`                           |
-| `queryFrontend.livenessProbe.failureThreshold`           | Failure threshold for livenessProbe                                                                     | `3`                           |
-| `queryFrontend.livenessProbe.successThreshold`           | Success threshold for livenessProbe                                                                     | `1`                           |
-| `queryFrontend.readinessProbe.enabled`                   | Enable readinessProbe on queryFrontend nodes                                                            | `true`                        |
-| `queryFrontend.readinessProbe.initialDelaySeconds`       | Initial delay seconds for readinessProbe                                                                | `10`                          |
-| `queryFrontend.readinessProbe.periodSeconds`             | Period seconds for readinessProbe                                                                       | `10`                          |
-| `queryFrontend.readinessProbe.timeoutSeconds`            | Timeout seconds for readinessProbe                                                                      | `1`                           |
-| `queryFrontend.readinessProbe.failureThreshold`          | Failure threshold for readinessProbe                                                                    | `3`                           |
-| `queryFrontend.readinessProbe.successThreshold`          | Success threshold for readinessProbe                                                                    | `1`                           |
-| `queryFrontend.customLivenessProbe`                      | Custom livenessProbe that overrides the default one                                                     | `{}`                          |
-| `queryFrontend.customReadinessProbe`                     | Custom readinessProbe that overrides the default one                                                    | `{}`                          |
-| `queryFrontend.resources.limits`                         | The resources limits for the queryFrontend containers                                                   | `{}`                          |
-| `queryFrontend.resources.requests`                       | The requested resources for the queryFrontend containers                                                | `{}`                          |
-| `queryFrontend.podSecurityContext.enabled`               | Enabled queryFrontend pods' Security Context                                                            | `true`                        |
-| `queryFrontend.podSecurityContext.fsGroup`               | Set queryFrontend pod's Security Context fsGroup                                                        | `1001`                        |
-| `queryFrontend.containerSecurityContext.enabled`         | Enabled queryFrontend containers' Security Context                                                      | `true`                        |
-| `queryFrontend.containerSecurityContext.runAsUser`       | Set queryFrontend containers' Security Context runAsUser                                                | `1001`                        |
-| `queryFrontend.command`                                  | Override default container command (useful when using custom images)                                    | `[]`                          |
-| `queryFrontend.args`                                     | Override default container args (useful when using custom images)                                       | `[]`                          |
-| `queryFrontend.hostAliases`                              | queryFrontend pods host aliases                                                                         | `[]`                          |
-| `queryFrontend.podLabels`                                | Extra labels for queryFrontend pods                                                                     | `{}`                          |
-| `queryFrontend.podAnnotations`                           | Annotations for queryFrontend pods                                                                      | `{}`                          |
-| `queryFrontend.podAffinityPreset`                        | Pod affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`       | `""`                          |
-| `queryFrontend.podAntiAffinityPreset`                    | Pod anti-affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                        |
-| `queryFrontend.nodeAffinityPreset.type`                  | Node affinity preset type. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard` | `""`                          |
-| `queryFrontend.nodeAffinityPreset.key`                   | Node label key to match. Ignored if `queryFrontend.affinity` is set                                     | `""`                          |
-| `queryFrontend.nodeAffinityPreset.values`                | Node label values to match. Ignored if `queryFrontend.affinity` is set                                  | `[]`                          |
-| `queryFrontend.affinity`                                 | Affinity for queryFrontend pods assignment                                                              | `{}`                          |
-| `queryFrontend.nodeSelector`                             | Node labels for queryFrontend pods assignment                                                           | `{}`                          |
-| `queryFrontend.tolerations`                              | Tolerations for queryFrontend pods assignment                                                           | `[]`                          |
-| `queryFrontend.updateStrategy.type`                      | queryFrontend statefulset strategy type                                                                 | `RollingUpdate`               |
-| `queryFrontend.priorityClassName`                        | queryFrontend pods' priorityClassName                                                                   | `""`                          |
-| `queryFrontend.lifecycleHooks`                           | for the queryFrontend container(s) to automate configuration before or after startup                    | `{}`                          |
-| `queryFrontend.extraEnvVars`                             | Array with extra environment variables to add to queryFrontend nodes                                    | `[]`                          |
-| `queryFrontend.extraEnvVarsCM`                           | Name of existing ConfigMap containing extra env vars for queryFrontend nodes                            | `""`                          |
-| `queryFrontend.extraEnvVarsSecret`                       | Name of existing Secret containing extra env vars for queryFrontend nodes                               | `""`                          |
-| `queryFrontend.extraVolumes`                             | Optionally specify extra list of additional volumes for the queryFrontend pod(s)                        | `[]`                          |
-| `queryFrontend.extraVolumeMounts`                        | Optionally specify extra list of additional volumeMounts for the queryFrontend container(s)             | `[]`                          |
-| `queryFrontend.sidecars`                                 | Add additional sidecar containers to the queryFrontend pod(s)                                           | `[]`                          |
-| `queryFrontend.initContainers`                           | Add additional init containers to the queryFrontend pod(s)                                              | `[]`                          |
-| `queryFrontend.query.image.registry`                     | Grafana Tempo Query image registry                                                                      | `docker.io`                   |
-| `queryFrontend.query.image.repository`                   | Grafana Tempo Query image repository                                                                    | `bitnami/grafana-tempo-query` |
-| `queryFrontend.query.image.tag`                          | Grafana Tempo Query image tag (immutable tags are recommended)                                          | `1.2.1-debian-10-r57`         |
-| `queryFrontend.query.image.pullPolicy`                   | Grafana Tempo Query image pull policy                                                                   | `IfNotPresent`                |
-| `queryFrontend.query.image.pullSecrets`                  | Grafana Tempo Query image pull secrets                                                                  | `[]`                          |
-| `queryFrontend.query.command`                            | Override default container command (useful when using custom images)                                    | `[]`                          |
-| `queryFrontend.query.args`                               | Override default container args (useful when using custom images)                                       | `[]`                          |
-| `queryFrontend.query.configuration`                      | Query sidecar configuration                                                                             | `""`                          |
-| `queryFrontend.query.jaegerMetricsContainerPort`         | Jaeger metrics container port                                                                           | `16687`                       |
-| `queryFrontend.query.jaegerUIContainerPort`              | Jaeger UI container port                                                                                | `16686`                       |
-| `queryFrontend.query.existingConfigmap`                  | Name of a configmap with the query configuration                                                        | `""`                          |
-| `queryFrontend.query.livenessProbe.enabled`              | Enable livenessProbe on query sidecar nodes                                                             | `true`                        |
-| `queryFrontend.query.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                 | `10`                          |
-| `queryFrontend.query.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                        | `10`                          |
-| `queryFrontend.query.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                       | `1`                           |
-| `queryFrontend.query.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                     | `3`                           |
-| `queryFrontend.query.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                     | `1`                           |
-| `queryFrontend.query.readinessProbe.enabled`             | Enable readinessProbe on query sidecar nodes                                                            | `true`                        |
-| `queryFrontend.query.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                | `10`                          |
-| `queryFrontend.query.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                       | `10`                          |
-| `queryFrontend.query.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                      | `1`                           |
-| `queryFrontend.query.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                    | `3`                           |
-| `queryFrontend.query.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                    | `1`                           |
-| `queryFrontend.query.resources.limits`                   | The resources limits for the query sidecar containers                                                   | `{}`                          |
-| `queryFrontend.query.resources.requests`                 | The requested resources for the query sidecar containers                                                | `{}`                          |
-| `queryFrontend.query.lifecycleHooks`                     | for the query sidecar container(s) to automate configuration before or after startup                    | `{}`                          |
-| `queryFrontend.query.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                     | `{}`                          |
-| `queryFrontend.query.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                    | `{}`                          |
-| `queryFrontend.query.extraEnvVars`                       | Array with extra environment variables to add to queryFrontend nodes                                    | `[]`                          |
-| `queryFrontend.query.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for queryFrontend nodes                            | `""`                          |
-| `queryFrontend.query.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for queryFrontend nodes                               | `""`                          |
-| `queryFrontend.query.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the queryFrontend container(s)             | `[]`                          |
-| `queryFrontend.query.containerSecurityContext.enabled`   | Enabled query-frontend query sidecar containers' Security Context                                       | `true`                        |
-| `queryFrontend.query.containerSecurityContext.runAsUser` | Set query-frontend query sidecar containers' Security Context runAsUser                                 | `1001`                        |
+| Name                                                        | Description                                                                                             | Value                         |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `queryFrontend.extraEnvVars`                                | Array with extra environment variables to add to queryFrontend nodes                                    | `[]`                          |
+| `queryFrontend.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for queryFrontend nodes                            | `""`                          |
+| `queryFrontend.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for queryFrontend nodes                               | `""`                          |
+| `queryFrontend.command`                                     | Override default container command (useful when using custom images)                                    | `[]`                          |
+| `queryFrontend.args`                                        | Override default container args (useful when using custom images)                                       | `[]`                          |
+| `queryFrontend.replicaCount`                                | Number of queryFrontend replicas to deploy                                                              | `1`                           |
+| `queryFrontend.livenessProbe.enabled`                       | Enable livenessProbe on queryFrontend nodes                                                             | `true`                        |
+| `queryFrontend.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                 | `10`                          |
+| `queryFrontend.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                        | `10`                          |
+| `queryFrontend.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                       | `1`                           |
+| `queryFrontend.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                     | `3`                           |
+| `queryFrontend.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                     | `1`                           |
+| `queryFrontend.readinessProbe.enabled`                      | Enable readinessProbe on queryFrontend nodes                                                            | `true`                        |
+| `queryFrontend.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                                | `10`                          |
+| `queryFrontend.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                       | `10`                          |
+| `queryFrontend.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                      | `1`                           |
+| `queryFrontend.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                    | `3`                           |
+| `queryFrontend.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                    | `1`                           |
+| `queryFrontend.startupProbe.enabled`                        | Enable startupProbe on queryFrontend containers                                                         | `false`                       |
+| `queryFrontend.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                  | `30`                          |
+| `queryFrontend.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                         | `10`                          |
+| `queryFrontend.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                        | `1`                           |
+| `queryFrontend.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                      | `15`                          |
+| `queryFrontend.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                      | `1`                           |
+| `queryFrontend.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                     | `{}`                          |
+| `queryFrontend.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                    | `{}`                          |
+| `queryFrontend.customStartupProbe`                          | Custom startupProbe that overrides the default one                                                      | `{}`                          |
+| `queryFrontend.resources.limits`                            | The resources limits for the queryFrontend containers                                                   | `{}`                          |
+| `queryFrontend.resources.requests`                          | The requested resources for the queryFrontend containers                                                | `{}`                          |
+| `queryFrontend.podSecurityContext.enabled`                  | Enabled queryFrontend pods' Security Context                                                            | `true`                        |
+| `queryFrontend.podSecurityContext.fsGroup`                  | Set queryFrontend pod's Security Context fsGroup                                                        | `1001`                        |
+| `queryFrontend.containerSecurityContext.enabled`            | Enabled queryFrontend containers' Security Context                                                      | `true`                        |
+| `queryFrontend.containerSecurityContext.runAsUser`          | Set queryFrontend containers' Security Context runAsUser                                                | `1001`                        |
+| `queryFrontend.containerSecurityContext.runAsNonRoot`       | Set queryFrontend containers' Security Context runAsNonRoot                                             | `true`                        |
+| `queryFrontend.lifecycleHooks`                              | for the queryFrontend container(s) to automate configuration before or after startup                    | `{}`                          |
+| `queryFrontend.hostAliases`                                 | queryFrontend pods host aliases                                                                         | `[]`                          |
+| `queryFrontend.podLabels`                                   | Extra labels for queryFrontend pods                                                                     | `{}`                          |
+| `queryFrontend.podAnnotations`                              | Annotations for queryFrontend pods                                                                      | `{}`                          |
+| `queryFrontend.podAffinityPreset`                           | Pod affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`       | `""`                          |
+| `queryFrontend.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                        |
+| `queryFrontend.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `queryFrontend.affinity` is set. Allowed values: `soft` or `hard` | `""`                          |
+| `queryFrontend.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `queryFrontend.affinity` is set                                     | `""`                          |
+| `queryFrontend.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `queryFrontend.affinity` is set                                  | `[]`                          |
+| `queryFrontend.affinity`                                    | Affinity for queryFrontend pods assignment                                                              | `{}`                          |
+| `queryFrontend.nodeSelector`                                | Node labels for queryFrontend pods assignment                                                           | `{}`                          |
+| `queryFrontend.tolerations`                                 | Tolerations for queryFrontend pods assignment                                                           | `[]`                          |
+| `queryFrontend.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains         | `{}`                          |
+| `queryFrontend.priorityClassName`                           | queryFrontend pods' priorityClassName                                                                   | `""`                          |
+| `queryFrontend.schedulerName`                               | Kubernetes pod scheduler registry                                                                       | `""`                          |
+| `queryFrontend.updateStrategy.type`                         | queryFrontend statefulset strategy type                                                                 | `RollingUpdate`               |
+| `queryFrontend.updateStrategy.rollingUpdate`                | queryFrontend statefulset rolling update configuration parameters                                       | `{}`                          |
+| `queryFrontend.extraVolumes`                                | Optionally specify extra list of additional volumes for the queryFrontend pod(s)                        | `[]`                          |
+| `queryFrontend.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the queryFrontend container(s)             | `[]`                          |
+| `queryFrontend.sidecars`                                    | Add additional sidecar containers to the queryFrontend pod(s)                                           | `[]`                          |
+| `queryFrontend.initContainers`                              | Add additional init containers to the queryFrontend pod(s)                                              | `[]`                          |
+| `queryFrontend.query.image.registry`                        | Grafana Tempo Query image registry                                                                      | `docker.io`                   |
+| `queryFrontend.query.image.repository`                      | Grafana Tempo Query image repository                                                                    | `bitnami/grafana-tempo-query` |
+| `queryFrontend.query.image.tag`                             | Grafana Tempo Query image tag (immutable tags are recommended)                                          | `1.2.1-debian-10-r57`         |
+| `queryFrontend.query.image.pullPolicy`                      | Grafana Tempo Query image pull policy                                                                   | `IfNotPresent`                |
+| `queryFrontend.query.image.pullSecrets`                     | Grafana Tempo Query image pull secrets                                                                  | `[]`                          |
+| `queryFrontend.query.configuration`                         | Query sidecar configuration                                                                             | `""`                          |
+| `queryFrontend.query.containerPorts.jaegerMetrics`          | queryFrontend query sidecar Jaeger metrics container port                                               | `16687`                       |
+| `queryFrontend.query.containerPorts.jaegerUI`               | queryFrontend query sidecar Jaeger UI container port                                                    | `16686`                       |
+| `queryFrontend.query.jaegerMetricsContainerPort`            | Jaeger metrics container port                                                                           | `16687`                       |
+| `queryFrontend.query.jaegerUIContainerPort`                 | Jaeger UI container port                                                                                | `16686`                       |
+| `queryFrontend.query.existingConfigmap`                     | Name of a configmap with the query configuration                                                        | `""`                          |
+| `queryFrontend.query.extraEnvVars`                          | Array with extra environment variables to add to queryFrontend nodes                                    | `[]`                          |
+| `queryFrontend.query.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for queryFrontend nodes                            | `""`                          |
+| `queryFrontend.query.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for queryFrontend nodes                               | `""`                          |
+| `queryFrontend.query.command`                               | Override default container command (useful when using custom images)                                    | `[]`                          |
+| `queryFrontend.query.args`                                  | Override default container args (useful when using custom images)                                       | `[]`                          |
+| `queryFrontend.query.livenessProbe.enabled`                 | Enable livenessProbe on Query sidecar nodes                                                             | `true`                        |
+| `queryFrontend.query.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                 | `10`                          |
+| `queryFrontend.query.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                        | `10`                          |
+| `queryFrontend.query.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                       | `1`                           |
+| `queryFrontend.query.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                     | `3`                           |
+| `queryFrontend.query.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                     | `1`                           |
+| `queryFrontend.query.readinessProbe.enabled`                | Enable readinessProbe on Query sidecar nodes                                                            | `true`                        |
+| `queryFrontend.query.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                | `10`                          |
+| `queryFrontend.query.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                       | `10`                          |
+| `queryFrontend.query.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                      | `1`                           |
+| `queryFrontend.query.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                    | `3`                           |
+| `queryFrontend.query.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                    | `1`                           |
+| `queryFrontend.query.startupProbe.enabled`                  | Enable startupProbe on Query sidecar containers                                                         | `false`                       |
+| `queryFrontend.query.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                  | `30`                          |
+| `queryFrontend.query.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                         | `10`                          |
+| `queryFrontend.query.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                        | `1`                           |
+| `queryFrontend.query.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                      | `15`                          |
+| `queryFrontend.query.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                      | `1`                           |
+| `queryFrontend.query.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                     | `{}`                          |
+| `queryFrontend.query.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                    | `{}`                          |
+| `queryFrontend.query.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                      | `{}`                          |
+| `queryFrontend.query.lifecycleHooks`                        | for the query sidecar container(s) to automate configuration before or after startup                    | `{}`                          |
+| `queryFrontend.query.containerSecurityContext.enabled`      | Enabled queryFrontend query sidecar containers' Security Context                                        | `true`                        |
+| `queryFrontend.query.containerSecurityContext.runAsUser`    | Set queryFrontend query sidecar containers' Security Context runAsUser                                  | `1001`                        |
+| `queryFrontend.query.containerSecurityContext.runAsNonRoot` | Set queryFrontend query sidecar containers' Security Context runAsNonRoot                               | `true`                        |
+| `queryFrontend.query.resources.limits`                      | The resources limits for the query sidecar containers                                                   | `{}`                          |
+| `queryFrontend.query.resources.requests`                    | The requested resources for the query sidecar containers                                                | `{}`                          |
+| `queryFrontend.query.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the queryFrontend container(s)             | `[]`                          |
 
 
 ### Query Frontend Traffic Exposure Parameters
 
-| Name                                             | Description                                             | Value       |
-| ------------------------------------------------ | ------------------------------------------------------- | ----------- |
-| `queryFrontend.service.type`                     | queryFrontend service type                              | `ClusterIP` |
-| `queryFrontend.service.port`                     | queryFrontend service HTTP port                         | `3100`      |
-| `queryFrontend.service.grpcPort`                 | queryFrontend service HTTP port                         | `9095`      |
-| `queryFrontend.service.nodePorts.http`           | Node port for HTTP                                      | `""`        |
-| `queryFrontend.service.nodePorts.grpc`           | Node port for GRPC                                      | `""`        |
-| `queryFrontend.service.clusterIP`                | queryFrontend service Cluster IP                        | `""`        |
-| `queryFrontend.service.loadBalancerIP`           | queryFrontend service Load Balancer IP                  | `""`        |
-| `queryFrontend.service.loadBalancerSourceRanges` | queryFrontend service Load Balancer sources             | `[]`        |
-| `queryFrontend.service.externalTrafficPolicy`    | queryFrontend service external traffic policy           | `Cluster`   |
-| `queryFrontend.service.annotations`              | Additional custom annotations for queryFrontend service | `{}`        |
+| Name                                             | Description                                                      | Value       |
+| ------------------------------------------------ | ---------------------------------------------------------------- | ----------- |
+| `queryFrontend.service.type`                     | queryFrontend service type                                       | `ClusterIP` |
+| `queryFrontend.service.ports.http`               | queryFrontend HTTP service port                                  | `3100`      |
+| `queryFrontend.service.ports.grpc`               | queryFrontend GRPC service port                                  | `9095`      |
+| `queryFrontend.service.nodePorts.http`           | Node port for HTTP                                               | `""`        |
+| `queryFrontend.service.nodePorts.grpc`           | Node port for GRPC                                               | `""`        |
+| `queryFrontend.service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin | `None`      |
+| `queryFrontend.service.clusterIP`                | queryFrontend service Cluster IP                                 | `""`        |
+| `queryFrontend.service.loadBalancerIP`           | queryFrontend service Load Balancer IP                           | `""`        |
+| `queryFrontend.service.loadBalancerSourceRanges` | queryFrontend service Load Balancer sources                      | `[]`        |
+| `queryFrontend.service.externalTrafficPolicy`    | queryFrontend service external traffic policy                    | `Cluster`   |
+| `queryFrontend.service.annotations`              | Additional custom annotations for queryFrontend service          | `{}`        |
+| `queryFrontend.service.extraPorts`               | Extra ports to expose in the queryFrontend service               | `[]`        |
 
 
 ### Vulture Deployment Parameters
 
-| Name                                         | Description                                                                                       | Value                           |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------- |
-| `vulture.enabled`                            | Enable vulture deployment                                                                         | `true`                          |
-| `vulture.image.registry`                     | Grafana Vulture image registry                                                                    | `docker.io`                     |
-| `vulture.image.repository`                   | Grafana Vulture image repository                                                                  | `bitnami/grafana-tempo-vulture` |
-| `vulture.image.tag`                          | Grafana Vulture image tag (immutable tags are recommended)                                        | `1.2.1-debian-10-r58`           |
-| `vulture.image.pullPolicy`                   | Grafana Vulture image pull policy                                                                 | `IfNotPresent`                  |
-| `vulture.image.pullSecrets`                  | Grafana Vulture image pull secrets                                                                | `[]`                            |
-| `vulture.replicaCount`                       | Number of vulture replicas to deploy                                                              | `1`                             |
-| `vulture.livenessProbe.enabled`              | Enable livenessProbe on vulture nodes                                                             | `true`                          |
-| `vulture.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                           | `10`                            |
-| `vulture.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                  | `10`                            |
-| `vulture.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                 | `1`                             |
-| `vulture.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                               | `3`                             |
-| `vulture.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                               | `1`                             |
-| `vulture.readinessProbe.enabled`             | Enable readinessProbe on vulture nodes                                                            | `true`                          |
-| `vulture.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                          | `10`                            |
-| `vulture.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                 | `10`                            |
-| `vulture.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                | `1`                             |
-| `vulture.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                              | `3`                             |
-| `vulture.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                              | `1`                             |
-| `vulture.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                               | `{}`                            |
-| `vulture.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                              | `{}`                            |
-| `vulture.resources.limits`                   | The resources limits for the vulture containers                                                   | `{}`                            |
-| `vulture.resources.requests`                 | The requested resources for the vulture containers                                                | `{}`                            |
-| `vulture.podSecurityContext.enabled`         | Enabled vulture pods' Security Context                                                            | `true`                          |
-| `vulture.podSecurityContext.fsGroup`         | Set vulture pod's Security Context fsGroup                                                        | `1001`                          |
-| `vulture.containerSecurityContext.enabled`   | Enabled vulture containers' Security Context                                                      | `true`                          |
-| `vulture.containerSecurityContext.runAsUser` | Set vulture containers' Security Context runAsUser                                                | `1001`                          |
-| `vulture.command`                            | Override default container command (useful when using custom images)                              | `[]`                            |
-| `vulture.args`                               | Override default container args (useful when using custom images)                                 | `[]`                            |
-| `vulture.hostAliases`                        | vulture pods host aliases                                                                         | `[]`                            |
-| `vulture.podLabels`                          | Extra labels for vulture pods                                                                     | `{}`                            |
-| `vulture.podAnnotations`                     | Annotations for vulture pods                                                                      | `{}`                            |
-| `vulture.podAffinityPreset`                  | Pod affinity preset. Ignored if `vulture.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
-| `vulture.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `vulture.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
-| `vulture.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `vulture.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
-| `vulture.nodeAffinityPreset.key`             | Node label key to match. Ignored if `vulture.affinity` is set                                     | `""`                            |
-| `vulture.nodeAffinityPreset.values`          | Node label values to match. Ignored if `vulture.affinity` is set                                  | `[]`                            |
-| `vulture.containerPort`                      | Vulture container port                                                                            | `8080`                          |
-| `vulture.affinity`                           | Affinity for vulture pods assignment                                                              | `{}`                            |
-| `vulture.nodeSelector`                       | Node labels for vulture pods assignment                                                           | `{}`                            |
-| `vulture.tolerations`                        | Tolerations for vulture pods assignment                                                           | `[]`                            |
-| `vulture.updateStrategy.type`                | vulture statefulset strategy type                                                                 | `RollingUpdate`                 |
-| `vulture.priorityClassName`                  | vulture pods' priorityClassName                                                                   | `""`                            |
-| `vulture.lifecycleHooks`                     | for the vulture container(s) to automate configuration before or after startup                    | `{}`                            |
-| `vulture.extraEnvVars`                       | Array with extra environment variables to add to vulture nodes                                    | `[]`                            |
-| `vulture.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for vulture nodes                            | `""`                            |
-| `vulture.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for vulture nodes                               | `""`                            |
-| `vulture.extraVolumes`                       | Optionally specify extra list of additional volumes for the vulture pod(s)                        | `[]`                            |
-| `vulture.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the vulture container(s)             | `[]`                            |
-| `vulture.sidecars`                           | Add additional sidecar containers to the vulture pod(s)                                           | `[]`                            |
-| `vulture.initContainers`                     | Add additional init containers to the vulture pod(s)                                              | `[]`                            |
+| Name                                            | Description                                                                                       | Value                           |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `vulture.enabled`                               | Enable vulture deployment                                                                         | `true`                          |
+| `vulture.image.registry`                        | Grafana Vulture image registry                                                                    | `docker.io`                     |
+| `vulture.image.repository`                      | Grafana Vulture image repository                                                                  | `bitnami/grafana-tempo-vulture` |
+| `vulture.image.tag`                             | Grafana Vulture image tag (immutable tags are recommended)                                        | `1.2.1-debian-10-r58`           |
+| `vulture.image.pullPolicy`                      | Grafana Vulture image pull policy                                                                 | `IfNotPresent`                  |
+| `vulture.image.pullSecrets`                     | Grafana Vulture image pull secrets                                                                | `[]`                            |
+| `vulture.extraEnvVars`                          | Array with extra environment variables to add to vulture nodes                                    | `[]`                            |
+| `vulture.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for vulture nodes                            | `""`                            |
+| `vulture.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for vulture nodes                               | `""`                            |
+| `vulture.command`                               | Override default container command (useful when using custom images)                              | `[]`                            |
+| `vulture.args`                                  | Override default container args (useful when using custom images)                                 | `[]`                            |
+| `vulture.replicaCount`                          | Number of Vulture replicas to deploy                                                              | `1`                             |
+| `vulture.livenessProbe.enabled`                 | Enable livenessProbe on Vulture nodes                                                             | `true`                          |
+| `vulture.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                           | `10`                            |
+| `vulture.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                  | `10`                            |
+| `vulture.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                 | `1`                             |
+| `vulture.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                               | `3`                             |
+| `vulture.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                               | `1`                             |
+| `vulture.readinessProbe.enabled`                | Enable readinessProbe on Vulture nodes                                                            | `true`                          |
+| `vulture.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                          | `10`                            |
+| `vulture.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                 | `10`                            |
+| `vulture.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                | `1`                             |
+| `vulture.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                              | `3`                             |
+| `vulture.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                              | `1`                             |
+| `vulture.startupProbe.enabled`                  | Enable startupProbe on Vulture containers                                                         | `false`                         |
+| `vulture.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                            | `30`                            |
+| `vulture.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                   | `10`                            |
+| `vulture.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                  | `1`                             |
+| `vulture.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                | `15`                            |
+| `vulture.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                | `1`                             |
+| `vulture.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                               | `{}`                            |
+| `vulture.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                              | `{}`                            |
+| `vulture.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                | `{}`                            |
+| `vulture.resources.limits`                      | The resources limits for the Vulture containers                                                   | `{}`                            |
+| `vulture.resources.requests`                    | The requested resources for the Vulture containers                                                | `{}`                            |
+| `vulture.podSecurityContext.enabled`            | Enabled Vulture pods' Security Context                                                            | `true`                          |
+| `vulture.podSecurityContext.fsGroup`            | Set Vulture pod's Security Context fsGroup                                                        | `1001`                          |
+| `vulture.containerSecurityContext.enabled`      | Enabled Vulture containers' Security Context                                                      | `true`                          |
+| `vulture.containerSecurityContext.runAsUser`    | Set Vulture containers' Security Context runAsUser                                                | `1001`                          |
+| `vulture.containerSecurityContext.runAsNonRoot` | Set Vulture containers' Security Context runAsNonRoot                                             | `true`                          |
+| `vulture.lifecycleHooks`                        | for the vulture container(s) to automate configuration before or after startup                    | `{}`                            |
+| `vulture.hostAliases`                           | vulture pods host aliases                                                                         | `[]`                            |
+| `vulture.podLabels`                             | Extra labels for vulture pods                                                                     | `{}`                            |
+| `vulture.podAnnotations`                        | Annotations for vulture pods                                                                      | `{}`                            |
+| `vulture.podAffinityPreset`                     | Pod affinity preset. Ignored if `vulture.affinity` is set. Allowed values: `soft` or `hard`       | `""`                            |
+| `vulture.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `vulture.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                          |
+| `vulture.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `vulture.affinity` is set. Allowed values: `soft` or `hard` | `""`                            |
+| `vulture.nodeAffinityPreset.key`                | Node label key to match. Ignored if `vulture.affinity` is set                                     | `""`                            |
+| `vulture.nodeAffinityPreset.values`             | Node label values to match. Ignored if `vulture.affinity` is set                                  | `[]`                            |
+| `vulture.containerPorts.http`                   | Vulture components HTTP container port                                                            | `8080`                          |
+| `vulture.affinity`                              | Affinity for Vulture pods assignment                                                              | `{}`                            |
+| `vulture.nodeSelector`                          | Node labels for Vulture pods assignment                                                           | `{}`                            |
+| `vulture.tolerations`                           | Tolerations for Vulture pods assignment                                                           | `[]`                            |
+| `vulture.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains   | `{}`                            |
+| `vulture.priorityClassName`                     | Vulture pods' priorityClassName                                                                   | `""`                            |
+| `vulture.schedulerName`                         | Kubernetes pod scheduler registry                                                                 | `""`                            |
+| `vulture.updateStrategy.type`                   | Vulture statefulset strategy type                                                                 | `RollingUpdate`                 |
+| `vulture.updateStrategy.rollingUpdate`          | Vulture statefulset rolling update configuration parameters                                       | `{}`                            |
+| `vulture.extraVolumes`                          | Optionally specify extra list of additional volumes for the Vulture pod(s)                        | `[]`                            |
+| `vulture.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Vulture container(s)             | `[]`                            |
+| `vulture.sidecars`                              | Add additional sidecar containers to the Vulture pod(s)                                           | `[]`                            |
+| `vulture.initContainers`                        | Add additional init containers to the Vulture pod(s)                                              | `[]`                            |
 
 
 ### Vulture Traffic Exposure Parameters
 
-| Name                                       | Description                                       | Value       |
-| ------------------------------------------ | ------------------------------------------------- | ----------- |
-| `vulture.service.type`                     | vulture service type                              | `ClusterIP` |
-| `vulture.service.port`                     | vulture service HTTP port                         | `3100`      |
-| `vulture.service.nodePorts.http`           | Node port for HTTP                                | `""`        |
-| `vulture.service.clusterIP`                | vulture service Cluster IP                        | `""`        |
-| `vulture.service.loadBalancerIP`           | vulture service Load Balancer IP                  | `""`        |
-| `vulture.service.loadBalancerSourceRanges` | vulture service Load Balancer sources             | `[]`        |
-| `vulture.service.externalTrafficPolicy`    | vulture service external traffic policy           | `Cluster`   |
-| `vulture.service.annotations`              | Additional custom annotations for vulture service | `{}`        |
+| Name                                       | Description                                                      | Value       |
+| ------------------------------------------ | ---------------------------------------------------------------- | ----------- |
+| `vulture.service.type`                     | Vulture service type                                             | `ClusterIP` |
+| `vulture.service.ports.http`               | Vulture HTTP service port                                        | `3100`      |
+| `vulture.service.nodePorts.http`           | Node port for HTTP                                               | `""`        |
+| `vulture.service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin | `None`      |
+| `vulture.service.clusterIP`                | Vulture service Cluster IP                                       | `""`        |
+| `vulture.service.loadBalancerIP`           | Vulture service Load Balancer IP                                 | `""`        |
+| `vulture.service.loadBalancerSourceRanges` | Vulture service Load Balancer sources                            | `[]`        |
+| `vulture.service.externalTrafficPolicy`    | Vulture service external traffic policy                          | `Cluster`   |
+| `vulture.service.annotations`              | Additional custom annotations for Vulture service                | `{}`        |
+| `vulture.service.extraPorts`               | Extra ports to expose in the Vulture service                     | `[]`        |
 
 
 ### Init Container Parameters
@@ -572,22 +659,29 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other Parameters
 
-| Name                    | Description                                          | Value  |
-| ----------------------- | ---------------------------------------------------- | ------ |
-| `serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
-| `serviceAccount.name`   | The name of the ServiceAccount to use.               | `""`   |
+| Name                                          | Description                                                            | Value   |
+| --------------------------------------------- | ---------------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Enable creation of ServiceAccount for Tempo pods                       | `false` |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use                                  | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created | `true`  |
+| `serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                   | `{}`    |
 
 
 ### Metrics Parameters
 
-| Name                                   | Description                                                                     | Value   |
-| -------------------------------------- | ------------------------------------------------------------------------------- | ------- |
-| `metrics.enabled`                      | Enable metrics                                                                  | `false` |
-| `metrics.serviceMonitor.enabled`       | Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator | `false` |
-| `metrics.serviceMonitor.namespace`     | The namespace in which the ServiceMonitor will be created                       | `""`    |
-| `metrics.serviceMonitor.interval`      | The interval at which metrics should be scraped                                 | `30s`   |
-| `metrics.serviceMonitor.scrapeTimeout` | The timeout after which the scrape is ended                                     | `""`    |
-| `metrics.serviceMonitor.selector`      | Scrape selector                                                                 | `{}`    |
+| Name                                       | Description                                                                           | Value   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------- | ------- |
+| `metrics.enabled`                          | Enable metrics                                                                        | `false` |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using Prometheus Operator         | `false` |
+| `metrics.serviceMonitor.namespace`         | Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)         | `""`    |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                          | `""`    |
+| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                               | `""`    |
+| `metrics.serviceMonitor.additionalLabels`  | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`    |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                   | `{}`    |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                    | `[]`    |
+| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                             | `[]`    |
+| `metrics.serviceMonitor.honorLabels`       | Specify honorLabels parameter to add the scrape endpoint                              | `false` |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.     | `""`    |
 
 
 ### External Memcached Parameters
@@ -600,10 +694,13 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Memcached Sub-chart Parameters
 
-| Name                     | Description                | Value   |
-| ------------------------ | -------------------------- | ------- |
-| `memcached.enabled`      | Deploy memcached sub-chart | `true`  |
-| `memcached.service.port` | Memcached service port     | `11211` |
+| Name                                | Description                     | Value   |
+| ----------------------------------- | ------------------------------- | ------- |
+| `memcached.enabled`                 | Deploy memcached sub-chart      | `true`  |
+| `memcached.auth.enabled`            | Enable Memcached authentication | `false` |
+| `memcached.auth.username`           | Memcached admin user            | `""`    |
+| `memcached.auth.password`           | Memcached admin password        | `""`    |
+| `memcached.service.ports.memcached` | Memcached service port          | `11211` |
 
 
 See https://github.com/bitnami-labs/readme-generator-for-helm to create the table
@@ -704,6 +801,19 @@ externalMemcached.port=11211
 ## Troubleshooting
 
 Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## Upgrading
+
+### To 1.0.0
+
+This major release renames several values in this chart and adds missing features, in order to be inline with the rest of assets in the Bitnami charts repository.
+
+- `tempo.containerPort`, `tempo.grpcContainerPort` and `tempo.gossipRing.containerPort` have been regrouped under the `tempo.containerPorts` map.
+- `queryFrontend.query.jaegerMetricsContainerPort` and `queryFrontend.query.jaegerUIContainerPort` have been regrouped under the `queryFrontend.query.containerPorts` map.
+- `vulture.containerPort` has been regrouped under the `vulture.containerPorts` map.
+- `XXX.service.port` and `XXX.service.grpcPort` have been regrouped under the `XXX.service.ports` map.
+
+Additionally updates the Memcached subchart to its newest major `6.x.x`, which contains similar changes.
 
 ## License
 

--- a/bitnami/grafana-tempo/README.md
+++ b/bitnami/grafana-tempo/README.md
@@ -676,7 +676,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.serviceMonitor.namespace`         | Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)         | `""`    |
 | `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                          | `""`    |
 | `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                               | `""`    |
-| `metrics.serviceMonitor.additionalLabels`  | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`    |
+| `metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`    |
 | `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                   | `{}`    |
 | `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                    | `[]`    |
 | `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                             | `[]`    |

--- a/bitnami/grafana-tempo/ci/values-with-init-container-and-metrics.yaml
+++ b/bitnami/grafana-tempo/ci/values-with-init-container-and-metrics.yaml
@@ -1,0 +1,6 @@
+volumePermissions:
+  enabled: true
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true

--- a/bitnami/grafana-tempo/templates/NOTES.txt
+++ b/bitnami/grafana-tempo/templates/NOTES.txt
@@ -45,15 +45,12 @@ Installed components:
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ template "common.names.fullname" . }}
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    echo http://$SERVICE_IP:{{ .Values.queryFrontend.service.port }}
+    echo http://$SERVICE_IP:{{ .Values.queryFrontend.service.ports.http }}
 {{- else if contains "ClusterIP" .Values.queryFrontend.service.type }}
-    echo "The Query Frontend is available at http://127.0.0.1:{{ .Values.queryFrontend.service.port }}"
-    kubectl port-forward svc/{{ template "grafana-tempo.query-frontend.fullname" . }} {{ .Values.queryFrontend.service.port }}:{{ .Values.queryFrontend.service.port }} &
+    echo "The Query Frontend is available at http://127.0.0.1:{{ .Values.queryFrontend.service.ports.http }}"
+    kubectl port-forward svc/{{ template "grafana-tempo.query-frontend.fullname" . }} {{ .Values.queryFrontend.service.ports.http }}:{{ .Values.queryFrontend.service.ports.http }} &
 {{- end }}
 {{- end }}
 
-{{- include "common.warnings.rollingTag" .Values.tempo.image }}
-{{- include "common.warnings.rollingTag" .Values.queryFrontend.query.image }}
-{{- include "common.warnings.rollingTag" .Values.vulture.image }}
-{{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
+{{- include "grafana-tempo.checkRollingTags" . }}
 {{- include "grafana-tempo.validateValues" . }}

--- a/bitnami/grafana-tempo/templates/_helpers.tpl
+++ b/bitnami/grafana-tempo/templates/_helpers.tpl
@@ -142,18 +142,28 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "grafana-tempo.memcached.url" -}}
 {{- $port := "" -}}
 {{- if .Values.externalMemcached.host -}}
-{{- $servicePortString := printf "%v" .Values.externalMemcached.port -}}
-{{- if (not (eq $servicePortString "11211")) -}}
-  {{- $port = printf ":%s" $servicePortString -}}
-{{- end -}}
-{{- printf "%s%s" .Values.externalMemcached.host $port }}
+  {{- $servicePortString := printf "%v" .Values.externalMemcached.port -}}
+  {{- if (not (eq $servicePortString "11211")) -}}
+    {{- $port = printf ":%s" $servicePortString -}}
+  {{- end -}}
+  {{- printf "%s%s" .Values.externalMemcached.host $port }}
 {{- else -}}
-{{- $servicePortString := printf "%v" .Values.memcached.service.port -}}
-{{- if (not (eq $servicePortString "11211")) -}}
-  {{- $port = printf ":%s" $servicePortString -}}
+  {{- $servicePortString := printf "%v" .Values.memcached.service.ports.memcached -}}
+  {{- if (not (eq $servicePortString "11211")) -}}
+    {{- $port = printf ":%s" $servicePortString -}}
+  {{- end -}}
+  {{- printf "%s%s" (include "grafana-tempo.memcached.fullname" .) $port }}
 {{- end -}}
-{{- printf "%s%s" (include "grafana-tempo.memcached.fullname" .) $port }}
 {{- end -}}
+
+{{/*
+Check if there are rolling tags in the images
+*/}}
+{{- define "grafana-tempo.checkRollingTags" -}}
+{{- include "common.warnings.rollingTag" .Values.tempo.image }}
+{{- include "common.warnings.rollingTag" .Values.queryFrontend.query.image }}
+{{- include "common.warnings.rollingTag" .Values.vulture.image }}
+{{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
 {{- end -}}
 
 {{/*

--- a/bitnami/grafana-tempo/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/deployment.yaml
@@ -114,7 +114,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.tempo.containerPorts.web }}
           {{- else if .Values.compactor.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -122,7 +122,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.tempo.containerPorts.web }}
           {{- else if .Values.compactor.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/deployment.yaml
@@ -51,8 +51,14 @@ spec:
       {{- if .Values.compactor.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.tolerations "context" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.compactor.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.compactor.priorityClassName }}
       priorityClassName: {{ .Values.compactor.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.compactor.schedulerName }}
+      schedulerName: {{ .Values.compactor.schedulerName }}
       {{- end }}
       {{- if .Values.compactor.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.compactor.podSecurityContext "enabled" | toYaml | nindent 8 }}
@@ -96,43 +102,40 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.compactor.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
-            - containerPort: {{ .Values.tempo.containerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.web }}
               name: http
-            - containerPort: {{ .Values.tempo.gossipRing.containerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.gossipRing }}
               name: http-memberlist
           {{- if .Values.compactor.resources }}
           resources: {{- toYaml .Values.compactor.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.compactor.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.compactor.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.compactor.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.compactor.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.compactor.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.compactor.livenessProbe.failureThreshold }}
           {{- else if .Values.compactor.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.compactor.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.compactor.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.compactor.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.compactor.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.compactor.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.compactor.readinessProbe.failureThreshold }}
           {{- else if .Values.compactor.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.compactor.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.compactor.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.compactor.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.lifecycleHooks "context" $) | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             - name: tempo-config

--- a/bitnami/grafana-tempo/templates/compactor/service.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/service.yaml
@@ -20,6 +20,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.compactor.service.type }}
+  sessionAffinity: {{ .Values.compactor.service.sessionAffinity }}
   {{- if .Values.compactor.service.clusterIP }}
   clusterIP: {{ .Values.compactor.service.clusterIP }}
   {{- end }}
@@ -34,7 +35,7 @@ spec:
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.compactor.service.port }}
+      port: {{ .Values.compactor.service.ports.http }}
       targetPort: http
       protocol: TCP
       {{- if (and (or (eq .Values.compactor.service.type "NodePort") (eq .Values.compactor.service.type "LoadBalancer")) (not (empty .Values.compactor.service.nodePorts.http))) }}
@@ -42,6 +43,9 @@ spec:
       {{- else if eq .Values.compactor.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.compactor.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.compactor.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: compactor
 {{- end }}

--- a/bitnami/grafana-tempo/templates/compactor/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/servicemonitor.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/compactor/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/servicemonitor.yaml
@@ -17,6 +17,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       {{- if .Values.metrics.serviceMonitor.selector }}
@@ -30,6 +33,15 @@ spec:
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/grafana-tempo/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/deployment.yaml
@@ -50,8 +50,14 @@ spec:
       {{- if .Values.distributor.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.tolerations "context" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.distributor.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.distributor.priorityClassName }}
       priorityClassName: {{ .Values.distributor.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.distributor.schedulerName }}
+      schedulerName: {{ .Values.distributor.schedulerName }}
       {{- end }}
       {{- if .Values.distributor.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.distributor.podSecurityContext "enabled" | toYaml | nindent 8 }}
@@ -95,11 +101,11 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.distributor.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
-            - containerPort: {{ .Values.tempo.containerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.web }}
               name: http
-            - containerPort: {{ .Values.tempo.gossipRing.containerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.gossipRing }}
               name: http-memberlist
-            - containerPort: {{ .Values.tempo.grpcContainerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.grpc }}
               name: grpc
             {{- if .Values.tempo.traces.jaeger.thriftCompact }}
             - containerPort: 6831
@@ -146,34 +152,31 @@ spec:
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.distributor.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.distributor.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.distributor.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.distributor.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.distributor.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.distributor.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.distributor.livenessProbe.failureThreshold }}
           {{- else if .Values.distributor.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.distributor.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.distributor.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.distributor.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.distributor.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.distributor.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.distributor.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.distributor.readinessProbe.failureThreshold }}
           {{- else if .Values.distributor.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.distributor.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.distributor.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.distributor.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.distributor.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.lifecycleHooks "context" $) | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             - name: tempo-config

--- a/bitnami/grafana-tempo/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/deployment.yaml
@@ -155,7 +155,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.distributor.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.tempo.containerPorts.web }}
           {{- else if .Values.distributor.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -163,7 +163,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.distributor.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.tempo.containerPorts.web }}
           {{- else if .Values.distributor.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/distributor/service.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/service.yaml
@@ -19,6 +19,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.distributor.service.type }}
+  sessionAffinity: {{ .Values.distributor.service.sessionAffinity }}
   {{- if .Values.distributor.service.clusterIP }}
   clusterIP: {{ .Values.distributor.service.clusterIP }}
   {{- end }}
@@ -33,7 +34,7 @@ spec:
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.distributor.service.port }}
+      port: {{ .Values.distributor.service.ports.http }}
       targetPort: http
       protocol: TCP
       {{- if (and (or (eq .Values.distributor.service.type "NodePort") (eq .Values.distributor.service.type "LoadBalancer")) (not (empty .Values.distributor.service.nodePorts.http))) }}
@@ -42,7 +43,7 @@ spec:
       nodePort: null
       {{- end }}
     - name: grpc
-      port: {{ .Values.distributor.service.grpcPort }}
+      port: {{ .Values.distributor.service.ports.grpc }}
       protocol: TCP
       targetPort: grpc
       {{- if (and (or (eq .Values.distributor.service.type "NodePort") (eq .Values.distributor.service.type "LoadBalancer")) (not (empty .Values.distributor.service.nodePorts.grpc))) }}
@@ -102,6 +103,9 @@ spec:
       port: 55678
       protocol: TCP
       targetPort: opencensus
+    {{- end }}
+    {{- if .Values.distributor.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.distributor.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: distributor

--- a/bitnami/grafana-tempo/templates/distributor/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/servicemonitor.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/distributor/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/servicemonitor.yaml
@@ -17,6 +17,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       {{- if .Values.metrics.serviceMonitor.selector }}
@@ -30,6 +33,15 @@ spec:
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/grafana-tempo/templates/gossip-ring-headless-service.yaml
+++ b/bitnami/grafana-tempo/templates/gossip-ring-headless-service.yaml
@@ -23,7 +23,7 @@ spec:
   clusterIP: None
   ports:
     - name: http
-      port: {{ .Values.tempo.gossipRing.service.port }}
+      port: {{ .Values.tempo.gossipRing.service.ports.http }}
       targetPort: http-memberlist
       protocol: TCP
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/grafana-tempo/templates/ingester/service.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/service.yaml
@@ -19,6 +19,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.ingester.service.type }}
+  sessionAffinity: {{ .Values.ingester.service.sessionAffinity }}
   {{- if .Values.ingester.service.clusterIP }}
   clusterIP: {{ .Values.ingester.service.clusterIP }}
   {{- end }}
@@ -33,7 +34,7 @@ spec:
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.ingester.service.port }}
+      port: {{ .Values.ingester.service.ports.http }}
       targetPort: http
       protocol: TCP
       {{- if (and (or (eq .Values.ingester.service.type "NodePort") (eq .Values.ingester.service.type "LoadBalancer")) (not (empty .Values.ingester.service.nodePorts.http))) }}
@@ -42,7 +43,7 @@ spec:
       nodePort: null
       {{- end }}
     - name: grpc
-      port: {{ .Values.ingester.service.grpcPort }}
+      port: {{ .Values.ingester.service.ports.grpc }}
       targetPort: grpc
       protocol: TCP
       {{- if (and (or (eq .Values.ingester.service.type "NodePort") (eq .Values.ingester.service.type "LoadBalancer")) (not (empty .Values.ingester.service.nodePorts.grpc))) }}
@@ -50,5 +51,8 @@ spec:
       {{- else if eq .Values.ingester.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.ingester.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingester.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: ingester

--- a/bitnami/grafana-tempo/templates/ingester/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/servicemonitor.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/ingester/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/servicemonitor.yaml
@@ -17,6 +17,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       {{- if .Values.metrics.serviceMonitor.selector }}
@@ -30,6 +33,15 @@ spec:
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
@@ -141,7 +141,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.tempo.containerPorts.web }}
           {{- else if .Values.ingester.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -149,7 +149,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.tempo.containerPorts.web }}
           {{- else if .Values.ingester.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
@@ -51,8 +51,14 @@ spec:
       {{- if .Values.ingester.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.tolerations "context" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.ingester.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.ingester.priorityClassName }}
       priorityClassName: {{ .Values.ingester.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.ingester.schedulerName }}
+      schedulerName: {{ .Values.ingester.schedulerName }}
       {{- end }}
       {{- if .Values.ingester.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.ingester.podSecurityContext "enabled" | toYaml | nindent 8 }}
@@ -67,12 +73,12 @@ spec:
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
           command:
             - /bin/bash
-            - -ec
           args:
+            - -ec
             - |
               mkdir -p {{ .Values.tempo.dataDir }}{{- if .Values.ingester.persistence.subPath }}/{{ .Values.ingester.persistence.subPath }}{{- end }}
-              {{- if and .Values.podSecurityContext.enabled .Values.containerSecurityContext.enabled }}
-              chown -R "{{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}" "{{ .Values.tempo.dataDir }}{{- if .Values.ingester.persistence.subPath }}/{{ .Values.ingester.persistence.subPath }}{{- end }}"
+              {{- if and .Values.ingester.podSecurityContext.enabled .Values.ingester.containerSecurityContext.enabled }}
+              find {{ .Values.tempo.dataDir }}{{- if .Values.ingester.persistence.subPath }}/{{ .Values.ingester.persistence.subPath }}{{- end }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ .Values.ingester.containerSecurityContext.runAsUser }}:{{ .Values.ingester.podSecurityContext.fsGroup }}
               {{- end }}
           {{- if eq ( toString ( .Values.volumePermissions.containerSecurityContext.runAsUser )) "auto" }}
           securityContext: {{- omit .Values.volumePermissions.containerSecurityContext "runAsUser" | toYaml | nindent 12 }}
@@ -121,43 +127,42 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.ingester.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
-            - containerPort: {{ .Values.tempo.containerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.web }}
               name: http
-            - containerPort: {{ .Values.tempo.gossipRing.containerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.gossipRing }}
               name: http-memberlist
-            - containerPort: {{ .Values.tempo.grpcContainerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.grpc }}
               name: grpc
           {{- if .Values.ingester.resources }}
           resources: {{- toYaml .Values.ingester.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.ingester.livenessProbe.enabled }}
-          livenessProbe:
-            tcpSocket:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.ingester.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.ingester.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.ingester.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.ingester.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.ingester.livenessProbe.failureThreshold }}
           {{- else if .Values.ingester.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.ingester.readinessProbe.enabled }}
-          readinessProbe:
-            tcpSocket:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.readinessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.ingester.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.ingester.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.ingester.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.ingester.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.ingester.readinessProbe.failureThreshold }}
           {{- else if .Values.ingester.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.ingester.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.ingester.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.ingester.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.lifecycleHooks "context" $) | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             - name: tempo-config
@@ -191,9 +196,16 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: data
-        {{- if .Values.ingester.persistence.annotations }}
-        annotations: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.persistence.annotations "context" $) | nindent 10 }}
+        {{- if .Values.commonLabels }}
+        labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
         {{- end }}
+        annotations:
+          {{- if .Values.ingester.persistence.annotations }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.ingester.persistence.annotations "context" $) | nindent 10 }}
+          {{- end }}
+          {{- if .Values.commonAnnotations }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
+          {{- end }}
       spec:
         accessModes:
         {{- range .Values.ingester.persistence.accessModes }}
@@ -202,14 +214,8 @@ spec:
         resources:
           requests:
             storage: {{ .Values.ingester.persistence.size | quote }}
-            {{- if .Values.ingester.persistence.volumeClaimTemplates.requests }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.ingester.persistence.volumeClaimTemplates.requests "context" $) | nindent 12 }}
-            {{- end }}
-        {{- if .Values.ingester.persistence.volumeClaimTemplates.dataSource }}
-        dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.persistence.volumeClaimTemplates.dataSource "context" $) | nindent 10 }}
+        {{- if .Values.ingester.persistence.selector }}
+        selector: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.persistence.selector "context" $) | nindent 10 }}
         {{- end }}
-        {{- if .Values.ingester.persistence.volumeClaimTemplates.selector }}
-        selector: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.persistence.volumeClaimTemplates.selector "context" $) | nindent 10 }}
-        {{- end }}
-        {{ include "common.storage.class" (dict "persistence" .Values.ingester.persistence "global" .Values.global) }}
+        {{- include "common.storage.class" (dict "persistence" .Values.ingester.persistence "global" .Values.global) | nindent 8 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
@@ -139,17 +139,15 @@ spec:
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.ingester.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
-              port: {{ .Values.tempo.containerPorts.web }}
+            tcpSocket:
+              port: http
           {{- else if .Values.ingester.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.ingester.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.readinessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
-              port: {{ .Values.tempo.containerPorts.web }}
+            tcpSocket:
+              port: http
           {{- else if .Values.ingester.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/querier/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/querier/deployment.yaml
@@ -115,7 +115,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.querier.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.tempo.containerPorts.web }}
           {{- else if .Values.querier.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -123,7 +123,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.querier.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.tempo.containerPorts.web }}
           {{- else if .Values.querier.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/querier/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/querier/deployment.yaml
@@ -50,8 +50,14 @@ spec:
       {{- if .Values.querier.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.querier.tolerations "context" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.querier.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.querier.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.querier.priorityClassName }}
       priorityClassName: {{ .Values.querier.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.querier.schedulerName }}
+      schedulerName: {{ .Values.querier.schedulerName }}
       {{- end }}
       {{- if .Values.querier.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.querier.podSecurityContext "enabled" | toYaml | nindent 8 }}
@@ -95,45 +101,42 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.querier.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
-            - containerPort: {{ .Values.tempo.containerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.web }}
               name: http
-            - containerPort: {{ .Values.tempo.gossipRing.containerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.gossipRing }}
               name: http-memberlist
-            - containerPort: {{ .Values.tempo.grpcContainerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.grpc }}
               name: grpc
           {{- if .Values.querier.resources }}
           resources: {{- toYaml .Values.querier.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.querier.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.querier.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.querier.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.querier.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.querier.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.querier.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.querier.livenessProbe.failureThreshold }}
           {{- else if .Values.querier.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.querier.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.querier.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.querier.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.querier.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.querier.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.querier.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.querier.readinessProbe.failureThreshold }}
           {{- else if .Values.querier.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.querier.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.querier.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.querier.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.querier.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.querier.lifecycleHooks "context" $) | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             - name: tempo-config

--- a/bitnami/grafana-tempo/templates/querier/service.yaml
+++ b/bitnami/grafana-tempo/templates/querier/service.yaml
@@ -19,6 +19,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.querier.service.type }}
+  sessionAffinity: {{ .Values.querier.service.sessionAffinity }}
   {{- if .Values.querier.service.clusterIP }}
   clusterIP: {{ .Values.querier.service.clusterIP }}
   {{- end }}
@@ -33,7 +34,7 @@ spec:
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.querier.service.port }}
+      port: {{ .Values.querier.service.ports.http }}
       targetPort: http
       protocol: TCP
       {{- if (and (or (eq .Values.querier.service.type "NodePort") (eq .Values.querier.service.type "LoadBalancer")) (not (empty .Values.querier.service.nodePorts.http))) }}
@@ -42,7 +43,7 @@ spec:
       nodePort: null
       {{- end }}
     - name: grpc
-      port: {{ .Values.querier.service.grpcPort }}
+      port: {{ .Values.querier.service.ports.grpc }}
       targetPort: grpc
       protocol: TCP
       {{- if (and (or (eq .Values.querier.service.type "NodePort") (eq .Values.querier.service.type "LoadBalancer")) (not (empty .Values.querier.service.nodePorts.grpc))) }}
@@ -50,5 +51,8 @@ spec:
       {{- else if eq .Values.querier.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.querier.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.querier.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: querier

--- a/bitnami/grafana-tempo/templates/querier/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/querier/servicemonitor.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/querier/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/querier/servicemonitor.yaml
@@ -17,6 +17,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       {{- if .Values.metrics.serviceMonitor.selector }}
@@ -30,6 +33,15 @@ spec:
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
@@ -50,8 +50,14 @@ spec:
       {{- if .Values.queryFrontend.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.tolerations "context" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.queryFrontend.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.queryFrontend.priorityClassName }}
       priorityClassName: {{ .Values.queryFrontend.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.queryFrontend.schedulerName }}
+      schedulerName: {{ .Values.queryFrontend.schedulerName }}
       {{- end }}
       {{- if .Values.queryFrontend.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.queryFrontend.podSecurityContext "enabled" | toYaml | nindent 8 }}
@@ -95,45 +101,42 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.queryFrontend.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
-            - containerPort: {{ .Values.tempo.containerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.web }}
               name: http
-            - containerPort: {{ .Values.tempo.gossipRing.containerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.gossipRing }}
               name: http-memberlist
-            - containerPort: {{ .Values.tempo.grpcContainerPort }}
+            - containerPort: {{ .Values.tempo.containerPorts.grpc }}
               name: grpc
           {{- if .Values.queryFrontend.resources }}
           resources: {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.queryFrontend.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.queryFrontend.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.queryFrontend.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.queryFrontend.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.queryFrontend.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.queryFrontend.livenessProbe.failureThreshold }}
           {{- else if .Values.queryFrontend.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.queryFrontend.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.queryFrontend.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.queryFrontend.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.queryFrontend.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.queryFrontend.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.queryFrontend.readinessProbe.failureThreshold }}
           {{- else if .Values.queryFrontend.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.queryFrontend.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.queryFrontend.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.queryFrontend.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.lifecycleHooks "context" $) | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             - name: tempo-config
@@ -179,41 +182,40 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
-            - containerPort: {{ .Values.queryFrontend.query.jaegerUIContainerPort }}
+            - containerPort: {{ .Values.queryFrontend.query.containerPorts.jaegerUI }}
               name: jaeger-ui
-            - containerPort: {{ .Values.queryFrontend.query.jaegerMetricsContainerPort }}
+            - containerPort: {{ .Values.queryFrontend.query.containerPorts.jaegerMetrics }}
               name: jaeger-metrics
           {{- if .Values.queryFrontend.query.resources }}
           resources: {{- toYaml .Values.queryFrontend.query.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.queryFrontend.query.livenessProbe.enabled }}
-          livenessProbe:
-            tcpSocket:
-              port: jaeger-ui
-            initialDelaySeconds: {{ .Values.queryFrontend.query.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.queryFrontend.query.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.queryFrontend.query.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.queryFrontend.query.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.queryFrontend.query.livenessProbe.failureThreshold }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /ready
+              port: http
           {{- else if .Values.queryFrontend.query.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.queryFrontend.query.readinessProbe.enabled }}
-          readinessProbe:
-            tcpSocket:
-              port: jaeger-ui
-            initialDelaySeconds: {{ .Values.queryFrontend.query.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.queryFrontend.query.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.queryFrontend.query.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.queryFrontend.query.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.queryFrontend.query.readinessProbe.failureThreshold }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.readinessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /ready
+              port: http
           {{- else if .Values.queryFrontend.query.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.queryFrontend.query.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.queryFrontend.query.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.queryFrontend.query.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.lifecycleHooks "context" $) | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             - name: tempo-query-config

--- a/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
@@ -115,7 +115,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.tempo.containerPorts.web }}
           {{- else if .Values.queryFrontend.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -123,7 +123,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.tempo.containerPorts.web }}
           {{- else if .Values.queryFrontend.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -194,7 +194,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.queryFrontend.query.containerPorts.jaegerUI }}
           {{- else if .Values.queryFrontend.query.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -202,7 +202,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.queryFrontend.query.containerPorts.jaegerUI }}
           {{- else if .Values.queryFrontend.query.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
@@ -192,24 +192,22 @@ spec:
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.queryFrontend.query.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.livenessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
-              port: {{ .Values.queryFrontend.query.containerPorts.jaegerUI }}
+            tcpSocket:
+              port: jaeger-ui
           {{- else if .Values.queryFrontend.query.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.queryFrontend.query.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.readinessProbe "enabled") "context" $) | nindent 12 }}
-            httpGet:
-              path: /ready
-              port: {{ .Values.queryFrontend.query.containerPorts.jaegerUI }}
+            tcpSocket:
+              port: jaeger-ui
           {{- else if .Values.queryFrontend.query.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.queryFrontend.query.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
-              port: http
+              port: jaeger-ui
           {{- else if .Values.queryFrontend.query.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/query-frontend/headless-service.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/headless-service.yaml
@@ -18,11 +18,11 @@ spec:
   clusterIP: None
   ports:
     - name: http
-      port: {{ .Values.queryFrontend.service.port }}
+      port: {{ .Values.queryFrontend.service.ports.http }}
       targetPort: http
       protocol: TCP
     - name: grpc
-      port: {{ .Values.queryFrontend.service.grpcPort }}
+      port: {{ .Values.queryFrontend.service.ports.grpc }}
       targetPort: grpc
       protocol: TCP
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/grafana-tempo/templates/query-frontend/service.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/service.yaml
@@ -19,6 +19,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.queryFrontend.service.type }}
+  sessionAffinity: {{ .Values.queryFrontend.service.sessionAffinity }}
   {{- if .Values.queryFrontend.service.clusterIP }}
   clusterIP: {{ .Values.queryFrontend.service.clusterIP }}
   {{- end }}
@@ -34,7 +35,7 @@ spec:
   publishNotReadyAddresses: true
   ports:
     - name: http
-      port: {{ .Values.queryFrontend.service.port }}
+      port: {{ .Values.queryFrontend.service.ports.http }}
       targetPort: http
       protocol: TCP
       {{- if (and (or (eq .Values.queryFrontend.service.type "NodePort") (eq .Values.queryFrontend.service.type "LoadBalancer")) (not (empty .Values.queryFrontend.service.nodePorts.http))) }}
@@ -43,8 +44,11 @@ spec:
       nodePort: null
       {{- end }}
     - name: grpc
-      port: {{ .Values.queryFrontend.service.grpcPort }}
+      port: {{ .Values.queryFrontend.service.ports.grpc }}
       targetPort: grpc
       protocol: TCP
+    {{- if .Values.queryFrontend.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend

--- a/bitnami/grafana-tempo/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/servicemonitor.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/query-frontend/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/servicemonitor.yaml
@@ -17,6 +17,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       {{- if .Values.metrics.serviceMonitor.selector }}
@@ -30,6 +33,15 @@ spec:
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/grafana-tempo/templates/service-account.yaml
+++ b/bitnami/grafana-tempo/templates/service-account.yaml
@@ -2,14 +2,19 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: {{ template "grafana-tempo.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: tempo
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ template "grafana-tempo.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/bitnami/grafana-tempo/templates/vulture/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/deployment.yaml
@@ -111,7 +111,7 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.vulture.containerPorts.http }}
           {{- else if .Values.vulture.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -119,7 +119,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
-              port: http
+              port: {{ .Values.vulture.containerPorts.http }}
           {{- else if .Values.vulture.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}

--- a/bitnami/grafana-tempo/templates/vulture/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/deployment.yaml
@@ -110,7 +110,7 @@ spec:
           {{- if .Values.vulture.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /ready
+              path: /metrics
               port: {{ .Values.vulture.containerPorts.http }}
           {{- else if .Values.vulture.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customLivenessProbe "context" $) | nindent 12 }}
@@ -118,7 +118,7 @@ spec:
           {{- if .Values.vulture.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /ready
+              path: /metrics
               port: {{ .Values.vulture.containerPorts.http }}
           {{- else if .Values.vulture.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customReadinessProbe "context" $) | nindent 12 }}

--- a/bitnami/grafana-tempo/templates/vulture/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/deployment.yaml
@@ -50,8 +50,14 @@ spec:
       {{- if .Values.vulture.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.tolerations "context" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.vulture.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.vulture.priorityClassName }}
       priorityClassName: {{ .Values.vulture.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.vulture.schedulerName }}
+      schedulerName: {{ .Values.vulture.schedulerName }}
       {{- end }}
       {{- if .Values.vulture.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.vulture.podSecurityContext "enabled" | toYaml | nindent 8 }}
@@ -78,9 +84,9 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.args "context" $) | nindent 12 }}
           {{- else }}
           args:
-            - -prometheus-listen-address=0.0.0.0:{{ .Values.vulture.containerPort }}
+            - -prometheus-listen-address=0.0.0.0:{{ .Values.vulture.containerPorts.http }}
             - -tempo-push-url=http://{{ template "grafana-tempo.distributor.fullname" . }}
-            - -tempo-query-url=http://{{ template "grafana-tempo.query-frontend.fullname" . }}:{{ .Values.queryFrontend.service.port }}
+            - -tempo-query-url=http://{{ template "grafana-tempo.query-frontend.fullname" . }}:{{ .Values.queryFrontend.service.ports.http }}
           {{- end }}
           {{- if .Values.vulture.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.extraEnvVars "context" $) | nindent 12 }}
@@ -95,41 +101,38 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.vulture.extraEnvVarsSecret "context" $) }}
             {{- end }}
           ports:
-            - containerPort: {{ .Values.vulture.containerPort }}
+            - containerPort: {{ .Values.vulture.containerPorts.http }}
               name: http
           {{- if .Values.vulture.resources }}
           resources: {{- toYaml .Values.vulture.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.vulture.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.vulture.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.vulture.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.vulture.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.vulture.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.vulture.livenessProbe.failureThreshold }}
           {{- else if .Values.vulture.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.vulture.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /ready
               port: http
-            initialDelaySeconds: {{ .Values.vulture.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.vulture.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.vulture.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.vulture.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.vulture.readinessProbe.failureThreshold }}
           {{- else if .Values.vulture.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.vulture.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.vulture.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.vulture.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.lifecycleHooks "context" $) | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             - name: tempo-config

--- a/bitnami/grafana-tempo/templates/vulture/service.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/service.yaml
@@ -20,6 +20,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.vulture.service.type }}
+  sessionAffinity: {{ .Values.vulture.service.sessionAffinity }}
   {{- if .Values.vulture.service.clusterIP }}
   clusterIP: {{ .Values.vulture.service.clusterIP }}
   {{- end }}
@@ -33,15 +34,18 @@ spec:
   loadBalancerIP: {{ .Values.vulture.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: prom-metrics
-      port: {{ .Values.vulture.service.port }}
-      targetPort: prom-metrics
+    - name: http
+      port: {{ .Values.vulture.service.ports.http }}
+      targetPort: http
       protocol: TCP
       {{- if (and (or (eq .Values.vulture.service.type "NodePort") (eq .Values.vulture.service.type "LoadBalancer")) (not (empty .Values.vulture.service.nodePorts.http))) }}
       nodePort: {{ .Values.vulture.service.nodePorts.http }}
       {{- else if eq .Values.vulture.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.vulture.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.vulture.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: vulture
 {{- end }}

--- a/bitnami/grafana-tempo/templates/vulture/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/servicemonitor.yaml
@@ -13,6 +13,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-tempo/templates/vulture/servicemonitor.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/servicemonitor.yaml
@@ -17,6 +17,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   selector:
     matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
       {{- if .Values.metrics.serviceMonitor.selector }}
@@ -30,6 +33,15 @@ spec:
       {{- end }}
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -1543,7 +1543,7 @@ queryFrontend:
     ## @param queryFrontend.query.configuration [string] Query sidecar configuration
     ##
     configuration: |
-      backend: 127.0.0.1:{{ .Values.tempo.containerPort }}
+      backend: 127.0.0.1:{{ .Values.tempo.containerPorts.web }}
     ## @param queryFrontend.query.containerPorts.jaegerMetrics queryFrontend query sidecar Jaeger metrics container port
     ## @param queryFrontend.query.containerPorts.jaegerUI queryFrontend query sidecar Jaeger UI container port
     ##

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -42,17 +42,17 @@ clusterDomain: cluster.local
 ##
 extraDeploy: []
 
-## Enable diagnostic mode in the deployment
+## Enable diagnostic mode in the deployments/statefulsets
 ##
 diagnosticMode:
   ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
   ##
   enabled: false
-  ## @param diagnosticMode.command Command to override all containers in the deployment
+  ## @param diagnosticMode.command Command to override all containers in the deployments/statefulsets
   ##
   command:
     - sleep
-  ## @param diagnosticMode.args Args to override all containers in the deployment
+  ## @param diagnosticMode.args Args to override all containers in the deployments/statefulsets
   ##
   args:
     - infinity
@@ -61,7 +61,7 @@ diagnosticMode:
 ##
 tempo:
   ## Bitnami Grafana Tempo image
-  ## ref: https://hub.docker.com/r/bitnami/redis/tags/
+  ## ref: https://hub.docker.com/r/bitnami/grafana-tempo/tags/
   ## @param tempo.image.registry Grafana Tempo image registry
   ## @param tempo.image.repository Grafana Tempo image repository
   ## @param tempo.image.tag Grafana Tempo image tag (immutable tags are recommended)
@@ -85,19 +85,14 @@ tempo:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-
-  ## @param tempo.containerPort Tempo components web port
-  ##
-  containerPort: 3100
-  ## @param tempo.grpcContainerPort Tempo components GRPC port
-  ##
-  grpcContainerPort: 9095
   ## @param tempo.memBallastSizeMbs Tempo components memory ballast size in MB
   ##
   memBallastSizeMbs: 1024
   ## @param tempo.dataDir Tempo components data directory
   ##
   dataDir: /bitnami/grafana-tempo/data
+  ## Tempo trace parameters
+  ##
   traces:
     jaeger:
       ## @param tempo.traces.jaeger.grpc Enable Tempo to ingest Jaeger GRPC traces
@@ -112,34 +107,19 @@ tempo:
       ## @param tempo.traces.jaeger.thriftHttp Enable Tempo to ingest Jaeger Thrift HTTP traces
       ##
       thriftHttp: true
-    ## @param tempo.traces.zipkin Enable Tempo to ingest Zipkin traces
-    ##
-    zipkin: false
     otlp:
-      ## @param tempo.traces.otlp.http Enable Tempo to ingest Open Telementry HTTP traces
+      ## @param tempo.traces.otlp.http Enable Tempo to ingest Open Telemetry HTTP traces
       ##
       http: false
-      ## @param tempo.traces.otlp.grpc Enable Tempo to ingest Open Telementry GRPC traces
+      ## @param tempo.traces.otlp.grpc Enable Tempo to ingest Open Telemetry GRPC traces
       ##
       grpc: false
     ## @param tempo.traces.opencensus Enable Tempo to ingest Open Census traces
     ##
     opencensus: false
-
-  gossipRing:
-    ## @param tempo.gossipRing.containerPort gossip service HTTP port
+    ## @param tempo.traces.zipkin Enable Tempo to ingest Zipkin traces
     ##
-    containerPort: 7946
-    ## gossip service parameters
-    ##
-    service:
-      ## @param tempo.gossipRing.service.port gossip headless service HTTP port
-      ##
-      port: 7946
-      ## @param tempo.gossipRing.service.annotations Additional custom annotations for gossip headless service
-      ##
-      annotations: {}
-
+    zipkin: false
   ## @param tempo.configuration [string] Tempo components configuration
   ##
   configuration: |
@@ -197,7 +177,7 @@ tempo:
         {{- end }}
     querier:
       frontend_worker:
-        frontend_address: {{ template "grafana-tempo.query-frontend.fullname" . }}-headless:{{ .Values.queryFrontend.service.grpcPort }}
+        frontend_address: {{ include "grafana-tempo.query-frontend.fullname" . }}-headless:{{ .Values.queryFrontend.service.grpcPort }}
     ingester:
       lifecycler:
         ring:
@@ -208,11 +188,11 @@ tempo:
     memberlist:
       abort_if_cluster_join_fails: false
       join_members:
-        - {{ template "grafana-tempo.gossip-ring.fullname" . }}
+        - {{ include "grafana-tempo.gossip-ring.fullname" . }}
     overrides:
       per_tenant_override_config: /bitnami/grafana-tempo/conf/overrides.yaml
     server:
-      http_listen_port: 3100
+      http_listen_port: {{ .Values.tempo.containerPorts.web }}
     storage:
       trace:
         backend: local
@@ -224,35 +204,72 @@ tempo:
         cache: memcached
         memcached:
           consistent_hash: true
-          host: {{ template "grafana-tempo.memcached.url" . }}
+          host: {{ include "grafana-tempo.memcached.url" . }}
           service: memcache
           timeout: 500ms
-
-  ## @param tempo.existingConfigmap Name of a ConfigMap with the tempo configuration
+  ## @param tempo.existingConfigmap Name of a ConfigMap with the Tempo configuration
   ##
   existingConfigmap: ""
-
   ## @param tempo.overridesConfiguration [string] Tempo components overrides configuration settings
   ##
   overridesConfiguration: |
     overrides: {}
-
   ## @param tempo.existingOverridesConfigmap Name of a ConfigMap with the tempo overrides configuration
   ##
   existingOverridesConfigmap: ""
+  ## @param tempo.containerPorts.web Tempo components web container port
+  ## @param tempo.containerPorts.grpc Tempo components GRPC container port
+  ## @param tempo.containerPorts.gossipRing Tempo components Gossip Ring container port
+  ##
+  containerPorts:
+    web: 3100
+    grpc: 9095
+    gossipRing: 7946
+  ## Gossip Ring parameters
+  ##
+  gossipRing:
+    ## Gossip Ring service parameters
+    ##
+    service:
+      ## @param tempo.gossipRing.service.ports.http Gossip Ring HTTP headless service port
+      ##
+      ports:
+        http: 7946
+      ## @param tempo.gossipRing.service.annotations Additional custom annotations for Gossip Ring headless service
+      ##
+      annotations: {}
 
 ## @section Compactor Deployment Parameters
 ##
 compactor:
-  ## @param compactor.enabled Enable compactor deployment
+  ## @param compactor.enabled Enable Compactor deployment
   ##
   enabled: true
-  ## @param compactor.replicaCount Number of compactor replicas to deploy
+  ## @param compactor.extraEnvVars Array with extra environment variables to add to compactor nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param compactor.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for compactor nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param compactor.extraEnvVarsSecret Name of existing Secret containing extra env vars for compactor nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param compactor.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param compactor.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param compactor.replicaCount Number of Compactor replicas to deploy
   ##
   replicaCount: 1
-  ## Configure extra options for compactor containers' liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param compactor.livenessProbe.enabled Enable livenessProbe on compactor nodes
+  ## Configure extra options for Compactor containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param compactor.livenessProbe.enabled Enable livenessProbe on Compactor nodes
   ## @param compactor.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param compactor.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param compactor.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -266,7 +283,7 @@ compactor:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
-  ## @param compactor.readinessProbe.enabled Enable readinessProbe on compactor nodes
+  ## @param compactor.readinessProbe.enabled Enable readinessProbe on Compactor nodes
   ## @param compactor.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param compactor.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param compactor.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -280,12 +297,29 @@ compactor:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+  ## @param compactor.startupProbe.enabled Enable startupProbe on Compactor containers
+  ## @param compactor.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param compactor.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param compactor.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param compactor.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param compactor.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
   ## @param compactor.customLivenessProbe Custom livenessProbe that overrides the default one
   ##
   customLivenessProbe: {}
   ## @param compactor.customReadinessProbe Custom readinessProbe that overrides the default one
   ##
   customReadinessProbe: {}
+  ## @param compactor.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
   ## compactor resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param compactor.resources.limits The resources limits for the compactor containers
@@ -296,27 +330,25 @@ compactor:
     requests: {}
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param compactor.podSecurityContext.enabled Enabled compactor pods' Security Context
-  ## @param compactor.podSecurityContext.fsGroup Set compactor pod's Security Context fsGroup
+  ## @param compactor.podSecurityContext.enabled Enabled Compactor pods' Security Context
+  ## @param compactor.podSecurityContext.fsGroup Set Compactor pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param compactor.containerSecurityContext.enabled Enabled compactor containers' Security Context
-  ## @param compactor.containerSecurityContext.runAsUser Set compactor containers' Security Context runAsUser
+  ## @param compactor.containerSecurityContext.enabled Enabled Compactor containers' Security Context
+  ## @param compactor.containerSecurityContext.runAsUser Set Compactor containers' Security Context runAsUser
+  ## @param compactor.containerSecurityContext.runAsNonRoot Set Compactor containers' Security Context runAsNonRoot
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
-
-  ## @param compactor.command Override default container command (useful when using custom images)
+    runAsNonRoot: true
+  ## @param compactor.lifecycleHooks for the compactor container(s) to automate configuration before or after startup
   ##
-  command: []
-  ## @param compactor.args Override default container args (useful when using custom images)
-  ##
-  args: []
+  lifecycleHooks: {}
   ## @param compactor.hostAliases compactor pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -354,53 +386,44 @@ compactor:
     ##   - e2e-az2
     ##
     values: []
-  ## @param compactor.affinity Affinity for compactor pods assignment
+  ## @param compactor.affinity Affinity for Compactor pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## NOTE: `compactor.podAffinityPreset`, `compactor.podAntiAffinityPreset`, and `compactor.nodeAffinityPreset` will be ignored when it's set
   ##
   affinity: {}
-  ## @param compactor.nodeSelector Node labels for compactor pods assignment
+  ## @param compactor.nodeSelector Node labels for Compactor pods assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
-  ## @param compactor.tolerations Tolerations for compactor pods assignment
+  ## @param compactor.tolerations Tolerations for Compactor pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param compactor.updateStrategy.type compactor statefulset strategy type
+  ## @param compactor.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: {}
+  ## @param compactor.priorityClassName Compactor pods' priorityClassName
+  ##
+  priorityClassName: ""
+  ## @param compactor.schedulerName Kubernetes pod scheduler registry
+  ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param compactor.updateStrategy.type Compactor statefulset strategy type
+  ## @param compactor.updateStrategy.rollingUpdate Compactor statefulset rolling update configuration parameters
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy:
-    ## StrategyType
-    ## Can be set to RollingUpdate or OnDelete
-    ##
     type: RollingUpdate
-  ## @param compactor.priorityClassName compactor pods' priorityClassName
-  ##
-  priorityClassName: ""
-  ## @param compactor.lifecycleHooks for the compactor container(s) to automate configuration before or after startup
-  ##
-  lifecycleHooks: {}
-  ## @param compactor.extraEnvVars Array with extra environment variables to add to compactor nodes
-  ## e.g:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
-  ##
-  extraEnvVars: []
-  ## @param compactor.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for compactor nodes
-  ##
-  extraEnvVarsCM: ""
-  ## @param compactor.extraEnvVarsSecret Name of existing Secret containing extra env vars for compactor nodes
-  ##
-  extraEnvVarsSecret: ""
-  ## @param compactor.extraVolumes Optionally specify extra list of additional volumes for the compactor pod(s)
+    rollingUpdate: {}
+  ## @param compactor.extraVolumes Optionally specify extra list of additional volumes for the Compactor pod(s)
   ##
   extraVolumes: []
-  ## @param compactor.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the compactor container(s)
+  ## @param compactor.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Compactor container(s)
   ##
   extraVolumeMounts: []
-  ## @param compactor.sidecars Add additional sidecar containers to the compactor pod(s)
+  ## @param compactor.sidecars Add additional sidecar containers to the Compactor pod(s)
   ## e.g:
   ## sidecars:
   ##   - name: your-image-name
@@ -411,7 +434,7 @@ compactor:
   ##         containerPort: 1234
   ##
   sidecars: []
-  ## @param compactor.initContainers Add additional init containers to the compactor pod(s)
+  ## @param compactor.initContainers Add additional init containers to the Compactor pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
   ## e.g:
   ## initContainers:
@@ -421,57 +444,85 @@ compactor:
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
   initContainers: []
+
   ## @section Compactor Traffic Exposure Parameters
-  ##
 
   ## compactor service parameters
   ##
   service:
-    ## @param compactor.service.type compactor service type
+    ## @param compactor.service.type Compactor service type
     ##
     type: ClusterIP
-    ## @param compactor.service.port compactor service HTTP port
+    ## @param compactor.service.ports.http Compactor HTTP service port
     ##
-    port: 3100
+    ports:
+      http: 3100
     ## Node ports to expose
-    ## @param compactor.service.nodePorts.http Node port for HTTP
     ## NOTE: choose port between <30000-32767>
+    ## @param compactor.service.nodePorts.http Node port for HTTP
     ##
     nodePorts:
       http: ""
-    ## @param compactor.service.clusterIP compactor service Cluster IP
+    ## @param compactor.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
+    ## @param compactor.service.clusterIP Compactor service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
     clusterIP: ""
-    ## @param compactor.service.loadBalancerIP compactor service Load Balancer IP
+    ## @param compactor.service.loadBalancerIP Compactor service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
     loadBalancerIP: ""
-    ## @param compactor.service.loadBalancerSourceRanges compactor service Load Balancer sources
+    ## @param compactor.service.loadBalancerSourceRanges Compactor service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
     ##   - 10.10.10.0/24
     ##
     loadBalancerSourceRanges: []
-    ## @param compactor.service.externalTrafficPolicy compactor service external traffic policy
+    ## @param compactor.service.externalTrafficPolicy Compactor service external traffic policy
     ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
     externalTrafficPolicy: Cluster
-    ## @param compactor.service.annotations Additional custom annotations for compactor service
+    ## @param compactor.service.annotations Additional custom annotations for Compactor service
     ##
     annotations: {}
+    ## @param compactor.service.extraPorts Extra ports to expose in the Compactor service
+    ##
+    extraPorts: []
 
 ## @section Distributor Deployment Parameters
 ##
 distributor:
-  ## @param distributor.replicaCount Number of distributor replicas to deploy
+  ## @param distributor.extraEnvVars Array with extra environment variables to add to distributor nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param distributor.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for distributor nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param distributor.extraEnvVarsSecret Name of existing Secret containing extra env vars for distributor nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param distributor.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param distributor.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param distributor.replicaCount Number of Distributor replicas to deploy
   ##
   replicaCount: 1
-  ## Configure extra options for distributor containers' liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param distributor.livenessProbe.enabled Enable livenessProbe on distributor nodes
+  ## Configure extra options for Distributor containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param distributor.livenessProbe.enabled Enable livenessProbe on Distributor nodes
   ## @param distributor.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param distributor.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param distributor.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -485,7 +536,7 @@ distributor:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
-  ## @param distributor.readinessProbe.enabled Enable readinessProbe on distributor nodes
+  ## @param distributor.readinessProbe.enabled Enable readinessProbe on Distributor nodes
   ## @param distributor.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param distributor.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param distributor.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -499,12 +550,29 @@ distributor:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+  ## @param distributor.startupProbe.enabled Enable startupProbe on Distributor containers
+  ## @param distributor.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param distributor.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param distributor.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param distributor.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param distributor.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
   ## @param distributor.customLivenessProbe Custom livenessProbe that overrides the default one
   ##
   customLivenessProbe: {}
   ## @param distributor.customReadinessProbe Custom readinessProbe that overrides the default one
   ##
   customReadinessProbe: {}
+  ## @param distributor.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
   ## distributor resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param distributor.resources.limits The resources limits for the distributor containers
@@ -515,27 +583,25 @@ distributor:
     requests: {}
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param distributor.podSecurityContext.enabled Enabled distributor pods' Security Context
-  ## @param distributor.podSecurityContext.fsGroup Set distributor pod's Security Context fsGroup
+  ## @param distributor.podSecurityContext.enabled Enabled Distributor pods' Security Context
+  ## @param distributor.podSecurityContext.fsGroup Set Distributor pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param distributor.containerSecurityContext.enabled Enabled distributor containers' Security Context
-  ## @param distributor.containerSecurityContext.runAsUser Set distributor containers' Security Context runAsUser
+  ## @param distributor.containerSecurityContext.enabled Enabled Distributor containers' Security Context
+  ## @param distributor.containerSecurityContext.runAsUser Set Distributor containers' Security Context runAsUser
+  ## @param distributor.containerSecurityContext.runAsNonRoot Set Distributor containers' Security Context runAsNonRoot
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
-
-  ## @param distributor.command Override default container command (useful when using custom images)
+    runAsNonRoot: true
+  ## @param distributor.lifecycleHooks for the distributor container(s) to automate configuration before or after startup
   ##
-  command: []
-  ## @param distributor.args Override default container args (useful when using custom images)
-  ##
-  args: []
+  lifecycleHooks: {}
   ## @param distributor.hostAliases distributor pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -573,53 +639,44 @@ distributor:
     ##   - e2e-az2
     ##
     values: []
-  ## @param distributor.affinity Affinity for distributor pods assignment
+  ## @param distributor.affinity Affinity for Distributor pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## NOTE: `distributor.podAffinityPreset`, `distributor.podAntiAffinityPreset`, and `distributor.nodeAffinityPreset` will be ignored when it's set
   ##
   affinity: {}
-  ## @param distributor.nodeSelector Node labels for distributor pods assignment
+  ## @param distributor.nodeSelector Node labels for Distributor pods assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
-  ## @param distributor.tolerations Tolerations for distributor pods assignment
+  ## @param distributor.tolerations Tolerations for Distributor pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param distributor.updateStrategy.type distributor statefulset strategy type
+  ## @param distributor.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: {}
+  ## @param distributor.priorityClassName Distributor pods' priorityClassName
+  ##
+  priorityClassName: ""
+  ## @param distributor.schedulerName Kubernetes pod scheduler registry
+  ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param distributor.updateStrategy.type Distributor statefulset strategy type
+  ## @param distributor.updateStrategy.rollingUpdate Distributor statefulset rolling update configuration parameters
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy:
-    ## StrategyType
-    ## Can be set to RollingUpdate or OnDelete
-    ##
     type: RollingUpdate
-  ## @param distributor.priorityClassName distributor pods' priorityClassName
-  ##
-  priorityClassName: ""
-  ## @param distributor.lifecycleHooks for the distributor container(s) to automate configuration before or after startup
-  ##
-  lifecycleHooks: {}
-  ## @param distributor.extraEnvVars Array with extra environment variables to add to distributor nodes
-  ## e.g:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
-  ##
-  extraEnvVars: []
-  ## @param distributor.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for distributor nodes
-  ##
-  extraEnvVarsCM: ""
-  ## @param distributor.extraEnvVarsSecret Name of existing Secret containing extra env vars for distributor nodes
-  ##
-  extraEnvVarsSecret: ""
-  ## @param distributor.extraVolumes Optionally specify extra list of additional volumes for the distributor pod(s)
+    rollingUpdate: {}
+  ## @param distributor.extraVolumes Optionally specify extra list of additional volumes for the Distributor pod(s)
   ##
   extraVolumes: []
-  ## @param distributor.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the distributor container(s)
+  ## @param distributor.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Distributor container(s)
   ##
   extraVolumeMounts: []
-  ## @param distributor.sidecars Add additional sidecar containers to the distributor pod(s)
+  ## @param distributor.sidecars Add additional sidecar containers to the Distributor pod(s)
   ## e.g:
   ## sidecars:
   ##   - name: your-image-name
@@ -630,7 +687,7 @@ distributor:
   ##         containerPort: 1234
   ##
   sidecars: []
-  ## @param distributor.initContainers Add additional init containers to the distributor pod(s)
+  ## @param distributor.initContainers Add additional init containers to the Distributor pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
   ## e.g:
   ## initContainers:
@@ -640,62 +697,89 @@ distributor:
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
   initContainers: []
+
   ## @section Distributor Traffic Exposure Parameters
-  ##
 
   ## distributor service parameters
   ##
   service:
-    ## @param distributor.service.type distributor service type
+    ## @param distributor.service.type Distributor service type
     ##
     type: ClusterIP
-    ## @param distributor.service.port distributor service HTTP port
+    ## @param distributor.service.ports.http Distributor HTTP service port
+    ## @param distributor.service.ports.grpc Distributor GRPC service port
     ##
-    port: 3100
-    ## @param distributor.service.grpcPort distributor service HTTP port
-    ##
-    grpcPort: 9095
+    ports:
+      http: 3100
+      grpc: 9095
     ## Node ports to expose
+    ## NOTE: choose port between <30000-32767>
     ## @param distributor.service.nodePorts.http Node port for HTTP
     ## @param distributor.service.nodePorts.grpc Node port for GRPC
-    ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
       http: ""
       grpc: ""
-    ## @param distributor.service.clusterIP distributor service Cluster IP
+    ## @param distributor.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
+    ## @param distributor.service.clusterIP Distributor service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
     clusterIP: ""
-    ## @param distributor.service.loadBalancerIP distributor service Load Balancer IP
+    ## @param distributor.service.loadBalancerIP Distributor service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
     loadBalancerIP: ""
-    ## @param distributor.service.loadBalancerSourceRanges distributor service Load Balancer sources
+    ## @param distributor.service.loadBalancerSourceRanges Distributor service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
     ##   - 10.10.10.0/24
     ##
     loadBalancerSourceRanges: []
-    ## @param distributor.service.externalTrafficPolicy distributor service external traffic policy
+    ## @param distributor.service.externalTrafficPolicy Distributor service external traffic policy
     ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
     externalTrafficPolicy: Cluster
-    ## @param distributor.service.annotations Additional custom annotations for distributor service
+    ## @param distributor.service.annotations Additional custom annotations for Distributor service
     ##
     annotations: {}
+    ## @param distributor.service.extraPorts Extra ports to expose in the Distributor service
+    ##
+    extraPorts: []
 
 ## @section Ingester Deployment Parameters
 ##
 ingester:
-  ## @param ingester.replicaCount Number of ingester replicas to deploy
+  ## @param ingester.extraEnvVars Array with extra environment variables to add to ingester nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param ingester.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for ingester nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param ingester.extraEnvVarsSecret Name of existing Secret containing extra env vars for ingester nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param ingester.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param ingester.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param ingester.replicaCount Number of Ingester replicas to deploy
   ##
   replicaCount: 1
-  ## Configure extra options for ingester containers' liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param ingester.livenessProbe.enabled Enable livenessProbe on ingester nodes
+  ## Configure extra options for Ingester containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param ingester.livenessProbe.enabled Enable livenessProbe on Ingester nodes
   ## @param ingester.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param ingester.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param ingester.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -709,7 +793,7 @@ ingester:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
-  ## @param ingester.readinessProbe.enabled Enable readinessProbe on ingester nodes
+  ## @param ingester.readinessProbe.enabled Enable readinessProbe on Ingester nodes
   ## @param ingester.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param ingester.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param ingester.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -723,43 +807,58 @@ ingester:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+  ## @param ingester.startupProbe.enabled Enable startupProbe on Ingester containers
+  ## @param ingester.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param ingester.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param ingester.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param ingester.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param ingester.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
   ## @param ingester.customLivenessProbe Custom livenessProbe that overrides the default one
   ##
   customLivenessProbe: {}
   ## @param ingester.customReadinessProbe Custom readinessProbe that overrides the default one
   ##
   customReadinessProbe: {}
+  ## @param ingester.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## @param ingester.lifecycleHooks for the ingester container(s) to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
   ## ingester resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## @param ingester.resources.limits The resources limits for the ingester containers
-  ## @param ingester.resources.requests The requested resources for the ingester containers
+  ## @param ingester.resources.limits The resources limits for the Ingester containers
+  ## @param ingester.resources.requests The requested resources for the Ingester containers
   ##
   resources:
     limits: {}
     requests: {}
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param ingester.podSecurityContext.enabled Enabled ingester pods' Security Context
-  ## @param ingester.podSecurityContext.fsGroup Set ingester pod's Security Context fsGroup
+  ## @param ingester.podSecurityContext.enabled Enabled Ingester pods' Security Context
+  ## @param ingester.podSecurityContext.fsGroup Set Ingester pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param ingester.containerSecurityContext.enabled Enabled ingester containers' Security Context
-  ## @param ingester.containerSecurityContext.runAsUser Set ingester containers' Security Context runAsUser
+  ## @param ingester.containerSecurityContext.enabled Enabled Ingester containers' Security Context
+  ## @param ingester.containerSecurityContext.runAsUser Set Ingester containers' Security Context runAsUser
+  ## @param ingester.containerSecurityContext.runAsNonRoot Set Ingester containers' Security Context runAsNonRoot
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
-
-  ## @param ingester.command Override default container command (useful when using custom images)
-  ##
-  command: []
-  ## @param ingester.args Override default container args (useful when using custom images)
-  ##
-  args: []
+    runAsNonRoot: true
   ## @param ingester.hostAliases ingester pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -802,48 +901,39 @@ ingester:
   ## NOTE: `ingester.podAffinityPreset`, `ingester.podAntiAffinityPreset`, and `ingester.nodeAffinityPreset` will be ignored when it's set
   ##
   affinity: {}
-  ## @param ingester.nodeSelector Node labels for ingester pods assignment
+  ## @param ingester.nodeSelector Node labels for Ingester pods assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
-  ## @param ingester.tolerations Tolerations for ingester pods assignment
+  ## @param ingester.tolerations Tolerations for Ingester pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param ingester.updateStrategy.type ingester statefulset strategy type
+  ## @param ingester.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: {}
+  ## @param ingester.priorityClassName Ingester pods' priorityClassName
+  ##
+  priorityClassName: ""
+  ## @param ingester.schedulerName Kubernetes pod scheduler registry
+  ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param ingester.updateStrategy.type Ingester statefulset strategy type
+  ## @param ingester.updateStrategy.rollingUpdate Ingester statefulset rolling update configuration parameters
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy:
-    ## StrategyType
-    ## Can be set to RollingUpdate or OnDelete
-    ##
     type: RollingUpdate
-  ## @param ingester.priorityClassName ingester pods' priorityClassName
-  ##
-  priorityClassName: ""
-  ## @param ingester.lifecycleHooks for the ingester container(s) to automate configuration before or after startup
-  ##
-  lifecycleHooks: {}
-  ## @param ingester.extraEnvVars Array with extra environment variables to add to ingester nodes
-  ## e.g:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
-  ##
-  extraEnvVars: []
-  ## @param ingester.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for ingester nodes
-  ##
-  extraEnvVarsCM: ""
-  ## @param ingester.extraEnvVarsSecret Name of existing Secret containing extra env vars for ingester nodes
-  ##
-  extraEnvVarsSecret: ""
-  ## @param ingester.extraVolumes Optionally specify extra list of additional volumes for the ingester pod(s)
+    rollingUpdate: {}
+  ## @param ingester.extraVolumes Optionally specify extra list of additional volumes for the Ingester pod(s)
   ##
   extraVolumes: []
   ## @param ingester.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the ingester container(s)
   ##
   extraVolumeMounts: []
-  ## @param ingester.sidecars Add additional sidecar containers to the ingester pod(s)
+  ## @param ingester.sidecars Add additional sidecar containers to the Ingester pod(s)
   ## e.g:
   ## sidecars:
   ##   - name: your-image-name
@@ -854,7 +944,7 @@ ingester:
   ##         containerPort: 1234
   ##
   sidecars: []
-  ## @param ingester.initContainers Add additional init containers to the ingester pod(s)
+  ## @param ingester.initContainers Add additional init containers to the Ingester pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
   ## e.g:
   ## initContainers:
@@ -866,59 +956,46 @@ ingester:
   initContainers: []
 
   ## @section Ingester Persistence Parameters
-  ##
 
   ## Enable persistence using Persistent Volume Claims
   ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
   ##
   persistence:
-    ## @param ingester.persistence.enabled Enable persistence in ingester instances
+    ## @param ingester.persistence.enabled Enable persistence in Ingester instances
     ##
     enabled: true
-    ## PV Storage Class
+    ## @param ingester.persistence.existingClaim Name of an existing PVC to use
+    ##
+    existingClaim: ""
+    ## @param ingester.persistence.storageClass PVC Storage Class for Memcached data volume
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
     ## If undefined (the default) or set to null, no storageClassName spec is
-    ## set, choosing the default provisioner.
-    ## @param ingester.persistence.storageClass Persistent Volumes storage class
+    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
     ##
     storageClass: ""
-    ## The subdirectory of the volume to mount to, useful in dev environments
-    ## and one PV for multiple services.
     ## @param ingester.persistence.subPath The subdirectory of the volume to mount to
     ##
     subPath: ""
-    ## PV Access Mode
-    ## @param ingester.persistence.accessModes [array] Persistent Volumes access modes
+    ## @param ingester.persistence.accessModes PVC Access modes
     ##
     accessModes:
       - ReadWriteOnce
-    ## PVC size
-    ## @param ingester.persistence.size Persistent Volumes size
+    ## @param ingester.persistence.size PVC Storage Request for Memcached data volume
     ##
     size: 8Gi
-    ## PVC annotations
-    ## @param ingester.persistence.annotations Persistent Volumes annotations
+    ## @param ingester.persistence.annotations Additional PVC annotations
     ##
     annotations: {}
-    ## Fine tuning for volumeClaimTemplates
+    ## @param ingester.persistence.selector Selector to match an existing Persistent Volume for Ingester's data PVC
+    ## If set, the PVC can't have a PV dynamically provisioned for it
+    ## E.g.
+    ## selector:
+    ##   matchLabels:
+    ##     app: my-app
     ##
-    volumeClaimTemplates:
-      ## A label query over volumes to consider for binding (e.g. when using local volumes)
-      ## See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#labelselector-v1-meta for more details
-      ## @param ingester.persistence.volumeClaimTemplates.selector Persistent Volumes selector
-      ##
-      selector: {}
-      ## Override the requests attribute
-      ## Sometime cloud providers use additional requests attributes to provision custom storage instance
-      ## See https://cloud.ibm.com/docs/containers?topic=containers-file_storage#file_dynamic_statefulset
-      ## @param ingester.persistence.volumeClaimTemplates.requests Persistent Volumes requests
-      ##
-      requests: {}
-      ## Set volumeClaimTemplate dataSource
-      ## @param ingester.persistence.volumeClaimTemplates.dataSource Persistent Volumes data source
-      ##
-      dataSource: {}
+    selector: {}
 
   ## @section Ingester Traffic Exposure Parameters
   ##
@@ -926,56 +1003,83 @@ ingester:
   ## ingester service parameters
   ##
   service:
-    ## @param ingester.service.type ingester service type
+    ## @param ingester.service.type Ingester service type
     ##
     type: ClusterIP
-    ## @param ingester.service.port ingester service HTTP port
+    ## @param ingester.service.ports.http Ingester HTTP service port
+    ## @param ingester.service.ports.grpc Ingester GRPC service port
     ##
-    port: 3100
-    ## @param ingester.service.grpcPort ingester service HTTP port
-    ##
-    grpcPort: 9095
+    ports:
+      http: 3100
+      grpc: 9095
     ## Node ports to expose
+    ## NOTE: choose port between <30000-32767>
     ## @param ingester.service.nodePorts.http Node port for HTTP
     ## @param ingester.service.nodePorts.grpc Node port for GRPC
-    ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
       http: ""
       grpc: ""
-    ## @param ingester.service.clusterIP ingester service Cluster IP
+    ## @param ingester.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
+    ## @param ingester.service.clusterIP Ingester service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
     clusterIP: ""
-    ## @param ingester.service.loadBalancerIP ingester service Load Balancer IP
+    ## @param ingester.service.loadBalancerIP Ingester service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
     loadBalancerIP: ""
-    ## @param ingester.service.loadBalancerSourceRanges ingester service Load Balancer sources
+    ## @param ingester.service.loadBalancerSourceRanges Ingester service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
     ##   - 10.10.10.0/24
     ##
     loadBalancerSourceRanges: []
-    ## @param ingester.service.externalTrafficPolicy ingester service external traffic policy
+    ## @param ingester.service.externalTrafficPolicy Ingester service external traffic policy
     ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
     externalTrafficPolicy: Cluster
-    ## @param ingester.service.annotations Additional custom annotations for ingester service
+    ## @param ingester.service.annotations Additional custom annotations for Ingester service
     ##
     annotations: {}
+    ## @param ingester.service.extraPorts Extra ports to expose in the Ingester service
+    ##
+    extraPorts: []
 
 ## @section Querier Deployment Parameters
 ##
 querier:
-  ## @param querier.replicaCount Number of querier replicas to deploy
+  ## @param querier.replicaCount Number of Querier replicas to deploy
   ##
   replicaCount: 1
-  ## Configure extra options for querier containers' liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param querier.livenessProbe.enabled Enable livenessProbe on querier nodes
+  ## @param querier.extraEnvVars Array with extra environment variables to add to Querier nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param querier.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for Querier nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param querier.extraEnvVarsSecret Name of existing Secret containing extra env vars for Querier nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param querier.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param querier.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## Configure extra options for Querier containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param querier.livenessProbe.enabled Enable livenessProbe on Querier nodes
   ## @param querier.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param querier.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param querier.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -989,7 +1093,7 @@ querier:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
-  ## @param querier.readinessProbe.enabled Enable readinessProbe on querier nodes
+  ## @param querier.readinessProbe.enabled Enable readinessProbe on Querier nodes
   ## @param querier.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param querier.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param querier.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -1003,43 +1107,58 @@ querier:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+  ## @param querier.startupProbe.enabled Enable startupProbe on Querier containers
+  ## @param querier.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param querier.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param querier.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param querier.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param querier.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
   ## @param querier.customLivenessProbe Custom livenessProbe that overrides the default one
   ##
   customLivenessProbe: {}
   ## @param querier.customReadinessProbe Custom readinessProbe that overrides the default one
   ##
   customReadinessProbe: {}
+  ## @param querier.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
   ## querier resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## @param querier.resources.limits The resources limits for the querier containers
-  ## @param querier.resources.requests The requested resources for the querier containers
+  ## @param querier.resources.limits The resources limits for the Querier containers
+  ## @param querier.resources.requests The requested resources for the Querier containers
   ##
   resources:
     limits: {}
     requests: {}
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param querier.podSecurityContext.enabled Enabled querier pods' Security Context
-  ## @param querier.podSecurityContext.fsGroup Set querier pod's Security Context fsGroup
+  ## @param querier.podSecurityContext.enabled Enabled Querier pods' Security Context
+  ## @param querier.podSecurityContext.fsGroup Set Querier pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param querier.containerSecurityContext.enabled Enabled querier containers' Security Context
-  ## @param querier.containerSecurityContext.runAsUser Set querier containers' Security Context runAsUser
+  ## @param querier.containerSecurityContext.enabled Enabled Querier containers' Security Context
+  ## @param querier.containerSecurityContext.runAsUser Set Querier containers' Security Context runAsUser
+  ## @param querier.containerSecurityContext.runAsNonRoot Set Querier containers' Security Context runAsNonRoot
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
-
-  ## @param querier.command Override default container command (useful when using custom images)
+    runAsNonRoot: true
+  ## @param querier.lifecycleHooks for the Querier container(s) to automate configuration before or after startup
   ##
-  command: []
-  ## @param querier.args Override default container args (useful when using custom images)
-  ##
-  args: []
+  lifecycleHooks: {}
   ## @param querier.hostAliases querier pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1077,53 +1196,44 @@ querier:
     ##   - e2e-az2
     ##
     values: []
-  ## @param querier.affinity Affinity for querier pods assignment
+  ## @param querier.affinity Affinity for Querier pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## NOTE: `querier.podAffinityPreset`, `querier.podAntiAffinityPreset`, and `querier.nodeAffinityPreset` will be ignored when it's set
   ##
   affinity: {}
-  ## @param querier.nodeSelector Node labels for querier pods assignment
+  ## @param querier.nodeSelector Node labels for Querier pods assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
-  ## @param querier.tolerations Tolerations for querier pods assignment
+  ## @param querier.tolerations Tolerations for Querier pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param querier.updateStrategy.type querier statefulset strategy type
+  ## @param querier.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: {}
+  ## @param querier.priorityClassName Querier pods' priorityClassName
+  ##
+  priorityClassName: ""
+  ## @param querier.schedulerName Kubernetes pod scheduler registry
+  ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param querier.updateStrategy.type Querier statefulset strategy type
+  ## @param querier.updateStrategy.rollingUpdate Querier statefulset rolling update configuration parameters
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy:
-    ## StrategyType
-    ## Can be set to RollingUpdate or OnDelete
-    ##
     type: RollingUpdate
-  ## @param querier.priorityClassName querier pods' priorityClassName
-  ##
-  priorityClassName: ""
-  ## @param querier.lifecycleHooks for the querier container(s) to automate configuration before or after startup
-  ##
-  lifecycleHooks: {}
-  ## @param querier.extraEnvVars Array with extra environment variables to add to querier nodes
-  ## e.g:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
-  ##
-  extraEnvVars: []
-  ## @param querier.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for querier nodes
-  ##
-  extraEnvVarsCM: ""
-  ## @param querier.extraEnvVarsSecret Name of existing Secret containing extra env vars for querier nodes
-  ##
-  extraEnvVarsSecret: ""
-  ## @param querier.extraVolumes Optionally specify extra list of additional volumes for the querier pod(s)
+    rollingUpdate: {}
+  ## @param querier.extraVolumes Optionally specify extra list of additional volumes for the Querier pod(s)
   ##
   extraVolumes: []
   ## @param querier.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the querier container(s)
   ##
   extraVolumeMounts: []
-  ## @param querier.sidecars Add additional sidecar containers to the querier pod(s)
+  ## @param querier.sidecars Add additional sidecar containers to the Querier pod(s)
   ## e.g:
   ## sidecars:
   ##   - name: your-image-name
@@ -1134,7 +1244,7 @@ querier:
   ##         containerPort: 1234
   ##
   sidecars: []
-  ## @param querier.initContainers Add additional init containers to the querier pod(s)
+  ## @param querier.initContainers Add additional init containers to the Querier pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
   ## e.g:
   ## initContainers:
@@ -1144,61 +1254,88 @@ querier:
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
   initContainers: []
+
   ## @section Querier Traffic Exposure Parameters
-  ##
 
   ## querier service parameters
   ##
   service:
-    ## @param querier.service.type querier service type
+    ## @param querier.service.type Querier service type
     ##
     type: ClusterIP
-    ## @param querier.service.port querier service HTTP port
+    ## @param querier.service.ports.http Querier HTTP service port
+    ## @param querier.service.ports.grpc Querier GRPC service port
     ##
-    port: 3100
-    ## @param querier.service.grpcPort querier service HTTP port
-    ##
-    grpcPort: 9095
+    ports:
+      http: 3100
+      grpc: 9095
     ## Node ports to expose
+    ## NOTE: choose port between <30000-32767>
     ## @param querier.service.nodePorts.http Node port for HTTP
     ## @param querier.service.nodePorts.grpc Node port for GRPC
-    ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
       http: ""
       grpc: ""
-    ## @param querier.service.clusterIP querier service Cluster IP
+    ## @param querier.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
+    ## @param querier.service.clusterIP Querier service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
     clusterIP: ""
-    ## @param querier.service.loadBalancerIP querier service Load Balancer IP
+    ## @param querier.service.loadBalancerIP Querier service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
     loadBalancerIP: ""
-    ## @param querier.service.loadBalancerSourceRanges querier service Load Balancer sources
+    ## @param querier.service.loadBalancerSourceRanges Querier service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
     ##   - 10.10.10.0/24
     ##
     loadBalancerSourceRanges: []
-    ## @param querier.service.externalTrafficPolicy querier service external traffic policy
+    ## @param querier.service.externalTrafficPolicy Querier service external traffic policy
     ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
     externalTrafficPolicy: Cluster
-    ## @param querier.service.annotations Additional custom annotations for querier service
+    ## @param querier.service.annotations Additional custom annotations for Querier service
     ##
     annotations: {}
+    ## @param querier.service.extraPorts Extra ports to expose in the Querier service
+    ##
+    extraPorts: []
 
 ## @section Query Frontend Deployment Parameters
 ##
 queryFrontend:
+  ## @param queryFrontend.extraEnvVars Array with extra environment variables to add to queryFrontend nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param queryFrontend.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for queryFrontend nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param queryFrontend.extraEnvVarsSecret Name of existing Secret containing extra env vars for queryFrontend nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param queryFrontend.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param queryFrontend.args Override default container args (useful when using custom images)
+  ##
+  args: []
   ## @param queryFrontend.replicaCount Number of queryFrontend replicas to deploy
   ##
   replicaCount: 1
-  ## Configure extra options for queryFrontend containers' liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## Configure extra options for queryFrontend containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
   ## @param queryFrontend.livenessProbe.enabled Enable livenessProbe on queryFrontend nodes
   ## @param queryFrontend.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param queryFrontend.livenessProbe.periodSeconds Period seconds for livenessProbe
@@ -1227,12 +1364,29 @@ queryFrontend:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+  ## @param queryFrontend.startupProbe.enabled Enable startupProbe on queryFrontend containers
+  ## @param queryFrontend.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param queryFrontend.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param queryFrontend.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param queryFrontend.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param queryFrontend.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
   ## @param queryFrontend.customLivenessProbe Custom livenessProbe that overrides the default one
   ##
   customLivenessProbe: {}
   ## @param queryFrontend.customReadinessProbe Custom readinessProbe that overrides the default one
   ##
   customReadinessProbe: {}
+  ## @param queryFrontend.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
   ## queryFrontend resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## @param queryFrontend.resources.limits The resources limits for the queryFrontend containers
@@ -1253,17 +1407,15 @@ queryFrontend:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param queryFrontend.containerSecurityContext.enabled Enabled queryFrontend containers' Security Context
   ## @param queryFrontend.containerSecurityContext.runAsUser Set queryFrontend containers' Security Context runAsUser
+  ## @param queryFrontend.containerSecurityContext.runAsNonRoot Set queryFrontend containers' Security Context runAsNonRoot
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
-
-  ## @param queryFrontend.command Override default container command (useful when using custom images)
+    runAsNonRoot: true
+  ## @param queryFrontend.lifecycleHooks for the queryFrontend container(s) to automate configuration before or after startup
   ##
-  command: []
-  ## @param queryFrontend.args Override default container args (useful when using custom images)
-  ##
-  args: []
+  lifecycleHooks: {}
   ## @param queryFrontend.hostAliases queryFrontend pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1314,33 +1466,24 @@ queryFrontend:
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param queryFrontend.updateStrategy.type queryFrontend statefulset strategy type
-  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ## @param queryFrontend.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
-  updateStrategy:
-    ## StrategyType
-    ## Can be set to RollingUpdate or OnDelete
-    ##
-    type: RollingUpdate
+  topologySpreadConstraints: {}
   ## @param queryFrontend.priorityClassName queryFrontend pods' priorityClassName
   ##
   priorityClassName: ""
-  ## @param queryFrontend.lifecycleHooks for the queryFrontend container(s) to automate configuration before or after startup
+  ## @param queryFrontend.schedulerName Kubernetes pod scheduler registry
+  ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
-  lifecycleHooks: {}
-  ## @param queryFrontend.extraEnvVars Array with extra environment variables to add to queryFrontend nodes
-  ## e.g:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
+  schedulerName: ""
+  ## @param queryFrontend.updateStrategy.type queryFrontend statefulset strategy type
+  ## @param queryFrontend.updateStrategy.rollingUpdate queryFrontend statefulset rolling update configuration parameters
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
-  extraEnvVars: []
-  ## @param queryFrontend.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for queryFrontend nodes
-  ##
-  extraEnvVarsCM: ""
-  ## @param queryFrontend.extraEnvVarsSecret Name of existing Secret containing extra env vars for queryFrontend nodes
-  ##
-  extraEnvVarsSecret: ""
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate: {}
   ## @param queryFrontend.extraVolumes Optionally specify extra list of additional volumes for the queryFrontend pod(s)
   ##
   extraVolumes: []
@@ -1373,7 +1516,7 @@ queryFrontend:
   ##
   query:
     ## Bitnami Grafana Tempo Query image
-    ## ref: https://hub.docker.com/r/bitnami/redis/tags/
+    ## ref: https://hub.docker.com/r/bitnami/grafana-tempo-query/tags/
     ## @param queryFrontend.query.image.registry Grafana Tempo Query image registry
     ## @param queryFrontend.query.image.repository Grafana Tempo Query image repository
     ## @param queryFrontend.query.image.tag Grafana Tempo Query image tag (immutable tags are recommended)
@@ -1397,77 +1540,25 @@ queryFrontend:
       ##   - myRegistryKeySecretName
       ##
       pullSecrets: []
-
-    ## @param queryFrontend.query.command Override default container command (useful when using custom images)
-    ##
-    command: []
-    ## @param queryFrontend.query.args Override default container args (useful when using custom images)
-    ##
-    args: []
     ## @param queryFrontend.query.configuration [string] Query sidecar configuration
     ##
     configuration: |
       backend: 127.0.0.1:{{ .Values.tempo.containerPort }}
-
+    ## @param queryFrontend.query.containerPorts.jaegerMetrics queryFrontend query sidecar Jaeger metrics container port
+    ## @param queryFrontend.query.containerPorts.jaegerUI queryFrontend query sidecar Jaeger UI container port
+    ##
+    containerPorts:
+      jaegerMetrics: 16687
+      jaegerUI: 16686
     ## @param queryFrontend.query.jaegerMetricsContainerPort Jaeger metrics container port
     ##
     jaegerMetricsContainerPort: 16687
     ## @param queryFrontend.query.jaegerUIContainerPort Jaeger UI container port
     ##
     jaegerUIContainerPort: 16686
-
     ## @param queryFrontend.query.existingConfigmap Name of a configmap with the query configuration
     ##
     existingConfigmap: ""
-    ## Configure extra options for query sidecar containers' liveness and readiness probes
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-    ## @param queryFrontend.query.livenessProbe.enabled Enable livenessProbe on query sidecar nodes
-    ## @param queryFrontend.query.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
-    ## @param queryFrontend.query.livenessProbe.periodSeconds Period seconds for livenessProbe
-    ## @param queryFrontend.query.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
-    ## @param queryFrontend.query.livenessProbe.failureThreshold Failure threshold for livenessProbe
-    ## @param queryFrontend.query.livenessProbe.successThreshold Success threshold for livenessProbe
-    ##
-    livenessProbe:
-      enabled: true
-      failureThreshold: 3
-      initialDelaySeconds: 10
-      periodSeconds: 10
-      successThreshold: 1
-      timeoutSeconds: 1
-    ## @param queryFrontend.query.readinessProbe.enabled Enable readinessProbe on query sidecar nodes
-    ## @param queryFrontend.query.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
-    ## @param queryFrontend.query.readinessProbe.periodSeconds Period seconds for readinessProbe
-    ## @param queryFrontend.query.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
-    ## @param queryFrontend.query.readinessProbe.failureThreshold Failure threshold for readinessProbe
-    ## @param queryFrontend.query.readinessProbe.successThreshold Success threshold for readinessProbe
-    ##
-    readinessProbe:
-      enabled: true
-      failureThreshold: 3
-      initialDelaySeconds: 10
-      periodSeconds: 10
-      successThreshold: 1
-      timeoutSeconds: 1
-
-    ## query sidecar resource requests and limits
-    ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-    ## @param queryFrontend.query.resources.limits The resources limits for the query sidecar containers
-    ## @param queryFrontend.query.resources.requests The requested resources for the query sidecar containers
-    ##
-    resources:
-      limits: {}
-      requests: {}
-
-    ## @param queryFrontend.query.lifecycleHooks for the query sidecar container(s) to automate configuration before or after startup
-    ##
-    lifecycleHooks: {}
-    ## @param queryFrontend.query.customLivenessProbe Custom livenessProbe that overrides the default one
-    ##
-    customLivenessProbe: {}
-    ## @param queryFrontend.query.customReadinessProbe Custom readinessProbe that overrides the default one
-    ##
-    customReadinessProbe: {}
     ## @param queryFrontend.query.extraEnvVars Array with extra environment variables to add to queryFrontend nodes
     ## e.g:
     ## extraEnvVars:
@@ -1481,17 +1572,90 @@ queryFrontend:
     ## @param queryFrontend.query.extraEnvVarsSecret Name of existing Secret containing extra env vars for queryFrontend nodes
     ##
     extraEnvVarsSecret: ""
-    ## @param queryFrontend.query.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the queryFrontend container(s)
+    ## @param queryFrontend.query.command Override default container command (useful when using custom images)
     ##
-    extraVolumeMounts: []
+    command: []
+    ## @param queryFrontend.query.args Override default container args (useful when using custom images)
+    ##
+    args: []
+    ## Configure extra options for Query sidecar containers' liveness, readiness and startup probes
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+    ## @param queryFrontend.query.livenessProbe.enabled Enable livenessProbe on Query sidecar nodes
+    ## @param queryFrontend.query.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+    ## @param queryFrontend.query.livenessProbe.periodSeconds Period seconds for livenessProbe
+    ## @param queryFrontend.query.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+    ## @param queryFrontend.query.livenessProbe.failureThreshold Failure threshold for livenessProbe
+    ## @param queryFrontend.query.livenessProbe.successThreshold Success threshold for livenessProbe
+    ##
+    livenessProbe:
+      enabled: true
+      failureThreshold: 3
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+    ## @param queryFrontend.query.readinessProbe.enabled Enable readinessProbe on Query sidecar nodes
+    ## @param queryFrontend.query.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+    ## @param queryFrontend.query.readinessProbe.periodSeconds Period seconds for readinessProbe
+    ## @param queryFrontend.query.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+    ## @param queryFrontend.query.readinessProbe.failureThreshold Failure threshold for readinessProbe
+    ## @param queryFrontend.query.readinessProbe.successThreshold Success threshold for readinessProbe
+    ##
+    readinessProbe:
+      enabled: true
+      failureThreshold: 3
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 1
+    ## @param queryFrontend.query.startupProbe.enabled Enable startupProbe on Query sidecar containers
+    ## @param queryFrontend.query.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+    ## @param queryFrontend.query.startupProbe.periodSeconds Period seconds for startupProbe
+    ## @param queryFrontend.query.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+    ## @param queryFrontend.query.startupProbe.failureThreshold Failure threshold for startupProbe
+    ## @param queryFrontend.query.startupProbe.successThreshold Success threshold for startupProbe
+    ##
+    startupProbe:
+      enabled: false
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+    ## @param queryFrontend.query.customLivenessProbe Custom livenessProbe that overrides the default one
+    ##
+    customLivenessProbe: {}
+    ## @param queryFrontend.query.customReadinessProbe Custom readinessProbe that overrides the default one
+    ##
+    customReadinessProbe: {}
+    ## @param queryFrontend.query.customStartupProbe Custom startupProbe that overrides the default one
+    ##
+    customStartupProbe: {}
+    ## @param queryFrontend.query.lifecycleHooks for the query sidecar container(s) to automate configuration before or after startup
+    ##
+    lifecycleHooks: {}
     ## Configure Container Security Context
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-    ## @param queryFrontend.query.containerSecurityContext.enabled Enabled query-frontend query sidecar containers' Security Context
-    ## @param queryFrontend.query.containerSecurityContext.runAsUser Set query-frontend query sidecar containers' Security Context runAsUser
+    ## @param queryFrontend.query.containerSecurityContext.enabled Enabled queryFrontend query sidecar containers' Security Context
+    ## @param queryFrontend.query.containerSecurityContext.runAsUser Set queryFrontend query sidecar containers' Security Context runAsUser
+    ## @param queryFrontend.query.containerSecurityContext.runAsNonRoot Set queryFrontend query sidecar containers' Security Context runAsNonRoot
     ##
     containerSecurityContext:
       enabled: true
       runAsUser: 1001
+      runAsNonRoot: true
+    ## Query sidecar resource requests and limits
+    ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    ## @param queryFrontend.query.resources.limits The resources limits for the query sidecar containers
+    ## @param queryFrontend.query.resources.requests The requested resources for the query sidecar containers
+    ##
+    resources:
+      limits: {}
+      requests: {}
+    ## @param queryFrontend.query.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the queryFrontend container(s)
+    ##
+    extraVolumeMounts: []
+
 
   ## @section Query Frontend Traffic Exposure Parameters
   ##
@@ -1502,20 +1666,25 @@ queryFrontend:
     ## @param queryFrontend.service.type queryFrontend service type
     ##
     type: ClusterIP
-    ## @param queryFrontend.service.port queryFrontend service HTTP port
+    ## @param queryFrontend.service.ports.http queryFrontend HTTP service port
+    ## @param queryFrontend.service.ports.grpc queryFrontend GRPC service port
     ##
-    port: 3100
-    ## @param queryFrontend.service.grpcPort queryFrontend service HTTP port
-    ##
-    grpcPort: 9095
+    ports:
+      http: 3100
+      grpc: 9095
     ## Node ports to expose
+    ## NOTE: choose port between <30000-32767>
     ## @param queryFrontend.service.nodePorts.http Node port for HTTP
     ## @param queryFrontend.service.nodePorts.grpc Node port for GRPC
-    ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
       http: ""
       grpc: ""
+    ## @param queryFrontend.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
     ## @param queryFrontend.service.clusterIP queryFrontend service Cluster IP
     ## e.g.:
     ## clusterIP: None
@@ -1539,6 +1708,9 @@ queryFrontend:
     ## @param queryFrontend.service.annotations Additional custom annotations for queryFrontend service
     ##
     annotations: {}
+    ## @param queryFrontend.service.extraPorts Extra ports to expose in the queryFrontend service
+    ##
+    extraPorts: []
 
 ## @section Vulture Deployment Parameters
 ##
@@ -1546,9 +1718,8 @@ vulture:
   ## @param vulture.enabled Enable vulture deployment
   ##
   enabled: true
-
   ## Bitnami Grafana Vulture image
-  ## ref: https://hub.docker.com/r/bitnami/redis/tags/
+  ## ref: https://hub.docker.com/r/bitnami/grafana-tempo-vulture/tags/
   ## @param vulture.image.registry Grafana Vulture image registry
   ## @param vulture.image.repository Grafana Vulture image repository
   ## @param vulture.image.tag Grafana Vulture image tag (immutable tags are recommended)
@@ -1572,13 +1743,31 @@ vulture:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-
-  ## @param vulture.replicaCount Number of vulture replicas to deploy
+  ## @param vulture.extraEnvVars Array with extra environment variables to add to vulture nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param vulture.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for vulture nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param vulture.extraEnvVarsSecret Name of existing Secret containing extra env vars for vulture nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param vulture.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param vulture.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param vulture.replicaCount Number of Vulture replicas to deploy
   ##
   replicaCount: 1
-  ## Configure extra options for vulture containers' liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param vulture.livenessProbe.enabled Enable livenessProbe on vulture nodes
+  ## Configure extra options for Vulture containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param vulture.livenessProbe.enabled Enable livenessProbe on Vulture nodes
   ## @param vulture.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param vulture.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param vulture.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -1592,7 +1781,7 @@ vulture:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
-  ## @param vulture.readinessProbe.enabled Enable readinessProbe on vulture nodes
+  ## @param vulture.readinessProbe.enabled Enable readinessProbe on Vulture nodes
   ## @param vulture.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param vulture.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param vulture.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -1606,43 +1795,58 @@ vulture:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+  ## @param vulture.startupProbe.enabled Enable startupProbe on Vulture containers
+  ## @param vulture.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param vulture.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param vulture.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param vulture.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param vulture.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
   ## @param vulture.customLivenessProbe Custom livenessProbe that overrides the default one
   ##
   customLivenessProbe: {}
   ## @param vulture.customReadinessProbe Custom readinessProbe that overrides the default one
   ##
   customReadinessProbe: {}
+  ## @param vulture.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
   ## vulture resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## @param vulture.resources.limits The resources limits for the vulture containers
-  ## @param vulture.resources.requests The requested resources for the vulture containers
+  ## @param vulture.resources.limits The resources limits for the Vulture containers
+  ## @param vulture.resources.requests The requested resources for the Vulture containers
   ##
   resources:
     limits: {}
     requests: {}
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param vulture.podSecurityContext.enabled Enabled vulture pods' Security Context
-  ## @param vulture.podSecurityContext.fsGroup Set vulture pod's Security Context fsGroup
+  ## @param vulture.podSecurityContext.enabled Enabled Vulture pods' Security Context
+  ## @param vulture.podSecurityContext.fsGroup Set Vulture pod's Security Context fsGroup
   ##
   podSecurityContext:
     enabled: true
     fsGroup: 1001
   ## Configure Container Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
-  ## @param vulture.containerSecurityContext.enabled Enabled vulture containers' Security Context
-  ## @param vulture.containerSecurityContext.runAsUser Set vulture containers' Security Context runAsUser
+  ## @param vulture.containerSecurityContext.enabled Enabled Vulture containers' Security Context
+  ## @param vulture.containerSecurityContext.runAsUser Set Vulture containers' Security Context runAsUser
+  ## @param vulture.containerSecurityContext.runAsNonRoot Set Vulture containers' Security Context runAsNonRoot
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
-
-  ## @param vulture.command Override default container command (useful when using custom images)
+    runAsNonRoot: true
+  ## @param vulture.lifecycleHooks for the vulture container(s) to automate configuration before or after startup
   ##
-  command: []
-  ## @param vulture.args Override default container args (useful when using custom images)
-  ##
-  args: []
+  lifecycleHooks: {}
   ## @param vulture.hostAliases vulture pods host aliases
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
@@ -1680,57 +1884,48 @@ vulture:
     ##   - e2e-az2
     ##
     values: []
-
-  ## @param vulture.containerPort Vulture container port
+  ## @param vulture.containerPorts.http Vulture components HTTP container port
   ##
-  containerPort: 8080
-  ## @param vulture.affinity Affinity for vulture pods assignment
+  containerPorts:
+    http: 8080
+  ## @param vulture.affinity Affinity for Vulture pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## NOTE: `vulture.podAffinityPreset`, `vulture.podAntiAffinityPreset`, and `vulture.nodeAffinityPreset` will be ignored when it's set
   ##
   affinity: {}
-  ## @param vulture.nodeSelector Node labels for vulture pods assignment
+  ## @param vulture.nodeSelector Node labels for Vulture pods assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
-  ## @param vulture.tolerations Tolerations for vulture pods assignment
+  ## @param vulture.tolerations Tolerations for Vulture pods assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param vulture.updateStrategy.type vulture statefulset strategy type
+  ## @param vulture.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: {}
+  ## @param vulture.priorityClassName Vulture pods' priorityClassName
+  ##
+  priorityClassName: ""
+  ## @param vulture.schedulerName Kubernetes pod scheduler registry
+  ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param vulture.updateStrategy.type Vulture statefulset strategy type
+  ## @param vulture.updateStrategy.rollingUpdate Vulture statefulset rolling update configuration parameters
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy:
-    ## StrategyType
-    ## Can be set to RollingUpdate or OnDelete
-    ##
     type: RollingUpdate
-  ## @param vulture.priorityClassName vulture pods' priorityClassName
-  ##
-  priorityClassName: ""
-  ## @param vulture.lifecycleHooks for the vulture container(s) to automate configuration before or after startup
-  ##
-  lifecycleHooks: {}
-  ## @param vulture.extraEnvVars Array with extra environment variables to add to vulture nodes
-  ## e.g:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
-  ##
-  extraEnvVars: []
-  ## @param vulture.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for vulture nodes
-  ##
-  extraEnvVarsCM: ""
-  ## @param vulture.extraEnvVarsSecret Name of existing Secret containing extra env vars for vulture nodes
-  ##
-  extraEnvVarsSecret: ""
-  ## @param vulture.extraVolumes Optionally specify extra list of additional volumes for the vulture pod(s)
+    rollingUpdate: {}
+  ## @param vulture.extraVolumes Optionally specify extra list of additional volumes for the Vulture pod(s)
   ##
   extraVolumes: []
-  ## @param vulture.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the vulture container(s)
+  ## @param vulture.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Vulture container(s)
   ##
   extraVolumeMounts: []
-  ## @param vulture.sidecars Add additional sidecar containers to the vulture pod(s)
+  ## @param vulture.sidecars Add additional sidecar containers to the Vulture pod(s)
   ## e.g:
   ## sidecars:
   ##   - name: your-image-name
@@ -1741,7 +1936,7 @@ vulture:
   ##         containerPort: 1234
   ##
   sidecars: []
-  ## @param vulture.initContainers Add additional init containers to the vulture pod(s)
+  ## @param vulture.initContainers Add additional init containers to the Vulture pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
   ## e.g:
   ## initContainers:
@@ -1751,47 +1946,56 @@ vulture:
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
   initContainers: []
-  ## @section Vulture Traffic Exposure Parameters
-  ##
 
-  ## vulture service parameters
+  ## @section Vulture Traffic Exposure Parameters
+
+  ## Vulture service parameters
   ##
   service:
-    ## @param vulture.service.type vulture service type
+    ## @param vulture.service.type Vulture service type
     ##
     type: ClusterIP
-    ## @param vulture.service.port vulture service HTTP port
+    ## @param vulture.service.ports.http Vulture HTTP service port
     ##
-    port: 3100
+    ports:
+      http: 3100
     ## Node ports to expose
-    ## @param vulture.service.nodePorts.http Node port for HTTP
     ## NOTE: choose port between <30000-32767>
+    ## @param vulture.service.nodePorts.http Node port for HTTP
     ##
     nodePorts:
       http: ""
-    ## @param vulture.service.clusterIP vulture service Cluster IP
+    ## @param vulture.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
+    ## @param vulture.service.clusterIP Vulture service Cluster IP
     ## e.g.:
     ## clusterIP: None
     ##
     clusterIP: ""
-    ## @param vulture.service.loadBalancerIP vulture service Load Balancer IP
+    ## @param vulture.service.loadBalancerIP Vulture service Load Balancer IP
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
     loadBalancerIP: ""
-    ## @param vulture.service.loadBalancerSourceRanges vulture service Load Balancer sources
+    ## @param vulture.service.loadBalancerSourceRanges Vulture service Load Balancer sources
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
     ## e.g:
     ## loadBalancerSourceRanges:
     ##   - 10.10.10.0/24
     ##
     loadBalancerSourceRanges: []
-    ## @param vulture.service.externalTrafficPolicy vulture service external traffic policy
+    ## @param vulture.service.externalTrafficPolicy Vulture service external traffic policy
     ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
     externalTrafficPolicy: Cluster
-    ## @param vulture.service.annotations Additional custom annotations for vulture service
+    ## @param vulture.service.annotations Additional custom annotations for Vulture service
     ##
     annotations: {}
+    ## @param vulture.service.extraPorts Extra ports to expose in the Vulture service
+    ##
+    extraPorts: []
 
 ## @section Init Container Parameters
 ##
@@ -1844,18 +2048,25 @@ volumePermissions:
     runAsUser: 0
 
 ## @section Other Parameters
-##
 
-## ServiceAccount configuration
+## Service account for Tempo to use
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
 serviceAccount:
-  ## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Tempo pods
   ##
-  create: true
-  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  create: false
+  ## @param serviceAccount.name The name of the ServiceAccount to use
   ## If not set and create is true, a name is generated using the common.names.fullname template
   ##
   name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: true
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
 
 ## @section Metrics Parameters
 ## Prometheus Exporter / Metrics
@@ -1864,28 +2075,42 @@ metrics:
   ## @param metrics.enabled Enable metrics
   ##
   enabled: false
-  ## Prometheus Service Monitor
-  ## ref: https://github.com/coreos/prometheus-operator
-  ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md
+  ## Prometheus Operator ServiceMonitor configuration
   ##
   serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor resource(s) for scraping metrics using PrometheusOperator
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using Prometheus Operator
     ##
     enabled: false
-
-    ## @param metrics.serviceMonitor.namespace The namespace in which the ServiceMonitor will be created
+    ## @param metrics.serviceMonitor.namespace Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)
     ##
     namespace: ""
-
-    ## @param metrics.serviceMonitor.interval The interval at which metrics should be scraped
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
-    interval: 30s
-    ## @param metrics.serviceMonitor.scrapeTimeout The timeout after which the scrape is ended
+    interval: ""
+    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     scrapeTimeout: ""
-    ## @param metrics.serviceMonitor.selector Scrape selector
+    ## @param metrics.serviceMonitor.additionalLabels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+    ##
+    additionalLabels: {}
+    ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
+    ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
     ##
     selector: {}
+    ## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+    ##
+    relabelings: []
+    ## @param metrics.serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
+    ##
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
+    ##
+    honorLabels: false
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+    ##
+    jobLabel: ""
 
 ## @section External Memcached Parameters
 ##
@@ -1904,7 +2129,21 @@ memcached:
   ## @param memcached.enabled Deploy memcached sub-chart
   ##
   enabled: true
-  ## @param memcached.service.port Memcached service port
+  ## Authentication parameters
+  ## ref: https://github.com/bitnami/bitnami-docker-memcached#creating-the-memcached-admin-user
+  ##
+  auth:
+    ## @param memcached.auth.enabled Enable Memcached authentication
+    ##
+    enabled: false
+    ## @param memcached.auth.username Memcached admin user
+    ##
+    username: ""
+    ## @param memcached.auth.password Memcached admin password
+    ##
+    password: ""
+  ## @param memcached.service.ports.memcached Memcached service port
   ##
   service:
-    port: 11211
+    ports:
+      memcached: 11211

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -177,7 +177,7 @@ tempo:
         {{- end }}
     querier:
       frontend_worker:
-        frontend_address: {{ include "grafana-tempo.query-frontend.fullname" . }}-headless:{{ .Values.queryFrontend.service.grpcPort }}
+        frontend_address: {{ include "grafana-tempo.query-frontend.fullname" . }}-headless:{{ .Values.queryFrontend.service.ports.grpc }}
     ingester:
       lifecycler:
         ring:

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -71,7 +71,7 @@ tempo:
   image:
     registry: docker.io
     repository: bitnami/grafana-tempo
-    tag: 1.2.1-debian-10-r47
+    tag: 1.2.1-debian-10-r52
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1526,7 +1526,7 @@ queryFrontend:
     image:
       registry: docker.io
       repository: bitnami/grafana-tempo-query
-      tag: 1.2.1-debian-10-r57
+      tag: 1.2.1-debian-10-r61
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1729,7 +1729,7 @@ vulture:
   image:
     registry: docker.io
     repository: bitnami/grafana-tempo-vulture
-    tag: 1.2.1-debian-10-r58
+    tag: 1.2.1-debian-10-r62
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2019,7 +2019,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r309
+    tag: 10-debian-10-r313
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -2092,9 +2092,9 @@ metrics:
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
     ##
     scrapeTimeout: ""
-    ## @param metrics.serviceMonitor.additionalLabels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+    ## @param metrics.serviceMonitor.labels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
     ##
-    additionalLabels: {}
+    labels: {}
     ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
     ##


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR standardizes the `bitnami/grafana-tempo` chart to be in line with the rest of the catalog.

**Benefits**

Standardization.

**Possible drawbacks**

Changes the values structure forcing a major bump, check the README.md for more information.

**Applicable issues**

N/A

**Additional information**

Blocked by https://github.com/bitnami/charts/pull/8668 (major bump in dep)

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])