### PR TITLE
[bitnami/grafana-operator] Add `patch events` permissions to grafana-operator ClusterRole

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 2.2.0
+version: 2.2.1

--- a/bitnami/grafana-operator/templates/rbac.yaml
+++ b/bitnami/grafana-operator/templates/rbac.yaml
@@ -106,6 +106,7 @@ rules:
       - get
       - list
       - watch
+      - patch
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
**Description of the change**

Added missing permissions.

**Benefits**

This won't happen:
```
2022-01-17T20:13:47.638Z    DEBUG    controller-runtime.manager.events    Warning    {"object": {"kind":"Grafana","namespace":"test-0","name":"release-grafana-operator-grafana","uid":"0f1af8f4-9bd7-4e37-89db-69fd98a15d62","apiVersion":"integreatly.org/v1alpha1","resourceVersion":"168620319"}, "reason": "ProcessingError", "message": "deployment not ready"}E0117 20:13:47.640482       1 event.go:264] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"release-grafana-operator-grafana.16cb2725e2b9218b", GenerateName:"", Namespace:"test-0", SelfLink:"", UID:"", ResourceVersion:"8303976", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"Grafana", Namespace:"test-0", Name:"release-grafana-operator-grafana", UID:"0f1af8f4-9bd7-4e37-89db-69fd98a15d62", APIVersion:"integreatly.org/v1alpha1", ResourceVersion:"168620319", FieldPath:""}, Reason:"ProcessingError", Message:"deployment not ready", Source:v1.EventSource{Component:"GrafanaDashboard", Host:""}, FirstTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63778046332, loc:(*time.Location)(0x25a29a0)}}, LastTimestamp:v1.Time{Time:time.Time{wall:0xc071915ee60a8d27, ext:5373709343041, loc:(*time.Location)(0x25a29a0)}}, Count:25, Type:"Warning", EventTime:v1.MicroTime{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events "fusion-grafana-operator-grafana.16cb2725e2b9218b" is forbidden: User "system:serviceaccount:default:fc-grafana-operator" cannot patch resource "events" in API group "" in the namespace "meteor-0"' (will not retry!)
```

**Possible drawbacks**

None.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)