### PR TITLE
[bitnami/mongodb] Fix exporter command

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 11.0.0
+version: 11.0.1

--- a/bitnami/mongodb/ci/metrics-values.yaml
+++ b/bitnami/mongodb/ci/metrics-values.yaml
@@ -1,0 +1,2 @@
+metrics:
+  enabled: true

--- a/bitnami/mongodb/ci/metrics-values.yaml
+++ b/bitnami/mongodb/ci/metrics-values.yaml
@@ -1,2 +1,0 @@
-metrics:
-  enabled: true

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -387,44 +387,10 @@ spec:
           {{- end }}
           command:
             - /bin/bash
-          args:
             - -ec
+          args:
             - |
-                #!/bin/bash
-
-                set -o errexit
-                set -o nounset
-                set -o pipefail
-
-                retry_while() {
-                    local cmd="${1:?cmd is missing}"
-                    local retries="${2:-12}"
-                    local sleep_time="${3:-5}"
-                    local return_value=1
-
-                    read -r -a command <<< "$cmd"
-                    for ((i = 1 ; i <= retries ; i+=1 )); do
-                        "${command[@]}" && return_value=0 && break
-                        sleep "$sleep_time"
-                    done
-                    return $return_value
-                }
-
-                check_mongodb_connection() {
-                  /bin/mongodb_exporter --test --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }} >/dev/null 2>&1
-                  ret=$?
-                  if [ $ret -ne 0 ]; then
-                    false
-                  fi
-                }
-
-                echo "Checking MongoDB connection..."
-                if ! retry_while "check_mongodb_connection"; then
-                    echo "Could not connect to the MongoDB server"
-                    return 1
-                else
-                    /bin/mongodb_exporter --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
-                fi
+              /bin/mongodb_exporter --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
           env:
           {{- if .Values.auth.enabled }}
           {{- if not .Values.metrics.username }}


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amorenoc@vmware.com>

**Description of the change**
Fix the command for the exporter.

The command was using a `--test` flag that isn't supported anymore. This was added to the chart logic in order to try and make the exporter start after MongoDB is already live, to avoid connection issues. However, this is not needed since each call to the exporter endpoint will create a new connection to get the data.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)