### PR TITLE
[bitnami/aspnet-core] Detect ingress apiVersion

### DIFF
--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -22,4 +22,4 @@ name: aspnet-core
 sources:
   - https://github.com/bitnami/bitnami-docker-aspnet-core
   - https://dotnet.microsoft.com/apps/aspnet
-version: 3.0.3
+version: 3.0.4

--- a/bitnami/aspnet-core/templates/health-ingress.yaml
+++ b/bitnami/aspnet-core/templates/health-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.healthIngress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "aspnet-core.fullname" . }}-health


### PR DESCRIPTION
**Description of the change**

This PR fixes aspnet-core health ingress which is currently hard coded to use the beta version of the ingress api which is no longer supported in latest version of k8

**Benefits**

Charts compatible with all Kubernetes versions

**Possible drawbacks**

None

**Applicable issues**

  - fixes #8739

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)