### PR TITLE
Avoid running chart version increment validation when it's not required

### DIFF
--- a/.github/ct-lint.yaml
+++ b/.github/ct-lint.yaml
@@ -2,7 +2,6 @@ chart-dirs:
   - bitnami
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
-check-version-increment: true
 debug: true
 remote: origin
 validate-chart-schema: true

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: |
-          if grep -q 'templates\|crds\|Chart.yaml\|values.yaml']; then
+          if grep -q 'templates\|crds\|Chart.yaml\|values.yaml' $HOME/files.txt; then
             ct lint --config .github/ct-lint.yaml --check-version-increment
           else
             ct lint --config .github/ct-lint.yaml

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -15,8 +15,19 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.1.0
 
+      - name: Get list of files with changes in Pull Request
+        id: pr-file-changes
+        uses: trilom/file-changes-action@v1.2.4
+        with:
+          fileOutput: ' '
+
       - name: Run chart-testing (lint)
-        run: ct lint --config .github/ct-lint.yaml
+        run: |
+          if grep -q 'templates\|crds\|Chart.yaml\|values.yaml']; then
+            ct lint --config .github/ct-lint.yaml --check-version-increment
+          else
+            ct lint --config .github/ct-lint.yaml
+          fi
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

It shouldn't be required to increment the chart version to update README.md(s) or equivalent files.

**Benefits**

N/A

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)