### PR TITLE
[bitnami/postgresql] Fix "postgresql.primary.extendedConfigmapName" named template

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 11.0.0
+version: 11.0.1

--- a/bitnami/postgresql/ci/extended-config.yaml
+++ b/bitnami/postgresql/ci/extended-config.yaml
@@ -1,0 +1,4 @@
+primary:
+  extendedConfiguration: |
+    pg_stat_statements.max = 10000
+    pg_stat_statements.track = all

--- a/bitnami/postgresql/templates/_helpers.tpl
+++ b/bitnami/postgresql/templates/_helpers.tpl
@@ -158,7 +158,7 @@ Get the PostgreSQL primary extended configuration ConfigMap name.
 {{- if .Values.primary.existingExtendedConfigmap -}}
     {{- printf "%s" (tpl .Values.primary.existingExtendedConfigmap $) -}}
 {{- else -}}
-    {{- printf printf "%s-extended-configuration" (include "postgresql.primary.fullname" .) -}}
+    {{- printf "%s-extended-configuration" (include "postgresql.primary.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR fixes a bug introduced in the "postgresql.primary.extendedConfigmapName" at #8827. It also improves the githooks coverage to ensure we don't include break this functionality anymore.

**Benefits**

Users can actually use the `primary. extendedConfiguration` parameter.

**Possible drawbacks**

None

**Applicable issues**

  - fixes #8884

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)