### PR TITLE
[bitnami/postgresql-ha]: Add existingSecret to pgpool values

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 8.2.6
+version: 8.2.7

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -221,6 +221,7 @@ Additionally, if `persistence.resourcePolicy` is set to `keep`, you should manua
 | `pgpool.passwords`                          | Comma or semicolon separated list of the associated passwords for the users above                                                        | `""`                 |
 | `pgpool.hostAliases`                        | Deployment pod host aliases                                                                                                              | `[]`                 |
 | `pgpool.customUsersSecret`                  | Name of a secret containing the usernames and passwords of accounts that will be added to pgpool_passwd                                  | `""`                 |
+| `pgpool.existingSecret`                     | Pgpool admin password using existing secret                                                                                              | `""`                 |
 | `pgpool.srCheckDatabase`                    | Name of the database to perform streaming replication checks                                                                             | `postgres`           |
 | `pgpool.labels`                             | Labels to add to the Deployment. Evaluated as template                                                                                   | `{}`                 |
 | `pgpool.podLabels`                          | Labels to add to the pods. Evaluated as template                                                                                         | `{}`                 |

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -618,6 +618,9 @@ pgpool:
   ## The secret must contain the keys "usernames" and "passwords" respectively.
   ##
   customUsersSecret: ""
+  ## @param pgpool.existingSecret Pgpool admin password using existing secret
+  ##
+  existingSecret: ""
   ## @param pgpool.srCheckDatabase Name of the database to perform streaming replication checks
   ##
   srCheckDatabase: postgres


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Add option to pgpool postgresql-ha chart to use an existing secret store for the Pgpool admin password.

**Benefits**

<!-- What benefits will be realized by the code change? -->
Possibility to use own secret store for Pgpool admin password.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #8093

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)