### PR TITLE
[bitnami/kube-state-metrics] .Values.namespaces: Fix condition and add rendering

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -23,4 +23,4 @@ name: kube-state-metrics
 sources:
   - https://github.com/bitnami/bitnami-docker-kube-state-metrics
   - https://github.com/kubernetes/kube-state-metrics
-version: 2.2.2
+version: 2.2.3

--- a/bitnami/kube-state-metrics/templates/deployment.yaml
+++ b/bitnami/kube-state-metrics/templates/deployment.yaml
@@ -153,7 +153,7 @@ spec:
             - --resources=volumeattachments
             {{- end }}
             {{- if .Values.namespaces }}
-            - --namespaces={{ .Values.namespaces }}
+            - --namespaces={{- include "common.tplvalues.render" ( dict "value" .Values.namespaces "context" $ ) }}
             {{- end }}
             {{- range $key, $value := .Values.extraArgs }}
             {{- if $value }}

--- a/bitnami/kube-state-metrics/templates/deployment.yaml
+++ b/bitnami/kube-state-metrics/templates/deployment.yaml
@@ -152,7 +152,7 @@ spec:
             {{- if .Values.kubeResources.volumeattachments }}
             - --resources=volumeattachments
             {{- end }}
-            {{- if .Values.namespace }}
+            {{- if .Values.namespaces }}
             - --namespaces={{ .Values.namespaces }}
             {{- end }}
             {{- range $key, $value := .Values.extraArgs }}

--- a/bitnami/kube-state-metrics/values.yaml
+++ b/bitnami/kube-state-metrics/values.yaml
@@ -95,7 +95,7 @@ image:
 ## @param extraArgs Additional command line arguments to pass to kube-state-metrics
 ##
 extraArgs: {}
-## @param namespaces Comma-separated list of namespaces to be enabled. Defaults to all namespaces
+## @param namespaces Comma-separated list of namespaces to be enabled. Defaults to all namespaces. Evaluated as a template.
 ##
 namespaces: ""
 ## kube-state-metrics resources to be enabled


### PR DESCRIPTION
**Description of the change**

- Fix the condition to match the `namespaces` key in values.yaml
- Add the ability to have templated value in `namespaces` key (like `namespaces: "{{ .Release.Namespace }}"` to restrict scope to the NS where kube-state-metrics is deployed)

**Benefits**

- Regarding the ability o have templated value in `namespaces` key, it will avoid users to explicitly define the key to the namespace kube-state-metrics is currently deployed

**Possible drawbacks**

None that I know of (so far)

**Applicable issues**

None apparently

**Additional information**

None

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm] =>**N/A (already documented)**
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)