### PR TITLE
[bitnami/spring-cloud-dataflow] Add common application properties configuration

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 5.1.1
+version: 5.2.0

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -183,6 +183,7 @@ helm uninstall my-release
 | `server.jdwp.enabled`                               | Set to true to enable Java debugger                                                                                              | `false`                                              |
 | `server.jdwp.port`                                  | Specify port for remote debugging                                                                                                | `5005`                                               |
 | `server.proxy`                                      | Add proxy configuration for SCDF server                                                                                          | `{}`                                                 |
+| `server.applicationProperties`                      | Specify common application properties added by SCDF server to streams and/or tasks                                               | `{}`                                                 |
 
 
 ### Dataflow Skipper parameters

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -30,6 +30,9 @@ data:
     spring:
       cloud:
         dataflow:
+          {{- if .Values.server.applicationProperties }}
+          applicationProperties: {{- include "common.tplvalues.render" (dict "value" .Values.server.applicationProperties "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.server.configuration.batchEnabled }}
           task:
             platform:

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -545,6 +545,9 @@ server:
   ##   password: ""
   ##
   proxy: {}
+  ## @param server.applicationProperties Specify common application properties added by SCDF server to streams and/or tasks
+  ## ref: https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#spring-cloud-dataflow-global-properties
+  applicationProperties: {}
 
 ## @section Dataflow Skipper parameters
 


### PR DESCRIPTION
Signed-off-by: CEDDM <52827991+CEDDM@users.noreply.github.com>

**Description of the change**

Change values.yml and server/configmap.yml

**Benefits**

Allow common application properties configuration in SCDF server configmap

**Applicable issues**

fixes #8955 

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)