### PR TITLE
[bitnami/Keycloak] Improve documentation for tls ingress

### DIFF
--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -387,7 +387,8 @@ The chart also facilitates the creation of TLS secrets for use with the Ingress 
 
 ### Use with ingress offloading SSL
 
-If your ingress controller has the SSL Termination, you can add the following env vars in `extraEnvVars`
+If your ingress controller has the SSL Termination, you should set `proxyAddressForwarding` to `true` or you should add the following env vars in `extraEnvVars`
+
 ```yaml
 - name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
   value: "true"


### PR DESCRIPTION
Setting proxyAddressForwarding to true should work, according to #7734.
It should be configured if one wants to access keycloak's admin console.


**Description of the change**

Documentation.

**Benefits**

It may save time to the readers.

**Possible drawbacks**

It may be wrong and not work.

**Applicable issues**

#7734

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)