### PR TITLE
Enable PR VIB workflow on forks

### DIFF
--- a/.github/workflows/vib.yaml
+++ b/.github/workflows/vib.yaml
@@ -1,6 +1,6 @@
 name: 'vib'
 on: # rebuild any PRs and main branch changes
-  pull_request:
+  pull_request_target:
     branches:
       - master
       - bitnami:master
@@ -20,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: vmware-samples/vmware-image-builder-examples/vib-action@main
 
   vib-k8s-verify: # verify in multiple target platforms
@@ -39,6 +42,9 @@ jobs:
     name: K8s verify ${{ matrix.target-platform}}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: vmware-samples/vmware-image-builder-examples/vib-action@main
         with: 
           pipeline: vib-platform-verify.json


### PR DESCRIPTION
Signed-off-by: Martin Perez <martinpe@vmware.com>

Enables VIB workflow on fork pull requests too. This will run on limited products right now, i.e. wordpress.