### PR TITLE
[bitnami/spring-cloud-dataflow] Fix metrics

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 5.0.2
+version: 5.0.3

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
@@ -17,32 +17,32 @@ metadata:
   {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.service.type }}
-  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
-  clusterIP: {{ .Values.service.clusterIP }}
+  type: {{ .Values.metrics.service.type }}
+  {{- if and .Values.metrics.service.clusterIP (eq .Values.metrics.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.metrics.service.clusterIP }}
   {{- end }}
-  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
-  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- if or (eq .Values.metrics.service.type "LoadBalancer") (eq .Values.metrics.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.metrics.service.externalTrafficPolicy | quote }}
   {{- end }}
-  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- if and (eq .Values.metrics.service.type "LoadBalancer") .Values.metrics.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.metrics.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
-  {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
-  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- if (and (eq .Values.metrics.service.type "LoadBalancer") (not (empty .Values.metrics.service.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.service.sessionAffinity }}
-  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- if .Values.metrics.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.metrics.service.sessionAffinity }}
   {{- end }}
-  {{- if .Values.service.sessionAffinityConfig }}
-  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- if .Values.metrics.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
     - name: http
       port: {{ coalesce .Values.metrics.service.ports.http .Values.metrics.service.httpPort }}
       protocol: TCP
       targetPort: http
-      {{- if and .Values.service.nodePorts.http (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
-      nodePort: {{ .Values.service.nodePorts.http }}
+      {{- if and .Values.metrics.service.nodePorts.http (or (eq .Values.metrics.service.type "NodePort") (eq .Values.metrics.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.metrics.service.nodePorts.http }}
       {{- else }}
       nodePort: null
       {{- end }}
@@ -50,8 +50,8 @@ spec:
       port: {{ coalesce .Values.metrics.service.ports.rsocket .Values.metrics.service.rsocketPort }}
       protocol: TCP
       targetPort: rsocket
-      {{- if and .Values.service.nodePorts.rsocket (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
-      nodePort: {{ .Values.service.nodePorts.rsocket }}
+      {{- if and .Values.metrics.service.nodePorts.rsocket (or (eq .Values.metrics.service.type "NodePort") (eq .Values.metrics.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.metrics.service.nodePorts.rsocket }}
       {{- else }}
       nodePort: null
       {{- end }}

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -1261,7 +1261,7 @@ metrics:
     ##
     annotations:
       prometheus.io/scrape: 'true'
-      prometheus.io/port: '{{ coalesce .Values.metrics.service.ports.http .Values.metrics.service.httpPort }}'
+      prometheus.io/port: '{{ .Values.metrics.service.ports.http }}'
       prometheus.io/path: '/metrics/proxy'
     ## @param metrics.service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
     ## If "ClientIP", consecutive client requests will be directed to the same Pod


### PR DESCRIPTION
**Description of the change**

An error is thrown when enabling metrics, as reported in #8670:

```console
$ helm install scdf-test bitnami/spring-cloud-dataflow --set metrics.enabled=true --dry-run

Error: UPGRADE FAILED: template: spring-cloud-dataflow/templates/prometheus-proxy/service.yaml:17:6: executing "spring-cloud-dataflow/templates/prometheus-proxy/service.yaml" at <include "common.tplvalues.render" (dict "value" .Values.metrics.service.annotations "context" $)>: error calling include: template: spring-cloud-dataflow/charts/common/templates/_tplvalues.tpl:11:12: executing "common.tplvalues.render" at <tpl (.value | toYaml) .context>: error calling tpl: error during tpl function execution for "prometheus.io/path: /metrics/proxy\nprometheus.io/port: '{{ coalesce .Values.metrics.service.ports.http .Values.metrics.service.httpPort\n }}'\nprometheus.io/scrape: \"true\"": parse error at (spring-cloud-dataflow/templates/prometheus-proxy/service.yaml:2): unclosed action 
```

**Applicable issues**
  - fixes #8670

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)