### PR TITLE
[bitnami/oauth2-proxy] Google is secret always created

### DIFF
--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -30,4 +30,4 @@ name: oauth2-proxy
 sources:
   - https://github.com/bitnami/bitnami-docker-oauth2-proxy
   - https://github.com/oauth2-proxy/oauth2-proxy
-version: 2.0.1
+version: 2.0.2

--- a/bitnami/oauth2-proxy/templates/secret-google.yaml
+++ b/bitnami/oauth2-proxy/templates/secret-google.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.configuration.google (not .Values.configuration.google.existingSecret) }}
+{{- if and .Values.configuration.google.enabled (not .Values.configuration.google.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
**Description of the change**

Fix the condition for google secret creation

**Applicable issues**

  - fixes #8850

**Checklist**
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)