### PR TITLE
[bitnami/kafka] Fix SASL mechanisms in Kafka exporter

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 15.1.0
+version: 15.1.1

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -288,11 +288,11 @@ The exporter uses a different nomenclature so we need to do this hack
 {{- define "kafka.metrics.kafka.saslMechanism" -}}
 {{- $saslMechanisms := .Values.auth.sasl.mechanisms }}
 {{- if contains "scram-sha-512" $saslMechanisms }}
-    {{- printf "scram-sha512" -}}
+    {{- print "scram-sha512" -}}
 {{- else if contains "scram-sha-256" $saslMechanisms }}
-    {{- printf "scram-sha256" -}}
+    {{- print "scram-sha256" -}}
 {{- else -}}
-    {{- printf "plain" -}}
+    {{- print "plain" -}}
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/kafka/templates/kafka-metrics-deployment.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-deployment.yaml
@@ -96,7 +96,7 @@ spec:
             - --sasl.enabled
             - --sasl.username="$SASL_USERNAME"
             - --sasl.password="${SASL_USER_PASSWORD%%,*}"
-            - --sasl.mechanism="{{ include "kafka.metrics.kafka.saslMechanism" . }}"
+            - --sasl.mechanism={{ include "kafka.metrics.kafka.saslMechanism" . }}
             {{- end }}
             {{- if (include "kafka.client.tlsEncryption" .) }}
             - --tls.enabled


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

We're including extra quotes in the `--sasl.mechanism` flag value and the exporter is complaining about it:

```
dev-kafka-exporter-7c84bf4ffb-bz6zn F0210 10:41:37.984761       1 kafka_exporter.go:865] invalid sasl mechanism ""scram-sha512"": can only be "scram-sha256", "scram-sha512", "gssapi" or "plain"
```

This PR fixes this issue.

**Benefits**

You can install the Kafka chart exporting metrics using SASL authentication.

**Possible drawbacks**

None

**Applicable issues**

  - fixes #8965

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)