### PR TITLE
[bitnami/node] Added possibility to overwrite npm install-command

### DIFF
--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -28,4 +28,4 @@ name: node
 sources:
   - https://github.com/bitnami/bitnami-docker-node
   - http://nodejs.org/
-version: 16.2.5
+version: 16.3.0

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -77,6 +77,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                                    | Description                                                                                                          | Value                             |
 | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `installCommand`                        | Override default container install command (useful when using custom images or repositories)                         | `["/bin/bash","-ec","npm install"]` |
 | `command`                               | Override default container command (useful when using custom images)                                                 | `["/bin/bash","-ec","npm start"]` |
 | `args`                                  | Override default container args (useful when using custom images)                                                    | `[]`                              |
 | `hostAliases`                           | Deployment pod host aliases                                                                                          | `[]`                              |

--- a/bitnami/node/templates/deployment.yaml
+++ b/bitnami/node/templates/deployment.yaml
@@ -69,11 +69,9 @@ spec:
           image: {{ template "node.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           workingDir: /app
-          command:
-            - /bin/bash
-            - -ec
-            - |
-              npm install
+          {{- if .Values.installCommand }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.installCommand "context" $) | nindent 12 }}
+          {{- end }}
           env:
             - name: HOME
               value: /tmp

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -36,6 +36,9 @@ commonAnnotations: {}
 
 ## @section Node parameters
 
+## @param installCommand Override default container install command (useful when using custom images or repositories)
+##
+installCommand: ['/bin/bash', '-ec', 'npm install']
 ## @param command Override default container command (useful when using custom images)
 ##
 command: ['/bin/bash', '-ec', 'npm start']


### PR DESCRIPTION
**Description of the change**

This pull request adds a Node parameter to overwrite the default install command (`npm install`) with a custom one.

**Benefits**

There are deloy scenarios, in which `npm install` is not desired upon initialization - for example, when a complete and tested "fixed package", including node_modules, is put together through CI workflows and saved in a "distribution"-repository. In those cases, it is desired to prevent npm from changing node_modules, package.json or package-lock.json by accident. I thought it would be better to give the option to overwrite the install-command instead of just making it optional.

**Possible drawbacks**

This feature should be non-breaking, since the default option is the same as the hard-coded command before the change. In case someone had, for unknown-reasons, `installCommand` in their helm charts before, the deployments might be affected by this change. I guess that is rather unlikely since `installCommand` was not used before.

**Applicable issues**

None

**Additional information**

None

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)