### PR TITLE
[bitnami/keycloak] fix missing config for ingress.existingSecret

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 6.1.1
+version: 6.1.2

--- a/bitnami/keycloak/templates/ingress.yaml
+++ b/bitnami/keycloak/templates/ingress.yaml
@@ -44,12 +44,16 @@ spec:
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "keycloak.fullname" $) "servicePort" $.Values.ingress.servicePort "context" $) | nindent 14 }}
     {{- end }}
-  {{- if or (and .Values.ingress.tls (or (include "keycloak.ingress.certManagerRequest" .Values.ingress.annotations) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+  {{- if or (and .Values.ingress.tls (or (include "keycloak.ingress.certManagerRequest" .Values.ingress.annotations) .Values.ingress.selfSigned)) .Values.ingress.extraTls .Values.ingress.existingSecret }}
   tls:
-    {{- if and .Values.ingress.tls (or (include "keycloak.ingress.certManagerRequest" .Values.ingress.annotations) .Values.ingress.selfSigned) }}
+    {{- if or (and .Values.ingress.tls (or (include "keycloak.ingress.certManagerRequest" .Values.ingress.annotations) .Values.ingress.selfSigned)) .Values.ingress.existingSecret }}
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
+    {{- if and .Values.ingress.tls (or (include "keycloak.ingress.certManagerRequest" .Values.ingress.annotations) .Values.ingress.selfSigned) }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- else if .Values.ingress.existingSecret }}
+      secretName: {{ .Values.ingress.existingSecret }}
+    {{- end }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
This PR fixes a bug implemented in #8772. Basically the `ingress.existingSecret` option was removed during the last PR and will be added again with this PR. 
<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
The chart behaves again like described in the chart values.
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
No drawbacks
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)