### PR TITLE
[bitnami/common] Improve "common.secrets.passwords.manage" helper

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 1.11.0
+appVersion: 1.11.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - https://www.bitnami.com/
 type: library
-version: 1.11.0
+version: 1.11.1

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -86,14 +86,7 @@ Params:
   {{- if hasKey $secretData .key }}
     {{- $password = index $secretData .key }}
   {{- else }}
-    {{- if .strong }}
-      {{- $subStr := list (lower (randAlpha 1)) (randNumeric 1) (upper (randAlpha 1)) | join "_" }}
-      {{- $password = randAscii $passwordLength }}
-      {{- $password = regexReplaceAllLiteral "\\W" $password "@" | substr 5 $passwordLength }}
-      {{- $password = printf "%s%s" $subStr $password | toString | shuffle | b64enc | quote }}
-    {{- else }}
-      {{- $password = randAlphaNum $passwordLength | b64enc | quote }}
-    {{- end }}
+    {{- printf "\nPASSWORDS ERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
   {{- end -}}
 {{- else if $providedPasswordValue }}
   {{- $password = $providedPasswordValue | toString | b64enc | quote }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

The current **"common.secrets.passwords.manage"** is a helper to manage secret passwords for a given secret/key. It basically does two things:

- If the given secret exists (release upgrade), it reuses the secret password that was previously set in the existing secret for the given key.
- If the given secret doesn't exist (new release installation), it creates a random secret password if the corresponding parameter is not set.
- If the given secret doesn't exist (new release installation), it creates a secret password based on a parameter if that parameter is set.

This help work flawlessly but there's a scenario it doesn't take into account:

- what happens if the given secret exists but the given key does not? E.g. upgrading between two chart versions where a key was renamed from `foo-pass` to `bar-pass`. 
 
This PR tries to answer this question by throwing a proper error. 

**Benefits**

The **"common.secrets.passwords.manage"** helper manages existing secrets that don't contain an expected key properly.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)