### PR TITLE
[bitnami/aspnet-core] add ingressClassName option to health ingress

### DIFF
--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -22,4 +22,4 @@ name: aspnet-core
 sources:
   - https://github.com/bitnami/bitnami-docker-aspnet-core
   - https://dotnet.microsoft.com/apps/aspnet
-version: 3.0.4
+version: 3.1.0

--- a/bitnami/aspnet-core/README.md
+++ b/bitnami/aspnet-core/README.md
@@ -211,6 +211,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `healthIngress.hostname`           | When the health ingress is enabled, a host pointing to this will be created                                                      | `aspnet-core.local`      |
 | `healthIngress.annotations`        | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
 | `healthIngress.tls`                | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |
+| `healthIngress.ingressClassName`   | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `healthIngress.extraHosts`         | n array with additional hostname(s) to be covered with the ingress record                                                        | `[]`                     |
 | `healthIngress.extraTls`           | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                     |
 | `healthIngress.secrets`            | Custom TLS certificates as secrets                                                                                               | `[]`                     |

--- a/bitnami/aspnet-core/templates/health-ingress.yaml
+++ b/bitnami/aspnet-core/templates/health-ingress.yaml
@@ -18,6 +18,9 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
+  {{- if and .Values.healthIngress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  ingressClassName: {{ .Values.healthIngress.ingressClassName | quote }}
+  {{- end }}
   rules:
     {{- if .Values.healthIngress.hostname }}
     - host: {{ .Values.healthIngress.hostname }}

--- a/bitnami/aspnet-core/values.yaml
+++ b/bitnami/aspnet-core/values.yaml
@@ -615,7 +615,11 @@ healthIngress:
   ## DEPRECATED: Use healthIngress.annotations instead of healthIngress.certManager
   ## certManager: false
   ##
-
+  ## @param healthIngress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName: ""
   ## @param healthIngress.extraHosts n array with additional hostname(s) to be covered with the ingress record
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
   ## extraHosts:


### PR DESCRIPTION
**Description of the change**

Add `IngressClass` as an option when defining ingress-health

**Benefits**

Make health-ingress options the same as ingress and allow consumer to use standard k8 fields.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - see #8739

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)