### PR TITLE
[bitnami/external-dns]fix: add commonAnnotations to deployment

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 6.1.3
+version: 6.1.4

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ template "external-dns.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "external-dns.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ coalesce .Values.replicas .Values.replicaCount }}
   {{- if .Values.updateStrategy }}


### PR DESCRIPTION
**Description of the change**
It would be great to be able to add annotations for the main deployment.
Our use case is that we automatically inspect all components running in the cluster to give advice about best practices etc. To ignore some rules per object we need to be able to set annotations.

There is already a property called commonAnnotations, but it is not applied to the deployment


**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)