### PR TITLE
[bitnami/thanos] fix receive-distributor pdb selector

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 9.0.1
+version: 9.0.2

--- a/bitnami/thanos/templates/receive-distributor/pdb.yaml
+++ b/bitnami/thanos/templates/receive-distributor/pdb.yaml
@@ -21,5 +21,5 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: receive
+      app.kubernetes.io/component: receive-distributor
 {{- end }}


### PR DESCRIPTION
**Thanos receive-distributor PDB selector labels**

**Benefits**

The PDB for receive-distributor target the right pods instead of reciever pods.

**Possible drawbacks**

None

**Applicable issues**

**Additional information**


**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)