### PR TITLE
[bitnami/dokuwiki] Add support for customPostInitScripts

### DIFF
--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -24,4 +24,4 @@ name: dokuwiki
 sources:
   - https://github.com/bitnami/bitnami-docker-dokuwiki
   - http://www.dokuwiki.org/
-version: 12.1.1
+version: 12.2.0

--- a/bitnami/dokuwiki/README.md
+++ b/bitnami/dokuwiki/README.md
@@ -69,81 +69,82 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Dokuwiki parameters
 
-| Name                                    | Description                                                                                                           | Value                         |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `image.registry`                        | DokuWiki image registry                                                                                               | `docker.io`                   |
-| `image.repository`                      | DokuWiki image repository                                                                                             | `bitnami/dokuwiki`            |
-| `image.tag`                             | DokuWiki image tag                                                                                                    | `20200729.0.0-debian-10-r370` |
-| `image.pullPolicy`                      | Image pull policy                                                                                                     | `IfNotPresent`                |
-| `image.pullSecrets`                     | Image pull policy                                                                                                     | `[]`                          |
-| `image.debug`                           | Enable image debugging                                                                                                | `false`                       |
-| `hostAliases`                           | Add deployment host aliases                                                                                           | `[]`                          |
-| `dokuwikiUsername`                      | User of the application                                                                                               | `user`                        |
-| `dokuwikiPassword`                      | Application password                                                                                                  | `""`                          |
-| `existingSecret`                        | Use an existing secret with the dokuwiki password                                                                     | `""`                          |
-| `dokuwikiEmail`                         | Admin email                                                                                                           | `user@example.com`            |
-| `dokuwikiFullName`                      | User's Full Name                                                                                                      | `User Name`                   |
-| `dokuwikiWikiName`                      | Wiki name                                                                                                             | `My Wiki`                     |
-| `updateStrategy`                        | Strategy to use to update Pods                                                                                        | `{}`                          |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                        | `[]`                          |
-| `persistence.enabled`                   | Enable persistence using PVC                                                                                          | `true`                        |
-| `persistence.storageClass`              | PVC Storage Class for DokuWiki volume                                                                                 | `""`                          |
-| `persistence.accessModes`               | PVC Access Mode for DokuWiki volume                                                                                   | `[]`                          |
-| `persistence.size`                      | PVC Storage Request for DokuWiki volume                                                                               | `8Gi`                         |
-| `persistence.existingClaim`             | Name of an existing PVC to be used                                                                                    | `""`                          |
-| `persistence.annotations`               | Annotations to add to the PVC                                                                                         | `{}`                          |
-| `podSecurityContext.enabled`            | Enable securityContext on for DokuWiki deployment                                                                     | `true`                        |
-| `podSecurityContext.fsGroup`            | Group to configure permissions for volumes                                                                            | `1001`                        |
-| `containerSecurityContext.enabled`      | Enable securityContext on for DokuWiki deployment                                                                     | `true`                        |
-| `containerSecurityContext.runAsUser`    | User for the securityContext                                                                                          | `1001`                        |
-| `containerSecurityContext.runAsNonRoot` | Force the container as be run as non root                                                                             | `true`                        |
-| `resources.requests`                    | The requested resources for the container                                                                             | `{}`                          |
-| `resources.limits`                      | The requested limits for the container                                                                                | `{}`                          |
-| `livenessProbe.enabled`                 | Enable/disable the liveness probe                                                                                     | `true`                        |
-| `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                                              | `120`                         |
-| `livenessProbe.periodSeconds`           | How often to perform the probe                                                                                        | `10`                          |
-| `livenessProbe.timeoutSeconds`          | When the probe times out                                                                                              | `5`                           |
-| `livenessProbe.failureThreshold`        | Minimum consecutive failures to be considered failed                                                                  | `6`                           |
-| `livenessProbe.successThreshold`        | Minimum consecutive successes to be considered successful                                                             | `1`                           |
-| `readinessProbe.enabled`                | Enable/disable the readiness probe                                                                                    | `true`                        |
-| `readinessProbe.initialDelaySeconds`    | Delay before readinessProbe is initiated                                                                              | `30`                          |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                     | `10`                          |
-| `readinessProbe.timeoutSeconds`         | When the probe times out                                                                                              | `5`                           |
-| `readinessProbe.failureThreshold`       | Minimum consecutive failures to be considered failed                                                                  | `6`                           |
-| `readinessProbe.successThreshold`       | Minimum consecutive successes to be considered successful                                                             | `1`                           |
-| `startupProbe.enabled`                  | Enable/disable the startup probe                                                                                      | `false`                       |
-| `startupProbe.initialDelaySeconds`      | Delay before startup probe is initiated                                                                               | `120`                         |
-| `startupProbe.periodSeconds`            | How often to perform the probe                                                                                        | `10`                          |
-| `startupProbe.timeoutSeconds`           | When the probe times out                                                                                              | `5`                           |
-| `startupProbe.failureThreshold`         | Minimum consecutive failures to be considered failed                                                                  | `6`                           |
-| `startupProbe.successThreshold`         | Minimum consecutive successes to be considered successful                                                             | `1`                           |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                   | `""`                          |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `soft`                        |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                          |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                                 | `""`                          |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                             | `[]`                          |
-| `affinity`                              | Affinity for pod assignment                                                                                           | `{}`                          |
-| `nodeSelector`                          | Node labels for pod assignment                                                                                        | `{}`                          |
-| `tolerations`                           | Tolerations for pod assignment                                                                                        | `[]`                          |
-| `command`                               | Override default container command (useful when using custom images)                                                  | `[]`                          |
-| `args`                                  | Override default container args (useful when using custom images)                                                     | `[]`                          |
-| `extraEnvVars`                          | An array to add extra env vars                                                                                        | `[]`                          |
-| `extraEnvVarsCM`                        | ConfigMap containing extra env vars                                                                                   | `""`                          |
-| `extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)                                                          | `""`                          |
-| `podAnnotations`                        | Pod annotations                                                                                                       | `{}`                          |
-| `customLivenessProbe`                   | Override default liveness probe                                                                                       | `{}`                          |
-| `customReadinessProbe`                  | Override default readiness probe                                                                                      | `{}`                          |
-| `customStartupProbe`                    | Override default startup probe                                                                                        | `{}`                          |
-| `extraVolumes`                          | Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`    | `[]`                          |
-| `extraVolumeMounts`                     | Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`. | `[]`                          |
-| `lifecycleHooks`                        | LifecycleHook to set additional configuration at startup. Evaluated as a template                                     | `{}`                          |
-| `podLabels`                             | Add additional labels to the pod (evaluated as a template)                                                            | `{}`                          |
-| `initContainers`                        | Attach additional init containers to the pod (evaluated as a template)                                                | `[]`                          |
-| `sidecars`                              | Attach additional containers to the pod (evaluated as a template)                                                     | `[]`                          |
-| `priorityClassName`                     | Priority class assigned to the Pods                                                                                   | `""`                          |
-| `schedulerName`                         | Alternative scheduler                                                                                                 | `""`                          |
-| `containerPorts.http`                   | Container HTTP port                                                                                                   | `8080`                        |
-| `containerPorts.https`                  | Container HTTPS port                                                                                                  | `8443`                        |
+| Name                                    | Description                                                                                                              | Value                         |
+|-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------|-------------------------------|
+| `image.registry`                        | DokuWiki image registry                                                                                                  | `docker.io`                   |
+| `image.repository`                      | DokuWiki image repository                                                                                                | `bitnami/dokuwiki`            |
+| `image.tag`                             | DokuWiki image tag                                                                                                       | `20200729.0.0-debian-10-r370` |
+| `image.pullPolicy`                      | Image pull policy                                                                                                        | `IfNotPresent`                |
+| `image.pullSecrets`                     | Image pull policy                                                                                                        | `[]`                          |
+| `image.debug`                           | Enable image debugging                                                                                                   | `false`                       |
+| `hostAliases`                           | Add deployment host aliases                                                                                              | `[]`                          |
+| `dokuwikiUsername`                      | User of the application                                                                                                  | `user`                        |
+| `dokuwikiPassword`                      | Application password                                                                                                     | `""`                          |
+| `existingSecret`                        | Use an existing secret with the dokuwiki password                                                                        | `""`                          |
+| `dokuwikiEmail`                         | Admin email                                                                                                              | `user@example.com`            |
+| `dokuwikiFullName`                      | User's Full Name                                                                                                         | `User Name`                   |
+| `dokuwikiWikiName`                      | Wiki name                                                                                                                | `My Wiki`                     |
+| `customPostInitScripts`                 | Custom post-init.d user scripts                                                                                          | `{}`                          |
+| `updateStrategy`                        | Strategy to use to update Pods                                                                                           | `{}`                          |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                           | `[]`                          |
+| `persistence.enabled`                   | Enable persistence using PVC                                                                                             | `true`                        |
+| `persistence.storageClass`              | PVC Storage Class for DokuWiki volume                                                                                    | `""`                          |
+| `persistence.accessModes`               | PVC Access Mode for DokuWiki volume                                                                                      | `[]`                          |
+| `persistence.size`                      | PVC Storage Request for DokuWiki volume                                                                                  | `8Gi`                         |
+| `persistence.existingClaim`             | Name of an existing PVC to be used                                                                                       | `""`                          |
+| `persistence.annotations`               | Annotations to add to the PVC                                                                                            | `{}`                          |
+| `podSecurityContext.enabled`            | Enable securityContext on for DokuWiki deployment                                                                        | `true`                        |
+| `podSecurityContext.fsGroup`            | Group to configure permissions for volumes                                                                               | `1001`                        |
+| `containerSecurityContext.enabled`      | Enable securityContext on for DokuWiki deployment                                                                        | `true`                        |
+| `containerSecurityContext.runAsUser`    | User for the securityContext                                                                                             | `1001`                        |
+| `containerSecurityContext.runAsNonRoot` | Force the container as be run as non root                                                                                | `true`                        |
+| `resources.requests`                    | The requested resources for the container                                                                                | `{}`                          |
+| `resources.limits`                      | The requested limits for the container                                                                                   | `{}`                          |
+| `livenessProbe.enabled`                 | Enable/disable the liveness probe                                                                                        | `true`                        |
+| `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                                                 | `120`                         |
+| `livenessProbe.periodSeconds`           | How often to perform the probe                                                                                           | `10`                          |
+| `livenessProbe.timeoutSeconds`          | When the probe times out                                                                                                 | `5`                           |
+| `livenessProbe.failureThreshold`        | Minimum consecutive failures to be considered failed                                                                     | `6`                           |
+| `livenessProbe.successThreshold`        | Minimum consecutive successes to be considered successful                                                                | `1`                           |
+| `readinessProbe.enabled`                | Enable/disable the readiness probe                                                                                       | `true`                        |
+| `readinessProbe.initialDelaySeconds`    | Delay before readinessProbe is initiated                                                                                 | `30`                          |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                          |
+| `readinessProbe.timeoutSeconds`         | When the probe times out                                                                                                 | `5`                           |
+| `readinessProbe.failureThreshold`       | Minimum consecutive failures to be considered failed                                                                     | `6`                           |
+| `readinessProbe.successThreshold`       | Minimum consecutive successes to be considered successful                                                                | `1`                           |
+| `startupProbe.enabled`                  | Enable/disable the startup probe                                                                                         | `false`                       |
+| `startupProbe.initialDelaySeconds`      | Delay before startup probe is initiated                                                                                  | `120`                         |
+| `startupProbe.periodSeconds`            | How often to perform the probe                                                                                           | `10`                          |
+| `startupProbe.timeoutSeconds`           | When the probe times out                                                                                                 | `5`                           |
+| `startupProbe.failureThreshold`         | Minimum consecutive failures to be considered failed                                                                     | `6`                           |
+| `startupProbe.successThreshold`         | Minimum consecutive successes to be considered successful                                                                | `1`                           |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                          |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                        |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                          |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                                    | `""`                          |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                          |
+| `affinity`                              | Affinity for pod assignment                                                                                              | `{}`                          |
+| `nodeSelector`                          | Node labels for pod assignment                                                                                           | `{}`                          |
+| `tolerations`                           | Tolerations for pod assignment                                                                                           | `[]`                          |
+| `command`                               | Override default container command (useful when using custom images)                                                     | `[]`                          |
+| `args`                                  | Override default container args (useful when using custom images)                                                        | `[]`                          |
+| `extraEnvVars`                          | An array to add extra env vars                                                                                           | `[]`                          |
+| `extraEnvVarsCM`                        | ConfigMap containing extra env vars                                                                                      | `""`                          |
+| `extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)                                                             | `""`                          |
+| `podAnnotations`                        | Pod annotations                                                                                                          | `{}`                          |
+| `customLivenessProbe`                   | Override default liveness probe                                                                                          | `{}`                          |
+| `customReadinessProbe`                  | Override default readiness probe                                                                                         | `{}`                          |
+| `customStartupProbe`                    | Override default startup probe                                                                                           | `{}`                          |
+| `extraVolumes`                          | Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`       | `[]`                          |
+| `extraVolumeMounts`                     | Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.    | `[]`                          |
+| `lifecycleHooks`                        | LifecycleHook to set additional configuration at startup. Evaluated as a template                                        | `{}`                          |
+| `podLabels`                             | Add additional labels to the pod (evaluated as a template)                                                               | `{}`                          |
+| `initContainers`                        | Attach additional init containers to the pod (evaluated as a template)                                                   | `[]`                          |
+| `sidecars`                              | Attach additional containers to the pod (evaluated as a template)                                                        | `[]`                          |
+| `priorityClassName`                     | Priority class assigned to the Pods                                                                                      | `""`                          |
+| `schedulerName`                         | Alternative scheduler                                                                                                    | `""`                          |
+| `containerPorts.http`                   | Container HTTP port                                                                                                      | `8080`                        |
+| `containerPorts.https`                  | Container HTTPS port                                                                                                     | `8443`                        |
 
 
 ### Traffic Exposure Parameters

--- a/bitnami/dokuwiki/templates/deployment.yaml
+++ b/bitnami/dokuwiki/templates/deployment.yaml
@@ -254,6 +254,10 @@ spec:
               readOnly: true
             {{- end }}
             {{- end }}
+            {{- if .Values.customPostInitScripts }}
+            - mountPath: /docker-entrypoint-init.d
+              name: custom-postinit
+            {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -317,6 +321,12 @@ spec:
             claimName: {{ default (include "common.names.fullname" .) .Values.persistence.existingClaim }}
         {{- else }}
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.customPostInitScripts }}
+        - name: custom-postinit
+          configMap:
+            name: {{ printf "%s-postinit" (include "common.names.fullname" .) }}
+            defaultMode: 0755
         {{- end }}
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/dokuwiki/templates/postinit-configmap.yaml
+++ b/bitnami/dokuwiki/templates/postinit-configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.customPostInitScripts }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-postinit" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  {{- if .Values.customPostInitScripts }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.customPostInitScripts "context" $) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/bitnami/dokuwiki/values.yaml
+++ b/bitnami/dokuwiki/values.yaml
@@ -105,6 +105,21 @@ dokuwikiFullName: User Name
 ## ref: https://github.com/bitnami/bitnami-docker-dokuwiki#environment-variables
 ##
 dokuwikiWikiName: My Wiki
+## @param customPostInitScripts Custom post-init.d user scripts
+## ref: https://github.com/bitnami/bitnami-docker-dokuwiki/tree/master/20200729/debian-10/rootfs/post-init.d
+## NOTE: supported formats are `.sh` or `.php`
+## NOTE: scripts are exclusively executed during the 1st boot of the container
+## e.g:
+## customPostInitScripts:
+##   custom-post-init.sh: |
+##     #!/bin/bash
+##     echo "Hello from custom-post-init.sh"
+##   .htaccess: |
+##     RewriteEngine On
+##     RewriteBase /
+##     ...
+##
+customPostInitScripts: {}
 
 ## @param updateStrategy Strategy to use to update Pods
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies


### PR DESCRIPTION
**Description of the change**

Adds support for post-init scripts.

**Benefits**

Adds additional feature supported by other charts.

**Possible drawbacks**

None known.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)