### PR TITLE
[bitnami/external-dns] Fix deployment error on AKS with MSI. (refs bitnami#8822)

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 6.1.2
+version: 6.1.3

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -609,7 +609,7 @@ spec:
             - name: azure-config-file
               {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
               mountPath: /etc/kubernetes/
-              {{- else if not .Values.azure.useManagedIdentityExtension }}
+              {{- else }}
               mountPath: /etc/kubernetes/azure.json
               {{- end }}
               readOnly: true
@@ -676,7 +676,10 @@ spec:
           {{- if or .Values.azure.secretName (and .Values.azure.resourceGroup .Values.azure.tenantId .Values.azure.subscriptionId) }}
           secret:
             secretName: {{ template "external-dns.secretName" . }}
-          {{- else if not .Values.azure.useManagedIdentityExtension }}
+          {{- else if .Values.azure.useManagedIdentityExtension }}
+          secret:
+            secretName: {{ template "external-dns.fullname" . }}
+          {{- else }}
           hostPath:
             path: /etc/kubernetes/azure.json
             type: File


### PR DESCRIPTION
**Description of the change**

Uses a generated secret resource if `azure.useManagedIdentity` is `true`

**Benefits**

Fixes #8822

**Possible drawbacks**

None

**Applicable issues**

  - fixes #8822

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)