### PR TITLE
[bitnami/kafka] fix resource-name for networkpolicy-egress.yaml

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 14.9.2
+version: 14.9.3

--- a/bitnami/kafka/templates/networkpolicy-egress.yaml
+++ b/bitnami/kafka/templates/networkpolicy-egress.yaml
@@ -2,7 +2,7 @@
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 metadata:
-  name: {{ printf "%s-ingress" (include "common.names.fullname" .) }}
+  name: {{ printf "%s-egress" (include "common.names.fullname" .) }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}


### PR DESCRIPTION
**Description of the change**

Fix duplicate resource-names for networkpolicies within kafka-chart.

**Benefits**

Fixes the resource-name for [networkpolicy-egress.yaml](bitnami/kafka/templates/networkpolicy-egress.yaml) to prevent failing deployments due to duplicate names.

**Applicable issues**

  - fixes #8724 

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)