### PR TITLE
[bitnami/wordpress] tpl externaldb secret

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - https://wordpress.org/
-version: 13.0.0
+version: 13.0.1

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -341,31 +341,31 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Database Parameters
 
-| Name                                       | Description                                                               | Value               |
-| ------------------------------------------ | ------------------------------------------------------------------------- | ------------------- |
-| `mariadb.enabled`                          | Deploy a MariaDB server to satisfy the applications database requirements | `true`              |
-| `mariadb.architecture`                     | MariaDB architecture. Allowed values: `standalone` or `replication`       | `standalone`        |
-| `mariadb.auth.rootPassword`                | MariaDB root password                                                     | `""`                |
-| `mariadb.auth.database`                    | MariaDB custom database                                                   | `bitnami_wordpress` |
-| `mariadb.auth.username`                    | MariaDB custom user name                                                  | `bn_wordpress`      |
-| `mariadb.auth.password`                    | MariaDB custom user password                                              | `""`                |
-| `mariadb.primary.persistence.enabled`      | Enable persistence on MariaDB using PVC(s)                                | `true`              |
-| `mariadb.primary.persistence.storageClass` | Persistent Volume storage class                                           | `""`                |
-| `mariadb.primary.persistence.accessModes`  | Persistent Volume access modes                                            | `[]`                |
-| `mariadb.primary.persistence.size`         | Persistent Volume size                                                    | `8Gi`               |
-| `externalDatabase.host`                    | External Database server host                                             | `localhost`         |
-| `externalDatabase.port`                    | External Database server port                                             | `3306`              |
-| `externalDatabase.user`                    | External Database username                                                | `bn_wordpress`      |
-| `externalDatabase.password`                | External Database user password                                           | `""`                |
-| `externalDatabase.database`                | External Database database name                                           | `bitnami_wordpress` |
-| `externalDatabase.existingSecret`          | The name of an existing secret with database credentials                  | `""`                |
-| `memcached.enabled`                        | Deploy a Memcached server for caching database queries                    | `false`             |
-| `memcached.auth.enabled`                   | Enable Memcached authentication                                           | `false`             |
-| `memcached.auth.username`                  | Memcached admin user                                                      | `""`                |
-| `memcached.auth.password`                  | Memcached admin password                                                  | `""`                |
-| `memcached.service.port`                   | Memcached service port                                                    | `11211`             |
-| `externalCache.host`                       | External cache server host                                                | `localhost`         |
-| `externalCache.port`                       | External cache server port                                                | `11211`             |
+| Name                                       | Description                                                                       | Value               |
+| ------------------------------------------ | --------------------------------------------------------------------------------- | ------------------- |
+| `mariadb.enabled`                          | Deploy a MariaDB server to satisfy the applications database requirements         | `true`              |
+| `mariadb.architecture`                     | MariaDB architecture. Allowed values: `standalone` or `replication`               | `standalone`        |
+| `mariadb.auth.rootPassword`                | MariaDB root password                                                             | `""`                |
+| `mariadb.auth.database`                    | MariaDB custom database                                                           | `bitnami_wordpress` |
+| `mariadb.auth.username`                    | MariaDB custom user name                                                          | `bn_wordpress`      |
+| `mariadb.auth.password`                    | MariaDB custom user password                                                      | `""`                |
+| `mariadb.primary.persistence.enabled`      | Enable persistence on MariaDB using PVC(s)                                        | `true`              |
+| `mariadb.primary.persistence.storageClass` | Persistent Volume storage class                                                   | `""`                |
+| `mariadb.primary.persistence.accessModes`  | Persistent Volume access modes                                                    | `[]`                |
+| `mariadb.primary.persistence.size`         | Persistent Volume size                                                            | `8Gi`               |
+| `externalDatabase.host`                    | External Database server host                                                     | `localhost`         |
+| `externalDatabase.port`                    | External Database server port                                                     | `3306`              |
+| `externalDatabase.user`                    | External Database username                                                        | `bn_wordpress`      |
+| `externalDatabase.password`                | External Database user password                                                   | `""`                |
+| `externalDatabase.database`                | External Database database name                                                   | `bitnami_wordpress` |
+| `externalDatabase.existingSecret`          | The name of an existing secret with database credentials. Evaluated as a template | `""`                |
+| `memcached.enabled`                        | Deploy a Memcached server for caching database queries                            | `false`             |
+| `memcached.auth.enabled`                   | Enable Memcached authentication                                                   | `false`             |
+| `memcached.auth.username`                  | Memcached admin user                                                              | `""`                |
+| `memcached.auth.password`                  | Memcached admin password                                                          | `""`                |
+| `memcached.service.port`                   | Memcached service port                                                            | `11211`             |
+| `externalCache.host`                       | External cache server host                                                        | `localhost`         |
+| `externalCache.port`                       | External cache server port                                                        | `11211`             |
 
 
 The above parameters map to the env variables defined in [bitnami/wordpress](https://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](https://github.com/bitnami/bitnami-docker-wordpress) image documentation.

--- a/bitnami/wordpress/templates/_helpers.tpl
+++ b/bitnami/wordpress/templates/_helpers.tpl
@@ -161,7 +161,7 @@ Return the MariaDB Secret Name
         {{- printf "%s" (include "wordpress.mariadb.fullname" .) -}}
     {{- end -}}
 {{- else if .Values.externalDatabase.existingSecret -}}
-    {{- printf "%s" .Values.externalDatabase.existingSecret -}}
+    {{- include "common.tplvalues.render" (dict "value" .Values.externalDatabase.existingSecret "context" $) -}}
 {{- else -}}
     {{- printf "%s-externaldb" (include "common.names.fullname" .) -}}
 {{- end -}}

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -1083,7 +1083,7 @@ externalDatabase:
   ## @param externalDatabase.database External Database database name
   ##
   database: bitnami_wordpress
-  ## @param externalDatabase.existingSecret The name of an existing secret with database credentials
+  ## @param externalDatabase.existingSecret The name of an existing secret with database credentials. Evaluated as a template
   ## NOTE: Must contain key `mariadb-password`
   ## NOTE: When it's set, the `externalDatabase.password` parameter is ignored
   ##


### PR DESCRIPTION
**Description of the change**

Allow templating externalDatabase.existingSecret, for example `{{ .Release.Name }}-mysql`

**Benefits**

We do not need to pass the exact secret name anymore for each release.

**Possible drawbacks**

**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)