### PR TITLE
[bitnami/concourse] Chart standardization

### DIFF
--- a/bitnami/concourse/Chart.lock
+++ b/bitnami/concourse/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.15.1
+  version: 11.0.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.10.3
-digest: sha256:50ca10131cb3dc2daac49dcf0a9b4cfcf28924d37706e1ba5c04a0d43777fb00
-generated: "2022-01-11T11:37:46.863323223Z"
+  version: 1.11.1
+digest: sha256:a4cdc1eda75b8956dc9a88597211401800cf3eb927441c9061baff86bcb215fe
+generated: "2022-02-07T11:53:31.689472+01:00"

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 10.X.X
+    version: 11.X.X
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
@@ -30,4 +30,4 @@ name: concourse
 sources:
   - https://github.com/bitnami/bitnami-docker-concourse
   - https://github.com/concourse/concourse
-version: 0.2.2
+version: 1.0.0

--- a/bitnami/concourse/README.md
+++ b/bitnami/concourse/README.md
@@ -61,14 +61,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                | Description                                        | Value |
-| ------------------- | -------------------------------------------------- | ----- |
-| `kubeVersion`       | Override Kubernetes version                        | `""`  |
-| `nameOverride`      | String to partially override common.names.fullname | `""`  |
-| `fullnameOverride`  | String to fully override common.names.fullname     | `""`  |
-| `commonLabels`      | Labels to add to all deployed objects              | `{}`  |
-| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`  |
-| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`  |
+| Name                     | Description                                                                             | Value          |
+| ------------------------ | --------------------------------------------------------------------------------------- | -------------- |
+| `kubeVersion`            | Override Kubernetes version                                                             | `""`           |
+| `nameOverride`           | String to partially override common.names.fullname                                      | `""`           |
+| `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`           |
+| `commonLabels`           | Labels to add to all deployed objects                                                   | `{}`           |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`           |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`           |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`        |
+| `diagnosticMode.command` | Command to override all containers in the deployment(s)/statefulset(s)                  | `["sleep"]`    |
+| `diagnosticMode.args`    | Args to override all containers in the deployment(s)/statefulset(s)                     | `["infinity"]` |
 
 
 ### Common Concourse Parameters
@@ -81,8 +84,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.pullPolicy`              | image pull policy                                                                                                                      | `IfNotPresent`        |
 | `image.pullSecrets`             | image pull secrets                                                                                                                     | `[]`                  |
 | `secrets.localAuth.enabled`     | the use of local authentication (basic auth).                                                                                          | `true`                |
-| `secrets.teamAuthorizedKeys`    | Array of team names and public keys for team external workers. A single                                                                | `[]`                  |
 | `secrets.localUsers`            | List of `username:password` or `username:bcrypted_password` combinations for all your local concourse users. Auto-generated if not set | `""`                  |
+| `secrets.teamAuthorizedKeys`    | Array of team names and public keys for team external workers                                                                          | `[]`                  |
 | `secrets.hostKey`               | Concourse Host Keys.                                                                                                                   | `""`                  |
 | `secrets.hostKeyPub`            | Concourse Host Keys.                                                                                                                   | `""`                  |
 | `secrets.sessionSigningKey`     | Concourse Session Signing Keys.                                                                                                        | `""`                  |
@@ -93,247 +96,284 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Concourse Web parameters
 
-| Name                                     | Description                                                                                                                                 | Value           |
-| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `web.enabled`                            | Enable web                                                                                                                                  | `true`          |
-| `web.replicaCount`                       | Number of web replicas to deploy                                                                                                            | `1`             |
-| `web.args`                               | Override default args of the startup command for the web component.                                                                         | `[]`            |
-| `web.baseUrl`                            | url                                                                                                                                         | `/`             |
-| `web.logLevel`                           | Minimum level of logs to see. Possible options: debug, info, error.                                                                         | `debug`         |
-| `web.clusterName`                        | A name for this Concourse cluster, to be displayed on the dashboard page.                                                                   | `""`            |
-| `web.bindIp`                             | IP address on which to listen for HTTP traffic (web UI and API).                                                                            | `0.0.0.0`       |
-| `web.containerPort`                      | Port on which to listen for HTTP traffic (web UI and API).                                                                                  | `8080`          |
-| `web.peerAddress`                        | Network address of this web node, reachable by other web nodes.                                                                             | `""`            |
-| `web.externalUrl`                        | URL used to reach any ATC from the outside world.                                                                                           | `""`            |
-| `web.enableAcrossStep`                   | Enable the experimental across step to be used in jobs. The API is subject to change.                                                       | `false`         |
-| `web.enablePipelineInstances`            | Enable the creation of instanced pipelines.                                                                                                 | `false`         |
-| `web.enableCacheStreamedVolumes`         | Enable caching streamed resource volumes on the destination worker.                                                                         | `false`         |
-| `web.livenessProbe.enabled`              | Enable livenessProbe on web nodes                                                                                                           | `true`          |
-| `web.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                                     | `10`            |
-| `web.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                                            | `15`            |
-| `web.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                                           | `3`             |
-| `web.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                                         | `1`             |
-| `web.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                                         | `1`             |
-| `web.readinessProbe.enabled`             | Enable readinessProbe                                                                                                                       | `true`          |
-| `web.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                                    | `10`            |
-| `web.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                                           | `15`            |
-| `web.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                                          | `3`             |
-| `web.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                                        | `1`             |
-| `web.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                                        | `1`             |
-| `web.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                                                         | `{}`            |
-| `web.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                                                        | `{}`            |
-| `web.resources.limits`                   | The resources limits for the web containers                                                                                                 | `{}`            |
-| `web.resources.requests`                 | The requested for the web containers                                                                                                        | `{}`            |
-| `web.rbac.create`                        | Specifies whether RBAC resources should be created                                                                                          | `true`          |
-| `web.serviceAccount.create`              | Specifies whether a ServiceAccount should be created                                                                                        | `true`          |
-| `web.serviceAccount.name`                | Override Web service account name                                                                                                           | `""`            |
-| `web.tls.enabled`                        | enable serving HTTPS traffic directly through the web component.                                                                            | `false`         |
-| `web.tls.containerPort`                  | on which to listen for HTTPS traffic.                                                                                                       | `443`           |
-| `web.existingConfigmap`                  | The name of an existing ConfigMap with your custom configuration for web                                                                    | `""`            |
-| `web.command`                            | Override default container command (useful when using custom images)                                                                        | `[]`            |
-| `web.hostAliases`                        | Deployment pod host aliases                                                                                                                 | `[]`            |
-| `web.podLabels`                          | Extra labels for web pods                                                                                                                   | `{}`            |
-| `web.podSecurityContext.enabled`         | Enabled web pods' Security Context                                                                                                          | `true`          |
-| `web.podSecurityContext.fsGroup`         | Set web pod's Security Context fsGroup                                                                                                      | `1001`          |
-| `web.containerSecurityContext.enabled`   | Enabled web containers' Security Context                                                                                                    | `true`          |
-| `web.containerSecurityContext.runAsUser` | Set web containers' Security Context runAsUser                                                                                              | `1001`          |
-| `web.psp.create`                         | Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later | `false`         |
-| `web.tsa.logLevel`                       | Minimum level of logs to see. Possible values: debug, info, error.                                                                          | `debug`         |
-| `web.tsa.bindIp`                         | IP address on which to listen for SSH.                                                                                                      | `0.0.0.0`       |
-| `web.tsa.containerPort`                  | Port on which to listen for SSH.                                                                                                            | `2222`          |
-| `web.tsa.debugbindIp`                    | IP address on which to listen for the pprof debugger endpoints (default: 127.0.0.1)                                                         | `127.0.0.1`     |
-| `web.tsa.debugContainerPort`             | Port on which to listen for TSA pprof server.                                                                                               | `2221`          |
-| `web.tsa.heartbeatInterval`              | Interval on which to heartbeat workers to the ATC.                                                                                          | `30s`           |
-| `web.tsa.gardenRequestTimeout`           | How long to wait for requests to Garden to complete. 0 means no timeout.                                                                    | `""`            |
-| `web.configRBAC`                         | set RBAC configuration                                                                                                                      | `""`            |
-| `web.auth.cookieSecure`                  | use cookie secure true or flase                                                                                                             | `false`         |
-| `web.auth.duration`                      | Length of time for which tokens are valid. Afterwards, users will have to log back in.                                                      | `24h`           |
-| `web.auth.passwordConnector`             | The connector to use for password authentication for `fly login -u ... -p ...`.                                                             | `""`            |
-| `web.auth.mainTeam.config`               | Configuration file for specifying the main teams params.                                                                                    | `""`            |
-| `web.auth.mainTeam.localUser`            | Comma-separated list of local Concourse users to be included as members of the `main` team.                                                 | `user`          |
-| `web.podAnnotations`                     | Annotations for web pods                                                                                                                    | `{}`            |
-| `web.podAffinityPreset`                  | Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                                                     | `""`            |
-| `web.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                                                | `soft`          |
-| `web.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                                               | `""`            |
-| `web.nodeAffinityPreset.key`             | Node label key to match. Ignored if `web.affinity` is set                                                                                   | `""`            |
-| `web.nodeAffinityPreset.values`          | Node label values to match. Ignored if `web.affinity` is set                                                                                | `[]`            |
-| `web.affinity`                           | Affinity for web pods assignment                                                                                                            | `{}`            |
-| `web.nodeSelector`                       | Node labels for web pods assignment                                                                                                         | `{}`            |
-| `web.tolerations`                        | Tolerations for web pods assignment                                                                                                         | `[]`            |
-| `web.updateStrategy.type`                | web statefulset strategy type                                                                                                               | `RollingUpdate` |
-| `web.priorityClassName`                  | web pods' priorityClassName                                                                                                                 | `""`            |
-| `web.lifecycleHooks`                     | for the web container(s) to automate configuration before or after startup                                                                  | `{}`            |
-| `web.extraEnvVars`                       | Array with extra environment variables to add to web nodes                                                                                  | `[]`            |
-| `web.baseResourceTypeDefaults`           | Configuration file for specifying defaults for base resource types                                                                          | `""`            |
-| `web.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for web nodes                                                                          | `""`            |
-| `web.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for web nodes                                                                             | `""`            |
-| `web.extraVolumes`                       | Optionally specify extra list of additional volumes for the web pod(s)                                                                      | `[]`            |
-| `web.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the web container(s)                                                           | `[]`            |
-| `web.sidecars`                           | Add additional sidecar containers to the web pod(s)                                                                                         | `[]`            |
-| `web.initContainers`                     | Add additional init containers to the web pod(s)                                                                                            | `[]`            |
-| `web.existingSecret`                     | Use an existing secret for the Web service credentials                                                                                      | `""`            |
+| Name                                              | Description                                                                                                                                 | Value           |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| `web.enabled`                                     | Enable Concourse web component                                                                                                              | `true`          |
+| `web.baseUrl`                                     | url                                                                                                                                         | `/`             |
+| `web.logLevel`                                    | Minimum level of logs to see. Possible options: debug, info, error.                                                                         | `debug`         |
+| `web.clusterName`                                 | A name for this Concourse cluster, to be displayed on the dashboard page.                                                                   | `""`            |
+| `web.bindIp`                                      | IP address on which to listen for HTTP traffic (web UI and API).                                                                            | `0.0.0.0`       |
+| `web.peerAddress`                                 | Network address of this web node, reachable by other web nodes.                                                                             | `""`            |
+| `web.externalUrl`                                 | URL used to reach any ATC from the outside world.                                                                                           | `""`            |
+| `web.auth.cookieSecure`                           | use cookie secure true or false                                                                                                             | `false`         |
+| `web.auth.duration`                               | Length of time for which tokens are valid. Afterwards, users will have to log back in.                                                      | `24h`           |
+| `web.auth.passwordConnector`                      | The connector to use for password authentication for `fly login -u ... -p ...`.                                                             | `""`            |
+| `web.auth.mainTeam.config`                        | Configuration file for specifying the main teams params.                                                                                    | `""`            |
+| `web.auth.mainTeam.localUser`                     | Comma-separated list of local Concourse users to be included as members of the `main` team.                                                 | `user`          |
+| `web.existingSecret`                              | Use an existing secret for the Web service credentials                                                                                      | `""`            |
+| `web.enableAcrossStep`                            | Enable the experimental across step to be used in jobs. The API is subject to change.                                                       | `false`         |
+| `web.enablePipelineInstances`                     | Enable the creation of instanced pipelines.                                                                                                 | `false`         |
+| `web.enableCacheStreamedVolumes`                  | Enable caching streamed resource volumes on the destination worker.                                                                         | `false`         |
+| `web.baseResourceTypeDefaults`                    | Configuration file for specifying defaults for base resource types                                                                          | `""`            |
+| `web.tsa.logLevel`                                | Minimum level of logs to see. Possible values: debug, info, error                                                                           | `debug`         |
+| `web.tsa.bindIp`                                  | IP address on which to listen for SSH                                                                                                       | `0.0.0.0`       |
+| `web.tsa.debugBindIp`                             | IP address on which to listen for the pprof debugger endpoints (default: 127.0.0.1)                                                         | `127.0.0.1`     |
+| `web.tsa.heartbeatInterval`                       | Interval on which to heartbeat workers to the ATC                                                                                           | `30s`           |
+| `web.tsa.gardenRequestTimeout`                    | How long to wait for requests to Garden to complete. 0 means no timeout                                                                     | `""`            |
+| `web.tls.enabled`                                 | enable serving HTTPS traffic directly through the web component.                                                                            | `false`         |
+| `web.configRBAC`                                  | Set RBAC configuration                                                                                                                      | `""`            |
+| `web.existingConfigmap`                           | The name of an existing ConfigMap with your custom configuration for web                                                                    | `""`            |
+| `web.command`                                     | Override default container command (useful when using custom images)                                                                        | `[]`            |
+| `web.args`                                        | Override default container args (useful when using custom images)                                                                           | `[]`            |
+| `web.extraEnvVars`                                | Array with extra environment variables to add to Concourse web nodes                                                                        | `[]`            |
+| `web.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Concourse web nodes                                                                | `""`            |
+| `web.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Concourse web nodes                                                                   | `""`            |
+| `web.replicaCount`                                | Number of Concourse web replicas to deploy                                                                                                  | `1`             |
+| `web.containerPorts.http`                         | Concourse web UI and API HTTP container port                                                                                                | `8080`          |
+| `web.containerPorts.https`                        | Concourse web UI and API HTTPS container port                                                                                               | `8443`          |
+| `web.containerPorts.tsa`                          | Concourse web TSA SSH container port                                                                                                        | `2222`          |
+| `web.containerPorts.pprof`                        | Concourse web TSA pprof server container port                                                                                               | `2221`          |
+| `web.livenessProbe.enabled`                       | Enable livenessProbe on Concourse web containers                                                                                            | `true`          |
+| `web.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                                                     | `10`            |
+| `web.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                                                            | `15`            |
+| `web.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                                                           | `3`             |
+| `web.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                                                         | `1`             |
+| `web.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                                                         | `1`             |
+| `web.readinessProbe.enabled`                      | Enable readinessProbe on Concourse web containers                                                                                           | `true`          |
+| `web.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                                                                    | `10`            |
+| `web.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                                                           | `15`            |
+| `web.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                                                          | `3`             |
+| `web.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                                                        | `1`             |
+| `web.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                                                        | `1`             |
+| `web.startupProbe.enabled`                        | Enable startupProbe on Concourse web containers                                                                                             | `false`         |
+| `web.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                                                      | `5`             |
+| `web.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                                                             | `10`            |
+| `web.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                                                            | `1`             |
+| `web.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                                                          | `15`            |
+| `web.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                                                          | `1`             |
+| `web.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                                                         | `{}`            |
+| `web.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                                                        | `{}`            |
+| `web.customStartupProbe`                          | Custom startupProbe that overrides the default one                                                                                          | `{}`            |
+| `web.resources.limits`                            | The resources limits for the Concourse web containers                                                                                       | `{}`            |
+| `web.resources.requests`                          | The requested resources for the Concourse web containers                                                                                    | `{}`            |
+| `web.podSecurityContext.enabled`                  | Enabled web pods' Security Context                                                                                                          | `true`          |
+| `web.podSecurityContext.fsGroup`                  | Set web pod's Security Context fsGroup                                                                                                      | `1001`          |
+| `web.containerSecurityContext.enabled`            | Enabled web containers' Security Context                                                                                                    | `true`          |
+| `web.containerSecurityContext.runAsUser`          | Set web containers' Security Context runAsUser                                                                                              | `1001`          |
+| `web.hostAliases`                                 | Concourse web pod host aliases                                                                                                              | `[]`            |
+| `web.podLabels`                                   | Extra labels for Concourse web pods                                                                                                         | `{}`            |
+| `web.podAnnotations`                              | Annotations for Concourse web pods                                                                                                          | `{}`            |
+| `web.podAffinityPreset`                           | Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                                                     | `""`            |
+| `web.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                                                | `soft`          |
+| `web.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                                               | `""`            |
+| `web.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `web.affinity` is set                                                                                   | `""`            |
+| `web.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `web.affinity` is set                                                                                | `[]`            |
+| `web.affinity`                                    | Affinity for web pods assignment                                                                                                            | `{}`            |
+| `web.nodeSelector`                                | Node labels for web pods assignment                                                                                                         | `{}`            |
+| `web.tolerations`                                 | Tolerations for web pods assignment                                                                                                         | `[]`            |
+| `web.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template                    | `{}`            |
+| `web.priorityClassName`                           | Priority Class to use for each pod (Concourse web)                                                                                          | `""`            |
+| `web.schedulerName`                               | Use an alternate scheduler, e.g. "stork".                                                                                                   | `""`            |
+| `web.terminationGracePeriodSeconds`               | Seconds Concourse web pod needs to terminate gracefully                                                                                     | `""`            |
+| `web.updateStrategy.rollingUpdate`                | Concourse web statefulset rolling update configuration parameters                                                                           | `{}`            |
+| `web.updateStrategy.type`                         | Concourse web statefulset strategy type                                                                                                     | `RollingUpdate` |
+| `web.lifecycleHooks`                              | lifecycleHooks for the Concourse web container(s)                                                                                           | `{}`            |
+| `web.extraVolumes`                                | Optionally specify extra list of additional volumeMounts for the Concourse web container(s)                                                 | `[]`            |
+| `web.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Concourse web container(s)                                                 | `[]`            |
+| `web.sidecars`                                    | Add additional sidecar containers to the Concourse web pod(s)                                                                               | `[]`            |
+| `web.initContainers`                              | Add additional init containers to the Concourse web pod(s)                                                                                  | `[]`            |
+| `web.psp.create`                                  | Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later | `false`         |
+| `web.rbac.create`                                 | Specifies whether RBAC resources should be created                                                                                          | `true`          |
+| `web.rbac.rules`                                  | Custom RBAC rules to set                                                                                                                    | `[]`            |
+| `web.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                                        | `true`          |
+| `web.serviceAccount.name`                         | Override Web service account name                                                                                                           | `""`            |
+| `web.serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created                                                                      | `false`         |
+| `web.serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                                                                        | `{}`            |
 
 
 ### Concourse Worker parameters
 
-| Name                                         | Description                                                                                                                                 | Value           |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
-| `worker.enabled`                             | Enable worker nodes                                                                                                                         | `true`          |
-| `worker.replicaCount`                        | Number of worker replicas                                                                                                                   | `2`             |
-| `worker.mode`                                | Selects kind of Deployment. Valid Options are: statefulSet | deployment                                                                     | `deployment`    |
-| `worker.logLevel`                            | Minimum level of logs to see. Possible options: debug, info, error                                                                          | `debug`         |
-| `worker.command`                             | Override default container command (useful when using custom images)                                                                        | `[]`            |
-| `worker.args`                                | Override worker default args                                                                                                                | `[]`            |
-| `worker.bindIp`                              | IP address on which to listen for the Garden server.                                                                                        | `127.0.0.1`     |
-| `worker.containerPort`                       | Port on which to listen for the Garden server.                                                                                              | `7777`          |
-| `worker.healthCheckContainerPort`            | Port on which to listen for the healh checks.                                                                                               | `8888`          |
-| `worker.tsa.hosts`                           | TSA host(s) to forward the worker through.                                                                                                  | `[]`            |
-| `worker.rbac.create`                         | Specifies whether RBAC resources should be created                                                                                          | `true`          |
-| `worker.serviceAccount.create`               | Specifies whether a ServiceAccount should be created                                                                                        | `true`          |
-| `worker.serviceAccount.name`                 | Override Worker service account name                                                                                                        | `""`            |
-| `worker.autoscaling.enabled`                 | Enable autoscaling for the worker nodes                                                                                                     | `false`         |
-| `worker.autoscaling.maxReplicas`             | Set maximum number of replicas to the worker nodes                                                                                          | `""`            |
-| `worker.autoscaling.minReplicas`             | Set minimum number of replicas to the worker nodes                                                                                          | `""`            |
-| `worker.autoscaling.builtInMetrics`          | Array with built-in metrics                                                                                                                 | `[]`            |
-| `worker.autoscaling.customMetrics`           | Array with custom metrics                                                                                                                   | `[]`            |
-| `worker.pdb.create`                          | Create Pod disruption budget object for worker nodes                                                                                        | `true`          |
-| `worker.pdb.minAvailable`                    | Minimum number of workers available after an eviction                                                                                       | `2`             |
-| `worker.livenessProbe.enabled`               | Enable livenessProbe on worker nodes                                                                                                        | `true`          |
-| `worker.livenessProbe.initialDelaySeconds`   | Initial delay seconds for livenessProbe                                                                                                     | `10`            |
-| `worker.livenessProbe.periodSeconds`         | Period seconds for livenessProbe                                                                                                            | `15`            |
-| `worker.livenessProbe.timeoutSeconds`        | Timeout seconds for livenessProbe                                                                                                           | `3`             |
-| `worker.livenessProbe.failureThreshold`      | Failure threshold for livenessProbe                                                                                                         | `5`             |
-| `worker.livenessProbe.successThreshold`      | Failure threshold for livenessProbe                                                                                                         | `1`             |
-| `worker.readinessProbe.enabled`              | Enable readiness probe on worker nodes                                                                                                      | `true`          |
-| `worker.readinessProbe.initialDelaySeconds`  | Initial delay seconds for readinessProbe                                                                                                    | `10`            |
-| `worker.readinessProbe.periodSeconds`        | Period seconds for readinessProbe                                                                                                           | `15`            |
-| `worker.readinessProbe.timeoutSeconds`       | Timeout seconds for readinessProbe                                                                                                          | `3`             |
-| `worker.readinessProbe.failureThreshold`     | Failure threshold for readinessProbe                                                                                                        | `5`             |
-| `worker.readinessProbe.successThreshold`     | Success threshold for readinessProbe                                                                                                        | `1`             |
-| `worker.customLivenessProbe`                 | Custom livenessProbe that overrides the default one                                                                                         | `{}`            |
-| `worker.customReadinessProbe`                | Custom readinessProbe that overrides the default one                                                                                        | `{}`            |
-| `worker.resources.limits`                    | Configure resource limits.                                                                                                                  | `{}`            |
-| `worker.resources.requests`                  | Configure resource request                                                                                                                  | `{}`            |
-| `worker.podSecurityContext.enabled`          | Enabled worker pods' Security Context                                                                                                       | `true`          |
-| `worker.podSecurityContext.fsGroup`          | Set worker pod's Security Context fsGroup                                                                                                   | `1001`          |
-| `worker.containerSecurityContext.enabled`    | Enabled worker containers' Security Context                                                                                                 | `true`          |
-| `worker.containerSecurityContext.privileged` | Set worker containers' Security Context with privileged or not                                                                              | `true`          |
-| `worker.containerSecurityContext.runAsUser`  | Set worker containers' Security Context user                                                                                                | `0`             |
-| `worker.psp.create`                          | Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later | `false`         |
-| `worker.podLabels`                           | Custom labels for worker pods                                                                                                               | `{}`            |
-| `worker.podAnnotations`                      | Annotations for worker pods                                                                                                                 | `{}`            |
-| `worker.podAffinityPreset`                   | Pod affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`                                                  | `""`            |
-| `worker.podAntiAffinityPreset`               | Pod anti-affinity preset                                                                                                                    | `soft`          |
-| `worker.hostAliases`                         | Deployment pod host aliases                                                                                                                 | `[]`            |
-| `worker.nodeAffinityPreset.type`             | Node affinity type                                                                                                                          | `""`            |
-| `worker.nodeAffinityPreset.key`              | Node label key to match                                                                                                                     | `""`            |
-| `worker.nodeAffinityPreset.values`           | Node label values to match                                                                                                                  | `[]`            |
-| `worker.affinity`                            | Affinity for pod assignment                                                                                                                 | `{}`            |
-| `worker.nodeSelector`                        | Node labels for pod assignment                                                                                                              | `{}`            |
-| `worker.tolerations`                         | Tolerations for worker pod assignment                                                                                                       | `[]`            |
-| `worker.updateStrategy.type`                 | worker statefulset strategy type                                                                                                            | `RollingUpdate` |
-| `worker.priorityClassName`                   | worker pods' priorityClassName                                                                                                              | `""`            |
-| `worker.lifecycleHooks`                      | for the worker container(s) to automate configuration before or after startup                                                               | `{}`            |
-| `worker.extraEnvVars`                        | Array with extra environment variables to add to worker nodes                                                                               | `[]`            |
-| `worker.extraEnvVarsCM`                      | Name of existing ConfigMap containing extra env vars for worker nodes                                                                       | `""`            |
-| `worker.extraEnvVarsSecret`                  | Name of existing Secret containing extra env vars for worker nodes                                                                          | `""`            |
-| `worker.extraVolumes`                        | Optionally specify extra list of additional volumes for the worker pod(s)                                                                   | `[]`            |
-| `worker.extraVolumeMounts`                   | Optionally specify extra list of additional volumeMounts for the worker container(s)                                                        | `[]`            |
-| `worker.sidecars`                            | Add additional sidecar containers to the worker pod(s)                                                                                      | `[]`            |
-| `worker.initContainers`                      | Add additional init containers to the worker pod(s)                                                                                         | `[]`            |
-| `worker.existingSecret`                      | name of an existing secret resource containing the keys and the pub                                                                         | `""`            |
-| `worker.baggageclaim.logLevel`               | Minimum level of logs to see. Possible values: debug, info, error                                                                           | `info`          |
-| `worker.baggageclaim.bindIp`                 | IP address on which to listen for API traffic.                                                                                              | `127.0.0.1`     |
-| `worker.baggageclaim.containerPort`          | Port on which to listen for API traffic.                                                                                                    | `7788`          |
-| `worker.baggageclaim.debugbindIp`            | IP address on which to listen for the pprof debugger endpoints.                                                                             | `127.0.0.1`     |
-| `worker.baggageclaim.debugContainerPort`     | Port on which to listen for baggageclaim pprof server.                                                                                      | `7787`          |
-| `worker.baggageclaim.disableUserNamespaces`  | Disable remapping of user/group IDs in unprivileged volumes.                                                                                | `""`            |
-| `worker.baggageclaim.volumes`                | Directory in which to place volume data.                                                                                                    | `""`            |
-| `worker.baggageclaim.driver`                 | Driver to use for managing volumes.                                                                                                         | `""`            |
-| `worker.baggageclaim.btrfsBin`               | Path to btrfs binary                                                                                                                        | `btrfs`         |
-| `worker.baggageclaim.mkfsBin`                | Path to mkfs.btrfs binary                                                                                                                   | `mkfs.btrfs`    |
-| `worker.baggageclaim.overlaysDir`            | Path to directory in which to store overlay data                                                                                            | `""`            |
-| `worker.persistence.enabled`                 | Enable persistence using Persistent Volume Claims                                                                                           | `true`          |
-| `worker.persistence.storageClass`            | Persistent Volume storage class                                                                                                             | `""`            |
-| `worker.persistence.annotations`             | Persistent Volume Claim annotations                                                                                                         | `{}`            |
-| `worker.persistence.accessModes`             | Persistent Volume access modes                                                                                                              | `[]`            |
-| `worker.persistence.size`                    | Persistent Volume size                                                                                                                      | `8Gi`           |
-| `worker.persistence.selector`                | Additional labels to match for the PVC                                                                                                      | `{}`            |
+| Name                                                 | Description                                                                                                                                 | Value               |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `worker.enabled`                                     | Enable Concourse worker nodes                                                                                                               | `true`              |
+| `worker.logLevel`                                    | Minimum level of logs to see. Possible options: debug, info, error                                                                          | `debug`             |
+| `worker.bindIp`                                      | IP address on which to listen for the Garden server.                                                                                        | `127.0.0.1`         |
+| `worker.tsa.hosts`                                   | TSA host(s) to forward the worker through                                                                                                   | `[]`                |
+| `worker.existingSecret`                              | name of an existing secret resource containing the keys and the pub                                                                         | `""`                |
+| `worker.baggageclaim.logLevel`                       | Minimum level of logs to see. Allowed values: `debug`, `info`, and `error`                                                                  | `info`              |
+| `worker.baggageclaim.bindIp`                         | IP address on which to listen for API traffic                                                                                               | `127.0.0.1`         |
+| `worker.baggageclaim.debugbindIp`                    | IP address on which to listen for the pprof debugger endpoints                                                                              | `127.0.0.1`         |
+| `worker.baggageclaim.disableUserNamespaces`          | Disable remapping of user/group IDs in unprivileged volumes                                                                                 | `""`                |
+| `worker.baggageclaim.volumes`                        | Directory in which to place volume data                                                                                                     | `""`                |
+| `worker.baggageclaim.driver`                         | Driver to use for managing volumes. Allowed values: `detect`, `naive`, `btrfs`, and `overlay`                                               | `""`                |
+| `worker.baggageclaim.btrfsBin`                       | Path to btrfs binary                                                                                                                        | `btrfs`             |
+| `worker.baggageclaim.mkfsBin`                        | Path to mkfs.btrfs binary                                                                                                                   | `mkfs.btrfs`        |
+| `worker.baggageclaim.overlaysDir`                    | Path to directory in which to store overlay data                                                                                            | `""`                |
+| `worker.command`                                     | Override default container command (useful when using custom images)                                                                        | `[]`                |
+| `worker.args`                                        | Override worker default args                                                                                                                | `[]`                |
+| `worker.replicaCount`                                | Number of worker replicas                                                                                                                   | `2`                 |
+| `worker.mode`                                        | Selects kind of Deployment. Valid Options are: statefulSet | deployment                                                                     | `deployment`        |
+| `worker.containerPorts.garden`                       | Concourse worker Garden server container port                                                                                               | `7777`              |
+| `worker.containerPorts.health`                       | Concourse worker health-check container port                                                                                                | `8888`              |
+| `worker.containerPorts.baggageclaim`                 | Concourse worker baggageclaim API container port                                                                                            | `7788`              |
+| `worker.containerPorts.pprof`                        | Concourse worker baggageclaim pprof server container port                                                                                   | `7787`              |
+| `worker.livenessProbe.enabled`                       | Enable livenessProbe on Concourse worker containers                                                                                         | `true`              |
+| `worker.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                                                     | `10`                |
+| `worker.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                                                            | `15`                |
+| `worker.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                                                           | `3`                 |
+| `worker.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                                                         | `1`                 |
+| `worker.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                                                         | `1`                 |
+| `worker.readinessProbe.enabled`                      | Enable readinessProbe on Concourse worker containers                                                                                        | `true`              |
+| `worker.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                                                                    | `10`                |
+| `worker.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                                                           | `15`                |
+| `worker.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                                                          | `3`                 |
+| `worker.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                                                        | `1`                 |
+| `worker.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                                                        | `1`                 |
+| `worker.startupProbe.enabled`                        | Enable startupProbe on Concourse worker containers                                                                                          | `false`             |
+| `worker.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                                                      | `5`                 |
+| `worker.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                                                             | `10`                |
+| `worker.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                                                            | `1`                 |
+| `worker.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                                                          | `15`                |
+| `worker.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                                                          | `1`                 |
+| `worker.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                                                         | `{}`                |
+| `worker.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                                                        | `{}`                |
+| `worker.customStartupProbe`                          | Custom startupProbe that overrides the default one                                                                                          | `{}`                |
+| `worker.resources.limits`                            | The resources limits for the Concourse worker containers                                                                                    | `{}`                |
+| `worker.resources.requests`                          | The requested resources for the Concourse worker containers                                                                                 | `{}`                |
+| `worker.podSecurityContext.enabled`                  | Enabled worker pods' Security Context                                                                                                       | `true`              |
+| `worker.podSecurityContext.fsGroup`                  | Set worker pod's Security Context fsGroup                                                                                                   | `1001`              |
+| `worker.containerSecurityContext.enabled`            | Enabled worker containers' Security Context                                                                                                 | `true`              |
+| `worker.containerSecurityContext.privileged`         | Set worker containers' Security Context with privileged or not                                                                              | `true`              |
+| `worker.containerSecurityContext.runAsUser`          | Set worker containers' Security Context user                                                                                                | `0`                 |
+| `worker.hostAliases`                                 | Concourse worker pod host aliases                                                                                                           | `[]`                |
+| `worker.podLabels`                                   | Custom labels for Concourse worker pods                                                                                                     | `{}`                |
+| `worker.podAnnotations`                              | Annotations for Concourse worker pods                                                                                                       | `{}`                |
+| `worker.podAffinityPreset`                           | Pod affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`                                                  | `""`                |
+| `worker.podAntiAffinityPreset`                       | Pod anti-affinity preset                                                                                                                    | `soft`              |
+| `worker.nodeAffinityPreset.type`                     | Node affinity type                                                                                                                          | `""`                |
+| `worker.nodeAffinityPreset.key`                      | Node label key to match                                                                                                                     | `""`                |
+| `worker.nodeAffinityPreset.values`                   | Node label values to match                                                                                                                  | `[]`                |
+| `worker.affinity`                                    | Affinity for pod assignment                                                                                                                 | `{}`                |
+| `worker.nodeSelector`                                | Node labels for pod assignment                                                                                                              | `{}`                |
+| `worker.tolerations`                                 | Tolerations for worker pod assignment                                                                                                       | `[]`                |
+| `worker.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template                    | `{}`                |
+| `worker.priorityClassName`                           | Priority Class to use for each pod (Concourse worker)                                                                                       | `""`                |
+| `worker.schedulerName`                               | Use an alternate scheduler, e.g. "stork".                                                                                                   | `""`                |
+| `worker.terminationGracePeriodSeconds`               | Seconds Concourse worker pod needs to terminate gracefully                                                                                  | `""`                |
+| `worker.updateStrategy.rollingUpdate`                | Concourse worker statefulset rolling update configuration parameters                                                                        | `{}`                |
+| `worker.updateStrategy.type`                         | Concourse worker statefulset strategy type                                                                                                  | `RollingUpdate`     |
+| `worker.lifecycleHooks`                              | for the Concourse worker container(s) to automate configuration before or after startup                                                     | `{}`                |
+| `worker.extraEnvVars`                                | Array with extra environment variables to add to Concourse worker nodes                                                                     | `[]`                |
+| `worker.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Concourse worker nodes                                                             | `""`                |
+| `worker.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Concourse worker nodes                                                                | `""`                |
+| `worker.extraVolumes`                                | Optionally specify extra list of additional volumes for the Concourse worker pod(s)                                                         | `[]`                |
+| `worker.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Concourse worker container(s)                                              | `[]`                |
+| `worker.sidecars`                                    | Add additional sidecar containers to the Concourse worker pod(s)                                                                            | `[]`                |
+| `worker.initContainers`                              | Add additional init containers to the Concourse worker pod(s)                                                                               | `[]`                |
+| `worker.autoscaling.enabled`                         | Enable autoscaling for the Concourse worker nodes                                                                                           | `false`             |
+| `worker.autoscaling.maxReplicas`                     | Set maximum number of replicas to the Concourse worker nodes                                                                                | `""`                |
+| `worker.autoscaling.minReplicas`                     | Set minimum number of replicas to the Concourse worker nodes                                                                                | `""`                |
+| `worker.autoscaling.builtInMetrics`                  | Array with built-in metrics                                                                                                                 | `[]`                |
+| `worker.autoscaling.customMetrics`                   | Array with custom metrics                                                                                                                   | `[]`                |
+| `worker.pdb.create`                                  | Create Pod disruption budget object for Concourse worker nodes                                                                              | `true`              |
+| `worker.pdb.minAvailable`                            | Minimum number of Concourse workers available after an eviction                                                                             | `2`                 |
+| `worker.pdb.maxAvailable`                            | Maximum number of Concourse workers available                                                                                               | `""`                |
+| `worker.psp.create`                                  | Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later | `false`             |
+| `worker.persistence.enabled`                         | Enable Concourse worker data persistence using PVC                                                                                          | `true`              |
+| `worker.persistence.existingClaim`                   | Name of an existing PVC to use                                                                                                              | `""`                |
+| `worker.persistence.storageClass`                    | PVC Storage Class for Concourse worker data volume                                                                                          | `""`                |
+| `worker.persistence.accessModes`                     | PVC Access Mode for Concourse worker volume                                                                                                 | `["ReadWriteOnce"]` |
+| `worker.persistence.size`                            | PVC Storage Request for Concourse worker volume                                                                                             | `8Gi`               |
+| `worker.persistence.annotations`                     | Annotations for the PVC                                                                                                                     | `{}`                |
+| `worker.persistence.selector`                        | Selector to match an existing Persistent Volume (this value is evaluated as a template)                                                     | `{}`                |
+| `worker.rbac.create`                                 | Specifies whether RBAC resources should be created                                                                                          | `true`              |
+| `worker.rbac.rules`                                  | Custom RBAC rules to set                                                                                                                    | `[]`                |
+| `worker.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                                        | `true`              |
+| `worker.serviceAccount.name`                         | Override worker service account name                                                                                                        | `""`                |
+| `worker.serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created                                                                      | `false`             |
+| `worker.serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                                                                        | `{}`                |
 
 
 ### Traffic exposure parameters
 
 | Name                                             | Description                                                                                                                      | Value                    |
 | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `service.web.type`                               | For minikube, set this to ClusterIP, elsewhere use LoadBalancer or NodePort                                                      | `LoadBalancer`           |
-| `service.web.port`                               | Service HTTP port                                                                                                                | `80`                     |
-| `service.web.tlsPort`                            | Service HTTPS port                                                                                                               | `443`                    |
-| `service.web.clusterIP`                          | When using `service.web.type: ClusterIP`, sets the user-specified cluster IP.                                                    | `""`                     |
-| `service.web.loadBalancerIP`                     | When using `service.web.type: LoadBalancer`, sets the user-specified load balancer IP.                                           | `""`                     |
-| `service.web.labels`                             | Additional Labels to be added to the web api service.                                                                            | `{}`                     |
-| `service.web.annotations`                        | Annotations to be added to the web api service.                                                                                  | `{}`                     |
-| `service.web.loadBalancerSourceRanges`           | When using `service.web.type: LoadBalancer`, restrict access to the load balancer to particular IPs                              | `[]`                     |
-| `service.web.nodePort`                           | When using `service.web.type: NodePort`, sets the nodePort for api                                                               | `""`                     |
-| `service.web.tlsnodePort`                        | When using `service.web.type: NodePort`, sets the nodePort for api tls                                                           | `""`                     |
-| `service.web.externalTrafficPolicy`              | Set service externalTraffic policy                                                                                               | `""`                     |
-| `service.workerGateway.type`                     | For minikube, set this to ClusterIP, elsewhere use LoadBalancer or NodePort                                                      | `ClusterIP`              |
-| `service.workerGateway.clusterIP`                | When using `service.workerGateway.type: ClusterIP`, sets the user-specified cluster IP.                                          | `""`                     |
-| `service.workerGateway.port`                     | Service HTTP port                                                                                                                | `2222`                   |
-| `service.workerGateway.loadBalancerIP`           | When using `service.workerGateway.type: LoadBalancer`, sets the user-specified load balancer IP.                                 | `""`                     |
-| `service.workerGateway.labels`                   | Additional Labels to be added to the web workerGateway service.                                                                  | `{}`                     |
-| `service.workerGateway.annotations`              | Annotations to be added to the web workerGateway service.                                                                        | `{}`                     |
-| `service.workerGateway.loadBalancerSourceRanges` | When using `service.workerGateway.type: LoadBalancer`, restrict access to the load balancer to particular IPs                    | `[]`                     |
-| `service.workerGateway.nodePort`                 | When using `service.workerGateway.type: NodePort`, sets the nodePort for tsa                                                     | `""`                     |
-| `ingress.enabled`                                | Ingress configuration enabled                                                                                                    | `false`                  |
+| `service.web.type`                               | Concourse web service type                                                                                                       | `LoadBalancer`           |
+| `service.web.ports.http`                         | Concourse web service HTTP port                                                                                                  | `80`                     |
+| `service.web.ports.https`                        | Concourse web service HTTPS port                                                                                                 | `443`                    |
+| `service.web.nodePorts.http`                     | Node port for HTTP                                                                                                               | `""`                     |
+| `service.web.nodePorts.https`                    | Node port for HTTPS                                                                                                              | `""`                     |
+| `service.web.sessionAffinity`                    | Control where client requests go, to the same pod or round-robin                                                                 | `None`                   |
+| `service.web.clusterIP`                          | Concourse web service Cluster IP                                                                                                 | `""`                     |
+| `service.web.loadBalancerIP`                     | Concourse web service Load Balancer IP                                                                                           | `""`                     |
+| `service.web.loadBalancerSourceRanges`           | Concourse web service Load Balancer sources                                                                                      | `[]`                     |
+| `service.web.externalTrafficPolicy`              | Concourse web service external traffic policy                                                                                    | `Cluster`                |
+| `service.web.annotations`                        | Additional custom annotations for Concourse web service                                                                          | `{}`                     |
+| `service.web.extraPorts`                         | Extra port to expose on Concourse web service                                                                                    | `[]`                     |
+| `service.workerGateway.type`                     | Concourse worker gateway service type                                                                                            | `ClusterIP`              |
+| `service.workerGateway.ports.tsa`                | Concourse worker gateway service port                                                                                            | `2222`                   |
+| `service.workerGateway.nodePorts.tsa`            | Node port for worker gateway service                                                                                             | `""`                     |
+| `service.workerGateway.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                                                 | `None`                   |
+| `service.workerGateway.clusterIP`                | Concourse worker gateway service Cluster IP                                                                                      | `""`                     |
+| `service.workerGateway.loadBalancerIP`           | Concourse worker gateway service Load Balancer IP                                                                                | `""`                     |
+| `service.workerGateway.loadBalancerSourceRanges` | Concourse worker gateway service Load Balancer sources                                                                           | `[]`                     |
+| `service.workerGateway.externalTrafficPolicy`    | Concourse worker gateway service external traffic policy                                                                         | `Cluster`                |
+| `service.workerGateway.annotations`              | Additional custom annotations for Concourse worker gateway service                                                               | `{}`                     |
+| `service.workerGateway.extraPorts`               | Extra port to expose on Concourse worker gateway service                                                                         | `[]`                     |
+| `ingress.enabled`                                | Enable ingress record generation for Concourse                                                                                   | `false`                  |
+| `ingress.pathType`                               | Ingress path type                                                                                                                | `ImplementationSpecific` |
+| `ingress.apiVersion`                             | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
+| `ingress.hostname`                               | Default host for the ingress record                                                                                              | `Concourse.local`        |
+| `ingress.path`                                   | Default path for the ingress record                                                                                              | `/`                      |
 | `ingress.annotations`                            | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
-| `ingress.hostname`                               | Hostename for the Ingress object                                                                                                 | `concourse.local`        |
-| `ingress.path`                                   | The Path to Concourse                                                                                                            | `/`                      |
-| `ingress.rulesOverride`                          | Ingress rules override                                                                                                           | `[]`                     |
-| `ingress.tls`                                    | TLS configuration.                                                                                                               | `false`                  |
-| `ingress.pathType`                               | Ingress Path type                                                                                                                | `ImplementationSpecific` |
-| `ingress.extraHosts`                             | The list of additional hostnames to be covered with this ingress record.                                                         | `[]`                     |
-| `ingress.extraTls`                               | The tls configuration for additional hostnames to be covered with this ingress record.                                           | `[]`                     |
-| `ingress.secrets`                                | If you're providing your own certificates, please use this to add the certificates as secrets                                    | `[]`                     |
+| `ingress.tls`                                    | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |
+| `ingress.selfSigned`                             | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
+| `ingress.extraHosts`                             | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                     |
+| `ingress.extraPaths`                             | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                     |
+| `ingress.extraTls`                               | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                     |
+| `ingress.secrets`                                | Custom TLS certificates as secrets                                                                                               | `[]`                     |
 
 
 ### Init Container Parameters
 
-| Name                                                   | Description                                                                                     | Value                   |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ----------------------- |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
-| `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                    | `docker.io`             |
-| `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r305`     |
-| `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                | `[]`                    |
-| `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                    |
-| `volumePermissions.resources.requests`                 | The requested resources for the init container                                                  | `{}`                    |
-| `volumePermissions.containerSecurityContext.enabled`   | Enable init container's Security Context                                                        | `true`                  |
-| `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                 | `1001`                  |
+| Name                                                   | Description                                                                     | Value                   |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume | `false`                 |
+| `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                | `docker.io`             |
+| `volumePermissions.image.repository`                   | Init container volume-permissions image repository                              | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)    | `10-debian-10-r326`     |
+| `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                             | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                            | `[]`                    |
+| `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                               | `{}`                    |
+| `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                             | `{}`                    |
+| `volumePermissions.containerSecurityContext.enabled`   | Enabled init container Security Context                                         | `true`                  |
+| `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                  | `0`                     |
 
 
-### PostgreSQL sub-chart configuration
+### Concourse database parameters
 
-| Name                            | Description                                                                               | Value               |
-| ------------------------------- | ----------------------------------------------------------------------------------------- | ------------------- |
-| `postgresql.enabled`            | Switch to enable or disable the PostgreSQL helm chart                                     | `true`              |
-| `postgresql.nameOverride`       | Override Concourse Postgresql name                                                        | `""`                |
-| `postgresql.postgresqlUsername` | Concourse Postgresql username                                                             | `bn_concourse`      |
-| `postgresql.postgresqlDatabase` | Concourse Postgresql database                                                             | `bitnami_concourse` |
-| `postgresql.existingSecret`     | Name of an existing secret containing the PostgreSQL password ('postgresql-password' key) | `""`                |
+| Name                                 | Description                                                                                            | Value               |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------ | ------------------- |
+| `postgresql.enabled`                 | Switch to enable or disable the PostgreSQL helm chart                                                  | `true`              |
+| `postgresql.auth.enablePostgresUser` | Assign a password to the "postgres" admin user. Otherwise, remote access will be blocked for this user | `false`             |
+| `postgresql.auth.username`           | Name for a custom user to create                                                                       | `bn_concourse`      |
+| `postgresql.auth.password`           | Password for the custom user to create                                                                 | `""`                |
+| `postgresql.auth.database`           | Name for a custom database to create                                                                   | `bitnami_concourse` |
+| `postgresql.auth.existingSecret`     | Name of existing secret to use for PostgreSQL credentials                                              | `""`                |
+| `postgresql.architecture`            | PostgreSQL architecture (`standalone` or `replication`)                                                | `standalone`        |
 
 
 ### External PostgreSQL configuration
 
-| Name                                         | Description                                                    | Value               |
-| -------------------------------------------- | -------------------------------------------------------------- | ------------------- |
-| `externalDatabase.host`                      | Database host                                                  | `localhost`         |
-| `externalDatabase.user`                      | non-root Username for Airflow Database                         | `bn_concourse`      |
-| `externalDatabase.password`                  | Database password                                              | `""`                |
-| `externalDatabase.existingSecret`            | Name of an existing secret resource containing the DB password | `""`                |
-| `externalDatabase.existingSecretPasswordKey` | Name of an existing secret key containing the DB password      | `""`                |
-| `externalDatabase.database`                  | Database name                                                  | `bitnami_concourse` |
-| `externalDatabase.port`                      | Database port number                                           | `5432`              |
+| Name                                         | Description                                                             | Value               |
+| -------------------------------------------- | ----------------------------------------------------------------------- | ------------------- |
+| `externalDatabase.host`                      | Database host                                                           | `localhost`         |
+| `externalDatabase.port`                      | Database port number                                                    | `5432`              |
+| `externalDatabase.user`                      | Non-root username for Concourse                                         | `bn_concourse`      |
+| `externalDatabase.password`                  | Password for the non-root username for Concourse                        | `""`                |
+| `externalDatabase.database`                  | Concourse database name                                                 | `bitnami_concourse` |
+| `externalDatabase.existingSecret`            | Name of an existing secret resource containing the database credentials | `""`                |
+| `externalDatabase.existingSecretPasswordKey` | Name of an existing secret key containing the database credentials      | `""`                |
 
 
 See https://github.com/bitnami-labs/readme-generator-for-helm to create the table
@@ -345,11 +385,10 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 helm install my-release \
   --set secrets.localUsers=admin:password \
-  --set postgresql.postgresqlPassword=secretpassword \
     bitnami/concourse
 ```
 
-The above command sets the Concourse account username and password to `admin` and `password` respectively. Additionally, it sets the PostgreSQL password to `secretpassword`.
+The above command sets the Concourse account username and password to `admin` and `password` respectively.
 
 > NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
 
@@ -416,6 +455,10 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 ## Troubleshooting
 
 Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## Upgrading
+
+Refer to the [chart documentation for more information about how to upgrade from previous releases](https://docs.bitnami.com/kubernetes/infrastructure/concourse/administration/upgrade/).
 
 ## License
 

--- a/bitnami/concourse/ci/externaldb.yaml
+++ b/bitnami/concourse/ci/externaldb.yaml
@@ -1,0 +1,8 @@
+postgresql:
+  enabled: false
+externalDatabase:
+  host: localhost
+  port: 5432
+  user: bn_concourse
+  password: somepassword
+  database: bitnami_concourse

--- a/bitnami/concourse/ci/ingress.yaml
+++ b/bitnami/concourse/ci/ingress.yaml
@@ -1,0 +1,7 @@
+service:
+  web:
+    type: ClusterIP
+ingress:
+  enabled: true
+  tls: true
+  selfSigned: true

--- a/bitnami/concourse/templates/NOTES.txt
+++ b/bitnami/concourse/templates/NOTES.txt
@@ -48,7 +48,7 @@ host. To configure Concourse with the URL of your service:
 
 * Concourse can be accessed:
 
-  * Within your cluster, at the following DNS name at port {{ .Values.web.containerPort }}:
+  * Within your cluster, at the following DNS name at port {{ .Values.web.containerPorts.http }}:
 
     {{ template "concourse.web.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
 
@@ -63,12 +63,12 @@ host. To configure Concourse with the URL of your service:
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get svc -w {{ template "concourse.web.fullname" . }}'
 
-    echo http://$SERVICE_IP:{{ .Values.web.containerPort }}
+    echo http://$SERVICE_IP:{{ .Values.web.containerPorts.http }}
     {{- else if contains "ClusterIP"  .Values.service.web.type }}
 
     export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "concourse.web.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
     echo "Visit http://127.0.0.1:8080 to use Concourse"
-    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.web.containerPort }}
+    kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 8080:{{ .Values.web.containerPorts.http }}
     {{- end }}
 
   echo Username : Password  $(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "concourse.web.secretName" . }} -o jsonpath="{.data.local-users}" | base64 --decode)

--- a/bitnami/concourse/templates/_helpers.tpl
+++ b/bitnami/concourse/templates/_helpers.tpl
@@ -117,13 +117,13 @@ When using Ingress, it will be set to the Ingress hostname.
 */}}
 {{- define "concourse.host" -}}
 {{- if .Values.ingress.enabled -}}
-{{- $host := .Values.ingress.hostname | default "" -}}
-{{- printf "%s://%s" (ternary "https" "http" .Values.web.tls.enabled) (default (include "concourse.serviceIP" .) $host) -}}
+  {{- $host := .Values.ingress.hostname | default "" -}}
+  {{- printf "%s://%s" (ternary "https" "http" .Values.web.tls.enabled) (default (include "concourse.serviceIP" .) $host) -}}
 {{- else if .Values.web.externalUrl -}}
-{{- $host := .Values.web.externalUrl | default "" -}}
-{{- printf "%s://%s" (ternary "https" "http" .Values.web.tls.enabled) $host -}}
+  {{- $host := .Values.web.externalUrl | default "" -}}
+  {{- printf "%s://%s" (ternary "https" "http" .Values.web.tls.enabled) $host -}}
 {{- else if (include "concourse.serviceIP" .) -}}
-{{- printf "%s://%s" (ternary "https" "http" .Values.web.tls.enabled) (include "concourse.serviceIP" .) -}}
+  {{- printf "%s://%s" (ternary "https" "http" .Values.web.tls.enabled) (include "concourse.serviceIP" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -173,7 +173,7 @@ Creates the address of the TSA service.
 */}}
 {{- define "concourse.web.tsa.address" -}}
 {{- if .Values.web.enabled -}}
-{{- $port := printf "%v" .Values.web.tsa.containerPort -}}
+{{- $port := printf "%v" .Values.web.containerPorts.tsa -}}
 {{- printf "%s-gateway:%s" (include "concourse.web.fullname" .) $port -}}
 {{- else -}}
 {{- range $i, $tsaHost := .Values.worker.tsa.hosts -}}{{- if $i -}},{{ end -}}{{- $tsaHost -}}{{- end -}}
@@ -184,10 +184,10 @@ Creates the address of the TSA service.
 Get the Postgresql credentials secret.
 */}}
 {{- define "concourse.postgresql.secretName" -}}
-{{- if and (.Values.postgresql.enabled) (not .Values.postgresql.existingSecret) -}}
+{{- if and (.Values.postgresql.enabled) (not .Values.postgresql.auth.existingSecret) -}}
     {{- printf "%s" (include "concourse.postgresql.fullname" .) -}}
-{{- else if and (.Values.postgresql.enabled) (.Values.postgresql.existingSecret) -}}
-    {{- printf "%s" .Values.postgresql.existingSecret -}}
+{{- else if and (.Values.postgresql.enabled) (.Values.postgresql.auth.existingSecret) -}}
+    {{- printf "%s" .Values.postgresql.auth.existingSecret -}}
 {{- else -}}
     {{- if .Values.externalDatabase.existingSecret -}}
         {{- printf "%s" .Values.externalDatabase.existingSecret -}}
@@ -202,16 +202,16 @@ Add environment variables to configure database values
 */}}
 {{- define "concourse.database.existingsecret.key" -}}
 {{- if .Values.postgresql.enabled -}}
-    {{- printf "%s" "postgresql-password" -}}
+    {{- printf "%s" "password" -}}
 {{- else -}}
     {{- if .Values.externalDatabase.existingSecret -}}
         {{- if .Values.externalDatabase.existingSecretPasswordKey -}}
             {{- printf "%s" .Values.externalDatabase.existingSecretPasswordKey -}}
         {{- else -}}
-            {{- printf "%s" "postgresql-password" -}}
+            {{- printf "%s" "password" -}}
         {{- end -}}
     {{- else -}}
-        {{- printf "%s" "postgresql-password" -}}
+        {{- printf "%s" "password" -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/bitnami/concourse/templates/config/secret-external-db.yaml
+++ b/bitnami/concourse/templates/config/secret-external-db.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) (not .Values.postgresql.existingSecret) }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) (not .Values.postgresql.auth.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,5 +12,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  postgresql-password: {{ .Values.externalDatabase.password | b64enc | quote }}
+  password: {{ .Values.externalDatabase.password | b64enc | quote }}
 {{- end }}

--- a/bitnami/concourse/templates/web/deployment.yaml
+++ b/bitnami/concourse/templates/web/deployment.yaml
@@ -31,7 +31,6 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.web.podLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ template "concourse.web.serviceAccountName" . }}
       {{- include "imagePullSecrets" . | nindent 6 }}
       {{- if .Values.web.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.web.hostAliases "context" $) | nindent 8 }}
@@ -50,25 +49,37 @@ spec:
       {{- if .Values.web.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.web.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.web.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.web.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.web.priorityClassName }}
-      priorityClassName: {{ .Values.web.priorityClassName | quote }}
+      priorityClassName: {{ .Values.web.priorityClassName }}
+      {{- end }}
+      {{- if .Values.web.schedulerName }}
+      schedulerName: {{ .Values.web.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.web.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.web.terminationGracePeriodSeconds }}
       {{- end }}
       {{- if .Values.web.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.web.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ template "concourse.web.serviceAccountName" . }}
       initContainers:
         {{- if and .Values.volumePermissions.enabled }}
         - name: volume-permissions
           image: {{ include "concourse.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
           command:
-            - sh
-            - -c
+            - /bin/bash
+          args:
+            - -ec
             - |
-              mkdir -p "/bitnami/concourse"
-              chown -R "{{ .Values.web.containerSecurityContext.runAsUser }}:{{ .Values.web.podSecurityContext.fsGroup }}" "/bitnami/concourse"
-          securityContext:
-            runAsUser: 0
+              mkdir -p /bitnami/concourse
+              find /bitnami/concourse -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ .Values.web.containerSecurityContext.runAsUser }}:{{ .Values.web.podSecurityContext.fsGroup }}
+          {{- if .Values.volumePermissions.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.volumePermissions.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.volumePermissions.resources }}
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}
@@ -113,7 +124,7 @@ spec:
             - name: POSTGRESQL_CLIENT_DATABASE_HOST
               value: {{ ternary (include "concourse.database.host" .) .Values.externalDatabase.host .Values.postgresql.enabled | quote }}
             - name: POSTGRESQL_CLIENT_DATABASE_NAME
-              value: {{ ternary .Values.postgresql.postgresqlDatabase .Values.externalDatabase.port .Values.postgresql.enabled }}
+              value: {{ ternary .Values.postgresql.auth.database .Values.externalDatabase.port .Values.postgresql.enabled }}
             - name: POSTGRESQL_CLIENT_DATABASE_PORT_NUMBER
               value: {{ ternary "5432" .Values.externalDatabase.port .Values.postgresql.enabled | quote }}
             - name: POSTGRESQL_CLIENT_CREATE_DATABASE_PASSWORD
@@ -122,7 +133,7 @@ spec:
                   name: {{ include "concourse.postgresql.secretName" . }}
                   key: {{ include "concourse.database.existingsecret.key" . }}
             - name: POSTGRESQL_CLIENT_POSTGRES_USER
-              value: {{ ternary .Values.postgresql.postgresqlUsername .Values.externalDatabase.host .Values.postgresql.enabled | quote }}
+              value: {{ ternary .Values.postgresql.auth.username .Values.externalDatabase.user .Values.postgresql.enabled | quote }}
         {{- end }}
         - name: db-migrate
           image: {{ template "concourse.image" . }}
@@ -139,15 +150,15 @@ spec:
                   name: {{ include "concourse.postgresql.secretName" . }}
                   key: {{ include "concourse.database.existingsecret.key" . }}
             - name: CONCOURSE_POSTGRES_DATABASE
-              value: {{ ternary .Values.postgresql.postgresqlDatabase .Values.externalDatabase.database .Values.postgresql.enabled | quote }}
+              value: {{ ternary .Values.postgresql.auth.database .Values.externalDatabase.database .Values.postgresql.enabled | quote }}
             - name: CONCOURSE_POSTGRES_HOST
               value: {{ ternary (include "concourse.database.host" .) .Values.externalDatabase.host .Values.postgresql.enabled | quote }}
             - name: CONCOURSE_POSTGRES_PORT
               value: {{ include "concourse.database.port" . | quote }}
             - name: CONCOURSE_POSTGRES_USER
-              value: {{ ternary .Values.postgresql.postgresqlUsername .Values.externalDatabase.user .Values.postgresql.enabled | quote  }}
+              value: {{ ternary .Values.postgresql.auth.username .Values.externalDatabase.user .Values.postgresql.enabled | quote  }}
         {{- if .Values.web.initContainers }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.web.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.web.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
         - name: concourse
@@ -159,13 +170,17 @@ spec:
           {{- if .Values.web.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.web.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.web.command }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.web.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.web.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - /opt/bitnami/concourse/bin/concourse
           {{- end }}
-          {{- if .Values.web.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.web.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.web.args "context" $) | nindent 12 }}
           {{- else }}
           args:
@@ -185,17 +200,17 @@ spec:
               value: {{ .Values.web.tsa.bindIp | quote }}
             {{- end }}
             - name: CONCOURSE_TSA_BIND_PORT
-              value: {{ .Values.web.tsa.containerPort | quote }}
+              value: {{ .Values.web.containerPorts.tsa | quote }}
             {{- if .Values.web.tsa.debugbindIp }}
             - name: CONCOURSE_TSA_DEBUG_BIND_IP
               value: {{ .Values.web.tsa.debugbindIp | quote }}
             {{- end }}
-            {{- if .Values.web.tsa.debugContainerPort }}
+            {{- if .Values.web.containerPorts.pprof }}
             - name: CONCOURSE_TSA_DEBUG_BIND_PORT
-              value: {{ .Values.web.tsa.debugContainerPort | quote }}
+              value: {{ .Values.web.containerPorts.pprof | quote }}
             {{- end }}
             - name: CONCOURSE_BIND_PORT
-              value: {{ .Values.web.containerPort | quote }}
+              value: {{ .Values.web.containerPorts.http | quote }}
             - name: CONCOURSE_TSA_HOST_KEY
               value: "/bitnami/concourse/concourse-keys/host_key"
             - name: CONCOURSE_TSA_AUTHORIZED_KEYS
@@ -213,7 +228,7 @@ spec:
             - name: CONCOURSE_EXTERNAL_URL
               value: {{ include "concourse.host" . | quote }}
             - name: CONCOURSE_BIND_PORT
-              value: {{ .Values.web.containerPort | quote }}
+              value: {{ .Values.web.containerPorts.http | quote }}
             {{- if .Values.web.peerAddress }}
             - name: CONCOURSE_PEER_ADDRESS
               value: {{ .Values.web.peerAddress | quote }}
@@ -289,25 +304,25 @@ spec:
                   name: {{ include "concourse.postgresql.secretName" . }}
                   key: {{ include "concourse.database.existingsecret.key" . }}
             - name: CONCOURSE_POSTGRES_DATABASE
-              value: {{ ternary .Values.postgresql.postgresqlDatabase .Values.externalDatabase.database .Values.postgresql.enabled | quote }}
+              value: {{ ternary .Values.postgresql.auth.database .Values.externalDatabase.database .Values.postgresql.enabled | quote }}
             - name: CONCOURSE_POSTGRES_HOST
               value: {{ ternary (include "concourse.database.host" .) .Values.externalDatabase.host .Values.postgresql.enabled | quote }}
             - name: CONCOURSE_POSTGRES_PORT
               value: {{ include "concourse.database.port" . | quote }}
             - name: CONCOURSE_POSTGRES_USER
-              value: {{ ternary .Values.postgresql.postgresqlUsername .Values.externalDatabase.user .Values.postgresql.enabled | quote  }}
+              value: {{ ternary .Values.postgresql.auth.username .Values.externalDatabase.user .Values.postgresql.enabled | quote  }}
           ports:
             - name: http
-              containerPort: {{ .Values.web.containerPort }}
+              containerPort: {{ .Values.web.containerPorts.http }}
             - name: tsa
-              containerPort: {{ .Values.web.tsa.containerPort }}
+              containerPort: {{ .Values.web.containerPorts.tsa }}
             {{- if .Values.web.tls.enabled }}
             - name: https
-              containerPort: {{ .Values.web.tls.containerPort }}
+              containerPort: {{ .Values.web.containerPorts.https }}
             {{- end }}
-            {{- if .Values.web.tsa.debugContainerPort }}
+            {{- if .Values.web.containerPorts.tsa }}
             - name: http-debug
-              containerPort: {{ .Values.web.tsa.debugContainerPort }}
+              containerPort: {{ .Values.web.containerPorts.tsa }}
             {{- end }}
           envFrom:
             {{- if .Values.web.extraEnvVarsCM }}
@@ -321,31 +336,30 @@ spec:
           {{- if .Values.web.resources }}
           resources: {{- toYaml .Values.web.resources | nindent 12 }}
           {{- end }}
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.web.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.web.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.web.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: {{ .Values.web.baseUrl | trimSuffix "/" }}/api/v1/info
               port: http
-            initialDelaySeconds: {{ .Values.web.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.web.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.web.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.web.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.web.livenessProbe.successThreshold }}
           {{- else if .Values.web.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.web.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.web.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: {{ .Values.web.baseUrl | trimSuffix "/" }}/api/v1/info
               port: http
-            initialDelaySeconds: {{ .Values.web.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.web.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.web.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.web.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.web.readinessProbe.successThreshold }}
           {{- else if .Values.web.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.web.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             - name: concourse-keys

--- a/bitnami/concourse/templates/web/gateway-service.yaml
+++ b/bitnami/concourse/templates/web/gateway-service.yaml
@@ -1,21 +1,18 @@
-{{- if .Values.web.enabled -}}
+{{- if .Values.web.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "concourse.web.fullname" . }}-gateway
-  namespace: {{ .Release.Namespace | quote }}
+  name: {{ printf "%s-gateway" (include "concourse.web.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: web
-    {{- if .Values.service.workerGateway.labels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.workerGateway.labels "context" $ ) | nindent 4 }}
-    {{- end }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.commonAnnotations .Values.service.workerGateway.annotations }}
+  {{- if or .Values.service.workerGateway.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.service.workerGateway.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.workerGateway.annotations "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.workerGateway.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -23,25 +20,34 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.workerGateway.type }}
-  {{- if .Values.service.workerGateway.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-    {{- range .Values.service.workerGateway.loadBalancerSourceRanges }}
-    - {{ . }}
-    {{- end }}
+  sessionAffinity: {{ .Values.service.workerGateway.sessionAffinity }}
+  {{- if and .Values.service.workerGateway.clusterIP (eq .Values.service.workerGateway.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.workerGateway.clusterIP }}
   {{- end }}
-  {{- if and (eq "ClusterIP" .Values.service.workerGateway.type) .Values.service.workerGateway.clusterIP }}
-  {{ with .Values.service.workerGateway.clusterIP }}clusterIP: {{ quote . }}{{ end }}
+  {{- if (or (eq .Values.service.workerGateway.type "LoadBalancer") (eq .Values.service.workerGateway.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.service.workerGateway.externalTrafficPolicy | quote }}
   {{- end }}
-  {{- if and (eq "LoadBalancer" .Values.service.workerGateway.type) .Values.service.workerGateway.loadBalancerIP }}
+  {{- if (and (eq .Values.service.workerGateway.type "LoadBalancer") .Values.service.workerGateway.loadBalancerSourceRanges) }}
+  {{- with .Values.service.workerGateway.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if (and (eq .Values.service.workerGateway.type "LoadBalancer") (not (empty .Values.service.workerGateway.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.service.workerGateway.loadBalancerIP }}
   {{- end }}
   ports:
     - name: http-worker-gateway
-      port: {{ .Values.service.workerGateway.port }}
+      port: {{ .Values.service.workerGateway.ports.tsa }}
+      protocol: TCP
       targetPort: tsa
-      {{- if and (eq "nodePort" .Values.service.workerGateway.type) .Values.service.workerGateway.nodePort }}
-      nodePort: {{ .Values.service.workerGateway.nodePort }}
+      {{- if (and (or (eq .Values.service.workerGateway.type "NodePort") (eq .Values.service.workerGateway.type "LoadBalancer")) (not (empty .Values.service.workerGateway.nodePorts.tsa))) }}
+      nodePort: {{ .Values.service.workerGateway.nodePorts.tsa }}
+      {{- else if eq .Values.service.workerGateway.type "ClusterIP" }}
+      nodePort: null
       {{- end }}
-  selector:
+    {{- if .Values.service.workerGateway.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.workerGateway.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: web
 {{- end }}

--- a/bitnami/concourse/templates/web/ingress.yaml
+++ b/bitnami/concourse/templates/web/ingress.yaml
@@ -1,62 +1,57 @@
-{{- if .Values.web.enabled -}}
-{{- if .Values.ingress.enabled }}
+{{- if and .Values.web.enabled .Values.ingress.enabled }}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ template "concourse.web.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "concourse.web.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.ingress.annotations .Values.commonAnnotations .Values.ingress.certManager }}
   annotations:
-    {{- if .Values.ingress.certManager }}
-    kubernetes.io/tls-acme: "true"
-    {{- end }}
-    {{- if .Values.ingress.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
-    {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- end }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
 spec:
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   rules:
-    {{- if .Values.ingress.rulesOverride }}
-    {{- toYaml .Values.ingress.rulesOverride | nindent 4 }}
-    {{- else }}
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ include "common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ ) }}
       http:
         paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
           - path: {{ .Values.ingress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "concourse.web.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
-    {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ .name | quote }}
+    - host: {{ include "common.tplvalues.render" ( dict "value" .name "context" $ ) }}
       http:
         paths:
           - path: {{ default "/" .path }}
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
-            pathType: {{ .Values.ingress.pathType }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "concourse.web.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
-  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
+  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
   tls:
-    {{- if .Values.ingress.tls }}
+    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
     - hosts:
-      - {{ .Values.ingress.hostname }}
+        - {{ .Values.ingress.hostname | quote }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/bitnami/concourse/templates/web/podsecuritypolicy.yaml
+++ b/bitnami/concourse/templates/web/podsecuritypolicy.yaml
@@ -4,12 +4,15 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "concourse.web.fullname" . }}
-  labels:
-  {{- include "common.labels.standard" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: web
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/bitnami/concourse/templates/web/rbac.yaml
+++ b/bitnami/concourse/templates/web/rbac.yaml
@@ -1,13 +1,11 @@
-{{- if .Values.web.enabled }}
-{{- if .Values.web.rbac.create -}}
----
+{{- if and .Values.web.enabled .Values.web.rbac.create -}}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ template "concourse.web.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app: concourse
+    app.kubernetes.io/component: web
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,29 +13,20 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get"]
-{{- end }}
-
----
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.web.psp.create }}
-apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
-kind: ClusterRole
-metadata:
-  name: {{ template "concourse.web.fullname" . }}
-  labels:
-    app.kubernetes.io/component: web
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-rules:
+  {{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
+  {{- if and $pspAvailable .Values.web.psp.create }}
   - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs:     ['use']
     resourceNames:
       - {{ template "concourse.web.fullname" . }}
+  {{- end }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  {{- if .Values.web.rbac.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.web.rbac.rules "context" $ ) | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
@@ -54,33 +43,10 @@ metadata:
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ template "concourse.web.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "concourse.web.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
----
-apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
-kind: RoleBinding
-metadata:
-  name:  {{ template "concourse.web.fullname" . }}-psp
-  namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: web
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name:  {{ template "concourse.web.fullname" . }}-psp
-subjects:
-  - kind: ServiceAccount
-    name: {{ template "concourse.web.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
 {{- end }}
-{{- end -}}

--- a/bitnami/concourse/templates/web/service-account.yaml
+++ b/bitnami/concourse/templates/web/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.web.enabled .Values.web.rbac.create -}}
+{{- if and .Values.web.enabled .Values.web.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,7 +9,12 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.web.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.web.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ .Values.web.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/bitnami/concourse/templates/web/service.yaml
+++ b/bitnami/concourse/templates/web/service.yaml
@@ -1,21 +1,18 @@
-{{- if .Values.web.enabled -}}
+{{- if .Values.web.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "concourse.web.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  name: {{ include "concourse.web.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: web
-    {{- if .Values.service.web.labels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.web.labels "context" $ ) | nindent 4 }}
-    {{- end }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.commonAnnotations .Values.service.web.annotations }}
+  {{- if or .Values.service.web.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.service.web.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.web.annotations "context" $ ) | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.web.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -23,31 +20,43 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.web.type }}
-  {{- if (or (eq .Values.service.web.type "LoadBalancer") (eq .Values.service.web.type "nodePort")) }}
+  sessionAffinity: {{ .Values.service.web.sessionAffinity }}
+  {{- if and .Values.service.web.clusterIP (eq .Values.service.web.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.web.clusterIP }}
+  {{- end }}
+  {{- if (or (eq .Values.service.web.type "LoadBalancer") (eq .Values.service.web.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.service.web.externalTrafficPolicy | quote }}
   {{- end }}
-  {{ if eq .Values.service.web.type "LoadBalancer" }}
-  loadBalancerSourceRanges: {{ .Values.service.web.loadBalancerSourceRanges }}
-  {{ end }}
+  {{- if (and (eq .Values.service.web.type "LoadBalancer") .Values.service.web.loadBalancerSourceRanges) }}
+  {{- with .Values.service.web.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{- if (and (eq .Values.service.web.type "LoadBalancer") (not (empty .Values.service.web.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.service.web.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.service.web.clusterIP }}
-  clusterIP: {{ .Values.service.web.clusterIP }}
-  {{- end }}
   ports:
     - name: http
-      port: {{ .Values.service.web.port }}
+      port: {{ .Values.service.web.ports.http }}
+      protocol: TCP
       targetPort: http
-      {{- if and (eq "nodePort" .Values.service.web.type) .Values.service.web.nodePort }}
-      nodePort: {{ .Values.service.web.nodePort }}
+      {{- if (and (or (eq .Values.service.web.type "NodePort") (eq .Values.service.web.type "LoadBalancer")) (not (empty .Values.service.web.nodePorts.http))) }}
+      nodePort: {{ .Values.service.web.nodePorts.http }}
+      {{- else if eq .Values.service.web.type "ClusterIP" }}
+      nodePort: null
       {{- end }}
     - name: https
-      port: {{ .Values.service.web.tlsPort }}
+      port: {{ .Values.service.web.ports.https }}
+      protocol: TCP
       targetPort: https
-      {{- if and (eq "nodePort" .Values.service.web.type) .Values.service.web.tlsNodePort }}
-      nodePort: {{ .Values.service.web.tlsNodePort }}
+      {{- if (and (or (eq .Values.service.web.type "NodePort") (eq .Values.service.web.type "LoadBalancer")) (not (empty .Values.service.web.nodePorts.https))) }}
+      nodePort: {{ .Values.service.web.nodePorts.https }}
+      {{- else if eq .Values.service.web.type "ClusterIP" }}
+      nodePort: null
       {{- end }}
+    {{- if .Values.service.web.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.web.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: web
 {{- end }}

--- a/bitnami/concourse/templates/web/tls-secrets.yaml
+++ b/bitnami/concourse/templates/web/tls-secrets.yaml
@@ -1,9 +1,11 @@
 {{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
 {{- range .Values.ingress.secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     {{- if $.Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
@@ -15,5 +17,29 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}
   tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- $ca := genCA "concourse-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+---
 {{- end }}
 {{- end }}

--- a/bitnami/concourse/templates/worker/deployment.yaml
+++ b/bitnami/concourse/templates/worker/deployment.yaml
@@ -51,23 +51,33 @@ spec:
       {{- if .Values.worker.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.worker.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.worker.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.worker.priorityClassName }}
-      priorityClassName: {{ .Values.worker.priorityClassName | quote }}
+      priorityClassName: {{ .Values.worker.priorityClassName }}
+      {{- end }}
+      {{- if .Values.worker.schedulerName }}
+      schedulerName: {{ .Values.worker.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.worker.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       {{- end }}
       {{- if .Values.worker.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.worker.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       initContainers:
-        {{- if and (.Values.volumePermissions.enabled) (.Values.worker.persistence.enabled) }}
+        {{- if .Values.volumePermissions.enabled }}
         - name: volume-permissions
           image: {{ include "concourse.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
           command:
-            - sh
-            - -c
+            - /bin/bash
+          args:
+            - -ec
             - |
-              mkdir -p "/bitnami/concourse"
-              chown -R "{{ .Values.worker.containerSecurityContext.runAsUser }}:{{ .Values.web.podSecurityContext.fsGroup }}" "/bitnami/concourse"
+              mkdir -p /bitnami/concourse
+              find /bitnami/concourse -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ .Values.worker.containerSecurityContext.runAsUser }}:{{ .Values.worker.podSecurityContext.fsGroup }}
           {{- if .Values.volumePermissions.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.volumePermissions.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
@@ -77,7 +87,7 @@ spec:
           volumeMounts:
         {{- end }}
         {{- if .Values.worker.initContainers }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
         - name: concourse
@@ -89,13 +99,17 @@ spec:
           {{- if .Values.worker.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.worker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.worker.command }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.worker.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.worker.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - /opt/bitnami/concourse/bin/concourse
           {{- end }}
-          {{- if .Values.worker.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.worker.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.worker.args "context" $) | nindent 12 }}
           {{- else }}
           args:
@@ -109,7 +123,7 @@ spec:
             - name: CONCOURSE_WORK_DIR
               value: "/bitnami/concourse/workdir"
             - name: CONCOURSE_HEALTHCHECK_BIND_PORT
-              value: {{ .Values.worker.healthCheckContainerPort | quote }}
+              value: {{ .Values.worker.containerPorts.health | quote }}
             {{- if .Values.worker.logLevel }}
             - name: CONCOURSE_LOG_LEVEL
               value: {{ .Values.worker.logLevel | quote }}
@@ -120,9 +134,9 @@ spec:
             - name: CONCOURSE_BIND_IP
               value: {{ .Values.worker.bindIp | quote }}
             {{- end }}
-            {{- if .Values.worker.containerPort }}
+            {{- if .Values.worker.containerPorts.garden }}
             - name: CONCOURSE_BIND_PORT
-              value: {{ .Values.worker.containerPort | quote }}
+              value: {{ .Values.worker.containerPorts.garden | quote }}
             {{- end }}
             {{- if .Values.worker.baggageclaim.logLevel }}
             - name: CONCOURSE_BAGGAGECLAIM_LOG_LEVEL
@@ -132,17 +146,17 @@ spec:
             - name: CONCOURSE_BAGGAGECLAIM_BIND_IP
               value: {{ .Values.worker.baggageclaim.bindIp | quote }}
             {{- end }}
-            {{- if .Values.worker.baggageclaim.containerPort }}
+            {{- if .Values.worker.containerPorts.baggageclaim }}
             - name: CONCOURSE_BAGGAGECLAIM_BIND_PORT
-              value: {{ .Values.worker.baggageclaim.containerPort | quote }}
+              value: {{ .Values.worker.containerPorts.baggageclaim | quote }}
             {{- end }}
             {{- if .Values.worker.baggageclaim.debugbindIp }}
             - name: CONCOURSE_BAGGAGECLAIM_DEBUG_BIND_IP
               value: {{ .Values.worker.baggageclaim.debugbindIp | quote }}
             {{- end }}
-            {{- if .Values.worker.baggageclaim.debugContainerPort }}
+            {{- if .Values.worker.containerPorts.pprof }}
             - name: CONCOURSE_BAGGAGECLAIM_DEBUG_BIND_PORT
-              value: {{ .Values.worker.baggageclaim.debugContainerPort | quote }}
+              value: {{ .Values.worker.containerPorts.pprof | quote }}
             {{- end }}
             {{- if .Values.worker.baggageclaim.volumes }}
             - name: CONCOURSE_BAGGAGECLAIM_VOLUMES
@@ -185,35 +199,33 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.worker.containerPort }}
+              containerPort: {{ .Values.worker.containerPorts.garden }}
             - name: healthz
-              containerPort: {{ .Values.worker.healthCheckContainerPort }}
-          {{- if .Values.worker.livenessProbe.enabled }}
-          livenessProbe:
-            httpGet:
-              path: "/"
+              containerPort: {{ .Values.worker.containerPorts.health }}
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.worker.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
               port: healthz
-            initialDelaySeconds: {{ .Values.worker.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.worker.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.worker.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.worker.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.worker.livenessProbe.successThreshold }}
-          {{- else if .Values.worker.customLivenessProbe }}
+          {{- else if .Values.worker.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.worker.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /
+              port: healthz
           {{- else if .Values.worker.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.worker.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: "/"
+              path: /
               port: healthz
-            initialDelaySeconds: {{ .Values.worker.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.worker.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.worker.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.worker.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.worker.readinessProbe.successThreshold }}
           {{- else if .Values.worker.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             - name: concourse-work-dir

--- a/bitnami/concourse/templates/worker/poddisruptionbudget.yaml
+++ b/bitnami/concourse/templates/worker/poddisruptionbudget.yaml
@@ -2,14 +2,23 @@
 kind: PodDisruptionBudget
 apiVersion: policy/v1beta1
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ template "concourse.worker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker
     {{- if .Values.commonLabels }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
+  {{- if .Values.worker.pdb.minAvailable }}
   minAvailable: {{ .Values.worker.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.worker.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.worker.pdb.maxUnavailable }}
+  {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: worker

--- a/bitnami/concourse/templates/worker/podsecuritypolicy.yaml
+++ b/bitnami/concourse/templates/worker/podsecuritypolicy.yaml
@@ -4,12 +4,15 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "concourse.worker.fullname" . }}
-  labels:
-  {{- include "common.labels.standard" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace | quote }}
 spec:
   privileged: {{ .Values.worker.containerSecurityContext.privileged }}
   allowPrivilegeEscalation: false

--- a/bitnami/concourse/templates/worker/rbac.yaml
+++ b/bitnami/concourse/templates/worker/rbac.yaml
@@ -1,13 +1,11 @@
-{{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- if and $pspAvailable .Values.worker.enabled .Values.worker.rbac.create .Values.worker.psp.create }}
----
+{{- if and .Values.worker.enabled .Values.worker.rbac.create -}}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
-kind: ClusterRole
+kind: Role
 metadata:
   name: {{ template "concourse.worker.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app: concourse
+    app.kubernetes.io/component: worker
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,19 +13,25 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 rules:
-- apiGroups:
-  - extensions
-  resources:
-  - podsecuritypolicies
-  resourceNames:
-  - {{ template "concourse.worker.fullname" . }}
-  verbs:
-  - use
+  {{- $pspAvailable := (semverCompare "<1.25-0" (include "common.capabilities.kubeVersion" .)) -}}
+  {{- if and $pspAvailable .Values.worker.psp.create }}
+  - apiGroups: ['policy']
+    resources: ['podsecuritypolicies']
+    verbs:     ['use']
+    resourceNames:
+      - {{ template "concourse.worker.fullname" . }}
+  {{- end }}
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  {{- if .Values.worker.rbac.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.worker.rbac.rules "context" $ ) | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
-  name:  {{ template "concourse.web.fullname" . }}-psp
+  name: {{ template "concourse.worker.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app: concourse
@@ -42,6 +46,7 @@ roleRef:
   kind: Role
   name: {{ template "concourse.worker.fullname" . }}
 subjects:
-- kind: ServiceAccount
-  name: {{ template "concourse.worker.serviceAccountName" . }}
+  - kind: ServiceAccount
+    name: {{ template "concourse.worker.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/concourse/templates/worker/service-account.yaml
+++ b/bitnami/concourse/templates/worker/service-account.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.worker.enabled .Values.worker.rbac.create -}}
+{{- if and .Values.worker.enabled .Values.worker.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -9,7 +9,12 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.worker.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.worker.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ .Values.worker.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/bitnami/concourse/templates/worker/statefulset.yaml
+++ b/bitnami/concourse/templates/worker/statefulset.yaml
@@ -52,8 +52,17 @@ spec:
       {{- if .Values.worker.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.worker.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.worker.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.worker.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.worker.priorityClassName }}
-      priorityClassName: {{ .Values.worker.priorityClassName | quote }}
+      priorityClassName: {{ .Values.worker.priorityClassName }}
+      {{- end }}
+      {{- if .Values.worker.schedulerName }}
+      schedulerName: {{ .Values.worker.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.worker.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.worker.terminationGracePeriodSeconds }}
       {{- end }}
       {{- if .Values.worker.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.worker.podSecurityContext "enabled" | toYaml | nindent 8 }}
@@ -64,11 +73,12 @@ spec:
           image: {{ include "concourse.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
           command:
-            - sh
-            - -c
+            - /bin/bash
+          args:
+            - -ec
             - |
-              mkdir -p "/bitnami/concourse"
-              chown -R "{{ .Values.worker.containerSecurityContext.runAsUser }}:{{ .Values.web.podSecurityContext.fsGroup }}" "/bitnami/concourse"
+              mkdir -p /bitnami/concourse
+              find /bitnami/concourse -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ .Values.worker.containerSecurityContext.runAsUser }}:{{ .Values.worker.podSecurityContext.fsGroup }}
           {{- if .Values.worker.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.worker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
@@ -78,7 +88,7 @@ spec:
           volumeMounts:
         {{- end }}
         {{- if .Values.worker.initContainers }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
         - name: concourse-web
@@ -90,14 +100,21 @@ spec:
           {{- if .Values.worker.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.worker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.worker.command }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.worker.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.worker.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - /opt/bitnami/concourse/bin/concourse
           {{- end }}
-          {{- if .Values.worker.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.worker.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.worker.args "context" $) | nindent 12 }}
+          {{- else }}
+          args:
+            - worker
           {{- end }}
           env:
             - name: CONCOURSE_TSA_PUBLIC_KEY
@@ -107,7 +124,7 @@ spec:
             - name: CONCOURSE_WORK_DIR
               value: /bitnami/concourse/workdir
             - name: CONCOURSE_HEALTHCHECK_BIND_PORT
-              value: {{ .Values.worker.healthCheckContainerPort }}
+              value: {{ .Values.worker.containerPorts.health }}
             {{- if .Values.worker.logLevel }}
             - name: CONCOURSE_LOG_LEVEL
               value: {{ .Values.worker.logLevel | quote }}
@@ -121,9 +138,9 @@ spec:
             - name: CONCOURSE_BIND_IP
               value: {{ .Values.worker.bindIp | quote }}
             {{- end }}
-            {{- if .Values.worker.containerPort }}
+            {{- if .Values.worker.containerPorts.garden }}
             - name: CONCOURSE_BIND_PORT
-              value: {{ .Values.worker.containerPort | quote }}
+              value: {{ .Values.worker.containerPorts.garden | quote }}
             {{- end }}
             {{- if .Values.worker.baggageclaim.logLevel }}
             - name: CONCOURSE_BAGGAGECLAIM_LOG_LEVEL
@@ -133,17 +150,17 @@ spec:
             - name: CONCOURSE_BAGGAGECLAIM_BIND_IP
               value: {{ .Values.worker.baggageclaim.bindIp | quote }}
             {{- end }}
-            {{- if .Values.worker.baggageclaim.containerPort }}
+            {{- if .Values.worker.containerPorts.baggageclaim }}
             - name: CONCOURSE_BAGGAGECLAIM_BIND_PORT
-              value: {{ .Values.worker.baggageclaim.containerPort | quote }}
+              value: {{ .Values.worker.containerPorts.baggageclaim | quote }}
             {{- end }}
             {{- if .Values.worker.baggageclaim.debugbindIp }}
             - name: CONCOURSE_BAGGAGECLAIM_DEBUG_BIND_IP
               value: {{ .Values.worker.baggageclaim.debugbindIp | quote }}
             {{- end }}
-            {{- if .Values.worker.baggageclaim.debugContainerPort }}
+            {{- if .Values.worker.containerPorts.pprof }}
             - name: CONCOURSE_BAGGAGECLAIM_DEBUG_BIND_PORT
-              value: {{ .Values.worker.baggageclaim.debugContainerPort | quote }}
+              value: {{ .Values.worker.containerPorts.pprof | quote }}
             {{- end }}
             {{- if .Values.worker.baggageclaim.volumes }}
             - name: CONCOURSE_BAGGAGECLAIM_VOLUMES
@@ -186,34 +203,33 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.worker.containerPort }}
+              containerPort: {{ .Values.worker.containerPorts.garden }}
             - name: healthz
-              containerPort: {{ .Values.worker.healthCheckContainerPort }}
-          {{- if .Values.worker.livenessProbe.enabled }}
-          livenessProbe:
-            httpGet:
-              path: "/"
+              containerPort: {{ .Values.worker.containerPorts.health }}
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.worker.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
               port: healthz
-            initialDelaySeconds: {{ .Values.worker.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.worker.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.worker.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.worker.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.worker.livenessProbe.successThreshold }}
+          {{- else if .Values.worker.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.worker.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.livenessProbe "enabled") "context" $) | nindent 12 }}
+            httpGet:
+              path: /
+              port: healthz
           {{- else if .Values.worker.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.worker.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: "/"
+              path: /
               port: healthz
-            initialDelaySeconds: {{ .Values.worker.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.worker.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.worker.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.worker.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.worker.readinessProbe.successThreshold }}
           {{- else if .Values.worker.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             - name: concourse-keys
@@ -235,7 +251,11 @@ spec:
         {{- if .Values.worker.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-  {{- if not .Values.worker.persistence.enabled }}
+  {{- if and .Values.worker.persistence.enabled .Values.worker.persistence.existingClaim }}
+        - name: concourse-work-dir
+          persistentVolumeClaim:
+            claimName: {{ tpl .Values.worker.persistence.existingClaim $ }}
+  {{- else if not .Values.worker.persistence.enabled }}
         - name: concourse-work-dir
           emptyDir: {}
   {{- else }}

--- a/bitnami/concourse/values.yaml
+++ b/bitnami/concourse/values.yaml
@@ -14,7 +14,9 @@ global:
   ##
   imagePullSecrets: []
   storageClass: ""
+
 ## @section Common parameters
+
 ## @param kubeVersion Override Kubernetes version
 ##
 kubeVersion: ""
@@ -34,8 +36,23 @@ commonAnnotations: {}
 ##
 extraDeploy: []
 
-## @section Common Concourse Parameters
+## Enable diagnostic mode in the deployment(s)/statefulset(s)
 ##
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ##
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the deployment(s)/statefulset(s)
+  ##
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the deployment(s)/statefulset(s)
+  ##
+  args:
+    - infinity
+
+## @section Common Concourse Parameters
+
 ## Bitnami Concourse image
 ## ref: https://hub.docker.com/r/bitnami/redis/tags/
 ## @param image.registry image registry
@@ -65,34 +82,30 @@ image:
 ## For managing secrets using Helm
 ##
 secrets:
-  localAuth:
-    ## @param secrets.localAuth.enabled the use of local authentication (basic auth).
-    ## Once enabled, users configured through `local-users` (secret)
-    ## are able to authenticate.
-    ## Ref: https://concourse-ci.org/local-auth.html
-    ##
-    enabled: true
-
-  ## @param secrets.teamAuthorizedKeys [array] Array of team names and public keys for team external workers. A single
-  ## team can have many keys defined in the key field.
+  ## @param secrets.localAuth.enabled the use of local authentication (basic auth).
+  ## Once enabled, users configured through `local-users` (secret)
+  ## are able to authenticate.
+  ## Ref: https://concourse-ci.org/local-auth.html
   ##
-  ## Example:
+  localAuth:
+    enabled: true
+  ## @param secrets.localUsers List of `username:password` or `username:bcrypted_password` combinations for all your local concourse users. Auto-generated if not set
+  ## For details of expected format, see https://concourse-ci.org/local-auth.html
+  ##
+  localUsers: ""
+  ## @param secrets.teamAuthorizedKeys Array of team names and public keys for team external workers
+  ## A single team can have many keys defined in the key field.
+  ## e.g:
   ## - team: main
   ##   key: |-
   ##     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYBQ9fG6IML+qsFaMh1Pl+81wyUwRilHdfhItAiAsLVQsOwI5+V4pn5aLhHPBuRQqIqYmbkZ7I1VUIN1+90PVJ3X7l9qqanb85AHMtLujw1j9u0zDyH2XHgpUloknUQzUSLIZjjU3Hn3Uo/XikF+vT8104isO7Ym8Xp7sIcRuvOQ3nuRsFVCRogxpLTVHD/k57rwYVqWWLaKLwvx01ZVXOq4GHk/BVaKa9ODC/dNgbZMfwvVVXuf7/NFGmSMyXb49Si4aoP4Gn7jAX6GngBbm/bgKqO0skQy/ggQm/YVF+s5q4EhleMBLVJKD1VpM5LeLDFpiu/y4bVd8wUcgK+QQ9 Concourse
   ##     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDzpK/sIOtL9SCjAWrvO8QvknzYbnXvP/BljTQFNLwzsPqawqTk3FqUIsEjsq4clV3nwADK8Iq9A/xRlPR+ANhoGDPDv34FsWz5qKcXV7aXcOma8vyU4MJPjveXcZX7FjwztGoRIND9CXlLCDuYeIwBxCcnBBAwQFZuCmEXcqwsRbCve1KkswV1yr9yvmNaKNKTkJGo+7wGyShjzkfqijYCdwYbUWpSB0/tOGszBONtKE6FyJUmVtBgj+CAGZtj1AxGBbMnxxV
   ##
-  ## Make sure to chack the security caveats here: https://concourse-ci.org/teams-caveats.html
+  ## Make sure to check the security caveats here: https://concourse-ci.org/teams-caveats.html
   ## Extra Reads: https://github.com/concourse/concourse/issues/1865#issuecomment-464166994
   ## https://concourse-ci.org/global-resources.html#complications-with-reusing-containers
   ##
   teamAuthorizedKeys: []
-
-  ## @param secrets.localUsers List of `username:password` or `username:bcrypted_password` combinations for all your local concourse users. Auto-generated if not set
-  ## For details of expected format, see https://concourse-ci.org/local-auth.html
-  ##
-  localUsers: ""
-
   ## @param secrets.hostKey [string] Concourse Host Keys.
   ## Example value taken from https://github.com/concourse/concourse-chart/blob/master/values.yaml
   ## Ref: https://concourse-ci.org/install.html#generating-keys
@@ -125,12 +138,10 @@ secrets:
     Occs+xkdEsI9w5phXzIEeOq2LqvWHDPxtdLpxOrrmx4AftAWdM8S1+OqTpzHihK1
     y1ZOrWfvON+XjWFFAEej/CpQZkNUkTzjTtSC0dnfAveZlasQHdI=
     -----END RSA PRIVATE KEY-----
-
   ## @param secrets.hostKeyPub [string] Concourse Host Keys.
   ##
   hostKeyPub: |-
     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYBQ9fG6IML+qsFaMh1Pl+81wyUwRilHdfhItAiAsLVQsOwI5+V4pn5aLhHPBuRQqIqYmbkZ7I1VUIN1+90PVJ3X7l9qqanb85AHMtLujw1j9u0zDyH2XHgpUloknUQzUSLIZjjU3Hn3Uo/XikF+vT8104isO7Ym8Xp7sIcRuvOQ3nuRsFVCRogxpLTVHD/k57rwYVqWWLaKLwvx01ZVXOq4GHk/BVaKa9ODC/dNgbZMfwvVVXuf7/NFGmSMyXb49Si4aoP4Gn7jAX6GngBbm/bgKqO0skQy/ggQm/YVF+s5q4EhleMBLVJKD1VpM5LeLDFpiu/y4bVd8wUcgK+QQ9 Concourse
-
   ## @param secrets.sessionSigningKey [string] Concourse Session Signing Keys.
   ## Example value taken from https://github.com/concourse/concourse-chart/blob/master/values.yaml
   ## Ref: https://concourse-ci.org/concourse-generate-key.html
@@ -163,7 +174,6 @@ secrets:
     L8x1+dp0q7czC8a/l1DUuiwDKl8OEpxLsGCq/J/wAfrSMPifu6EUlbUwlJOPdgha
     +p/KFAelHXJ2w/8yackAcarh35VP7ixhuvxswHNdgvfsBTFcjn30
     -----END RSA PRIVATE KEY-----
-
   ## @param secrets.workerKey [string] Concourse Worker Keys.
   ## Example value taken from https://github.com/concourse/concourse-chart/blob/master/values.yaml
   ## Ref: https://concourse-ci.org/concourse-generate-key.html
@@ -196,78 +206,154 @@ secrets:
     Yi3cwo9fE3U3kSmpl5MQwUjWm/BZ7JyueoY/4ndwaFPgc34IKsgJ0wau9pZiQAB1
     DxpOSF+BR71Jx3sxvIdCODNTtm645j5yrZVnJAuMPofo5XFmunDoJA==
     -----END RSA PRIVATE KEY-----
-
   ## @param secrets.workerKeyPub [string] Concourse Worker Keys.
   ## Example value taken from https://github.com/concourse/concourse-chart/blob/master/values.yaml
   ##
   workerKeyPub: |-
     ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC496FSYFcBAKgDtMsBAJiF/6/NxlXKP5UZecyEsedYuTt1GOgJTwaA1qZ1LmHsbfLDE68oDdiM4uvxfI4wtLhz57w3u0jOUxZ2JeF7SVwEf1nVqLn4Gh/f8GUNQGSyIp1zUD5Bx9fq0PAyQ47mt7Ufi84rcf8LKl7nzAIHTcdg2BvTkQN9bUGPaq/Pb1W2bKPAQy4OzXTSIyrAJ89TH2jFeaZfyxQFGbD9jVHH/yl0oiMrDeaRYgccE5II+KY7WoLjsBry/9Qf2ERELKTK4UeIGIqWci9lab1ti+GxFPPiC3krNFjo4jShV4eUs4cNIrjwNrxVaKPXmU6o7Y3Hpayx Concourse
-
   ## @param secrets.workerAdditionalCerts Additional certificates to add to the worker nodes
   ##
   workerAdditionalCerts: ""
 
 ## @section Concourse Web parameters
-##
+
 web:
-  ## @param web.enabled Enable web
+  ## @param web.enabled Enable Concourse web component
   ##
   enabled: true
-  ## @param web.replicaCount Number of web replicas to deploy
-  ##
-  replicaCount: 1
-
-  ## @param web.args Override default args of the startup command for the web component.
-  ##
-  args: []
-
   ## @param web.baseUrl url
   ##
   baseUrl: /
-
   ## @param web.logLevel Minimum level of logs to see. Possible options: debug, info, error.
   ##
   logLevel: debug
-
   ## @param web.clusterName A name for this Concourse cluster, to be displayed on the dashboard page.
   ##
   clusterName: ""
   ## @param web.bindIp IP address on which to listen for HTTP traffic (web UI and API).
   ##
   bindIp: 0.0.0.0
-
-  ## @param web.containerPort Port on which to listen for HTTP traffic (web UI and API).
-  ##
-  containerPort: 8080
-
   ## @param web.peerAddress Network address of this web node, reachable by other web nodes.
   ## Used for forwarded worker addresses. (default: $POD_IP)
   ##
   peerAddress: ""
-
   ## @param web.externalUrl URL used to reach any ATC from the outside world.
   ## This is *very* important for a proper authentication workflow as
   ## browser redirects are based on the value set here.
-  ##
-  ## Example: http://ci.concourse-ci.org
+  ## E.g: http://ci.concourse-ci.org
   ##
   externalUrl: ""
-
+  ## Force sending secure flags on http cookies
+  ##
+  auth:
+    ## @param web.auth.cookieSecure use cookie secure true or false
+    ##
+    cookieSecure: false
+    ## @param web.auth.duration Length of time for which tokens are valid. Afterwards, users will have to log back in.
+    ## The value must be specified as Go duration values (e.g.: 30m or 24h).
+    ##
+    duration: 24h
+    ## @param web.auth.passwordConnector The connector to use for password authentication for `fly login -u ... -p ...`.
+    ## Either "local" or "ldap". Defaults to "local".
+    ##
+    passwordConnector: ""
+    mainTeam:
+      ## @param web.auth.mainTeam.config Configuration file for specifying the main teams params.
+      ## ref: https://concourse-ci.org/managing-teams.html#setting-roles
+      ## E.g:
+      ## config: |
+      ##   roles:
+      ##   - name: owner
+      ##     local:
+      ##       users: ["admin"]
+      ##   - name: member
+      ##     local:
+      ##       users: ["test"]
+      ##
+      config: ""
+      ## @param web.auth.mainTeam.localUser Comma-separated list of local Concourse users to be included as members of the `main` team.
+      ## Make sure you have local users support enabled (`concourse.web.localAuth.enabled`) and
+      ## that the users were added (`secrets.localUsers`).
+      ##
+      localUser: "user"
+  ## @param web.existingSecret Use an existing secret for the Web service credentials
+  ##
+  existingSecret: ""
   ## @param web.enableAcrossStep Enable the experimental across step to be used in jobs. The API is subject to change.
   ##
   enableAcrossStep: false
-
   ## @param web.enablePipelineInstances Enable the creation of instanced pipelines.
   ##
   enablePipelineInstances: false
-
   ## @param web.enableCacheStreamedVolumes Enable caching streamed resource volumes on the destination worker.
   ##
   enableCacheStreamedVolumes: false
-
-  ## Configure extra options for web container liveness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param web.livenessProbe.enabled Enable livenessProbe on web nodes
+  ## @param web.baseResourceTypeDefaults Configuration file for specifying defaults for base resource types
+  ## ref: https://concourse-ci.org/concourse-web.html#resource-defaults
+  ## E.g:
+  ## baseResourceTypeDefaults: |
+  ##   registry-image:
+  ##     registry_mirror:
+  ##       host: https://registry.mirror.example.com
+  ##
+  baseResourceTypeDefaults: ""
+  ## @param web.tsa.logLevel Minimum level of logs to see. Possible values: debug, info, error
+  ## @param web.tsa.bindIp IP address on which to listen for SSH
+  ## @param web.tsa.debugBindIp IP address on which to listen for the pprof debugger endpoints (default: 127.0.0.1)
+  ## @param web.tsa.heartbeatInterval Interval on which to heartbeat workers to the ATC
+  ## @param web.tsa.gardenRequestTimeout How long to wait for requests to Garden to complete. 0 means no timeout
+  ##
+  tsa:
+    logLevel: debug
+    bindIp: 0.0.0.0
+    debugBindIp: 127.0.0.1
+    heartbeatInterval: 30s
+    gardenRequestTimeout: ""
+  ## @param web.tls.enabled enable serving HTTPS traffic directly through the web component.
+  ##
+  tls:
+    enabled: false
+  ## @param web.configRBAC Set RBAC configuration
+  ##
+  configRBAC: ""
+  ## @param web.existingConfigmap The name of an existing ConfigMap with your custom configuration for web
+  ##
+  existingConfigmap: ""
+  ## @param web.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param web.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param web.extraEnvVars Array with extra environment variables to add to Concourse web nodes
+  ## e.g:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param web.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for Concourse web nodes
+  ##
+  extraEnvVarsCM: ""
+  ## @param web.extraEnvVarsSecret Name of existing Secret containing extra env vars for Concourse web nodes
+  ##
+  extraEnvVarsSecret: ""
+  ## @param web.replicaCount Number of Concourse web replicas to deploy
+  ##
+  replicaCount: 1
+  ## @param web.containerPorts.http Concourse web UI and API HTTP container port
+  ## @param web.containerPorts.https Concourse web UI and API HTTPS container port
+  ## @param web.containerPorts.tsa Concourse web TSA SSH container port
+  ## @param web.containerPorts.pprof Concourse web TSA pprof server container port
+  ##
+  containerPorts:
+    http: 8080
+    https: 8443
+    tsa: 2222
+    pprof: 2221
+  ## Configure extra options for Concourse web containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param web.livenessProbe.enabled Enable livenessProbe on Concourse web containers
   ## @param web.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param web.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param web.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -281,10 +367,7 @@ web:
     timeoutSeconds: 3
     failureThreshold: 1
     successThreshold: 1
-
-  ## Configure extra options for web container readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes  ## @param web.readinessProbe.enabled Enable readinessProbe on web nodes
-  ## @param web.readinessProbe.enabled Enable readinessProbe
+  ## @param web.readinessProbe.enabled Enable readinessProbe on Concourse web containers
   ## @param web.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param web.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param web.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -298,67 +381,37 @@ web:
     timeoutSeconds: 3
     failureThreshold: 1
     successThreshold: 1
-
+  ## @param web.startupProbe.enabled Enable startupProbe on Concourse web containers
+  ## @param web.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param web.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param web.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param web.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param web.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
   ## @param web.customLivenessProbe Custom livenessProbe that overrides the default one
   ##
   customLivenessProbe: {}
   ## @param web.customReadinessProbe Custom readinessProbe that overrides the default one
   ##
   customReadinessProbe: {}
-  ## web resource requests and limits
+  ## @param web.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## Concourse web resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## @param web.resources.limits The resources limits for the web containers
-  ## The requested resources for the web containers
-  ## @param web.resources.requests The requested for the web containers
-  ## resources:
-  ##   limits: {}
-  ##   requests:
-  ##     cpu: "100m"
-  ##     memory: "128Mi"
+  ## @param web.resources.limits The resources limits for the Concourse web containers
+  ## @param web.resources.requests The requested resources for the Concourse web containers
   ##
   resources:
     limits: {}
     requests: {}
-
-  ## RBAC parameters
-  ##
-  rbac:
-    ## @param web.rbac.create Specifies whether RBAC resources should be created
-    ##
-    create: true
-
-  ## ServiceAccount parameters
-  ##
-  serviceAccount:
-    ## @param web.serviceAccount.create Specifies whether a ServiceAccount should be created
-    ##
-    create: true
-    ## @param web.serviceAccount.name Override Web service account name
-    ## If not set and create is true, a name is generated using the fullname template
-    ##
-    name: ""
-
-  ## @param web.tls.enabled enable serving HTTPS traffic directly through the web component.
-  ## @param web.tls.containerPort on which to listen for HTTPS traffic.
-  ##
-  tls:
-    enabled: false
-    containerPort: 443
-
-  ## @param web.existingConfigmap The name of an existing ConfigMap with your custom configuration for web
-  ##
-  existingConfigmap: ""
-  ## @param web.command Override default container command (useful when using custom images)
-  ##
-  command: []
-  ## @param web.hostAliases Deployment pod host aliases
-  ##
-  hostAliases: []
-  ## @param web.podLabels Extra labels for web pods
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-  ##
-  podLabels: {}
-
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param web.podSecurityContext.enabled Enabled web pods' Security Context
@@ -375,88 +428,14 @@ web:
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
-
-  ## @param web.psp.create Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later
+  ## @param web.hostAliases Concourse web pod host aliases
   ##
-  psp:
-    create: false
-
-  tsa:
-    ## Enable this flag in order to customize the `client_id` and
-    ## `client_secret` used when the TSA needs to communicate with the ATC.
-    ##
-    ## @param web.tsa.logLevel Minimum level of logs to see. Possible values: debug, info, error.
-    ##
-    logLevel: debug
-
-    ## @param web.tsa.bindIp IP address on which to listen for SSH.
-    ##
-    bindIp: 0.0.0.0
-
-    ## @param web.tsa.containerPort Port on which to listen for SSH.
-    ##
-    containerPort: 2222
-
-    ## @param web.tsa.debugbindIp IP address on which to listen for the pprof debugger endpoints (default: 127.0.0.1)
-    ##
-    debugbindIp: 127.0.0.1
-
-    ## @param web.tsa.debugContainerPort Port on which to listen for TSA pprof server.
-    ##
-    debugContainerPort: 2221
-
-    ## @param web.tsa.heartbeatInterval Interval on which to heartbeat workers to the ATC.
-    ##
-    heartbeatInterval: 30s
-
-    ## @param web.tsa.gardenRequestTimeout How long to wait for requests to Garden to complete. 0 means no timeout.
-    ##
-    gardenRequestTimeout: ""
-
-  ## @param web.configRBAC set RBAC configuration
+  hostAliases: []
+  ## @param web.podLabels Extra labels for Concourse web pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   ##
-  configRBAC: ""
-
-  ## Force sending secure flag on http cookies
-  ##
-  auth:
-    ##
-    ## @param web.auth.cookieSecure use cookie secure true or flase
-    ##
-    cookieSecure: false
-
-    ## @param web.auth.duration Length of time for which tokens are valid. Afterwards, users will have to log back in.
-    ## The value must be specified as Go duration values (e.g.: 30m or 24h).
-    ##
-    duration: 24h
-
-    ## @param web.auth.passwordConnector The connector to use for password authentication for `fly login -u ... -p ...`.
-    ## Either "local" or "ldap". Defaults to "local".
-    ##
-    passwordConnector: ""
-
-    mainTeam:
-      ## @param web.auth.mainTeam.config Configuration file for specifying the main teams params.
-      ## Ref: https://concourse-ci.org/managing-teams.html#setting-roles
-      ## Example:
-      ## config: |
-      ##   roles:
-      ##   - name: owner
-      ##     local:
-      ##       users: ["admin"]
-      ##   - name: member
-      ##     local:
-      ##       users: ["test"]
-      ##
-      config: ""
-
-      ## @param web.auth.mainTeam.localUser Comma-separated list of local Concourse users to be included as members of the `main` team.
-      ## Make sure you have local users support enabled (`concourse.web.localAuth.enabled`) and
-      ## that the users were added (`secrets.localUsers`).
-      ##
-      localUser: "user"
-
-  ## @param web.podAnnotations Annotations for web pods
+  podLabels: {}
+  ## @param web.podAnnotations Annotations for Concourse web pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
@@ -498,51 +477,38 @@ web:
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param web.updateStrategy.type web statefulset strategy type
+  ## @param web.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: {}
+  ## @param web.priorityClassName Priority Class to use for each pod (Concourse web)
+  ##
+  priorityClassName: ""
+  ## @param web.schedulerName Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param web.terminationGracePeriodSeconds Seconds Concourse web pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  ##
+  terminationGracePeriodSeconds: ""
+  ## @param web.updateStrategy.rollingUpdate Concourse web statefulset rolling update configuration parameters
+  ## @param web.updateStrategy.type Concourse web statefulset strategy type
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy:
-    ## StrategyType
-    ## Can be set to RollingUpdate or OnDelete
-    ##
     type: RollingUpdate
-  ## @param web.priorityClassName web pods' priorityClassName
-  ##
-  priorityClassName: ""
-  ## @param web.lifecycleHooks for the web container(s) to automate configuration before or after startup
+    rollingUpdate: {}
+  ## @param web.lifecycleHooks lifecycleHooks for the Concourse web container(s)
   ##
   lifecycleHooks: {}
-  ## @param web.extraEnvVars Array with extra environment variables to add to web nodes
-  ## e.g:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
-  ##
-
-  ## @param web.baseResourceTypeDefaults Configuration file for specifying defaults for base resource types
-  ## Ref: https://concourse-ci.org/concourse-web.html#resource-defaults
-  ## Example:
-  ## baseResourceTypeDefaults: |
-  ##   registry-image:
-  ##     registry_mirror:
-  ##       host: https://registry.mirror.example.com
-  ##
-  baseResourceTypeDefaults: ""
-
-  extraEnvVars: []
-  ## @param web.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for web nodes
-  ##
-  extraEnvVarsCM: ""
-  ## @param web.extraEnvVarsSecret Name of existing Secret containing extra env vars for web nodes
-  ##
-  extraEnvVarsSecret: ""
-  ## @param web.extraVolumes Optionally specify extra list of additional volumes for the web pod(s)
+  ## @param web.extraVolumes Optionally specify extra list of additional volumeMounts for the Concourse web container(s)
   ##
   extraVolumes: []
-  ## @param web.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the web container(s)
+  ## @param web.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Concourse web container(s)
   ##
   extraVolumeMounts: []
-  ## @param web.sidecars Add additional sidecar containers to the web pod(s)
+  ## @param web.sidecars Add additional sidecar containers to the Concourse web pod(s)
   ## e.g:
   ## sidecars:
   ##   - name: your-image-name
@@ -553,7 +519,7 @@ web:
   ##         containerPort: 1234
   ##
   sidecars: []
-  ## @param web.initContainers Add additional init containers to the web pod(s)
+  ## @param web.initContainers Add additional init containers to the Concourse web pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
   ## e.g:
   ## initContainers:
@@ -563,155 +529,170 @@ web:
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
   initContainers: []
-
-  ## @param web.existingSecret Use an existing secret for the Web service credentials
+  ## @param web.psp.create Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later
   ##
-  existingSecret: ""
+  psp:
+    create: false
+  ## RBAC parameters
+  ##
+  rbac:
+    ## @param web.rbac.create Specifies whether RBAC resources should be created
+    ##
+    create: true
+    ## @param web.rbac.rules Custom RBAC rules to set
+    ## e.g:
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - get
+    ##       - list
+    ##
+    rules: []
+  ## ServiceAccount parameters
+  ##
+  serviceAccount:
+    ## @param web.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## @param web.serviceAccount.name Override Web service account name
+    ## If not set and create is true, a name is generated using the fullname template
+    ##
+    name: ""
+    ## @param web.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+    ##
+    automountServiceAccountToken: true
+    ## @param web.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
 ## @section Concourse Worker parameters
 ##
 worker:
-  ## @param worker.enabled Enable worker nodes
+  ## @param worker.enabled Enable Concourse worker nodes
   ##
   enabled: true
-
+  ## @param worker.logLevel Minimum level of logs to see. Possible options: debug, info, error
+  ##
+  logLevel: debug
+  ## @param worker.bindIp IP address on which to listen for the Garden server.
+  ##
+  bindIp: 127.0.0.1
+  ## @param worker.tsa.hosts TSA host(s) to forward the worker through
+  ## Only used for worker-only deployments.
+  ##
+  tsa:
+    hosts: []
+  ## @param worker.existingSecret name of an existing secret resource containing the keys and the pub
+  ##
+  existingSecret: ""
+  ## @param worker.baggageclaim.logLevel Minimum level of logs to see. Allowed values: `debug`, `info`, and `error`
+  ## @param worker.baggageclaim.bindIp IP address on which to listen for API traffic
+  ## @param worker.baggageclaim.debugbindIp IP address on which to listen for the pprof debugger endpoints
+  ## @param worker.baggageclaim.disableUserNamespaces Disable remapping of user/group IDs in unprivileged volumes
+  ## @param worker.baggageclaim.volumes Directory in which to place volume data
+  ## @param worker.baggageclaim.driver Driver to use for managing volumes. Allowed values: `detect`, `naive`, `btrfs`, and `overlay`
+  ## @param worker.baggageclaim.btrfsBin Path to btrfs binary
+  ## @param worker.baggageclaim.mkfsBin Path to mkfs.btrfs binary
+  ## @param worker.baggageclaim.overlaysDir Path to directory in which to store overlay data
+  ##
+  baggageclaim:
+    logLevel: info
+    bindIp: 127.0.0.1
+    debugbindIp: 127.0.0.1
+    disableUserNamespaces: ""
+    volumes: ""
+    driver: ""
+    btrfsBin: btrfs
+    mkfsBin: mkfs.btrfs
+    overlaysDir: ""
+  ## @param worker.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param worker.args Override worker default args
+  ##
+  args: []
   ## @param worker.replicaCount Number of worker replicas
   ##
   replicaCount: 2
   ## @param worker.mode Selects kind of Deployment. Valid Options are: statefulSet | deployment
-  ## Using Deployment leads to ephemeral workers. Meaning workers do not
-  ## share state between restarts
+  ## Using Deployment leads to ephemeral workers. Meaning workers do not share state between restarts
   ##
   mode: deployment
-
-  ## @param worker.logLevel Minimum level of logs to see. Possible options: debug, info, error
+  ## @param worker.containerPorts.garden Concourse worker Garden server container port
+  ## @param worker.containerPorts.health Concourse worker health-check container port
+  ## @param worker.containerPorts.baggageclaim Concourse worker baggageclaim API container port
+  ## @param worker.containerPorts.pprof Concourse worker baggageclaim pprof server container port
   ##
-  logLevel: debug
-
-  ## @param worker.command Override default container command (useful when using custom images)
-  ##
-  command: []
-
-  ## @param worker.args Override worker default args
-  ##
-  args: []
-
-  ## @param worker.bindIp IP address on which to listen for the Garden server.
-  ##
-  bindIp: 127.0.0.1
-
-  ## @param worker.containerPort Port on which to listen for the Garden server.
-  ##
-  containerPort: 7777
-
-  ## @param worker.healthCheckContainerPort Port on which to listen for the healh checks.
-  ##
-  healthCheckContainerPort: 8888
-
-  tsa:
-    ## @param worker.tsa.hosts TSA host(s) to forward the worker through.
-    ## Only used for worker-only deployments.
-    ##
-    hosts: []
-
-  ## RBAC parameters
-  ##
-  rbac:
-    ## @param worker.rbac.create Specifies whether RBAC resources should be created
-    ##
-    create: true
-
-  ## ServiceAccount parameters
-  ##
-  serviceAccount:
-    ## @param worker.serviceAccount.create Specifies whether a ServiceAccount should be created
-    ##
-    create: true
-    ## @param worker.serviceAccount.name Override Worker service account name
-    ## If not set and create is true, a name is generated using the fullname template
-    ##
-    name: ""
-
-  ## Enable HorizontalPodAutoscaler for worker pods
-  ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
-  ##
-  ## @param worker.autoscaling.enabled Enable autoscaling for the worker nodes
-  ## @param worker.autoscaling.maxReplicas Set maximum number of replicas to the worker nodes
-  ## @param worker.autoscaling.minReplicas Set minimum number of replicas to the worker nodes
-  ## @param worker.autoscaling.builtInMetrics Array with built-in metrics
-  ## @param worker.autoscaling.customMetrics Array with custom metrics
-  ##
-  autoscaling:
-    enabled: false
-    maxReplicas: ""
-    minReplicas: ""
-    builtInMetrics: []
-    customMetrics: []
-
-  ## Concourse Pod Disruption Budget configuration
-  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-  ##
-  pdb:
-    create: true
-    ## @param worker.pdb.create Create Pod disruption budget object for worker nodes
-    ## @param worker.pdb.minAvailable Minimum number of workers available after an eviction
-    ##
-    minAvailable: 2
-
-  ## Configures the liveness probe used to determine if the Worker component is up.
-  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
-  ##
-  ## @param worker.livenessProbe.enabled Enable livenessProbe on worker nodes
+  containerPorts:
+    garden: 7777
+    health: 8888
+    baggageclaim: 7788
+    pprof: 7787
+  ## Configure extra options for Concourse worker containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param worker.livenessProbe.enabled Enable livenessProbe on Concourse worker containers
   ## @param worker.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param worker.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param worker.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
   ## @param worker.livenessProbe.failureThreshold Failure threshold for livenessProbe
-  ## @param worker.livenessProbe.successThreshold Failure threshold for livenessProbe
+  ## @param worker.livenessProbe.successThreshold Success threshold for livenessProbe
   ##
   livenessProbe:
     enabled: true
-    failureThreshold: 5
     initialDelaySeconds: 10
     periodSeconds: 15
     timeoutSeconds: 3
+    failureThreshold: 1
     successThreshold: 1
-
-  ## @param worker.readinessProbe.enabled Enable readiness probe on worker nodes
+  ## @param worker.readinessProbe.enabled Enable readinessProbe on Concourse worker containers
   ## @param worker.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param worker.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param worker.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
   ## @param worker.readinessProbe.failureThreshold Failure threshold for readinessProbe
   ## @param worker.readinessProbe.successThreshold Success threshold for readinessProbe
-  ## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
   ##
   readinessProbe:
     enabled: true
-    failureThreshold: 5
     initialDelaySeconds: 10
     periodSeconds: 15
     timeoutSeconds: 3
+    failureThreshold: 1
     successThreshold: 1
-
+  ## @param worker.startupProbe.enabled Enable startupProbe on Concourse worker containers
+  ## @param worker.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param worker.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param worker.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param worker.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param worker.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
   ## @param worker.customLivenessProbe Custom livenessProbe that overrides the default one
   ##
   customLivenessProbe: {}
   ## @param worker.customReadinessProbe Custom readinessProbe that overrides the default one
   ##
   customReadinessProbe: {}
-
-  ## @param worker.resources.limits Configure resource limits.
-  ## @param worker.resources.requests Configure resource request
-  ##  resources:
-  ##   limits: {}
-  ##   requests:
-  ##     cpu: "100m"
-  ##     memory: "512Mi"
-  ## Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param worker.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## Concourse worker resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param worker.resources.limits The resources limits for the Concourse worker containers
+  ## @param worker.resources.requests The requested resources for the Concourse worker containers
   ##
   resources:
     limits: {}
     requests: {}
-
   ## Configure Pods Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param worker.podSecurityContext.enabled Enabled worker pods' Security Context
@@ -730,16 +711,13 @@ worker:
     enabled: true
     privileged: true
     runAsUser: 0
-
-  ## @param worker.psp.create Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later
+  ## @param worker.hostAliases Concourse worker pod host aliases
   ##
-  psp:
-    create: false
-
-  ## @param worker.podLabels Custom labels for worker pods
+  hostAliases: []
+  ## @param worker.podLabels Custom labels for Concourse worker pods
   ##
   podLabels: {}
-  ## @param worker.podAnnotations Annotations for worker pods
+  ## @param worker.podAnnotations Annotations for Concourse worker pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
@@ -751,17 +729,11 @@ worker:
   ## Allowed values: soft, hard
   ##
   podAffinityPreset: ""
-
   ## @param worker.podAntiAffinityPreset Pod anti-affinity preset
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ## Allowed values: soft, hard
   ##
   podAntiAffinityPreset: soft
-
-  ## @param worker.hostAliases Deployment pod host aliases
-  ##
-  hostAliases: []
-
   ##  Node affinity preset
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   ## Allowed values: soft, hard
@@ -783,57 +755,65 @@ worker:
     ##   - e2e-az2
     ##
     values: []
-
   ## @param worker.affinity Affinity for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
   ##
   affinity: {}
-
   ## @param worker.nodeSelector Node labels for pod assignment
   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
   nodeSelector: {}
-
   ## @param worker.tolerations Tolerations for worker pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ## Note: this configuration supersedes the global tolerations configuration
   ##
   tolerations: []
-
-  ## @param worker.updateStrategy.type worker statefulset strategy type
-  ## StrategyType
-  ## Can be set to RollingUpdate or OnDelete
+  ## @param worker.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+  ##
+  topologySpreadConstraints: {}
+  ## @param worker.priorityClassName Priority Class to use for each pod (Concourse worker)
+  ##
+  priorityClassName: ""
+  ## @param worker.schedulerName Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+  ## @param worker.terminationGracePeriodSeconds Seconds Concourse worker pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  ##
+  terminationGracePeriodSeconds: ""
+  ## @param worker.updateStrategy.rollingUpdate Concourse worker statefulset rolling update configuration parameters
+  ## @param worker.updateStrategy.type Concourse worker statefulset strategy type
   ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy:
     type: RollingUpdate
-  ## @param worker.priorityClassName worker pods' priorityClassName
-  ##
-  priorityClassName: ""
-  ## @param worker.lifecycleHooks for the worker container(s) to automate configuration before or after startup
+    rollingUpdate: {}
+  ## @param worker.lifecycleHooks for the Concourse worker container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
-  ## @param worker.extraEnvVars Array with extra environment variables to add to worker nodes
+  ## @param worker.extraEnvVars Array with extra environment variables to add to Concourse worker nodes
   ## e.g:
   ## extraEnvVars:
   ##   - name: FOO
   ##     value: "bar"
   ##
   extraEnvVars: []
-  ## @param worker.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for worker nodes
+  ## @param worker.extraEnvVarsCM Name of existing ConfigMap containing extra env vars for Concourse worker nodes
   ##
   extraEnvVarsCM: ""
-  ## @param worker.extraEnvVarsSecret Name of existing Secret containing extra env vars for worker nodes
+  ## @param worker.extraEnvVarsSecret Name of existing Secret containing extra env vars for Concourse worker nodes
   ##
   extraEnvVarsSecret: ""
-  ## @param worker.extraVolumes Optionally specify extra list of additional volumes for the worker pod(s)
+  ## @param worker.extraVolumes Optionally specify extra list of additional volumes for the Concourse worker pod(s)
   ##
   extraVolumes: []
-  ## @param worker.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the worker container(s)
+  ## @param worker.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Concourse worker container(s)
   ##
   extraVolumeMounts: []
-  ## @param worker.sidecars Add additional sidecar containers to the worker pod(s)
+  ## @param worker.sidecars Add additional sidecar containers to the Concourse worker pod(s)
   ## e.g:
   ## sidecars:
   ##   - name: your-image-name
@@ -844,7 +824,7 @@ worker:
   ##         containerPort: 1234
   ##
   sidecars: []
-  ## @param worker.initContainers Add additional init containers to the worker pod(s)
+  ## @param worker.initContainers Add additional init containers to the Concourse worker pod(s)
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
   ## e.g:
   ## initContainers:
@@ -854,387 +834,374 @@ worker:
   ##    command: ['sh', '-c', 'echo "hello world"']
   ##
   initContainers: []
-
-  ## @param worker.existingSecret name of an existing secret resource containing the keys and the pub
+  ## Enable HorizontalPodAutoscaler for Concourse worker pods
+  ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
   ##
-  existingSecret: ""
-
-  baggageclaim:
-    ## @param worker.baggageclaim.logLevel Minimum level of logs to see. Possible values: debug, info, error
+  ## @param worker.autoscaling.enabled Enable autoscaling for the Concourse worker nodes
+  ## @param worker.autoscaling.maxReplicas Set maximum number of replicas to the Concourse worker nodes
+  ## @param worker.autoscaling.minReplicas Set minimum number of replicas to the Concourse worker nodes
+  ## @param worker.autoscaling.builtInMetrics Array with built-in metrics
+  ## @param worker.autoscaling.customMetrics Array with custom metrics
+  ##
+  autoscaling:
+    enabled: false
+    maxReplicas: ""
+    minReplicas: ""
+    builtInMetrics: []
+    customMetrics: []
+  ## Concourse Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
+  ##
+  pdb:
+    create: true
+    ## @param worker.pdb.create Create Pod disruption budget object for Concourse worker nodes
+    ## @param worker.pdb.minAvailable Minimum number of Concourse workers available after an eviction
+    ## @param worker.pdb.maxAvailable Maximum number of Concourse workers available
     ##
-    logLevel: info
-
-    ## @param worker.baggageclaim.bindIp IP address on which to listen for API traffic.
-    ##
-    bindIp: 127.0.0.1
-
-    ## @param worker.baggageclaim.containerPort Port on which to listen for API traffic.
-    ##
-    containerPort: 7788
-
-    ## @param worker.baggageclaim.debugbindIp IP address on which to listen for the pprof debugger endpoints.
-    ##
-    debugbindIp: 127.0.0.1
-
-    ## @param worker.baggageclaim.debugContainerPort Port on which to listen for baggageclaim pprof server.
-    ##
-    debugContainerPort: 7787
-
-    ## @param worker.baggageclaim.disableUserNamespaces Disable remapping of user/group IDs in unprivileged volumes.
-    ##
-    disableUserNamespaces: ""
-
-    ## @param worker.baggageclaim.volumes Directory in which to place volume data.
-    ##
-    volumes: ""
-
-    ## @param worker.baggageclaim.driver Driver to use for managing volumes.
-    ## Possible values: detect, naive, btrfs, and overlay.
-    ##
-    driver: ""
-
-    ## @param worker.baggageclaim.btrfsBin Path to btrfs binary
-    ##
-    btrfsBin: btrfs
-
-    ## @param worker.baggageclaim.mkfsBin Path to mkfs.btrfs binary
-    ##
-    mkfsBin: mkfs.btrfs
-
-    ## @param worker.baggageclaim.overlaysDir Path to directory in which to store overlay data
-    ##
-    overlaysDir: ""
-
-  ## If true, use a Persistent Volume Claim, If false, use emptyDir
-  ## @param worker.persistence.enabled Enable persistence using Persistent Volume Claims
+    minAvailable: 2
+    maxAvailable: ""
+  ## @param worker.psp.create Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later
+  ##
+  psp:
+    create: false
+  ## Concourse worker persistence configuration
   ##
   persistence:
+    ## @param worker.persistence.enabled Enable Concourse worker data persistence using PVC
+    ##
     enabled: true
-    ## Persistent Volume Storage Class
+    ## @param worker.persistence.existingClaim Name of an existing PVC to use
+    ##
+    existingClaim: ""
+    ## @param worker.persistence.storageClass PVC Storage Class for Concourse worker data volume
     ## If defined, storageClassName: <storageClass>
     ## If set to "-", storageClassName: "", which disables dynamic provisioning
     ## If undefined (the default) or set to null, no storageClassName spec is
     ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
     ##   GKE, AWS & OpenStack)
     ##
-    ## @param worker.persistence.storageClass Persistent Volume storage class
-    ##
     storageClass: ""
-    ## @param worker.persistence.annotations Persistent Volume Claim annotations
-    ##
-    annotations: {}
-    ## Persistent Volume Access Mode
-    ##
-    ## @param worker.persistence.accessModes [array] Persistent Volume access modes
+    ## @param worker.persistence.accessModes PVC Access Mode for Concourse worker volume
     ##
     accessModes:
       - ReadWriteOnce
-    ## Persistent Volume size
-    ##
-    ## @param worker.persistence.size Persistent Volume size
+    ## @param worker.persistence.size PVC Storage Request for Concourse worker volume
     ##
     size: 8Gi
-
-    ## @param worker.persistence.selector Additional labels to match for the PVC
-    ## e.g:
+    ## @param worker.persistence.annotations Annotations for the PVC
+    ##
+    annotations: {}
+    ## @param worker.persistence.selector Selector to match an existing Persistent Volume (this value is evaluated as a template)
     ## selector:
     ##   matchLabels:
     ##     app: my-app
     ##
     selector: {}
+  ## RBAC parameters
+  ##
+  rbac:
+    ## @param worker.rbac.create Specifies whether RBAC resources should be created
+    ##
+    create: true
+    ## @param worker.rbac.rules Custom RBAC rules to set
+    ## e.g:
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - get
+    ##       - list
+    ##
+    rules: []
+  ## ServiceAccount parameters
+  ##
+  serviceAccount:
+    ## @param worker.serviceAccount.create Specifies whether a ServiceAccount should be created
+    ##
+    create: true
+    ## @param worker.serviceAccount.name Override worker service account name
+    ## If not set and create is true, a name is generated using the fullname template
+    ##
+    name: ""
+    ## @param worker.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+    ##
+    automountServiceAccountToken: true
+    ## @param worker.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
+
 
 ## @section Traffic exposure parameters
-##
+
 service:
+  ## Concourse web service parameters
+  ##
   web:
-    ## @param service.web.type For minikube, set this to ClusterIP, elsewhere use LoadBalancer or NodePort
-    ## Ref: https://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
+    ## @param service.web.type Concourse web service type
     ##
     type: LoadBalancer
-
-    ## @param service.web.port  Service HTTP port
+    ## @param service.web.ports.http Concourse web service HTTP port
+    ## @param service.web.ports.https Concourse web service HTTPS port
     ##
-    port: 80
-
-    ## @param service.web.tlsPort  Service HTTPS port
+    ports:
+      http: 80
+      https: 443
+    ## Node ports to expose
+    ## @param service.web.nodePorts.http Node port for HTTP
+    ## @param service.web.nodePorts.https Node port for HTTPS
+    ## NOTE: choose port between <30000-32767>
     ##
-    tlsPort: 443
-
-    ## @param service.web.clusterIP When using `service.web.type: ClusterIP`, sets the user-specified cluster IP.
-    ## Example: 172.217.1.174
+    nodePorts:
+      http: ""
+      https: ""
+    ## @param service.web.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
+    ## @param service.web.clusterIP Concourse web service Cluster IP
+    ## e.g.:
+    ## clusterIP: None
     ##
     clusterIP: ""
-
-    ## @param service.web.loadBalancerIP  When using `service.web.type: LoadBalancer`, sets the user-specified load balancer IP.
-    ## Example: 172.217.1.174
+    ## @param service.web.loadBalancerIP Concourse web service Load Balancer IP
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
     loadBalancerIP: ""
-
-    ## @param service.web.labels Additional Labels to be added to the web api service.
-    ##
-    labels: {}
-
-    ## @param service.web.annotations Annotations to be added to the web api service.
-    ##
-    ##
-    ## When using `service.web.type: LoadBalancer` in AWS, enable HTTPS with an ACM cert:
-    ##
-    ##   service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:eu-west-1:123456789:certificate/abc123-abc123-abc123-abc123"
-    ##   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    ##   service.beta.kubernetes.io/aws-load-balancer-backend-port: "api"
-    ##   service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    ##
-    annotations: {}
-
-    ## @param service.web.loadBalancerSourceRanges When using `service.web.type: LoadBalancer`, restrict access to the load balancer to particular IPs
-    ## Example:
-    ##   - 192.168.1.10/32
+    ## @param service.web.loadBalancerSourceRanges Concourse web service Load Balancer sources
+    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ## e.g:
+    ## loadBalancerSourceRanges:
+    ##   - 10.10.10.0/24
     ##
     loadBalancerSourceRanges: []
-
-    ## @param service.web.nodePort When using `service.web.type: NodePort`, sets the nodePort for api
+    ## @param service.web.externalTrafficPolicy Concourse web service external traffic policy
+    ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
-    nodePort: ""
-
-    ## @param service.web.tlsnodePort When using `service.web.type: NodePort`, sets the nodePort for api tls
+    externalTrafficPolicy: Cluster
+    ## @param service.web.annotations Additional custom annotations for Concourse web service
     ##
-    tlsnodePort: ""
-
-    ## @param service.web.externalTrafficPolicy Set service externalTraffic policy
+    annotations: {}
+    ## @param service.web.extraPorts Extra port to expose on Concourse web service
     ##
-    externalTrafficPolicy: ""
-
+    extraPorts: []
+  ## Concourse worker gateway service parameters
+  ##
   workerGateway:
-    ## @param service.workerGateway.type For minikube, set this to ClusterIP, elsewhere use LoadBalancer or NodePort
-    ## Ref: https://kubernetes.io/docs/user-guide/services/#publishing-services---service-types
+    ## @param service.workerGateway.type Concourse worker gateway service type
     ##
     type: ClusterIP
-
-    ## @param service.workerGateway.clusterIP When using `service.workerGateway.type: ClusterIP`, sets the user-specified cluster IP.
-    ## Example: 172.217.1.174
+    ## @param service.workerGateway.ports.tsa Concourse worker gateway service port
+    ##
+    ports:
+      tsa: 2222
+    ## Node ports to expose
+    ## @param service.workerGateway.nodePorts.tsa Node port for worker gateway service
+    ## NOTE: choose port between <30000-32767>
+    ##
+    nodePorts:
+      tsa: ""
+    ## @param service.workerGateway.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
+    ## @param service.workerGateway.clusterIP Concourse worker gateway service Cluster IP
+    ## e.g.:
+    ## clusterIP: None
     ##
     clusterIP: ""
-
-    ## @param service.workerGateway.port Service HTTP port
-    ##
-    port: 2222
-
-    ## @param service.workerGateway.loadBalancerIP When using `service.workerGateway.type: LoadBalancer`, sets the user-specified load balancer IP.
-    ## Example: 172.217.1.174
+    ## @param service.workerGateway.loadBalancerIP Concourse worker gateway service Load Balancer IP
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
     ##
     loadBalancerIP: ""
-
-    ## @param service.workerGateway.labels Additional Labels to be added to the web workerGateway service.
-    ##
-    labels: {}
-
-    ## @param service.workerGateway.annotations Annotations to be added to the web workerGateway service.
-    ##
-    ## When using `service.workerGateway.type: LoadBalancer` in AWS, enable HTTPS with an ACM cert:
-    ##
-    ##   service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:eu-west-1:123456789:certificate/abc123-abc123-abc123-abc123"
-    ##   service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
-    ##   service.beta.kubernetes.io/aws-load-balancer-backend-port: "http"
-    ##   service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-    ##
-    annotations: {}
-
-    ## @param service.workerGateway.loadBalancerSourceRanges  When using `service.workerGateway.type: LoadBalancer`, restrict access to the load balancer to particular IPs
-    ## Example:
-    ##   - 192.168.1.10/32
+    ## @param service.workerGateway.loadBalancerSourceRanges Concourse worker gateway service Load Balancer sources
+    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ## e.g:
+    ## loadBalancerSourceRanges:
+    ##   - 10.10.10.0/24
     ##
     loadBalancerSourceRanges: []
-
-    ## @param service.workerGateway.nodePort When using `service.workerGateway.type: NodePort`, sets the nodePort for tsa
+    ## @param service.workerGateway.externalTrafficPolicy Concourse worker gateway service external traffic policy
+    ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
-    nodePort: ""
-
-## Ingress parameters
+    externalTrafficPolicy: Cluster
+    ## @param service.workerGateway.annotations Additional custom annotations for Concourse worker gateway service
+    ##
+    annotations: {}
+    ## @param service.workerGateway.extraPorts Extra port to expose on Concourse worker gateway service
+    ##
+    extraPorts: []
+## Concourse ingress parameters
+## ref: https://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
-  ## @param ingress.enabled Ingress configuration enabled
-  ## Ref: https://kubernetes.io/docs/user-guide/ingress/
-  ##
-  ## Enable Ingress.
+  ## @param ingress.enabled Enable ingress record generation for Concourse
   ##
   enabled: false
-
-  ## DEPRECATED: Use ingress.annotations instead of ingress.certManager
-  ## certManager: false
+  ## @param ingress.pathType Ingress path type
   ##
-
-  ## @param ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  pathType: ImplementationSpecific
+  ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
+  ##
+  apiVersion: ""
+  ## @param ingress.hostname Default host for the ingress record
+  ##
+  hostname: concourse.local
+  ## @param ingress.path Default path for the ingress record
+  ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
+  ##
+  path: /
+  ## @param ingress.annotations [object] Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
   ## Use this parameter to set the required annotations for cert-manager, see
   ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
-  ##
   ## e.g:
   ## annotations:
   ##   kubernetes.io/ingress.class: nginx
   ##   cert-manager.io/cluster-issuer: cluster-issuer-name
   ##
   annotations: {}
-
-  ## Either `hosts` or `rulesOverride` must be provided if Ingress is enabled.
-  ## `hosts` sets up the Ingress with default rules per provided hostname.
-  ## @param ingress.hostname Hostename for the Ingress object
-  ##
-  hostname: concourse.local
-
-  ## @param ingress.path The Path to Concourse
-  ##
-  path: /
-  ## @param ingress.rulesOverride Ingress rules override
-  ## Either `hosts` or `rulesOverride` must be provided if Ingress is enabled.
-  ## `rulesOverride` allows the user to define the full set of ingress rules, for more complex Ingress setups.
-  ##
-  rulesOverride: []
-
-  ## @param ingress.tls TLS configuration.
-  ## Secrets must be manually created in the namespace.
-  ## Example:
-  ##   - secretName: concourse-web-tls
-  ##     hosts:
-  ##       - concourse.domain.com
+  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting the corresponding annotations
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
   ##
   tls: false
-
-  ## @param ingress.pathType Ingress Path type
+  ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
   ##
-  pathType: ImplementationSpecific
-
-  ## @param ingress.extraHosts The list of additional hostnames to be covered with this ingress record.
-  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  selfSigned: false
+  ## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
+  ## e.g:
   ## extraHosts:
-  ## - name: concourse.local
-  ##   path: /
+  ##   - name: concourse.local
+  ##     path: /
   ##
   extraHosts: []
-
-  ## @param ingress.extraTls The tls configuration for additional hostnames to be covered with this ingress record.
-  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## @param ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  ## e.g:
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## e.g:
   ## extraTls:
   ## - hosts:
   ##     - concourse.local
   ##   secretName: concourse.local-tls
   ##
   extraTls: []
-
-  ## @param ingress.secrets If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
-  ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
+  ## @param ingress.secrets Custom TLS certificates as secrets
+  ## NOTE: 'key' and 'certificate' are expected in PEM format
+  ## NOTE: 'name' should line up with a 'secretName' set further up
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
-  ## Example:
-  ## - name: concourse.local-tls
-  ##   key:
-  ##   certificate:
+  ## e.g:
+  ## secrets:
+  ##   - name: concourse.local-tls
+  ##     key: |-
+  ##       -----BEGIN RSA PRIVATE KEY-----
+  ##       ...
+  ##       -----END RSA PRIVATE KEY-----
+  ##     certificate: |-
+  ##       -----BEGIN CERTIFICATE-----
+  ##       ...
+  ##       -----END CERTIFICATE-----
   ##
   secrets: []
 
 ## @section Init Container Parameters
-##
+
 ## Init containers parameters:
-## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup values from the securityContext section.
+## volumePermissions: Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each node
 ##
 volumePermissions:
-  ## @param volumePermissions.enabled Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`
+  ## @param volumePermissions.enabled Enable init container that changes the owner and group of the persistent volume
   ##
   enabled: false
-  ## Bitnami Shell image
-  ## ref: https://hub.docker.com/r/bitnami/bitnami-shell/tags/
-  ## @param volumePermissions.image.registry Bitnami Shell image registry
-  ## @param volumePermissions.image.repository Bitnami Shell image repository
-  ## @param volumePermissions.image.tag Bitnami Shell image tag (immutable tags are recommended)
-  ## @param volumePermissions.image.pullPolicy Bitnami Shell image pull policy
-  ## @param volumePermissions.image.pullSecrets Bitnami Shell image pull secrets
+  ## @param volumePermissions.image.registry Init container volume-permissions image registry
+  ## @param volumePermissions.image.repository Init container volume-permissions image repository
+  ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+  ## @param volumePermissions.image.pullSecrets Init container volume-permissions image pull secrets
   ##
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r305
+    tag: 10-debian-10-r326
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## e.g:
+    ## Example:
     ## pullSecrets:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
-  ## Init container's resource requests and limits
+  ## Init container resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## @param volumePermissions.resources.limits The resources limits for the init container
-  ## @param volumePermissions.resources.requests The requested resources for the init container
+  ## @param volumePermissions.resources.limits Init container volume-permissions resource limits
+  ## @param volumePermissions.resources.requests Init container volume-permissions resource requests
   ##
   resources:
     limits: {}
     requests: {}
-  ## Init container Container Security Context
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-  ## @param volumePermissions.containerSecurityContext.enabled Enable init container's Security Context
-  ## @param volumePermissions.containerSecurityContext.runAsUser Set init container's Security Context runAsUser
-  ## NOTE: when runAsUser is set to special value "auto", init container will try to chown the
-  ##   data folder to auto-determined user&group, using commands: `id -u`:`id -G | cut -d" " -f2`
-  ##   "auto" is especially useful for OpenShift which has scc with dynamic user ids (and 0 is not allowed)
+  ## Init container' Security Context
+  ## @param volumePermissions.containerSecurityContext.enabled Enabled init container Security Context
+  ## @param volumePermissions.containerSecurityContext.runAsUser User ID for the init container
   ##
   containerSecurityContext:
     enabled: true
-    runAsUser: 1001
+    runAsUser: 0
 
-## @section PostgreSQL sub-chart configuration
+## @section Concourse database parameters
+
 ## PostgreSQL chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 ## @param postgresql.enabled Switch to enable or disable the PostgreSQL helm chart
-## @param postgresql.nameOverride Override Concourse Postgresql name
-## @param postgresql.postgresqlUsername Concourse Postgresql username
-## @param postgresql.postgresqlDatabase Concourse Postgresql database
-## @param postgresql.existingSecret Name of an existing secret containing the PostgreSQL password ('postgresql-password' key)
+## @param postgresql.auth.enablePostgresUser Assign a password to the "postgres" admin user. Otherwise, remote access will be blocked for this user
+## @param postgresql.auth.username Name for a custom user to create
+## @param postgresql.auth.password Password for the custom user to create
+## @param postgresql.auth.database Name for a custom database to create
+## @param postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials
+## @param postgresql.architecture PostgreSQL architecture (`standalone` or `replication`)
 ##
 postgresql:
   enabled: true
-  nameOverride: ""
-  postgresqlUsername: bn_concourse
-  postgresqlDatabase: bitnami_concourse
-  ## In case of postgresql.enabled = true, allow the usage of existing secrets for postgresql
-  ##
-  existingSecret: ""
+  auth:
+    enablePostgresUser: false
+    username: bn_concourse
+    password: ""
+    database: bitnami_concourse
+    existingSecret: ""
+  architecture: standalone
 
 ## @section External PostgreSQL configuration
 ## All of these values are only used when postgresql.enabled is set to false
 ## @param externalDatabase.host Database host
-## @param externalDatabase.user non-root Username for Airflow Database
-## @param externalDatabase.password Database password
-## @param externalDatabase.existingSecret Name of an existing secret resource containing the DB password
-## @param externalDatabase.existingSecretPasswordKey Name of an existing secret key containing the DB password
-## @param externalDatabase.database Database name
 ## @param externalDatabase.port Database port number
+## @param externalDatabase.user Non-root username for Concourse
+## @param externalDatabase.password Password for the non-root username for Concourse
+## @param externalDatabase.database Concourse database name
+## @param externalDatabase.existingSecret Name of an existing secret resource containing the database credentials
+## @param externalDatabase.existingSecretPasswordKey Name of an existing secret key containing the database credentials
 ##
 externalDatabase:
-  ## All of these values are only used when postgresql.enabled is set to false
-  ## Database host
-  ##
   host: localhost
-  ## non-root Username for concourse Database
-  ##
-  user: bn_concourse
-  ## Database password
-  ##
-  password: ""
-  ## Name of an existing secret resource containing the DB password
-  ##
-  existingSecret: ""
-  ## Name of an existing secret key containing the DB password
-  ##
-  existingSecretPasswordKey: ""
-  ## Database name
-  ##
-  database: bitnami_concourse
-  ## Database port number
-  ##
   port: 5432
+  user: bn_concourse
+  password: ""
+  database: bitnami_concourse
+  existingSecret: ""
+  existingSecretPasswordKey: ""


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR standardizes the `bitnami/concour` chart to be in line with the rest of the catalog.

**Benefits**

Standardization.

**Possible drawbacks**

Changes the values structure forcing a major bump, check the README.md for more information.

**Applicable issues**

N/A

**Additional information**

Triggered after https://github.com/bitnami/charts/pull/8827 (major bump in PostgreSQL)

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])