### PR TITLE
[bitnami/grafana] Update initContainers type to list

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 7.6.2
+version: 7.6.3

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -416,7 +416,7 @@ grafana:
   ##    imagePullPolicy: Always
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
-  initContainers: {}
+  initContainers: []
   ## @param grafana.extraVolumes Additional volumes for the Grafana pod
   ## Example:
   ## extraVolumes:
@@ -948,7 +948,7 @@ imageRenderer:
   ##    imagePullPolicy: Always
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
-  initContainers: {}
+  initContainers: []
   ## @param imageRenderer.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes
   ##
   extraEnvVarsCM: ""


### PR DESCRIPTION
**Update initContainers type to list**

Update `initContainers` type from map `{}` to list `[]`. This update matches the existing parameter documentation:
```yaml
  ## @param imageRenderer.initContainers Add additional init containers to the Grafana Image Renderer pod(s)
  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
  ## e.g:
  ## initContainers:
  ##  - name: your-image-name
  ##    image: your-image
  ##    imagePullPolicy: Always
  ##    command: ['sh', '-c', 'echo "hello world"']
```

**Benefits**

Grafana chart originally installed with `initContainers` can be patched/upgraded.

**Possible drawbacks**

No obvious drawbacks.

**Applicable issues**

Not aware of any.

**Additional information**

This change is expected to resolve the error:
```
coalesce.go:199: warning: cannot overwrite table with non table for initContainers (map[])
```

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)