### PR TITLE
[bitnami/kube-prometheus] Fix typo in kube-prometheus README.md

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 6.6.3
+version: 6.6.4

--- a/bitnami/kube-prometheus/README.md
+++ b/bitnami/kube-prometheus/README.md
@@ -448,7 +448,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `exporters.node-exporter.enabled`                         | Enable node-exporter                                                                                                            | `true`        |
 | `exporters.kube-state-metrics.enabled`                    | Enable kube-state-metrics                                                                                                       | `true`        |
 | `node-exporter`                                           | Node Exporter deployment configuration                                                                                          | `{}`          |
-| `kube-state-metrics`                                      | Node Exporter deployment configuration                                                                                          | `{}`          |
+| `kube-state-metrics`                                      | Kube State Metrics deployment configuration                                                                                          | `{}`          |
 | `kubelet.enabled`                                         | Create a ServiceMonitor to scrape kubelet service                                                                               | `true`        |
 | `kubelet.namespace`                                       | Namespace where kubelet service is deployed. Related configuration `operator.kubeletService.namespace`                          | `kube-system` |
 | `kubelet.serviceMonitor.https`                            | Enable scraping of the kubelet over HTTPS                                                                                       | `true`        |

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -1566,7 +1566,7 @@ node-exporter:
   extraArgs:
     collector.filesystem.ignored-mount-points: "^/(dev|proc|sys|var/lib/docker/.+)($|/)"
     collector.filesystem.ignored-fs-types: "^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$"
-## @param kube-state-metrics [object] Node Exporter deployment configuration
+## @param kube-state-metrics [object] Kube State Metrics deployment configuration
 ##
 kube-state-metrics:
   serviceMonitor:


### PR DESCRIPTION
**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)