### PR TITLE
[bitnami/redis-cluster] Add namespace in metadata

### DIFF
--- a/bitnami/redis-cluster/Chart.lock
+++ b/bitnami/redis-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.10.3
-digest: sha256:710e8247ae70ea63a2fb2fde4320511ff28c7b5c7a738861427f104a7718bdf4
-generated: "2021-12-25T10:03:13.336457684Z"
+  version: 1.10.4
+digest: sha256:e177cdcd71e67a1e64e95260c4b780374e1d66e85be405d5dc58459654e49ffa
+generated: "2022-01-27T20:24:19.045906Z"

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 7.2.0
+version: 7.2.1

--- a/bitnami/redis-cluster/templates/configmap.yaml
+++ b/bitnami/redis-cluster/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}-default
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/headless-svc.yaml
+++ b/bitnami/redis-cluster/templates/headless-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}-headless
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/metrics-prometheus.yaml
+++ b/bitnami/redis-cluster/templates/metrics-prometheus.yaml
@@ -4,7 +4,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "common.names.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace | quote }}
+  {{- else}}
+  namespace: {{ .Release.Namespace | quote }}
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/bitnami/redis-cluster/templates/metrics-svc.yaml
+++ b/bitnami/redis-cluster/templates/metrics-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.service.labels }}
     {{ include "common.tplvalues.render" ( dict "value" .Values.metrics.service.labels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/networkpolicy.yaml
+++ b/bitnami/redis-cluster/templates/networkpolicy.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ template "networkPolicy.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+  namespace: {{ .Release.Namespace | quote }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/redis-cluster/templates/poddisruptionbudget.yaml
+++ b/bitnami/redis-cluster/templates/poddisruptionbudget.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/prometheusrule.yaml
+++ b/bitnami/redis-cluster/templates/prometheusrule.yaml
@@ -3,9 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "common.names.fullname" . }}
-{{- with .Values.metrics.prometheusRule.namespace }}
-  namespace: {{ . }}
-{{- end }}
+  {{- if .Values.metrics.prometheusRule.namespace }}
+  namespace: {{ .Values.metrics.prometheusRule.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/psp.yaml
+++ b/bitnami/redis-cluster/templates/psp.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/redis-role.yaml
+++ b/bitnami/redis-cluster/templates/redis-role.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/redis-rolebinding.yaml
+++ b/bitnami/redis-cluster/templates/redis-rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/redis-serviceaccount.yaml
+++ b/bitnami/redis-cluster/templates/redis-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "redis-cluster.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/redis-svc.yaml
+++ b/bitnami/redis-cluster/templates/redis-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.service.labels -}}
     {{ include "common.tplvalues.render" ( dict "value" .Values.service.labels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/scripts-configmap.yaml
+++ b/bitnami/redis-cluster/templates/scripts-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}-scripts
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/secret.yaml
+++ b/bitnami/redis-cluster/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml
+++ b/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml
@@ -12,6 +12,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" $ }}-{{ $i }}-svc
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     pod: {{ $targetPod }}
     {{- if $root.Values.commonLabels }}

--- a/bitnami/redis-cluster/templates/tls-secret.yaml
+++ b/bitnami/redis-cluster/templates/tls-secret.yaml
@@ -11,6 +11,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}-crt
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/redis-cluster/templates/update-cluster.yaml
+++ b/bitnami/redis-cluster/templates/update-cluster.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "common.names.fullname" . }}-cluster-update
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}


### PR DESCRIPTION
**Description of the change**

The scope of this work is to add namesapce into all the templates used to generate the yaml files required to deploy all the components of this chart, if enabled.

This pretty much replicate the work from the redis chart, with the adjustments required and all the parts dedicated to this chart completed.

We migrated from the redis chart (using sentinel) and we noticed that this one was missing the namespace in the metadata object. 
We added it, tested it and it is running in our dev environment for a while, so we believe that this is correctly done.

Also the tests and the template generated looks ok.

We have generated a template with a "test-ns" namespace and all the components enabled, not completely filled, except for the ones that were affected by the scope of this work.

**Benefits**

It will be easy to configure the namespace for the generated yaml files.

**Possible drawbacks**

None so far

**Applicable issues**

None so far

**Additional information**

We hope you like :)

The engineering YData team <developers@ydata.ai>


**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

Signed-off-by: Luís Portela Afonso <luis.portela@ydata.ai>