### PR TITLE
[bitnami/haproxy] Fix service duplicated 'loadBalancerSourceRanges'

### DIFF
--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -23,4 +23,4 @@ name: haproxy
 sources:
   - https://github.com/bitnami/bitnami-docker-haproxy
   - https://github.com/haproxytech/haproxy
-version: 0.3.1
+version: 0.3.2

--- a/bitnami/haproxy/templates/service.yaml
+++ b/bitnami/haproxy/templates/service.yaml
@@ -27,9 +27,6 @@ spec:
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}
-  {{ if eq .Values.service.type "LoadBalancer" }}
-  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
-  {{ end }}
   {{- if eq .Values.service.type "LoadBalancer" }}
   loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
   {{- end }}


### PR DESCRIPTION
**Description of the change**

Fixes issue with haproxy's service not working when LoadBalancer `service.type` is used, caused by a duplicated `loadBalancerSourceRanges` entry.

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)