### PR TITLE
[bitnami/orangehrm] Mark OrangeHRM chart as deprecated

### DIFF
--- a/bitnami/orangehrm/Chart.lock
+++ b/bitnami/orangehrm/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.3.0
+  version: 10.3.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.10.3
-digest: sha256:f89a673bf30d5cc0653f449eb07d7b7209d2d04ca6a42edf6abe8078f9a7ce06
-generated: "2022-01-11T12:34:03.672945303Z"
+digest: sha256:8d2dc3f109e1e2bd70762561ef4ec64c2f2b25c702ced2bb4666c561c454a857
+generated: "2022-01-17T18:06:28.901625887Z"

--- a/bitnami/orangehrm/Chart.yaml
+++ b/bitnami/orangehrm/Chart.yaml
@@ -12,7 +12,9 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: OrangeHRM is a free HR management system that offers a wealth of modules to suit the needs of your business.
+# The OrangeHRM chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED OrangeHRM is a free HR management system that offers a wealth of modules to suit the needs of your business.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/orangehrm
 icon: https://bitnami.com/assets/stacks/orangehrm/img/orangehrm-stack-220x234.png
@@ -24,11 +26,9 @@ keywords:
   - application
   - php
   - human resources
-maintainers:
-  - email: containers@bitnami.com
-    name: Bitnami
+maintainers: []
 name: orangehrm
 sources:
   - https://github.com/bitnami/bitnami-docker-orangehrm
   - https://www.orangehrm.com
-version: 11.0.2
+version: 11.0.3

--- a/bitnami/orangehrm/README.md
+++ b/bitnami/orangehrm/README.md
@@ -4,6 +4,10 @@
 
 [OrangeHRM](https://www.orangehrm.com) is a free HR management system that offers a wealth of modules to suit the needs of your business.
 
+## This Helm chart is deprecated
+
+The upstream project only works with deprecated PHP versions.
+
 ## TL;DR
 
 ```console

--- a/bitnami/orangehrm/templates/NOTES.txt
+++ b/bitnami/orangehrm/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The upstream project only works with deprecated PHP versions.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}

--- a/bitnami/orangehrm/values.yaml
+++ b/bitnami/orangehrm/values.yaml
@@ -51,7 +51,7 @@ commonLabels: {}
 image:
   registry: docker.io
   repository: bitnami/orangehrm
-  tag: 4.9.0-0-debian-10-r51
+  tag: 4.9.0-0-debian-10-r57
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -615,7 +615,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r305
+    tag: 10-debian-10-r311
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -661,7 +661,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.11.0-debian-10-r23
+    tag: 0.11.0-debian-10-r29
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -731,7 +731,7 @@ certificates:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r305
+    tag: 10-debian-10-r311
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: David Gomez <dgomezleon@vmware.com>

**Description of the change**

OrangeHRM helm chart will be deprecated since the upstream project only supports deprecated PHP versions.

**Checklist**
- [X] Chart version bumped in Chart.yaml according to semver.
- [X]  Variables are documented in the README.md
- [X]  Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])