### PR TITLE
Don't run readme-generator when a ci values.yaml file is modified

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     paths:
-      - 'bitnami/**/values.yaml'
+      - 'bitnami/*/values.yaml'
 
 jobs:
   generate-chart-readme:


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amorenoc@vmware.com>

**Description of the change**
Only run the readme-generator workflow when the `values.yaml` of a chart is modified, ignoring the files under the `ci` directory.

**Checklist**
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)