### PR TITLE
[bitnami/minio] Minio provisioning job toleration support

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-version: 10.0.3
+version: 10.0.4

--- a/bitnami/minio/templates/provisioning-job.yaml
+++ b/bitnami/minio/templates/provisioning-job.yaml
@@ -186,6 +186,9 @@ spec:
             {{- if .Values.provisioning.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.provisioning.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- end }}            
       volumes:
         {{- if .Values.provisioning.enabled }}
         - name: minio-provisioning


### PR DESCRIPTION
The Minio Helm chart does have an entry for entering tolerations for running on nodes which have taints, however, this is not cascaded over to the Provisioning Job when it's enabled and hence the Job will be stuck in a pending state since it cant find a node to deploy to.

**Description of the change**

Updated the provisioning-job.yaml to respect the tolerations set in the values.yaml chart

**Benefits**

Provisioning jobs can be successfully deployed on nodes which have taints

**Possible drawbacks**

N.A

**Applicable issues**

  - fixes  #8769


**Checklist**
- [ x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ x ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ x ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)