### PR TITLE
[bitnami/airflow] Add 'patch' verb to pod

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 11.4.0
+version: 11.4.1

--- a/bitnami/airflow/templates/rbac/role.yaml
+++ b/bitnami/airflow/templates/rbac/role.yaml
@@ -22,6 +22,7 @@ rules:
       - "get"
       - "watch"
       - "delete"
+      - "patch"
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
**Description of the change**

1. If a task goes orphan and is adopted by a new scheduler instance, then this change could patch the orphaned task instance rather than sending a SIGTERM.

**Benefits**

1. The Task will proceed further with its execution instead of receiving a SIGTERM and getting killed.

**Applicable issues**
  - fixes #8766 

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)