### PR TITLE
[bitnami/argo-cd] Fix tls certs configmap

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/bitnami-docker-dex
   - https://github.com/dexidp/dex
-version: 3.0.1
+version: 3.0.2

--- a/bitnami/argo-cd/templates/tls-certs-cm.yaml
+++ b/bitnami/argo-cd/templates/tls-certs-cm.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tlsCerts }}
+{{- if .Values..config.tlsCerts }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bitnami/argo-cd/templates/tls-certs-cm.yaml
+++ b/bitnami/argo-cd/templates/tls-certs-cm.yaml
@@ -1,4 +1,4 @@
-{{- if .Values..config.tlsCerts }}
+{{- if .Values.config.tlsCerts }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amorenoc@vmware.com>

**Description of the change**
Fix the condition for creating the TLS certs configmap.

**Applicable issues**
  - fixes #8567
 

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)