### PR TITLE
Removed internal VMware replace URL from bitnami public charts

### DIFF
--- a/.github/workflows/vib.yaml
+++ b/.github/workflows/vib.yaml
@@ -14,7 +14,6 @@ env:
   CSP_API_URL: https://console.cloud.vmware.com
   CSP_API_TOKEN: ${{ secrets.CSP_API_TOKEN }}
   VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
-  VIB_REPLACE_PUBLIC_URL: ${{ secrets.VIB_REPLACE_PUBLIC_URL }} # Replaces with VPN-friendly url
 jobs:
   vib-validate: # make sure chart is linted/safe
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removes the internal VMware URL replacement variable. This is only useful for within VMware VPN users but there is no need to use it within Bitnami charts repository

Signed-off-by: Martin Perez <martinpe@vmware.com>