### PR TITLE
[bitnami/redis] Support custom init command for metrics container

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Database
 apiVersion: v2
-appVersion: 6.2.6
+appVersion: 6.2.7
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Database
 apiVersion: v2
-appVersion: 6.2.7
+appVersion: 6.2.6
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.2.1
+version: 16.2.2

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.2.2
+version: 16.3.0

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -402,6 +402,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.image.tag`                          | Redis&trade; Redis&trade; Exporter image tag (immutable tags are recommended)                    | `1.33.0-debian-10-r27`   |
 | `metrics.image.pullPolicy`                   | Redis&trade; Exporter image pull policy                                                          | `IfNotPresent`           |
 | `metrics.image.pullSecrets`                  | Redis&trade; Exporter image pull secrets                                                         | `[]`                     |
+| `metrics.command`                            | Support custom init command for metrics container                                                | `[]`                     |
 | `metrics.redisTargetHost`                    | A way to specify an alternative Redis&trade; hostname                                            | `localhost`              |
 | `metrics.extraArgs`                          | Extra arguments for Redis&trade; exporter, for example:                                          | `{}`                     |
 | `metrics.containerSecurityContext.enabled`   | Enabled Redis&trade; exporter containers' Security Context                                       | `true`                   |

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -402,7 +402,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.image.tag`                          | Redis&trade; Redis&trade; Exporter image tag (immutable tags are recommended)                    | `1.33.0-debian-10-r27`   |
 | `metrics.image.pullPolicy`                   | Redis&trade; Exporter image pull policy                                                          | `IfNotPresent`           |
 | `metrics.image.pullSecrets`                  | Redis&trade; Exporter image pull secrets                                                         | `[]`                     |
-| `metrics.command`                            | Support custom init command for metrics container                                                | `[]`                     |
+| `metrics.command`                            | Override default metrics container init command (useful when using custom images)                | `[]`                     |
 | `metrics.redisTargetHost`                    | A way to specify an alternative Redis&trade; hostname                                            | `localhost`              |
 | `metrics.extraArgs`                          | Extra arguments for Redis&trade; exporter, for example:                                          | `{}`                     |
 | `metrics.containerSecurityContext.enabled`   | Enabled Redis&trade; exporter containers' Security Context                                       | `true`                   |

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -257,6 +257,8 @@ spec:
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - /bin/bash

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1205,7 +1205,7 @@ metrics:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-  ## @param metrics.command Override default metrics container command (useful when using custom images)
+  ## @param metrics.command Override default metrics container init command (useful when using custom images)
   ##
   command: []
   ## @param metrics.redisTargetHost A way to specify an alternative Redis&trade; hostname

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1206,7 +1206,7 @@ metrics:
     ##
     pullSecrets: []
   ## @param metrics.command Override default metrics container init command (useful when using custom images)
-  ##
+  ## 
   command: []
   ## @param metrics.redisTargetHost A way to specify an alternative Redis&trade; hostname
   ## Useful for certificate CN/SAN matching

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1205,6 +1205,9 @@ metrics:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
+  ## @param metrics.command Override default metrics container command (useful when using custom images)
+  ##
+  command: []
   ## @param metrics.redisTargetHost A way to specify an alternative Redis&trade; hostname
   ## Useful for certificate CN/SAN matching
   ##

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1206,7 +1206,7 @@ metrics:
     ##
     pullSecrets: []
   ## @param metrics.command Override default metrics container init command (useful when using custom images)
-  ## 
+  ##
   command: []
   ## @param metrics.redisTargetHost A way to specify an alternative Redis&trade; hostname
   ## Useful for certificate CN/SAN matching


### PR DESCRIPTION


**Description of the change**

Support custom init metrics container command

**Benefits**

useful for custom metrics image usage

**Possible drawbacks**
N/A

**Applicable issues**

N/A

**Additional information**
N/A


**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)