### PR TITLE
[bitnami/mongodb] fix duplicated arbiter MONGODB_EXTRA_FLAGS env var

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 11.0.2
+version: 11.0.3

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -187,13 +187,13 @@ spec:
             {{- end }}
             - name: ALLOW_EMPTY_PASSWORD
               value: {{ ternary "no" "yes" .Values.auth.enabled | quote }}
-            {{- if and .Values.tls.enabled .Values.arbiter.enabled }}
-            - name: MONGODB_EXTRA_FLAGS
-              value: --tlsMode={{ .Values.tls.mode }} --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert
+            {{- $extraFlags := .Values.arbiter.extraFlags | join " " -}}
+            {{- if and .Values.tls.enabled .Values.arbiter.enabled  }}
+              {{- $extraFlags = printf "--tlsMode=%s --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert %s" .Values.tls.mode $extraFlags  }}
             {{- end }}
-            {{- if .Values.arbiter.extraFlags }}
+            {{- if ne $extraFlags "" }}
             - name: MONGODB_EXTRA_FLAGS
-              value: {{ .Values.arbiter.extraFlags | join " " | quote }}
+              value: {{ $extraFlags | quote }}
             {{- end }}
             {{- if and .Values.tls.enabled  .Values.arbiter.enabled }}
             - name: MONGODB_CLIENT_EXTRA_FLAGS


### PR DESCRIPTION
**Description of the change**
This change allows a user to add arbiter.extraVars and to enable TLS without duplicating MONGODB_EXTRA_FLAGS environment variable. Details are given in the linked issue.

**Benefits**
Fix a bug.

**Possible drawbacks**
None.

**Applicable issues**

  - fixes #8872

**Additional information**
None.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)