### PR TITLE
[bitnami/tomcat] Another monitoring fixes

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/bitnami-docker-tomcat
   - http://tomcat.apache.org
-version: 10.1.8
+version: 10.1.9

--- a/bitnami/tomcat/templates/_helpers.tpl
+++ b/bitnami/tomcat/templates/_helpers.tpl
@@ -61,13 +61,11 @@ Expand the name of the chart.
 Return the proper CATALINA_OPTS value
 */}}
 {{- define "tomcat.catalinaOpts" -}}
-  {{- if and .Values.catalinaOpts .Values.metrics.jmx.enabled -}}
-    {{- printf "%s %s" .Values.catalinaOpts .Values.metrics.jmx.catalinaOpts  | trim  -}}
-  {{- else if .Values.catalinaOpts -}}
-    {{- printf "%s" .Values.catalinaOpts | trim  -}}
-  {{- else if .Values.metrics.jmx.enabled -}}
-    {{- printf "%s" .Values.metrics.jmx.catalinaOpts  | trim  -}}
-  {{- end -}}
+{{- if .Values.metrics.jmx.enabled -}}
+{{- default "" (cat .Values.catalinaOpts .Values.metrics.jmx.catalinaOpts) | trim  -}}
+{{- else -}} 
+{{- default "" .Values.catalinaOpts  | trim -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/tomcat/templates/_helpers.tpl
+++ b/bitnami/tomcat/templates/_helpers.tpl
@@ -61,7 +61,13 @@ Expand the name of the chart.
 Return the proper CATALINA_OPTS value
 */}}
 {{- define "tomcat.catalinaOpts" -}}
-  {{- printf "%s %s" .Values.catalinaOpts .Values.metrics.jmx.catalinaOpts  | trim  -}}
+  {{- if and .Values.catalinaOpts .Values.metrics.jmx.enabled -}}
+    {{- printf "%s %s" .Values.catalinaOpts .Values.metrics.jmx.catalinaOpts  | trim  -}}
+  {{- else if .Values.catalinaOpts -}}
+    {{- printf "%s" .Values.catalinaOpts | trim  -}}
+  {{- else if .Values.metrics.jmx.enabled -}}
+    {{- printf "%s" .Values.metrics.jmx.catalinaOpts  | trim  -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/tomcat/templates/_pod.tpl
+++ b/bitnami/tomcat/templates/_pod.tpl
@@ -76,6 +76,10 @@ containers:
             key: tomcat-password
       - name: TOMCAT_ALLOW_REMOTE_MANAGEMENT
         value: {{ .Values.tomcatAllowRemoteManagement | quote }}
+      {{- if or .Values.catalinaOpts .Values.metrics.jmx.enabled }}
+      - name: CATALINA_OPTS
+        value: {{ include "tomcat.catalinaOpts" . | quote }} 
+      {{- end }}
       {{- if .Values.extraEnvVars }}
       {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 6 }}
       {{- end }}


### PR DESCRIPTION
Signed-off-by: Peter Kassak <48527944+cache-sk@users.noreply.github.com>


**Description of the change**

After previous pull with metrics fixes i have noticed, that exporter is reporting only scrape error. It was caused by removing CATALINA_OPTS enviroment variable in pull #7707, so tomcat.catalinaOpts was unused at all and tomcat was not started with JMX enabled.

So this pull is restoring this eviroment variable and adding little tweak to tomcat.catalinaOpts to not add metrics.jmx.catalinaOpts if only catalinaOpts is used.

**Benefits**

Exporter is now exporting again! :)

**Possible drawbacks**

None?

**Applicable issues**

None reported.

**Additional information**

None.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)