### PR TITLE
[bitnami/kafka] Fix volumeMounts error for kafka-provisioning

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 15.0.4
+version: 15.0.5

--- a/bitnami/kafka/templates/kafka-provisioning.yaml
+++ b/bitnami/kafka/templates/kafka-provisioning.yaml
@@ -120,7 +120,7 @@ spec:
             {{- end }}
             {{- if (include "kafka.tlsEncryption" .) }}
             {{- if not (empty .Values.auth.tls.existingSecrets) }}
-            {{- range $index := .Values.auth.tls.existingSecrets }}
+            {{- range $index, $_ := .Values.auth.tls.existingSecrets }}
             - name: kafka-certs-{{ $index }}
               mountPath: /certs-{{ $index }}
               readOnly: true


### PR DESCRIPTION
**Description of the change**
Fix a bug when using auth.tls.existingSecrets along with kafka-provisioning. If the second value is not unpacked, then the $index variable is not the index as intended, but the name of the secret.

**Benefits**
Can use auth.tls.existingSecrets along with kafka-provisioning.

**Possible drawbacks**
None.

**Applicable issues**
None.

**Additional information**
None.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)