### PR TITLE
[bitnami/postgresql] .Values.global.postgresql.auth.username should overwrite .…

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 11.0.2
+version: 11.0.3

--- a/bitnami/postgresql/templates/secrets.yaml
+++ b/bitnami/postgresql/templates/secrets.yaml
@@ -16,7 +16,7 @@ data:
   {{- if .Values.auth.enablePostgresUser }}
   postgres-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "postgres-password" "providedValues" (list "global.postgresql.auth.postgresPassword" "auth.postgresPassword") "context" $) }}
   {{- end }}
-  {{- if not (empty .Values.auth.username) }}
+  {{- if not (empty (include "postgresql.username" .)) }}
   password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "password" "providedValues" (list "global.postgresql.auth.password" "auth.password") "context" $) }}
   {{- end }}
   {{- if eq .Values.architecture "replication" }}


### PR DESCRIPTION
…Values.auth.username,

so we have to use the helper function in a check that checks for .Values.auth.username to add the password to the secret

**Description of the change**

Currently, the global username values are not overwriting the username value. This change changes it, at least for the secret creation.

**Benefits**
Fix a bug, dont need to have duplicate entries in values.yaml

**Possible drawbacks**
I have not tested this and hopes CI will cover it.

**Applicable issues**
-

**Additional information**
-

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)