### PR TITLE
Replacing tkg target platform name

### DIFF
--- a/.github/workflows/vib.yaml
+++ b/.github/workflows/vib.yaml
@@ -36,7 +36,7 @@ jobs:
            target-platform-id: 91d398a2-25c4-4cda-8732-75a3cfc179a1
          - target-platform: aks
            target-platform-id: 7b13a7bb-011c-474f-ad71-8152fc321b9e
-         - target-platform: tkg-1.3.0-aws
+         - target-platform: tkg
            target-platform-id: 7ddab896-2e4e-4d58-a501-f79897eba3a0
       fail-fast: false
     name: K8s verify ${{ matrix.target-platform}}


### PR DESCRIPTION
**Renaming tkg target platform**

 Replacing _tkg-1.3.0-aws_ with _tkg_

- fixes #8838 