### PR TITLE
[bitnami/redis] Allow to change Workload as StatefulSet or Deployment

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.3.1
+version: 16.4.0

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -160,6 +160,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.podSecurityContext.fsGroup`         | Set Redis&trade; master pod's Security Context fsGroup                                            | `1001`                   |
 | `master.containerSecurityContext.enabled`   | Enabled Redis&trade; master containers' Security Context                                          | `true`                   |
 | `master.containerSecurityContext.runAsUser` | Set Redis&trade; master containers' Security Context runAsUser                                    | `1001`                   |
+| `master.kind`                               | Use either Deployment or StatefulSet (default)                                                    | `StatefulSet`            |
 | `master.schedulerName`                      | Alternate scheduler for Redis&trade; master pods                                                  | `""`                     |
 | `master.updateStrategy.type`                | Redis&trade; master statefulset strategy type                                                     | `RollingUpdate`          |
 | `master.priorityClassName`                  | Redis&trade; master pods' priorityClassName                                                       | `""`                     |

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -1,6 +1,6 @@
 {{- if or (not (eq .Values.architecture "replication")) (not .Values.sentinel.enabled) }}
 apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
-kind: StatefulSet
+kind: {{ .Values.master.kind }}
 metadata:
   name: {{ printf "%s-master" (include "common.names.fullname" .) }}
   namespace: {{ .Release.Namespace | quote }}
@@ -17,9 +17,15 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: master
+  {{- if (eq .Values.master.kind "StatefulSet") }}
   serviceName: {{ printf "%s-headless" (include "common.names.fullname" .) }}
+  {{- end }}
   {{- if .Values.master.updateStrategy }}
+  {{- if (eq .Values.master.kind "Deployment") }}
+  strategy: {{- toYaml .Values.master.updateStrategy | nindent 4 }}
+  {{- else }}
   updateStrategy: {{- toYaml .Values.master.updateStrategy | nindent 4 }}
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -428,6 +428,10 @@ spec:
         - name: redis-data
           persistentVolumeClaim:
             claimName: {{ printf "%s" (tpl .Values.master.persistence.existingClaim .) }}
+  {{- else if (eq .Values.master.kind "Deployment") }}
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: {{ printf "redis-data-%s-master" (include "common.names.fullname" .) }}
   {{- else }}
   volumeClaimTemplates:
     - metadata:

--- a/bitnami/redis/templates/master/pvc.yaml
+++ b/bitnami/redis/templates/master/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if and (eq .Values.architecture "standalone") (eq .Values.master.kind "Deployment") (.Values.master.persistence.enabled) (not .Values.master.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ printf "redis-data-%s-master" (include "common.names.fullname" .) }}
+  labels: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: master
+  {{- if .Values.master.persistence.annotations }}
+  annotations: {{- toYaml .Values.master.persistence.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+  {{- range .Values.master.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.master.persistence.size | quote }}
+  {{- if .Values.master.persistence.selector }}
+  selector: {{- include "common.tplvalues.render" (dict "value" .Values.master.persistence.selector "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.master.persistence.dataSource }}
+  dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.master.persistence.dataSource "context" $) | nindent 4 }}
+  {{- end }}
+  {{- include "common.storage.class" (dict "persistence" .Values.master.persistence "global" .Values.global) | nindent 4 }}
+{{- end }}

--- a/bitnami/redis/values.schema.json
+++ b/bitnami/redis/values.schema.json
@@ -36,6 +36,13 @@
       "title": "Master replicas settings",
       "form": true,
       "properties": {
+        "kind": {
+          "type": "string",
+          "title": "Workload Kind",
+          "form": true,
+          "description": "Allowed values: `Deployment` or `StatefulSet`",
+          "enum": ["Deployment", "StatefulSet"]
+        },
         "persistence": {
           "type": "object",
           "title": "Persistence for master replicas",

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -262,6 +262,10 @@ master:
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
+  ## @param master.kind Use either Deployment or StatefulSet (default)
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+  ##
+  kind: StatefulSet
   ## @param master.schedulerName Alternate scheduler for Redis&trade; master pods
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Allow user to change `Kind` type on Redis Master from default `StatefulSet` to `Deployment`.

**Benefits**

This can be useful for people who want a single Pod with no persistent storage, as per current behaviour, if the node where StatefulSet is running goes down, Redis won't start until the node is recovered.

**Possible drawbacks**

None, user is able to switch between options.

**Applicable issues**

  - fixes #6386

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)