### PR TITLE
[bitnami/elasticsearch] Bump Kibana subchart version

### DIFF
--- a/bitnami/elasticsearch/Chart.lock
+++ b/bitnami/elasticsearch/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.11.1
 - name: kibana
   repository: https://charts.bitnami.com/bitnami
-  version: 9.3.2
-digest: sha256:da13949845d45c25975bbde1a5f99f3fdea5e3a908784d051e10dff040131cae
-generated: "2022-02-03T20:51:35.515380844Z"
+  version: 9.3.3
+digest: sha256:f6657fa3742447e68898c41c7d97c407c17b42953364f15336c367ce3179acc9
+generated: "2022-02-10T11:30:17.457033+01:00"

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.9.1
+version: 17.9.2


### PR DESCRIPTION
**Description of the change**

Bumps Kibana subchart version, to match appVersion `7.17.0`

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)