### PR TITLE
[bitnami/tomcat] wrong indent for containerExtraPorts fix

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/bitnami-docker-tomcat
   - http://tomcat.apache.org
-version: 10.1.4
+version: 10.1.5

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -97,7 +97,7 @@ containers:
       - name: http
         containerPort: {{ .Values.containerPorts.http }}
       {{- if .Values.containerExtraPorts }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.containerExtraPorts "context" $) | nindent 4 }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.containerExtraPorts "context" $) | nindent 6 }}
       {{- end }}
     {{- if .Values.livenessProbe.enabled }}
     livenessProbe:


### PR DESCRIPTION
Signed-off-by: Peter Kassak <48527944+cache-sk@users.noreply.github.com>

**Description of the change**

When containerExtraPorts is used, it ends in "error converting YAML to JSON: yaml: line XY: did not find expected key", because of wrong indent.

**Benefits**

Fixed indent, so containerExtraPorts can be used.

**Possible drawbacks**

None?

**Applicable issues**

Not reported so far.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)