### PR TITLE
[bitnami/concourse] Add support to PostgreSQL globals

### DIFF
--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -30,4 +30,4 @@ name: concourse
 sources:
   - https://github.com/bitnami/bitnami-docker-concourse
   - https://github.com/concourse/concourse
-version: 1.0.0
+version: 1.0.1

--- a/bitnami/concourse/ci/global-values.yaml
+++ b/bitnami/concourse/ci/global-values.yaml
@@ -1,0 +1,9 @@
+global:
+  postgresql:
+    auth:
+      username: other_username
+      password: other_password
+      database: other_database
+service:
+  web:
+    type: ClusterIP

--- a/bitnami/concourse/templates/web/deployment.yaml
+++ b/bitnami/concourse/templates/web/deployment.yaml
@@ -104,18 +104,18 @@ spec:
           {{- end }}
           env:
             - name: POSTGRESQL_CLIENT_DATABASE_HOST
-              value: {{ ternary (include "concourse.database.host" .) .Values.externalDatabase.host .Values.postgresql.enabled | quote }}
+              value: {{ include "concourse.database.host" . }}
             - name: POSTGRESQL_CLIENT_DATABASE_NAME
-              value: {{ ternary .Values.postgresql.auth.database .Values.externalDatabase.port .Values.postgresql.enabled }}
+              value: {{ include "concourse.database.name" . }}
             - name: POSTGRESQL_CLIENT_DATABASE_PORT_NUMBER
-              value: {{ ternary "5432" .Values.externalDatabase.port .Values.postgresql.enabled | quote }}
+              value: {{ include "concourse.database.port" . }}
             - name: POSTGRESQL_CLIENT_CREATE_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "concourse.postgresql.secretName" . }}
                   key: {{ include "concourse.database.existingsecret.key" . }}
             - name: POSTGRESQL_CLIENT_POSTGRES_USER
-              value: {{ ternary .Values.postgresql.auth.username .Values.externalDatabase.user .Values.postgresql.enabled | quote }}
+              value: {{ include "concourse.database.user" . }}
         {{- end }}
         - name: db-migrate
           image: {{ template "concourse.image" . }}
@@ -132,13 +132,13 @@ spec:
                   name: {{ include "concourse.postgresql.secretName" . }}
                   key: {{ include "concourse.database.existingsecret.key" . }}
             - name: CONCOURSE_POSTGRES_DATABASE
-              value: {{ ternary .Values.postgresql.auth.database .Values.externalDatabase.database .Values.postgresql.enabled | quote }}
+              value: {{ include "concourse.database.name" . }}
             - name: CONCOURSE_POSTGRES_HOST
-              value: {{ ternary (include "concourse.database.host" .) .Values.externalDatabase.host .Values.postgresql.enabled | quote }}
+              value: {{ include "concourse.database.host" . }}
             - name: CONCOURSE_POSTGRES_PORT
-              value: {{ include "concourse.database.port" . | quote }}
+              value: {{ include "concourse.database.port" . }}
             - name: CONCOURSE_POSTGRES_USER
-              value: {{ ternary .Values.postgresql.auth.username .Values.externalDatabase.user .Values.postgresql.enabled | quote  }}
+              value: {{ include "concourse.database.user" . }}
         {{- if .Values.web.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.web.initContainers "context" $) | nindent 8 }}
         {{- end }}
@@ -286,13 +286,22 @@ spec:
                   name: {{ include "concourse.postgresql.secretName" . }}
                   key: {{ include "concourse.database.existingsecret.key" . }}
             - name: CONCOURSE_POSTGRES_DATABASE
-              value: {{ ternary .Values.postgresql.auth.database .Values.externalDatabase.database .Values.postgresql.enabled | quote }}
+              value: {{ include "concourse.database.name" . }}
             - name: CONCOURSE_POSTGRES_HOST
-              value: {{ ternary (include "concourse.database.host" .) .Values.externalDatabase.host .Values.postgresql.enabled | quote }}
+              value: {{ include "concourse.database.host" . }}
             - name: CONCOURSE_POSTGRES_PORT
-              value: {{ include "concourse.database.port" . | quote }}
+              value: {{ include "concourse.database.port" . }}
             - name: CONCOURSE_POSTGRES_USER
-              value: {{ ternary .Values.postgresql.auth.username .Values.externalDatabase.user .Values.postgresql.enabled | quote  }}
+              value: {{ include "concourse.database.user" . }}
+          envFrom:
+            {{- if .Values.web.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.web.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.web.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.web.extraEnvVarsSecret "context" $) }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.web.containerPorts.http }}
@@ -305,15 +314,6 @@ spec:
             {{- if .Values.web.containerPorts.tsa }}
             - name: http-debug
               containerPort: {{ .Values.web.containerPorts.tsa }}
-            {{- end }}
-          envFrom:
-            {{- if .Values.web.extraEnvVarsCM }}
-            - configMapRef:
-                name: {{ include "common.tplvalues.render" (dict "value" .Values.web.extraEnvVarsCM "context" $) }}
-            {{- end }}
-            {{- if .Values.web.extraEnvVarsSecret }}
-            - secretRef:
-                name: {{ include "common.tplvalues.render" (dict "value" .Values.web.extraEnvVarsSecret "context" $) }}
             {{- end }}
           {{- if .Values.web.resources }}
           resources: {{- toYaml .Values.web.resources | nindent 12 }}

--- a/bitnami/concourse/templates/worker/deployment.yaml
+++ b/bitnami/concourse/templates/worker/deployment.yaml
@@ -110,7 +110,7 @@ spec:
               value: {{ .Values.worker.logLevel | quote }}
             {{- end }}
             - name: CONCOURSE_TSA_HOST
-              value: {{ template "concourse.web.tsa.address" . }}
+              value: {{ include "concourse.web.tsa.address" . | quote }}
             {{- if .Values.worker.bindIp }}
             - name: CONCOURSE_BIND_IP
               value: {{ .Values.worker.bindIp | quote }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

The chart isn't taken into account the `global.postgresql.auth` values, this PR address this.

**Benefits**

The chart is consistent with its dependency's values.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>]).
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)].(https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work).