### PR TITLE
[bitnami/discourse] Chart standardization

### DIFF
--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.11.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.16.2
+  version: 11.0.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 15.7.6
-digest: sha256:7c2ed938bce4711ee6ae855023e66b3d3c99db0206ff8b479a05fa2d8577abf0
-generated: "2022-02-12T02:21:42.172620693Z"
+  version: 16.3.1
+digest: sha256:d677880b8990b5cb0bdd07a1402c23b8e203af157040edce9e8ee0636e0d0354
+generated: "2022-02-09T11:20:54.905493+01:00"

--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.11.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.0.2
+  version: 11.0.6
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.3.1
-digest: sha256:d677880b8990b5cb0bdd07a1402c23b8e203af157040edce9e8ee0636e0d0354
-generated: "2022-02-09T11:20:54.905493+01:00"
+  version: 16.4.0
+digest: sha256:c88524fd8e782cb2a46cdec56f8ce0722c995d8b2f61686b9e7868df85268a4b
+generated: "2022-02-21T12:21:08.625011+01:00"

--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.11.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.0.6
+  version: 11.0.7
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.4.0
-digest: sha256:c88524fd8e782cb2a46cdec56f8ce0722c995d8b2f61686b9e7868df85268a4b
-generated: "2022-02-21T12:21:08.625011+01:00"
+digest: sha256:c866d022249448366862c8d03b135cc3b56eb068854f4070e73cc8653e0d64d7
+generated: "2022-02-21T16:16:09.661401632Z"

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -11,11 +11,11 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 10.X.X
+    version: 11.X.X
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 15.X.X
+    version: 16.X.X
 description: Discourse is an open source discussion platform with built-in moderation and governance systems that let discussion communities protect themselves from bad actors even without official moderators.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/discourse
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 5.2.6
+version: 6.0.0

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -1,10 +1,10 @@
-<!--- app-name: Discourse(&reg;) -->
+<!--- app-name: Discourse&reg; -->
 
 # Discourse(R) packaged by Bitnami
 
 Discourse is an open source discussion platform with built-in moderation and governance systems that let discussion communities protect themselves from bad actors even without official moderators.
 
-[Overview of Discourse(&reg;)](http://www.discourse.org/)
+[Overview of Discourse&reg;](http://www.discourse.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
                            

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -65,199 +65,209 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                | Description                                                                               | Value |
-| ------------------- | ----------------------------------------------------------------------------------------- | ----- |
-| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                      | `""`  |
-| `nameOverride`      | String to partially override discourse.fullname template (will maintain the release name) | `""`  |
-| `fullnameOverride`  | String to fully override discourse.fullname template                                      | `""`  |
-| `commonLabels`      | Labels to be added to all deployed resources                                              | `{}`  |
-| `commonAnnotations` | Annotations to be added to all deployed resources                                         | `{}`  |
-| `extraDeploy`       | Array of extra objects to deploy with the release                                         | `[]`  |
+| Name                     | Description                                                                               | Value           |
+| ------------------------ | ----------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                      | `""`            |
+| `nameOverride`           | String to partially override discourse.fullname template (will maintain the release name) | `""`            |
+| `fullnameOverride`       | String to fully override discourse.fullname template                                      | `""`            |
+| `clusterDomain`          | Kubernetes Cluster Domain                                                                 | `cluster.local` |
+| `commonLabels`           | Labels to be added to all deployed resources                                              | `{}`            |
+| `commonAnnotations`      | Annotations to be added to all deployed resources                                         | `{}`            |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                         | `[]`            |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)   | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the the deployment(s)/statefulset(s)                | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the the deployment(s)/statefulset(s)                   | `["infinity"]`  |
 
 
-### Service parameters
+### Discourse Common parameters
 
-| Name                               | Description                                                     | Value          |
-| ---------------------------------- | --------------------------------------------------------------- | -------------- |
-| `service.type`                     | Kubernetes Service type                                         | `LoadBalancer` |
-| `service.port`                     | Service HTTP port                                               | `80`           |
-| `service.nodePort`                 | Node Ports to expose                                            | `""`           |
-| `service.loadBalancerIP`           | Use loadBalancerIP to request a specific static IP              | `""`           |
-| `service.externalTrafficPolicy`    | Enable client source IP preservation                            | `Cluster`      |
-| `service.annotations`              | Service annotations                                             | `{}`           |
-| `service.loadBalancerSourceRanges` | Limits which cidr blocks can connect to service's load balancer | `[]`           |
-| `service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)  | `[]`           |
-| `service.nodePorts.http`           | Kubernetes http node port                                       | `""`           |
-
-
-### Discourse parameters
-
-| Name                                           | Description                                                                                               | Value                 |
-| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
-| `image.registry`                               | Discourse image registry                                                                                  | `docker.io`           |
-| `image.repository`                             | Discourse image repository                                                                                | `bitnami/discourse`   |
-| `image.tag`                                    | Discourse image tag                                                                                       | `2.7.13-debian-10-r0` |
-| `image.pullPolicy`                             | Discourse image pull policy                                                                               | `IfNotPresent`        |
-| `image.pullSecrets`                            | Discourse image pull secrets                                                                              | `[]`                  |
-| `image.debug`                                  | Specify if debug logs should be enabled                                                                   | `false`               |
-| `imagePullSecrets`                             | Specify docker-registry secret names as an array                                                          | `[]`                  |
-| `discourse.host`                               | Discourse host to create application URLs (include the port if =/= 80)                                    | `""`                  |
-| `discourse.siteName`                           | Discourse site name                                                                                       | `My Site!`            |
-| `discourse.username`                           | Admin user of the application                                                                             | `user`                |
-| `discourse.password`                           | password. WARNING: Minimum length of 10 characters                                                        | `""`                  |
-| `discourse.existingSecret`                     | Name of an existing secret containing the password (ignores previous password)                            | `""`                  |
-| `discourse.email`                              | Admin user email of the application                                                                       | `user@example.com`    |
-| `discourse.command`                            | Custom command to override image cmd                                                                      | `[]`                  |
-| `discourse.args`                               | Custom args for the custom command                                                                        | `[]`                  |
-| `discourse.containerSecurityContext`           | Container security context specification                                                                  | `{}`                  |
-| `discourse.resources.limits`                   | The resources limits for the container                                                                    | `{}`                  |
-| `discourse.resources.requests`                 | The requested resources for the container                                                                 | `{}`                  |
-| `discourse.livenessProbe.enabled`              | Enable/disable livenessProbe                                                                              | `true`                |
-| `discourse.livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                                                                  | `500`                 |
-| `discourse.livenessProbe.periodSeconds`        | How often to perform the probe                                                                            | `10`                  |
-| `discourse.livenessProbe.timeoutSeconds`       | When the probe times out                                                                                  | `5`                   |
-| `discourse.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                                                                | `6`                   |
-| `discourse.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                                                               | `1`                   |
-| `discourse.readinessProbe.enabled`             | Enable/disable readinessProbe                                                                             | `true`                |
-| `discourse.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                                                                 | `30`                  |
-| `discourse.readinessProbe.periodSeconds`       | How often to perform the probe                                                                            | `10`                  |
-| `discourse.readinessProbe.timeoutSeconds`      | When the probe times out                                                                                  | `5`                   |
-| `discourse.readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe                                                                | `6`                   |
-| `discourse.readinessProbe.successThreshold`    | Minimum consecutive successes for the probe                                                               | `1`                   |
-| `discourse.customLivenessProbe`                | Custom liveness probe to execute (when the main one is disabled)                                          | `{}`                  |
-| `discourse.customReadinessProbe`               | Custom readiness probe to execute (when the main one is disabled)                                         | `{}`                  |
-| `discourse.smtp.enabled`                       | Enable/disable SMTP                                                                                       | `false`               |
-| `discourse.smtp.host`                          | SMTP host name                                                                                            | `""`                  |
-| `discourse.smtp.port`                          | SMTP port number                                                                                          | `""`                  |
-| `discourse.smtp.user`                          | SMTP account user name                                                                                    | `""`                  |
-| `discourse.smtp.password`                      | SMTP account password                                                                                     | `""`                  |
-| `discourse.smtp.protocol`                      | SMTP protocol (Allowed values: tls, ssl)                                                                  | `""`                  |
-| `discourse.smtp.auth`                          | SMTP authentication method                                                                                | `""`                  |
-| `discourse.smtp.existingSecret`                | Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password` | `""`                  |
-| `discourse.extraEnvVars`                       | An array to add extra env vars                                                                            | `[]`                  |
-| `discourse.extraEnvVarsCM`                     | Array to add extra configmaps                                                                             | `[]`                  |
-| `discourse.extraEnvVarsSecret`                 | Array to add extra environment variables from a secret                                                    | `""`                  |
-| `discourse.extraVolumeMounts`                  | Additional volume mounts (used along with `extraVolumes`)                                                 | `[]`                  |
-| `discourse.skipInstall`                        | Do not run the Discourse installation wizard                                                              | `false`               |
-| `replicaCount`                                 | Number of Discourse & Sidekiq replicas                                                                    | `1`                   |
-| `extraVolumes`                                 | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`                       | `[]`                  |
-| `sidecars`                                     | Attach additional sidecar containers to the pod                                                           | `[]`                  |
-| `initContainers`                               | Additional init containers to add to the pods                                                             | `[]`                  |
-| `serviceAccount.create`                        | Whether the service account should be created                                                             | `false`               |
-| `serviceAccount.annotations`                   | Annotations to add to the service account                                                                 | `{}`                  |
-| `serviceAccount.name`                          | Name to be used for the service account                                                                   | `""`                  |
-| `podSecurityContext`                           | Pod security context specification                                                                        | `{}`                  |
-| `hostAliases`                                  | Add deployment host aliases                                                                               | `[]`                  |
-| `persistence.enabled`                          | Whether to enable persistence based on Persistent Volume Claims                                           | `true`                |
-| `persistence.storageClass`                     | discourse & sidekiq data Persistent Volume Storage Class                                                  | `""`                  |
-| `persistence.existingClaim`                    | Use a existing PVC which must be created manually before bound                                            | `""`                  |
-| `persistence.accessMode`                       | PVC Access Mode (RWO, ROX, RWX)                                                                           | `ReadWriteOnce`       |
-| `persistence.size`                             | Size of the PVC to request                                                                                | `10Gi`                |
-| `persistence.selector`                         | Selector to match an existing Persistent Volume (this value is evaluated as a template)                   | `{}`                  |
-| `updateStrategy.type`                          | Update strategy type. Only really applicable for deployments with RWO PVs attached                        | `RollingUpdate`       |
-| `podAnnotations`                               | Additional pod annotations                                                                                | `{}`                  |
-| `podLabels`                                    | Additional pod labels                                                                                     | `{}`                  |
-| `podAffinityPreset`                            | Pod affinity preset. Allowed values: soft, hard                                                           | `""`                  |
-| `podAntiAffinityPreset`                        | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                  | `soft`                |
-| `nodeAffinityPreset.type`                      | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                 | `""`                  |
-| `nodeAffinityPreset.key`                       | Node label key to match Ignored if `affinity` is set.                                                     | `""`                  |
-| `nodeAffinityPreset.values`                    | Node label values to match. Ignored if `affinity` is set.                                                 | `[]`                  |
-| `affinity`                                     | Affinity for pod assignment                                                                               | `{}`                  |
-| `nodeSelector`                                 | Node labels for pod assignment.                                                                           | `{}`                  |
-| `tolerations`                                  | Tolerations for pod assignment.                                                                           | `[]`                  |
+| Name                            | Description                                                                                                              | Value                 |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------- |
+| `image.registry`                | Discourse image registry                                                                                                 | `docker.io`           |
+| `image.repository`              | Discourse image repository                                                                                               | `bitnami/discourse`   |
+| `image.tag`                     | Discourse image tag                                                                                                      | `2.7.13-debian-10-r0` |
+| `image.pullPolicy`              | Discourse image pull policy                                                                                              | `IfNotPresent`        |
+| `image.pullSecrets`             | Discourse image pull secrets                                                                                             | `[]`                  |
+| `image.debug`                   | Enable image debug mode                                                                                                  | `false`               |
+| `auth.email`                    | Discourse admin user email                                                                                               | `user@example.com`    |
+| `auth.username`                 | Discourse admin user                                                                                                     | `user`                |
+| `auth.password`                 | Discourse admin password. WARNING: Minimum length of 10 characters                                                       | `""`                  |
+| `auth.existingSecret`           | Name of an existing secret to use for Discourse credentials                                                              | `""`                  |
+| `host`                          | Hostname to create application URLs (include the port if =/= 80)                                                         | `""`                  |
+| `siteName`                      | Discourse site name                                                                                                      | `My Site!`            |
+| `smtp.enabled`                  | Enable/disable SMTP                                                                                                      | `false`               |
+| `smtp.host`                     | SMTP host name                                                                                                           | `""`                  |
+| `smtp.port`                     | SMTP port number                                                                                                         | `""`                  |
+| `smtp.user`                     | SMTP account user name                                                                                                   | `""`                  |
+| `smtp.password`                 | SMTP account password                                                                                                    | `""`                  |
+| `smtp.protocol`                 | SMTP protocol (Allowed values: tls, ssl)                                                                                 | `""`                  |
+| `smtp.auth`                     | SMTP authentication method                                                                                               | `""`                  |
+| `smtp.existingSecret`           | Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password`                | `""`                  |
+| `replicaCount`                  | Number of Discourse & Sidekiq replicas                                                                                   | `1`                   |
+| `podSecurityContext.enabled`    | Enabled Discourse pods' Security Context                                                                                 | `false`               |
+| `podSecurityContext.fsGroup`    | Set Discourse pod's Security Context fsGroup                                                                             | `0`                   |
+| `hostAliases`                   | Add deployment host aliases                                                                                              | `[]`                  |
+| `podAnnotations`                | Additional pod annotations                                                                                               | `{}`                  |
+| `podLabels`                     | Additional pod labels                                                                                                    | `{}`                  |
+| `podAffinityPreset`             | Pod affinity preset. Allowed values: soft, hard                                                                          | `""`                  |
+| `podAntiAffinityPreset`         | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                |
+| `nodeAffinityPreset.type`       | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                  |
+| `nodeAffinityPreset.key`        | Node label key to match Ignored if `affinity` is set.                                                                    | `""`                  |
+| `nodeAffinityPreset.values`     | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                  |
+| `affinity`                      | Affinity for pod assignment                                                                                              | `{}`                  |
+| `nodeSelector`                  | Node labels for pod assignment.                                                                                          | `{}`                  |
+| `tolerations`                   | Tolerations for pod assignment.                                                                                          | `[]`                  |
+| `topologySpreadConstraints`     | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                  |
+| `priorityClassName`             | Priority Class Name                                                                                                      | `""`                  |
+| `schedulerName`                 | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                  |
+| `terminationGracePeriodSeconds` | Seconds Discourse pod needs to terminate gracefully                                                                      | `""`                  |
+| `updateStrategy.type`           | Discourse deployment strategy type                                                                                       | `RollingUpdate`       |
+| `updateStrategy.rollingUpdate`  | Discourse deployment rolling update configuration parameters                                                             | `{}`                  |
+| `sidecars`                      | Add additional sidecar containers to the Discourse pods                                                                  | `[]`                  |
+| `initContainers`                | Add additional init containers to the Discourse pods                                                                     | `[]`                  |
+| `extraVolumeMounts`             | Optionally specify extra list of additional volumeMounts for the Discourse pods                                          | `[]`                  |
+| `extraVolumes`                  | Optionally specify extra list of additional volumes for the Discourse pods                                               | `[]`                  |
 
 
-### Sidekiq parameters
+### Discourse container parameters
 
-| Name                                         | Description                                                       | Value                                               |
-| -------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------- |
-| `sidekiq.containerSecurityContext`           | Container security context specification                          | `{}`                                                |
-| `sidekiq.command`                            | Custom command to override image cmd (evaluated as a template)    | `["/opt/bitnami/scripts/discourse/entrypoint.sh"]`  |
-| `sidekiq.args`                               | Custom args for the custom command (evaluated as a template)      | `["/opt/bitnami/scripts/discourse-sidekiq/run.sh"]` |
-| `sidekiq.resources`                          | Sidekiq container resource requests and limits                    | `{}`                                                |
-| `sidekiq.livenessProbe.enabled`              | Enable/disable livenessProbe                                      | `true`                                              |
-| `sidekiq.livenessProbe.initialDelaySeconds`  | Delay before liveness probe is initiated                          | `500`                                               |
-| `sidekiq.livenessProbe.periodSeconds`        | How often to perform the probe                                    | `10`                                                |
-| `sidekiq.livenessProbe.timeoutSeconds`       | When the probe times out                                          | `5`                                                 |
-| `sidekiq.livenessProbe.failureThreshold`     | Minimum consecutive failures for the probe                        | `6`                                                 |
-| `sidekiq.livenessProbe.successThreshold`     | Minimum consecutive successes for the probe                       | `1`                                                 |
-| `sidekiq.readinessProbe.enabled`             | Enable/disable readinessProbe                                     | `true`                                              |
-| `sidekiq.readinessProbe.initialDelaySeconds` | Delay before readiness probe is initiated                         | `30`                                                |
-| `sidekiq.readinessProbe.periodSeconds`       | How often to perform the probe                                    | `10`                                                |
-| `sidekiq.readinessProbe.timeoutSeconds`      | When the probe times out                                          | `5`                                                 |
-| `sidekiq.readinessProbe.failureThreshold`    | Minimum consecutive failures for the probe                        | `6`                                                 |
-| `sidekiq.readinessProbe.successThreshold`    | Minimum consecutive successes for the probe                       | `1`                                                 |
-| `sidekiq.customLivenessProbe`                | Custom liveness probe to execute (when the main one is disabled)  | `{}`                                                |
-| `sidekiq.customReadinessProbe`               | Custom readiness probe to execute (when the main one is disabled) | `{}`                                                |
-| `sidekiq.extraEnvVars`                       | An array to add extra env vars                                    | `[]`                                                |
-| `sidekiq.extraEnvVarsCM`                     | Array to add extra configmaps                                     | `[]`                                                |
-| `sidekiq.extraEnvVarsSecret`                 | Name of the secret that holds extra env vars                      | `""`                                                |
-| `sidekiq.extraVolumeMounts`                  | Additional volume mounts                                          | `[]`                                                |
+| Name                                              | Description                                                                                  | Value           |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------------- |
+| `discourse.skipInstall`                           | Do not run the Discourse installation wizard                                                 | `false`         |
+| `discourse.command`                               | Custom command to override image cmd                                                         | `[]`            |
+| `discourse.args`                                  | Custom args for the custom command                                                           | `[]`            |
+| `discourse.extraEnvVars`                          | Array with extra environment variables to add Discourse pods                                 | `[]`            |
+| `discourse.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Discourse pods                          | `""`            |
+| `discourse.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Discourse pods | `""`            |
+| `discourse.containerPorts.http`                   | Discourse HTTP container port                                                                | `8080`          |
+| `discourse.livenessProbe.enabled`                 | Enable livenessProbe on Discourse containers                                                 | `true`          |
+| `discourse.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                      | `500`           |
+| `discourse.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                             | `10`            |
+| `discourse.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                            | `5`             |
+| `discourse.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                          | `6`             |
+| `discourse.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                          | `1`             |
+| `discourse.readinessProbe.enabled`                | Enable readinessProbe on Discourse containers                                                | `true`          |
+| `discourse.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                     | `30`            |
+| `discourse.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                            | `10`            |
+| `discourse.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                           | `5`             |
+| `discourse.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                         | `6`             |
+| `discourse.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                         | `1`             |
+| `discourse.startupProbe.enabled`                  | Enable startupProbe on Discourse containers                                                  | `false`         |
+| `discourse.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                       | `60`            |
+| `discourse.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                              | `10`            |
+| `discourse.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                             | `5`             |
+| `discourse.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                           | `15`            |
+| `discourse.startupProbe.successThreshold`         | Success threshold for startupProbe                                                           | `1`             |
+| `discourse.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                          | `{}`            |
+| `discourse.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                         | `{}`            |
+| `discourse.customStartupProbe`                    | Custom startupProbe that overrides the default one                                           | `{}`            |
+| `discourse.resources.limits`                      | The resources limits for the Discourse containers                                            | `{}`            |
+| `discourse.resources.requests`                    | The requested resources for the Discourse containers                                         | `{}`            |
+| `discourse.containerSecurityContext.enabled`      | Enabled Discourse containers' Security Context                                               | `false`         |
+| `discourse.containerSecurityContext.runAsUser`    | Set Discourse containers' Security Context runAsUser                                         | `0`             |
+| `discourse.containerSecurityContext.runAsNonRoot` | Set Discourse containers' Security Context runAsNonRoot                                      | `false`         |
+| `discourse.lifecycleHooks`                        | for the Discourse container(s) to automate configuration before or after startup             | `{}`            |
+| `discourse.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Discourse pods              | `[]`            |
+| `persistence.enabled`                             | Enable persistence using Persistent Volume Claims                                            | `true`          |
+| `persistence.storageClass`                        | Persistent Volume storage class                                                              | `""`            |
+| `persistence.accessModes`                         | Persistent Volume access modes                                                               | `[]`            |
+| `persistence.accessMode`                          | Persistent Volume access mode (DEPRECATED: use `persistence.accessModes` instead)            | `ReadWriteOnce` |
+| `persistence.size`                                | Persistent Volume size                                                                       | `10Gi`          |
+| `persistence.existingClaim`                       | The name of an existing PVC to use for persistence                                           | `""`            |
+| `persistence.selector`                            | Selector to match an existing Persistent Volume for Discourse data PVC                       | `{}`            |
+
+
+### Sidekiq container parameters
+
+| Name                                            | Description                                                                                | Value                                               |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| `sidekiq.command`                               | Custom command to override image cmd (evaluated as a template)                             | `["/opt/bitnami/scripts/discourse/entrypoint.sh"]`  |
+| `sidekiq.args`                                  | Custom args for the custom command (evaluated as a template)                               | `["/opt/bitnami/scripts/discourse-sidekiq/run.sh"]` |
+| `sidekiq.extraEnvVars`                          | Array with extra environment variables to add Sidekiq pods                                 | `[]`                                                |
+| `sidekiq.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Sidekiq pods                          | `""`                                                |
+| `sidekiq.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Sidekiq pods | `""`                                                |
+| `sidekiq.livenessProbe.enabled`                 | Enable livenessProbe on Sidekiq containers                                                 | `true`                                              |
+| `sidekiq.livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                   | `500`                                               |
+| `sidekiq.livenessProbe.periodSeconds`           | How often to perform the probe                                                             | `10`                                                |
+| `sidekiq.livenessProbe.timeoutSeconds`          | When the probe times out                                                                   | `5`                                                 |
+| `sidekiq.livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe                                                 | `6`                                                 |
+| `sidekiq.livenessProbe.successThreshold`        | Minimum consecutive successes for the probe                                                | `1`                                                 |
+| `sidekiq.readinessProbe.enabled`                | Enable readinessProbe on Sidekiq containers                                                | `true`                                              |
+| `sidekiq.readinessProbe.initialDelaySeconds`    | Delay before readiness probe is initiated                                                  | `30`                                                |
+| `sidekiq.readinessProbe.periodSeconds`          | How often to perform the probe                                                             | `10`                                                |
+| `sidekiq.readinessProbe.timeoutSeconds`         | When the probe times out                                                                   | `5`                                                 |
+| `sidekiq.readinessProbe.failureThreshold`       | Minimum consecutive failures for the probe                                                 | `6`                                                 |
+| `sidekiq.readinessProbe.successThreshold`       | Minimum consecutive successes for the probe                                                | `1`                                                 |
+| `sidekiq.startupProbe.enabled`                  | Enable startupProbe on Sidekiq containers                                                  | `false`                                             |
+| `sidekiq.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                     | `60`                                                |
+| `sidekiq.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                            | `10`                                                |
+| `sidekiq.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                           | `5`                                                 |
+| `sidekiq.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                         | `15`                                                |
+| `sidekiq.startupProbe.successThreshold`         | Success threshold for startupProbe                                                         | `1`                                                 |
+| `sidekiq.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                        | `{}`                                                |
+| `sidekiq.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                       | `{}`                                                |
+| `sidekiq.customStartupProbe`                    | Custom startupProbe that overrides the default one                                         | `{}`                                                |
+| `sidekiq.resources.limits`                      | The resources limits for the Sidekiq containers                                            | `{}`                                                |
+| `sidekiq.resources.requests`                    | The requested resources for the Sidekiq containers                                         | `{}`                                                |
+| `sidekiq.containerSecurityContext.enabled`      | Enabled Sidekiq containers' Security Context                                               | `false`                                             |
+| `sidekiq.containerSecurityContext.runAsUser`    | Set Sidekiq containers' Security Context runAsUser                                         | `0`                                                 |
+| `sidekiq.containerSecurityContext.runAsNonRoot` | Set Sidekiq containers' Security Context runAsNonRoot                                      | `false`                                             |
+| `sidekiq.lifecycleHooks`                        | for the Sidekiq container(s) to automate configuration before or after startup             | `{}`                                                |
+| `sidekiq.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Sidekiq pods              | `[]`                                                |
+
+
+### Traffic Exposure Parameters
+
+| Name                               | Description                                                                                                                      | Value                    |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.type`                     | Discourse service type                                                                                                           | `ClusterIP`              |
+| `service.ports.http`               | Discourse service HTTP port                                                                                                      | `8080`                   |
+| `service.nodePorts.http`           | Node port for HTTP                                                                                                               | `""`                     |
+| `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                                                 | `None`                   |
+| `service.clusterIP`                | Discourse service Cluster IP                                                                                                     | `""`                     |
+| `service.loadBalancerIP`           | Discourse service Load Balancer IP                                                                                               | `""`                     |
+| `service.loadBalancerSourceRanges` | Discourse service Load Balancer sources                                                                                          | `[]`                     |
+| `service.externalTrafficPolicy`    | Discourse service external traffic policy                                                                                        | `Cluster`                |
+| `service.annotations`              | Additional custom annotations for Discourse service                                                                              | `{}`                     |
+| `service.extraPorts`               | Extra port to expose on Discourse service                                                                                        | `[]`                     |
+| `ingress.enabled`                  | Enable ingress record generation for Discourse                                                                                   | `false`                  |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
+| `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
+| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
+| `ingress.hostname`                 | Default host for the ingress record                                                                                              | `discourse.local`        |
+| `ingress.path`                     | Default path for the ingress record                                                                                              | `/`                      |
+| `ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
+| `ingress.tls`                      | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |
+| `ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
+| `ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                     |
+| `ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                     |
+| `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                     |
+| `ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`                     |
 
 
 ### Volume Permissions parameters
 
-| Name                                   | Description                                                                                                                                               | Value   |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false` |
-| `volumePermissions.resources.limits`   | The resources limits for the init container                                                                                                               | `{}`    |
-| `volumePermissions.resources.requests` | The requested resources for the init container                                                                                                            | `{}`    |
+| Name                                                   | Description                                                                     | Value                   |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume | `false`                 |
+| `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                | `docker.io`             |
+| `volumePermissions.image.repository`                   | Init container volume-permissions image repository                              | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)    | `10-debian-10-r312`     |
+| `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                             | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                            | `[]`                    |
+| `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                               | `{}`                    |
+| `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                             | `{}`                    |
+| `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                  | `0`                     |
 
 
-### Ingress parameters
+### Other Parameters
 
-| Name                  | Description                                                                                                                      | Value                    |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `ingress.enabled`     | Enable ingress controller resource                                                                                               | `false`                  |
-| `ingress.hostname`    | Default host for the ingress resource                                                                                            | `discourse.local`        |
-| `ingress.apiVersion`  | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
-| `ingress.path`        | Ingress path                                                                                                                     | `/`                      |
-| `ingress.pathType`    | Ingress path type                                                                                                                | `ImplementationSpecific` |
-| `ingress.annotations` | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
-| `ingress.tls`         | Enable TLS configuration for the hostname defined at ingress.hostname parameter                                                  | `false`                  |
-| `ingress.extraHosts`  | The list of additional hostnames to be covered with this ingress record.                                                         | `[]`                     |
-| `ingress.extraTls`    | The tls configuration for additional hostnames to be covered with this ingress record.                                           | `[]`                     |
-| `ingress.secrets`     | If you're providing your own certificates, please use this to add the certificates as secrets                                    | `[]`                     |
-
-
-### Database parameters
-
-| Name                                          | Description                                                                                        | Value                 |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------- |
-| `postgresql.enabled`                          | Deploy PostgreSQL container(s)                                                                     | `true`                |
-| `postgresql.postgresqlUsername`               | PostgreSQL user to create (used by Discourse). Has superuser privileges if username is `postgres`. | `bn_discourse`        |
-| `postgresql.postgresqlPassword`               | PostgreSQL password                                                                                | `""`                  |
-| `postgresql.postgresqlPostgresPassword`       | PostgreSQL admin password (used when `postgresqlUsername` is not `postgres`)                       | `bitnami`             |
-| `postgresql.existingSecret`                   | Name of existing secret object                                                                     | `""`                  |
-| `postgresql.postgresqlDatabase`               | Name of the database to create                                                                     | `bitnami_application` |
-| `postgresql.persistence.enabled`              | Enable database persistence using PVC                                                              | `true`                |
-| `externalDatabase.host`                       | Host of the external database                                                                      | `""`                  |
-| `externalDatabase.port`                       | Database port number (when using an external db)                                                   | `5432`                |
-| `externalDatabase.user`                       | Non-root PostgreSQL username (when using an external db)                                           | `bn_discourse`        |
-| `externalDatabase.password`                   | Password for the above username (when using an external db)                                        | `""`                  |
-| `externalDatabase.create`                     | PostgreSQL create user/database                                                                    | `true`                |
-| `externalDatabase.postgresqlPostgresUser`     | PostgreSQL admin user, used during the installation stage (when using an external db)              | `""`                  |
-| `externalDatabase.postgresqlPostgresPassword` | PostgreSQL admin password used in the installation stage (when using an external db)               | `""`                  |
-| `externalDatabase.existingSecret`             | Name of existing secret object                                                                     | `""`                  |
-| `externalDatabase.database`                   | Name of the existing database (when using an external db)                                          | `bitnami_application` |
-
-
-### Redis&trade; parameters
-
-| Name                                      | Description                                                                                                                                                               | Value            |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `redis.enabled`                           | Whether to deploy a redis server to satisfy the applications requirements. To use an external redis instance set this to false and configure the externalRedis parameters | `true`           |
-| `redis.auth.enabled`                      | Use password authentication                                                                                                                                               | `false`          |
-| `redis.auth.password`                     | Redis&trade; password (both master and replica)                                                                                                                           | `""`             |
-| `redis.auth.existingSecret`               | Name of an existing Kubernetes secret object containing the password                                                                                                      | `""`             |
-| `redis.auth.existingSecretPasswordKey`    | Name of the key pointing to the password in your Kubernetes secret                                                                                                        | `redis-password` |
-| `redis.architecture`                      | Cluster settings                                                                                                                                                          | `standalone`     |
-| `redis.master.persistence.enabled`        | Enable database persistence using PVC                                                                                                                                     | `true`           |
-| `externalRedis.host`                      | Host of the external database                                                                                                                                             | `""`             |
-| `externalRedis.port`                      | Database port number                                                                                                                                                      | `6379`           |
-| `externalRedis.password`                  | Password for the external Redis. Ignored if existingSecret is set                                                                                                         | `""`             |
-| `externalRedis.existingSecret`            | Name of an existing Kubernetes secret object containing the password                                                                                                      | `""`             |
-| `externalRedis.existingSecretPasswordKey` | Name of the key pointing to the password in your Kubernetes secret                                                                                                        | `redis-password` |
+| Name                                          | Description                                                            | Value   |
+| --------------------------------------------- | ---------------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Enable creation of ServiceAccount for Discourse pods                   | `false` |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                 | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created | `true`  |
+| `serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                   | `{}`    |
 
 
 ### NetworkPolicy parameters
@@ -278,17 +288,59 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                    | `{}`    |
 
 
+### Discourse database parameters
+
+| Name                                                 | Description                                                                                            | Value                 |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | --------------------- |
+| `postgresql.enabled`                                 | Switch to enable or disable the PostgreSQL helm chart                                                  | `true`                |
+| `postgresql.auth.enablePostgresUser`                 | Assign a password to the "postgres" admin user. Otherwise, remote access will be blocked for this user | `true`                |
+| `postgresql.auth.postgresPassword`                   | Password for the "postgres" admin user                                                                 | `bitnami`             |
+| `postgresql.auth.username`                           | Name for a custom user to create                                                                       | `bn_discourse`        |
+| `postgresql.auth.password`                           | Password for the custom user to create                                                                 | `""`                  |
+| `postgresql.auth.database`                           | Name for a custom database to create                                                                   | `bitnami_application` |
+| `postgresql.auth.existingSecret`                     | Name of existing secret to use for PostgreSQL credentials                                              | `""`                  |
+| `postgresql.architecture`                            | PostgreSQL architecture (`standalone` or `replication`)                                                | `standalone`          |
+| `externalDatabase.host`                              | Database host                                                                                          | `localhost`           |
+| `externalDatabase.port`                              | Database port number                                                                                   | `5432`                |
+| `externalDatabase.user`                              | Non-root username for Discourse                                                                        | `bn_discourse`        |
+| `externalDatabase.password`                          | Password for the non-root username for Discourse                                                       | `""`                  |
+| `externalDatabase.database`                          | Discourse database name                                                                                | `bitnami_application` |
+| `externalDatabase.create`                            | Switch to enable user/database creation during the installation stage                                  | `true`                |
+| `externalDatabase.postgresUser`                      | PostgreSQL admin user, used during the installation stage                                              | `""`                  |
+| `externalDatabase.postgresPassword`                  | PostgreSQL admin password, used during the installation stage                                          | `""`                  |
+| `externalDatabase.existingSecret`                    | Name of an existing secret resource containing the database credentials                                | `""`                  |
+| `externalDatabase.existingSecretPasswordKey`         | Name of an existing secret key containing the database credentials                                     | `password`            |
+| `externalDatabase.existingSecretPostgresPasswordKey` | Name of an existing secret key containing the database admin user credentials                          | `postgres-password`   |
+
+
+### Redis&trade; parameters
+
+| Name                                      | Description                                                                | Value            |
+| ----------------------------------------- | -------------------------------------------------------------------------- | ---------------- |
+| `redis.enabled`                           | Switch to enable or disable the Redis&trade; helm                          | `true`           |
+| `redis.auth.enabled`                      | Enable password authentication                                             | `true`           |
+| `redis.auth.password`                     | Redis&trade; password                                                      | `""`             |
+| `redis.auth.existingSecret`               | The name of an existing secret with Redis&trade; credentials               | `""`             |
+| `redis.architecture`                      | Redis&trade; architecture. Allowed values: `standalone` or `replication`   | `standalone`     |
+| `externalRedis.host`                      | Redis&trade; host                                                          | `localhost`      |
+| `externalRedis.port`                      | Redis&trade; port number                                                   | `6379`           |
+| `externalRedis.username`                  | Redis&trade; username                                                      | `""`             |
+| `externalRedis.password`                  | Redis&trade; password                                                      | `""`             |
+| `externalRedis.existingSecret`            | Name of an existing secret resource containing the Redis&trade credentials | `""`             |
+| `externalRedis.existingSecretPasswordKey` | Name of an existing secret key containing the Redis&trade credentials      | `redis-password` |
+
+
 The above parameters map to the env variables defined in [bitnami/discourse](https://github.com/bitnami/bitnami-docker-discourse). For more information please refer to the [bitnami/discourse](https://github.com/bitnami/bitnami-docker-discourse) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
 $ helm install my-release \
-  --set discourse.username=admin,discourse.password=password,postgresql.postgresqlPassword=secretpassword \
+  --set auth.username=admin,auth.password=password \
     bitnami/discourse
 ```
 
-The above command sets the Discourse administrator account username and password to `admin` and `password` respectively. Additionally, it sets the Postgresql `bn_discourse` user password to `secretpassword`.
+The above command sets the Discourse administrator account username and password to `admin` and `password` respectively.
 
 > NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
 
@@ -315,15 +367,14 @@ By default, this Chart only deploys a single pod running Discourse. Should you w
 > **Tip**: Running these steps ensures the PostgreSQL instance is correctly populated. If you already have an initialised DB, you may directly create a release with the desired number of replicas. Remind to set `discourse.skipInstall` to `true`!
 
 1. Create a conventional release, that will be scaled later:
+
 ```console
 $ helm install my-release bitnami/discourse
-...
-export DISCOURSE_PASSWORD=$(kubectl get secret --namespace default my-release-discourse -o jsonpath="{.data.discourse-password}" | base64 --decode)
-export POSTGRESQL_PASSWORD=$(kubectl get secret --namespace default my-release-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
 ...
 ```
 
 2. Wait for the release to complete and Discourse to be running successfully.
+
 ```console
 $ kubectl get pods
 NAME                               READY   STATUS    RESTARTS   AGE
@@ -333,8 +384,9 @@ my-release-redis-master-0               1/1     Running   0          5m11s
 ```
 
 3. Perform an upgrade specifying the number of replicas and the credentials used.
+
 ```console
-$ helm upgrade my-release --set replicaCount=2,discourse.password=$DISCOURSE_PASSWORD,postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD,discourse.skipInstall=true bitnami/discourse
+$ helm upgrade my-release --set replicaCount=2,discourse.skipInstall=true bitnami/discourse
 ```
 
 Note that for this to work properly, you need to provide ReadWriteMany PVCs. If you don't have a provisioner for this type of storage, we recommend that you install the NFS provisioner chart (with the correct parameters, such as `persistence.enabled=true` and `persistence.size=10Gi`) and map it to a RWO volume.
@@ -343,7 +395,7 @@ Then you can deploy Discourse chart using the proper parameters:
 
 ```console
 persistence.storageClass=nfs
-postgresql.persistence.storageClass=nfs
+postgresql.primary.persistence.storageClass=nfs
 ```
 
 ### Sidecars
@@ -380,8 +432,8 @@ postgresql.enabled=false
 externalDatabase.host=myexternalhost
 externalDatabase.user=myuser
 externalDatabase.password=mypassword
-externalDatabase.postgresqlPostgresUser=postgres
-externalDatabase.postgresqlPostgresPassword=rootpassword
+externalDatabase.postgresUser=postgres
+externalDatabase.postgresPassword=rootpassword
 externalDatabase.database=mydatabase
 externalDatabase.port=5432
 ```
@@ -401,55 +453,13 @@ externalRedis.port=5432
 
 ### Ingress
 
-This chart provides support for ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress](https://kubeapps.com/charts/stable/nginx-ingress) or [traefik](https://kubeapps.com/charts/stable/traefik) you can utilize the ingress controller to serve your Discourse application.
+This chart provides support for Ingress resources. If an Ingress controller, such as [nginx-ingress](https://kubeapps.com/charts/stable/nginx-ingress) or [traefik](https://kubeapps.com/charts/stable/traefik), that Ingress controller can be used to serve Discourse.
 
-To enable ingress integration, please set `ingress.enabled` to `true`
+To enable Ingress integration, set `ingress.enabled` to `true`. The `ingress.hostname` property can be used to set the host name. The `ingress.tls` parameter can be used to add the TLS configuration for this host. It is also possible to have more than one host, with a separate TLS configuration for each host. [Learn more about configuring and using Ingress](https://docs.bitnami.com/kubernetes/apps/discourse/configuration/configure-ingress/).
 
-### Hosts
+### TLS secrets
 
-Most likely you will only want to have one hostname that maps to this Discourse installation. If that's your case, the property `ingress.hostname` will set it. However, it is possible to have more than one host. To facilitate this, the `ingress.extraHosts` object can be specified as an array.
-
-For each host indicated at `ingress.extraHosts`, please indicate a `name`, `path`, and any `annotations` that you may want the ingress controller to know about.
-
-The actual TLS secret do not have to be generated by this chart. However, please note that if TLS is enabled, the ingress record will not work until this secret exists.
-
-For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers.
-
-### TLS Secrets
-
-This chart will facilitate the creation of TLS secrets for use with the ingress controller, however, this is not required.  There are three common use cases:
-
-- Helm generates/manages certificate secrets
-- User generates/manages certificates separately
-- An additional tool (like [kube-lego](https://kubeapps.com/charts/stable/kube-lego)) manages the secrets for the application
-
-In the first two cases, one will need a certificate and a key.  We would expect them to look like this:
-
-- certificate files should look like (and there can be more than one certificate if there is a certificate chain)
-
-```console
------BEGIN CERTIFICATE-----
-MIID6TCCAtGgAwIBAgIJAIaCwivkeB5EMA0GCSqGSIb3DQEBCwUAMFYxCzAJBgNV
-...
-jScrvkiBO65F46KioCL9h5tDvomdU1aqpI/CBzhvZn1c0ZTf87tGQR8NK7v7
------END CERTIFICATE-----
-```
-
-- keys should look like:
-
-```console
------BEGIN RSA PRIVATE KEY-----
-MIIEogIBAAKCAQEAvLYcyu8f3skuRyUgeeNpeDvYBCDcgq+LsWap6zbX5f8oLqp4
-...
-wrj2wDbCDCFmfqnSJ+dKI3vFLlEz44sAV8jX/kd4Y6ZTQhlLbYc=
------END RSA PRIVATE KEY-----
-```
-
-If you are going to use Helm to manage the certificates, please copy these values into the `certificate` and `key` values for a given `ingress.secrets` entry.
-
-If you are going to manage TLS secrets outside of Helm, please know that you can create a TLS secret (named `discourse.local-tls` for example).
-
-Please see [this example](https://github.com/kubernetes/contrib/tree/master/ingress/controllers/nginx/examples/tls) for more information.
+The chart also facilitates the creation of TLS secrets for use with the Ingress controller, with different options for certificate management. [Learn more about TLS secrets](https://docs.bitnami.com/kubernetes/apps/discourse/administration/enable-tls-ingress/).
 
 ### Setting Pod's affinity
 
@@ -464,198 +474,13 @@ The [Bitnami Discourse](https://github.com/bitnami/bitnami-docker-discourse) ima
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
 
-### Image
-
-The `image` parameter allows specifying which image will be pulled for the chart.
-
-#### Private registry
-
-If you configure the `image` value to one in a private registry, you will need to [specify an image pull secret](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).
-
-1. Manually create image pull secret(s) in the namespace. See [this YAML example reference](https://kubernetes.io/docs/concepts/containers/images/#creating-a-secret-with-a-docker-config). Consult your image registry's documentation about getting the appropriate secret.
-1. Note that the `imagePullSecrets` configuration value cannot currently be passed to helm using the `--set` parameter, so you must supply these using a `values.yaml` file, such as:
-
-```yaml
-imagePullSecrets:
-  - name: SECRET_NAME
-```
-
-1. Install the chart
-
 ## Troubleshooting
 
 Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
 
-### To 5.0.0
-
-This major update the Redis&trade; subchart to its newest major, 15.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1500) you can find more info about the specific changes.
-
-### To 4.0.0
-
-The [Bitnami Discourse](https://github.com/bitnami/bitnami-docker-discourse) image was refactored and now the source code is published in GitHub in the [`rootfs`](https://github.com/bitnami/bitnami-docker-discourse/tree/master/2/debian-10/rootfs) folder of the container image repository.
-
-Upgrades from previous versions require to specify `--set volumePermissions.enabled=true` in order for all features to work properly:
-
-```console
-$ helm upgrade discourse bitnami/discourse \
-    --set discourse.host=$DISCOURSE_HOST \
-    --set discourse.password=$DISCOURSE_PASSWORD \
-    --set postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD \
-    --set postgresql.persistence.existingClaim=$POSTGRESQL_PVC \
-    --set volumePermissions.enabled=true
-```
-
-Full compatibility is not guaranteed due to the amount of involved changes, however no breaking changes are expected aside from the ones mentioned above.
-
-### To 3.0.0
-
-This major updates the Redis&trade; subchart to it newest major, 14.0.0, which contains breaking changes. For more information on this subchart's major and the steps needed to migrate your data from your previous release, please refer to [Redis&trade; upgrade notes.](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1400).
-
-### To 2.0.0
-
-[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
-
-**What changes were introduced in this major version?**
-
-- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
-- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
-- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
-- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
-
-**Considerations when upgrading to this version**
-
-- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
-- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
-- This chart depends on the **PostgreSQL 10** instead of **PostgreSQL 9**. Apart from the same changes that are described in this section, there are also other major changes due to the master/slave nomenclature was replaced by primary/readReplica. [Here](https://github.com/bitnami/charts/pull/4385) you can find more information about the changes introduced.
-- If you want to upgrade to this version from a previous one installed with Helm v3, it should be done reusing the PVC used to hold the PostgreSQL data on your previous release. To do so, follow the instructions below (the following example assumes that the release name is `discourse`):
-
-> NOTE: Please, create a backup of your database before running any of those actions.
-
-##### Export secrets and required values to update
-
-```console
-$ export DISCOURSE_HOST=$(kubectl get svc --namespace default discourse --template "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}")
-$ export DISCOURSE_PASSWORD=$(kubectl get secret --namespace default discourse-discourse -o jsonpath="{.data.discourse-password}" | base64 --decode)
-$ export POSTGRESQL_PASSWORD=$(kubectl get secret --namespace default discourse-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
-$ export POSTGRESQL_PVC=$(kubectl get pvc -l app.kubernetes.io/instance=discourse,app.kubernetes.io/name=postgresql,role=master -o jsonpath="{.items[0].metadata.name}")
-```
-
-##### Delete statefulsets
-
-Delete the Discourse deployment and delete the PostgreSQL statefulset. Notice the option `--cascade=false` in the latter:
-
-```
-$ kubectl delete deployments.apps discourse
-$ kubectl delete statefulsets.apps --cascade=false discourse-postgresql
-```
-
-##### Upgrade the chart release
-
-```console
-$ helm upgrade discourse bitnami/discourse \
-    --set discourse.host=$DISCOURSE_HOST \
-    --set discourse.password=$DISCOURSE_PASSWORD \
-    --set postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD \
-    --set postgresql.persistence.existingClaim=$POSTGRESQL_PVC
-```
-
-##### Force new statefulset to create a new pod for postgresql
-
-```console
-$ kubectl delete pod discourse-postgresql-0
-```
-Finally, you should see the lines below in MariaDB container logs:
-
-```console
-$ kubectl logs $(kubectl get pods -l app.kubernetes.io/instance=postgresql,app.kubernetes.io/name=postgresql,role=primary -o jsonpath="{.items[0].metadata.name}")
-...
-postgresql 08:05:12.59 INFO  ==> Deploying PostgreSQL with persisted data...
-...
-```
-
-**Useful links**
-
-- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
-- https://helm.sh/docs/topics/v2_v3_migration/
-- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/
-
-### To 1.0.0
-
-This new major version includes the following changes:
-
-* PostgreSQL dependency version was bumped to a new major version `9.X.X`, which includes changes that do no longer guarantee backwards compatibility. Check [PostgreSQL Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/postgresql#900) for more information.
-* Redis&trade; dependency version was bumped to a new major version `11.X.X`, which includes breaking changes regarding sentinel. Discourse does not use this type of setup, so no issues are expected to happen in this case. Check [Redis&trade; Upgrading Notes](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1100) for more information.
-* Some non-breaking changes so as to use the `bitnami/common` library chart.
-
-As a consequence, backwards compatibility from previous versions is not guaranteed during the upgrade. To upgrade to this new version `1.0.0` there are two alternatives:
-
-* Install a new Discourse chart, and migrate your Discourse site using the [built-in backup/restore feature](https://meta.discourse.org/t/create-download-and-restore-a-backup-of-your-discourse-database/122710).
-
-* Reuse the PVC used to hold the PostgreSQL data on your previous release. To do so, follow the instructions below.
-
-> NOTE: Please, make sure to create or have a backup of your database before running any of those actions.
-
-1. Old version is up and running
-
-  ```console
-  $ helm ls
-  NAME	    NAMESPACE	REVISION	UPDATED                              	STATUS  	CHART          	APP VERSION
-  discourse 	default  	2       	2020-10-22 12:10:16.454369 +0200 CEST	deployed	discourse-0.5.1	2.5.3
-
-  $ kubectl get pods
-  NAME                                   READY   STATUS    RESTARTS   AGE
-  discourse-discourse-7554ddb864-d55ls   2/2     Running   0          3s
-  discourse-postgresql-0                 1/1     Running   0          16s
-  discourse-redis-master-0               1/1     Running   0          16s
-  ```
-
-2. Export both PostgreSQL and Discourse credentials in order to provide them in the update
-
-  ```console
-  $ export DISCOURSE_PASSWORD=$(kubectl get secret --namespace default discourse-discourse-discourse -o jsonpath="{.data.discourse-password}" | base64 --decode)
-
-  $ export POSTGRESQL_PASSWORD=$(kubectl get secret --namespace default discourse-postgresql -o jsonpath="{.data.postgresql-password}" | base64 --decode)
-  ```
-
-  > NOTE: You will need to export Redis&trade; credentials as well if your setup makes use of them.
-
-3. Scale down the Discourse deployment and delete the PostgreSQL statefulset. Notice the option `--cascade=false` in the latter.
-
-  ```console
-  $ kubectl scale --replicas 0 deployment.apps/discourse-discourse
-  deployment.apps/discourse-discourse scaled
-
-  $ kubectl delete statefulset.apps/discourse-postgresql --cascade=false
-  statefulset.apps "discourse-postgresql" deleted
-  ```
-
-4. Now the upgrade works
-
-  ```console
-  $ helm upgrade discourse bitnami/discourse --set discourse.password=$DISCOURSE_PASSWORD --set postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD --set skipInstall=true
-  $ helm ls
-  NAME	      NAMESPACE	REVISION	UPDATED                              	STATUS  	CHART      	APP VERSION
-  discourse 	default  	3       	2020-10-22 13:03:33.876084 +0200 CEST	deployed	discourse-1.0.0	2.5.3
-  ```
-
-5. You can kill the existing PostgreSQL pod and the new statefulset is going to create a new one
-
-  ```console
-  $ kubectl delete pod discourse-postgresql-0
-  pod "discourse-postgresql-0" deleted
-
-  $ kubectl get pods
-  NAME                                   READY   STATUS    RESTARTS   AGE
-  discourse-discourse-58fff99578-2xbjq   2/2     Running   3          5m4s
-  discourse-postgresql-0                 1/1     Running   0          3m42s
-  discourse-redis-master-0               1/1     Running   0          4m58s
-  ```
-
-### To 0.4.0
-
-This version also introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+Refer to the [chart documentation for more information about how to upgrade from previous releases](https://docs.bitnami.com/kubernetes/apps/discourse/administration/upgrade/).
 
 ## Community supported solution
 

--- a/bitnami/discourse/ci/global-values.yaml
+++ b/bitnami/discourse/ci/global-values.yaml
@@ -1,0 +1,10 @@
+# Test values files for generating all of the yaml and check that
+# the rendering is correct
+global:
+  postgresql:
+    auth:
+      username: other_username
+      password: other_password
+      database: other_database
+service:
+  type: ClusterIP

--- a/bitnami/discourse/ci/ingress.yaml
+++ b/bitnami/discourse/ci/ingress.yaml
@@ -1,0 +1,6 @@
+# Test values files for generating all of the yaml and check that
+# the rendering is correct
+ingress:
+  enabled: true
+  tls: true
+  selfSigned: true

--- a/bitnami/discourse/templates/NOTES.txt
+++ b/bitnami/discourse/templates/NOTES.txt
@@ -2,15 +2,36 @@ CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
+{{- $releaseNamespace := .Release.Namespace }}
+{{- $clusterDomain := .Values.clusterDomain }}
+{{- $fullname := include "common.names.fullname" . }}
+{{- $secretName := include "discourse.secretName" . }}
+
 ** Please be patient while the chart is being deployed **
 
-{{- $secretName := include "discourse.secretName" . -}}
-{{- $postgresqlSecretName := include "discourse.postgresql.secretName" . -}}
-{{- $redisSecretName := include "discourse.redis.secretName" . -}}
+{{- if .Values.diagnosticMode.enabled }}
 
-{{- if or .Values.postgresql.enabled .Values.externalDatabase.host -}}
+The chart has been deployed in diagnostic mode. All probes have been disabled and the command has been overwritten with:
 
-{{- if empty (include "discourse.host" .) -}}
+  command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 4 }}
+  args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 4 }}
+
+Get the list of pods by executing:
+
+    kubectl get pods --namespace {{ $releaseNamespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Access the pod you want to debug by executing
+
+    kubectl exec --namespace {{ $releaseNamespace }} -ti <NAME OF THE POD> -- bash
+
+In order to replicate the container startup scripts execute this command:
+
+    /opt/bitnami/scripts/discourse/entrypoint.sh /opt/bitnami/scripts/discourse/run.sh
+
+{{- else }}
+
+{{- if empty (include "discourse.host" .) }}
+
 ###############################################################################
 ### ERROR: You did not provide an external host in your 'helm install' call ###
 ###############################################################################
@@ -20,150 +41,82 @@ This deployment will be incomplete until you configure Discourse with a resolvab
 1. Get the discourse URL by running:
 
   {{- if contains "NodePort" .Values.service.type }}
-  export DISCOURSE_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}"):$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
-  {{- else if contains "LoadBalancer" .Values.service.type }}
-  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
 
-  export DISCOURSE_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
-  {{- end }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $secretName "field" "discourse-password" "context" $) }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $postgresqlSecretName "field" "postgresql-password" "context" $) }}
-  {{- if (include "discourse.redis.auth.enabled" .) }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $redisSecretName "field" "redis-password" "context" $) }}
+    export DISCOURSE_HOST=$(kubectl get nodes --namespace {{ $releaseNamespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export DISCOURSE_PORT=$(kubectl get svc {{ $fullname . }} --namespace {{ $releaseNamespace }} -o jsonpath="{.spec.ports[0].nodePort}")
+
+  {{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        Watch the status with: 'kubectl get svc --namespace {{ $releaseNamespace }} -w {{ $fullname . }}'
+
+    export DISCOURSE_HOST=$(kubectl get svc --namespace {{ $releaseNamespace }} {{ $fullname . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+    export DISCOURSE_PORT={{ .Values.service.ports.http }}
+
   {{- end }}
 
 2. Complete your Discourse deployment by running:
 
-{{- if .Values.postgresql.enabled }}
-
-  helm upgrade --namespace {{ .Release.Namespace }} {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    --set discourse.host=$DISCOURSE_HOST \
-    --set discourse.password=$DISCOURSE_PASSWORD \
-    {{- if .Values.global }}{{- if .Values.global.imagePullSecrets }}
-    --set global.imagePullSecrets={{ .Values.global.imagePullSecrets }} \
-    {{- end }}{{- end }}
-    {{- if and .Values.redis.enabled .Values.redis.auth.enabled (not .Values.redis.auth.existingSecret) (not .Values.redis.auth.password) }}
-    --set redis.auth.password=$REDIS_PASSWORD \
-    {{- end }}
-    --set postgresql.postgresqlPassword=$POSTGRESQL_PASSWORD
-
-{{- else }}
-
-  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
-
-  helm upgrade --namespace {{ .Release.Namespace }} {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    --set discourse.host=$DISCOURSE_HOST \
-    --set discourse.password=$DISCOURSE_PASSWORD \
-    --set service.type={{ .Values.service.type }} \
-    --set externalDatabase.host={{ .Values.externalDatabase.host }} \
-    --set externalDatabase.port={{ .Values.externalDatabase.port }} \
-    --set externalDatabase.user={{ .Values.externalDatabase.user }} \
-    --set externalDatabase.password=$POSTGRESQL_PASSWORD \
-    --set externalDatabase.database={{ .Values.externalDatabase.database }} \
-    {{- if .Values.global }}{{- if .Values.global.imagePullSecrets }}
-    --set global.imagePullSecrets={{ .Values.global.imagePullSecrets }} \
-    {{- end }}{{- end }}
-    {{- if and .Values.redis.enabled .Values.redis.auth.enabled (not .Values.redis.auth.existingSecret) (not .Values.redis.auth.password) }}
-    --set redis.auth.password=$REDIS_PASSWORD \
-    {{- end }}
-    --set postgresql.enabled=false
-{{- end }}
+    helm upgrade --namespace {{ $releaseNamespace }} {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
+      {{- if .Values.global }}
+      {{- if .Values.global.imagePullSecrets }}
+      --set global.imagePullSecrets={{ .Values.global.imagePullSecrets }} \
+      {{- end }}
+      {{- end }}
+      --set discourse.host="$DISCOURSE_HOST:$DISCOURSE_PORT"
 
 {{- else -}}
 
-1. Get the Discourse URL by running:
+Discourse can be accessed via port {{ .Values.service.ports.http }} on the following DNS name from within your cluster:
 
-  Discourse URL : http://{{ include "discourse.host" . }}/
+    {{ printf "%s.%s.svc.%s" $fullname $releaseNamespace $clusterDomain }}
 
-{{- if eq .Values.service.type "ClusterIP" }}
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} 80:{{ .Values.service.port }}
-{{- end }}
+To connect to Discourse from outside the cluster, perform the following steps:
 
-2. Get your Discourse login credentials by running:
+{{- if .Values.ingress.enabled }}
 
-  Username: {{ .Values.discourse.username }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $secretName "field" "discourse-password" "context" $) }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $postgresqlSecretName "field" "postgresql-password" "context" $) }}
-  {{- if (include "discourse.redis.auth.enabled" .) }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $redisSecretName "field" "redis-password" "context" $) }}
-  {{- end }}
+1. Get the Discourse URL and associate its hostname to your cluster external IP:
 
-{{- end }}
+    export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+    echo "Discourse URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}"
+    echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
 
-{{- else -}}
+{{- else if eq .Values.service.type "ClusterIP" }}
 
-########################################################################################
-### ERROR: You did not provide an external database host in your 'helm install' call ###
-########################################################################################
+1.  Create a port-forward to the service:
 
-This deployment will be incomplete until you configure Discourse with a resolvable database host. To configure Discourse to use and external database host:
+    kubectl port-forward --namespace {{ $releaseNamespace }} svc/{{ $fullname }} {{ .Values.service.ports.http }}:{{ .Values.service.ports.http }} &
+    echo "Discourse URL: http://127.0.0.1:{{ .Values.service.ports.http }}"
 
-1. Complete your Discourse deployment by running:
+{{- else if eq .Values.service.type "NodePort" }}
 
-{{- if contains "NodePort" .Values.service.type }}
-  export DISCOURSE_HOST=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}"):$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
-{{- else if contains "LoadBalancer" .Values.service.type }}
+1. Obtain the NodePort IP and port:
+
+    export NODE_IP=$(kubectl get nodes --namespace {{ $releaseNamespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT=$(kubectl get svc --namespace {{ $releaseNamespace }} {{ $fullname }} -o jsonpath="{.spec.ports[0].nodePort}")
+    echo "Discourse URL: http://${NODE_IP}:$NODE_PORT"
+
+{{- else if eq .Values.service.type "LoadBalancer" }}
+
+1. Obtain the LoadBalancer IP:
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ $fullname }}'
 
-  export DISCOURSE_HOST=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
-{{- else }}
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ $fullname }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+    echo "Discourse URL: http://${SERVICE_IP}:{{ .Values.service.ports.http }}"
 
-  export DISCOURSE_HOST=127.0.0.1
-{{- end }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $secretName "field" "discourse-password" "context" $) }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $postgresqlSecretName "field" "postgresql-password" "context" $) }}
-  {{- if (include "discourse.redis.auth.enabled" .) }}
-  {{ include "common.utils.secret.getvalue" (dict "secret" $redisSecretName "field" "redis-password" "context" $) }}
-  {{- end }}
-  ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
-
-  helm upgrade --namespace {{ .Release.Namespace }} {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
-    --set discourse.host=$DISCOURSE_HOST \
-    --set discourse.password=$DISCOURSE_PASSWORD \
-    --set postgresql.enabled=false \
-    {{- if not (empty .Values.externalDatabase.user) }}
-    --set externalDatabase.user={{ .Values.externalDatabase.user }} \
-    {{- end }}
-    {{- if not (empty .Values.externalDatabase.password) }}
-    --set externalDatabase.password=$POSTGRESQL_PASSWORD \
-    {{- end }}
-    {{- if not (empty .Values.externalDatabase.database) }}
-    --set externalDatabase.database={{ .Values.externalDatabase.database }}
-    {{- end }}
-    --set externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST \
-    {{- if .Values.global }}{{- if .Values.global.imagePullSecrets }}
-    --set global.imagePullSecrets={{ .Values.global.imagePullSecrets }} \
-    {{- end }}{{- end }}
-    {{- if and .Values.redis.enabled .Values.redis.auth.enabled (not .Values.redis.auth.existingSecret) (not .Values.redis.auth.password) }}
-    --set redis.auth.password=$REDIS_PASSWORD \
-    {{- end }}
-    --set service.type={{ .Values.service.type }}
 {{- end }}
 
-{{ if and .Values.postgresql.enabled (not .Values.postgresql.existingSecret) (eq .Values.postgresql.postgresqlPostgresPassword "bitnami") -}}
-#####################################################################################
-### WARNING: You did not change the default password for the PostgreSQL root user ###
-#####################################################################################
+2. Open a browser and access Discourse using the obtained URL.
+
+3. Get your Discourse login credentials by running:
+
+    {{ include "common.utils.secret.getvalue" (dict "secret" $secretName "field" "discourse-password" "context" $) }}
+    echo User:     {{ .Values.auth.username }}
+    echo Password: $DISCOURSE_PASSWORD
+
+{{- end }}
 {{- end }}
 
 {{- include "common.warnings.rollingTag" .Values.image }}
-
-{{- $passwordValidationErrors := list -}}
-{{- if not .Values.discourse.existingSecret -}}
-    {{- $requiredDiscoursePassword := dict "valueKey" "discourse.password" "secret" $secretName "field" "discourse-password" "context" $ -}}
-    {{- $requiredDiscoursePasswordError := include "common.validations.values.single.empty" $requiredDiscoursePassword -}}
-    {{- $passwordValidationErrors = append $passwordValidationErrors $requiredDiscoursePasswordError -}}
-{{- end -}}
-
-{{- $postgresqlPasswordValidationErrors := include "common.validations.values.postgresql.passwords" (dict "secret" $postgresqlSecretName "subchart" true "context" $) -}}
-{{- $passwordValidationErrors = append $passwordValidationErrors $postgresqlPasswordValidationErrors -}}
-
-{{- if (include "discourse.redis.auth.enabled" .) }}
-{{- $redisPasswordValidationErrors := include "common.validations.values.redis.passwords" (dict "secret" $redisSecretName "subchart" true "context" $) -}}
-{{- $passwordValidationErrors = append $passwordValidationErrors $redisPasswordValidationErrors -}}
-{{- end }}
-
-{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}

--- a/bitnami/discourse/templates/NOTES.txt
+++ b/bitnami/discourse/templates/NOTES.txt
@@ -43,14 +43,14 @@ This deployment will be incomplete until you configure Discourse with a resolvab
   {{- if contains "NodePort" .Values.service.type }}
 
     export DISCOURSE_HOST=$(kubectl get nodes --namespace {{ $releaseNamespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-    export DISCOURSE_PORT=$(kubectl get svc {{ $fullname . }} --namespace {{ $releaseNamespace }} -o jsonpath="{.spec.ports[0].nodePort}")
+    export DISCOURSE_PORT=$(kubectl get svc {{ $fullname }} --namespace {{ $releaseNamespace }} -o jsonpath="{.spec.ports[0].nodePort}")
 
   {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ $releaseNamespace }} -w {{ $fullname . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ $releaseNamespace }} -w {{ $fullname }}'
 
-    export DISCOURSE_HOST=$(kubectl get svc --namespace {{ $releaseNamespace }} {{ $fullname . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+    export DISCOURSE_HOST=$(kubectl get svc --namespace {{ $releaseNamespace }} {{ $fullname }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
     export DISCOURSE_PORT={{ .Values.service.ports.http }}
 
   {{- end }}
@@ -63,7 +63,8 @@ This deployment will be incomplete until you configure Discourse with a resolvab
       --set global.imagePullSecrets={{ .Values.global.imagePullSecrets }} \
       {{- end }}
       {{- end }}
-      --set discourse.host="$DISCOURSE_HOST:$DISCOURSE_PORT"
+      --set service.type={{ .Values.service.type }} \
+      --set host="$DISCOURSE_HOST:$DISCOURSE_PORT"
 
 {{- else -}}
 

--- a/bitnami/discourse/templates/configmaps.yaml
+++ b/bitnami/discourse/templates/configmaps.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  DISCOURSE_HOST: {{ include "discourse.host" . }}
+  DISCOURSE_HOST: {{ include "discourse.host" . | quote }}
   DISCOURSE_SKIP_INSTALL: {{ ternary "yes" "no" .Values.discourse.skipInstall | quote }}
   DISCOURSE_SITE_NAME: {{ .Values.siteName | quote }}
   DISCOURSE_USERNAME: {{ .Values.auth.username | quote }}

--- a/bitnami/discourse/templates/configmaps.yaml
+++ b/bitnami/discourse/templates/configmaps.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -10,41 +11,40 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
-  {{- $port := .Values.service.port | toString }}
-  DISCOURSE_HOST: "{{ include "discourse.host" . }}"
+  DISCOURSE_HOST: {{ include "discourse.host" . }}
   DISCOURSE_SKIP_INSTALL: {{ ternary "yes" "no" .Values.discourse.skipInstall | quote }}
-  DISCOURSE_SITE_NAME: {{ .Values.discourse.siteName | quote }}
-  DISCOURSE_USERNAME: {{ .Values.discourse.username | quote }}
-  DISCOURSE_EMAIL: {{ .Values.discourse.email | quote }}
-  DISCOURSE_REDIS_HOST: {{ template "discourse.redisHost" . }}
-  DISCOURSE_REDIS_PORT_NUMBER: {{ template "discourse.redisPort" . }}
-  DISCOURSE_DATABASE_HOST: {{ template "discourse.databaseHost" . }}
-  DISCOURSE_DATABASE_PORT_NUMBER: {{ template "discourse.databasePort" . }}
-  DISCOURSE_DATABASE_NAME: {{ template "discourse.databaseName" . }}
-  DISCOURSE_DATABASE_USER: {{ template "discourse.databaseUser" . }}
-  {{- if .Values.discourse.smtp.enabled }}
-  DISCOURSE_SMTP_HOST: {{ .Values.discourse.smtp.host | quote }}
-  DISCOURSE_SMTP_PORT: {{ .Values.discourse.smtp.port | quote }}
-  {{- if .Values.discourse.smtp.user }}
-  DISCOURSE_SMTP_USER: {{ .Values.discourse.smtp.user | quote }}
+  DISCOURSE_SITE_NAME: {{ .Values.siteName | quote }}
+  DISCOURSE_USERNAME: {{ .Values.auth.username | quote }}
+  DISCOURSE_EMAIL: {{ .Values.auth.email | quote }}
+  DISCOURSE_REDIS_HOST: {{ include "discourse.redis.host" . }}
+  DISCOURSE_REDIS_PORT_NUMBER: {{ include "discourse.redis.port" . }}
+  DISCOURSE_DATABASE_HOST: {{ include "discourse.database.host" . }}
+  DISCOURSE_DATABASE_PORT_NUMBER: {{ include "discourse.database.port" . }}
+  DISCOURSE_DATABASE_NAME: {{ include "discourse.database.name" . }}
+  DISCOURSE_DATABASE_USER: {{ include "discourse.database.user" . }}
+  {{- if .Values.smtp.enabled }}
+  DISCOURSE_SMTP_HOST: {{ .Values.smtp.host | quote }}
+  DISCOURSE_SMTP_PORT: {{ .Values.smtp.port | quote }}
+  {{- if .Values.smtp.user }}
+  DISCOURSE_SMTP_USER: {{ .Values.smtp.user | quote }}
   {{- end }}
-  {{- if .Values.discourse.smtp.protocol }}
-  DISCOURSE_SMTP_PROTOCOL: {{ .Values.discourse.smtp.protocol | quote }}
+  {{- if .Values.smtp.protocol }}
+  DISCOURSE_SMTP_PROTOCOL: {{ .Values.smtp.protocol | quote }}
   {{- end }}
-  {{- if .Values.discourse.smtp.auth }}
-  DISCOURSE_SMTP_AUTH: {{ .Values.discourse.smtp.auth | quote }}
+  {{- if .Values.smtp.auth }}
+  DISCOURSE_SMTP_AUTH: {{ .Values.smtp.auth | quote }}
   {{- end }}
   {{- end }}
   {{- if or .Values.postgresql.enabled .Values.externalDatabase.create }}
-  POSTGRESQL_CLIENT_DATABASE_HOST: {{ template "discourse.databaseHost" . }}
-  POSTGRESQL_CLIENT_DATABASE_PORT_NUMBER: {{ template "discourse.databasePort" . }}
-  {{- if or .Values.postgresql.enabled (not .Values.externalDatabase.postgresqlPostgresUser) }}
+  POSTGRESQL_CLIENT_DATABASE_HOST: {{ include "discourse.database.host" . }}
+  POSTGRESQL_CLIENT_DATABASE_PORT_NUMBER: {{ include "discourse.database.port" . }}
+  {{- if or .Values.postgresql.enabled (not .Values.externalDatabase.postgresUser) }}
   POSTGRESQL_CLIENT_POSTGRES_USER: "postgres"
   {{- else }}
-  POSTGRESQL_CLIENT_POSTGRES_USER: {{ .Values.externalDatabase.postgresqlPostgresUser | quote }}
+  POSTGRESQL_CLIENT_POSTGRES_USER: {{ .Values.externalDatabase.postgresUser | quote }}
   POSTGRESQL_CLIENT_CREATE_DATABASE_USERNAME: {{ .Values.externalDatabase.user | quote }}
   POSTGRESQL_CLIENT_CREATE_DATABASE_PASSWORD: {{ .Values.externalDatabase.password | quote }}
   {{- end }}
-  POSTGRESQL_CLIENT_CREATE_DATABASE_NAME: {{ template "discourse.databaseName" . }}
+  POSTGRESQL_CLIENT_CREATE_DATABASE_NAME: {{ include "discourse.database.name" . }}
   POSTGRESQL_CLIENT_CREATE_DATABASE_EXTENSIONS: "hstore,pg_trgm"
   {{- end }}

--- a/bitnami/discourse/templates/deployment.yaml
+++ b/bitnami/discourse/templates/deployment.yaml
@@ -1,10 +1,10 @@
 {{- if and (include "discourse.host" .) (or .Values.postgresql.enabled .Values.externalDatabase.host) -}}
-apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    component: discourse
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -15,7 +15,6 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      component: discourse
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
@@ -27,7 +26,6 @@ spec:
         checksum/secrets-database: {{ include (print $.Template.BasePath "/secrets-database.yaml") . | sha256sum }}
         checksum/secrets-redis: {{ include (print $.Template.BasePath "/secrets-redis.yaml") . | sha256sum }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        component: discourse
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}
@@ -53,8 +51,19 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
+      {{- end }}
       serviceAccountName: {{ include "discourse.serviceAccountName" . }}
-      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       initContainers:
         {{- if .Values.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
@@ -67,10 +76,11 @@ spec:
             - sh
             - -c
             - |
-              mkdir -p "/bitnami/discourse"
-              chown -R "discourse:root" "/bitnami/discourse"
-          securityContext:
-            runAsUser: 0
+              mkdir -p /bitnami/discourse
+              find /bitnami/discourse -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ .Values.discourse.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
+          {{- if .Values.volumePermissions.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.volumePermissions.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.volumePermissions.resources }}
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}
@@ -80,13 +90,19 @@ spec:
         {{- end }}
       containers:
         - name: discourse
-          securityContext: {{- toYaml .Values.discourse.containerSecurityContext | nindent 12 }}
-          image: {{ template "discourse.image" . }}
+          image: {{ include "discourse.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
-          {{- if .Values.discourse.command }}
+          {{- if .Values.discourse.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.discourse.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.discourse.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.command "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.discourse.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.discourse.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.args "context" $) | nindent 12 }}
           {{- end }}
           env:
@@ -97,17 +113,21 @@ spec:
                 secretKeyRef:
                   name: {{ include "discourse.secretName" . }}
                   key: discourse-password
+            - name: DISCOURSE_PORT_NUMBER
+              value: {{ .Values.discourse.containerPorts.http | quote }}
+            - name: DISCOURSE_EXTERNAL_HTTP_PORT_NUMBER
+              value: {{ .Values.service.ports.http | quote }}
             - name: DISCOURSE_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "discourse.postgresql.secretName" . }}
-                  key: postgresql-password
+                  name: {{ include "discourse.database.secretName" . }}
+                  key: {{ include "discourse.database.secretPasswordKey" . }}
             {{- if or .Values.postgresql.enabled .Values.externalDatabase.create }}
             - name: POSTGRESQL_CLIENT_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "discourse.postgresql.secretName" . }}
-                  key: postgresql-postgres-password
+                  name: {{ include "discourse.database.secretName" . }}
+                  key: {{ include "discourse.database.secretPostgresPasswordKey" . }}
             {{- end }}
             {{- if (include "discourse.redis.auth.enabled" .) }}
             - name: DISCOURSE_REDIS_PASSWORD
@@ -116,11 +136,11 @@ spec:
                   name: {{ include "discourse.redis.secretName" . }}
                   key: {{ include "discourse.redis.secretPasswordKey" . }}
             {{- end }}
-            {{- if (include "discourse.smtp.password.enabled" .) }}
+            {{- if (include "smtp.password.enabled" .) }}
             - name: DISCOURSE_SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "discourse.smtp.secretName" . }}
+                  name: {{ include "smtp.secretName" . }}
                   key: smtp-password
             {{- end }}
             {{- if .Values.discourse.extraEnvVars }}
@@ -139,8 +159,9 @@ spec:
             {{- end }}
           ports:
             - name: http
-              containerPort: 3000
+              containerPort: {{ .Values.discourse.containerPorts.http }}
               protocol: TCP
+          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.discourse.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
@@ -167,6 +188,20 @@ spec:
           {{- else if .Values.discourse.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.discourse.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.discourse.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.discourse.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.discourse.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.discourse.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.discourse.resources }}
+          resources: {{- toYaml .Values.discourse.resources | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: discourse-data
               mountPath: /bitnami/discourse
@@ -174,15 +209,22 @@ spec:
             {{- if .Values.discourse.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.discourse.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-          {{- if .Values.discourse.resources }}
-          resources: {{- toYaml .Values.discourse.resources | nindent 12 }}
-          {{- end }}
         - name: sidekiq
-          securityContext: {{- toYaml .Values.sidekiq.containerSecurityContext | nindent 12 }}
-          image: {{ template "discourse.image" . }}
+          image: {{ include "discourse.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.sidekiq.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.sidekiq.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.sidekiq.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.sidekiq.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.args "context" $) | nindent 12 }}
+          {{- end }}
           env:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
@@ -194,8 +236,8 @@ spec:
             - name: DISCOURSE_POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "discourse.postgresql.secretName" . }}
-                  key: postgresql-password
+                  name: {{ include "discourse.database.secretName" . }}
+                  key: {{ include "discourse.database.secretPasswordKey" . }}
             {{- if (include "discourse.redis.auth.enabled" .) }}
             - name: REDIS_PASSWORD
               valueFrom:
@@ -203,11 +245,11 @@ spec:
                   name: {{ include "discourse.redis.secretName" . }}
                   key: {{ include "discourse.redis.secretPasswordKey" . }}
             {{- end }}
-            {{- if (include "discourse.smtp.password.enabled" .) }}
+            {{- if (include "smtp.password.enabled" .) }}
             - name: DISCOURSE_SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "discourse.smtp.secretName" . }}
+                  name: {{ include "smtp.secretName" . }}
                   key: smtp-password
             {{- end }}
             {{- if .Values.sidekiq.extraEnvVars }}
@@ -224,6 +266,7 @@ spec:
             - secretRef:
                 name: {{ .Values.sidekiq.extraEnvVarsSecret }}
             {{- end }}
+          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.sidekiq.livenessProbe.enabled }}
           livenessProbe:
             exec:
@@ -248,6 +291,20 @@ spec:
           {{- else if .Values.sidekiq.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- if .Values.sidekiq.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.sidekiq.startupProbe "enabled") "context" $) | nindent 12 }}
+            exec:
+              command: ["/bin/sh", "-c", "pgrep -f ^sidekiq"]
+          {{- else if .Values.sidekiq.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.sidekiq.resources }}
+          resources: {{- toYaml .Values.sidekiq.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.sidekiq.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: discourse-data
               mountPath: /bitnami/discourse
@@ -255,9 +312,6 @@ spec:
             {{- if .Values.sidekiq.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.sidekiq.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-          {{- if .Values.sidekiq.resources }}
-          resources: {{- toYaml .Values.sidekiq.resources | nindent 12 }}
-          {{- end }}
         {{- if .Values.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | nindent 8 }}
         {{- end }}
@@ -265,7 +319,7 @@ spec:
         - name: discourse-data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.persistence.existingClaim | default (include "common.names.fullname" .) }}
+            claimName: {{ default (include "common.names.fullname" .) (tpl .Values.persistence.existingClaim $)}}
           {{- else }}
           emptyDir: {}
           {{ end }}

--- a/bitnami/discourse/templates/ingress.yaml
+++ b/bitnami/discourse/templates/ingress.yaml
@@ -1,41 +1,32 @@
-{{- if .Values.ingress.enabled -}}
-apiVersion: {{ template "common.capabilities.ingress.apiVersion" . }}
+{{- if .Values.ingress.enabled }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-  {{- if .Values.commonLabels }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-  {{- end }}
-  {{- if or .Values.ingress.annotations .Values.ingress.certManager .Values.commonAnnotations }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
+    {{- end }}
   annotations:
-  {{- if .Values.commonAnnotations }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
-  {{- if .Values.ingress.annotations }}
-  {{- toYaml .Values.ingress.annotations | nindent 4 }}
-  {{- end }}
-  {{- if .Values.ingress.certManager }}
-    kubernetes.io/tls-acme: "true"
-  {{- end }}
-  {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
 spec:
-  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
-  tls:
-    {{- if .Values.ingress.tls }}
-    - hosts:
-        - {{ .Values.ingress.hostname }}
-      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
-    {{- end }}
-    {{- if .Values.ingress.extraTls }}
-    {{- toYaml .Values.ingress.extraTls | nindent 4 }}
-    {{- end }}
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ include "common.tplvalues.render" ( dict "value" .Values.ingress.hostname "context" $ ) }}
       http:
         paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
           - path: {{ .Values.ingress.path }}
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.ingress.pathType }}
@@ -43,7 +34,7 @@ spec:
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
     {{- range .Values.ingress.extraHosts }}
-    - host: {{ .name }}
+    - host: {{ include "common.tplvalues.render" ( dict "value" .name "context" $ ) }}
       http:
         paths:
           - path: {{ default "/" .path }}
@@ -52,4 +43,16 @@ spec:
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
     {{- end }}
+  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+  tls:
+    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
+    - hosts:
+        - {{ .Values.ingress.hostname | quote }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
 {{- end }}
+

--- a/bitnami/discourse/templates/networkpolicy-backend-ingress.yaml
+++ b/bitnami/discourse/templates/networkpolicy-backend-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-postgresql-backend" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
@@ -18,8 +19,7 @@ spec:
   ingress:
     - from:
         - podSelector:
-            matchLabels:
-              {{- include "common.labels.matchLabels" . | nindent 14 }}
+            matchLabels:  {{- include "common.labels.matchLabels" . | nindent 14 }}
 {{- end }}
 ---
 {{- if and .Values.networkPolicy.enabled .Values.redis.enabled .Values.networkPolicy.ingressRules.backendOnlyAccessibleByFrontend }}
@@ -27,6 +27,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-redis-backend" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
@@ -46,8 +47,7 @@ spec:
   ingress:
     - from:
         - podSelector:
-            matchLabels:
-              {{- include "common.labels.matchLabels" . | nindent 14 }}
+            matchLabels: {{- include "common.labels.matchLabels" . | nindent 14 }}
 {{- end }}
 ---
 {{- if and .Values.networkPolicy.enabled .Values.networkPolicy.ingressRules.customBackendSelector .Values.networkPolicy.ingressRules.backendOnlyAccessibleByFrontend }}
@@ -55,6 +55,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-custom-backend" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
@@ -69,6 +70,5 @@ spec:
   ingress:
     - from:
         - podSelector:
-            matchLabels:
-              {{- include "common.labels.matchLabels" . | nindent 14 }}
+            matchLabels: {{- include "common.labels.matchLabels" . | nindent 14 }}
 {{- end }}

--- a/bitnami/discourse/templates/networkpolicy-egress.yaml
+++ b/bitnami/discourse/templates/networkpolicy-egress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-egress" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/discourse/templates/networkpolicy-ingress.yaml
+++ b/bitnami/discourse/templates/networkpolicy-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-ingress" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
@@ -12,33 +13,28 @@ metadata:
   {{- end }}
 spec:
   podSelector:
-    matchLabels:
-      {{- include "common.labels.standard" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.standard" . | nindent 6 }}
   ingress:
     {{- if and .Values.ingress.enabled .Values.networkPolicy.ingress.enabled (or .Values.networkPolicy.ingress.namespaceSelector .Values.networkPolicy.ingress.podSelector) }}
     - from:
         {{- if .Values.networkPolicy.ingress.namespaceSelector }}
         - namespaceSelector:
-            matchLabels:
-              {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingress.namespaceSelector "context" $) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingress.namespaceSelector "context" $) | nindent 14 }}
         {{- end }}
         {{- if .Values.networkPolicy.ingress.podSelector }}
         - podSelector:
-            matchLabels:
-              {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingress.podSelector "context" $) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingress.podSelector "context" $) | nindent 14 }}
         {{- end }}
     {{- end }}
     {{- if and .Values.networkPolicy.ingressRules.accessOnlyFrom.enabled (or .Values.networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector .Values.networkPolicy.ingressRules.accessOnlyFrom.podSelector) }}
     - from:
         {{- if .Values.networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector }}
         - namespaceSelector:
-            matchLabels:
-              {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector "context" $) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressRules.accessOnlyFrom.namespaceSelector "context" $) | nindent 14 }}
         {{- end }}
         {{- if .Values.networkPolicy.ingressRules.accessOnlyFrom.podSelector }}
         - podSelector:
-            matchLabels:
-              {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressRules.accessOnlyFrom.podSelector "context" $) | nindent 14 }}
+            matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.networkPolicy.ingressRules.accessOnlyFrom.podSelector "context" $) | nindent 14 }}
         {{- end }}
     {{- end }}
     {{- if .Values.networkPolicy.ingressRules.customRules }}

--- a/bitnami/discourse/templates/pvc.yaml
+++ b/bitnami/discourse/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -11,13 +12,17 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not (empty .Values.persistence.accessModes) }}
   accessModes:
-    - {{ .Values.persistence.accessMode | quote }}
+  {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
-  {{ include "discourse.storageClass" . }}
   {{- if .Values.persistence.selector }}
   selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 4 }}
   {{- end -}}
+  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 4 }}
 {{- end }}

--- a/bitnami/discourse/templates/secrets-database.yaml
+++ b/bitnami/discourse/templates/secrets-database.yaml
@@ -1,8 +1,9 @@
-{{- if (include "discourse.postgresql.createSecret" .) }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "common.names.fullname" . }}-database
+  name: {{ printf "%s-database" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -12,6 +13,6 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  postgresql-password: {{ .Values.externalDatabase.password | b64enc | quote }}
-  postgresql-postgres-password: {{ .Values.externalDatabase.postgresqlPostgresPassword | b64enc | quote }}
+  {{ include "discourse.database.secretPasswordKey" . }}: {{ .Values.externalDatabase.password | b64enc | quote }}
+  {{ include "discourse.database.secretPostgresPasswordKey" . }}: {{ .Values.externalDatabase.postgresPassword | b64enc | quote }}
 {{- end }}

--- a/bitnami/discourse/templates/secrets-discourse.yaml
+++ b/bitnami/discourse/templates/secrets-discourse.yaml
@@ -2,22 +2,21 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "common.names.fullname" . }}-discourse
+  name: {{ printf "%s-discourse" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-  {{- if .Values.commonLabels }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-  {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: Opaque
 data:
-  {{- if and (.Values.discourse.password) (not .Values.discourse.existingSecret) }}
-  discourse-password: {{ .Values.discourse.password | b64enc | quote }}
-  {{- else if not .Values.discourse.existingSecret }}
-  discourse-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{- if not .Values.auth.existingSecret }}
+  discourse-password: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-discourse" (include "common.names.fullname" .)) "key" "discourse-password" "providedValues" (list "auth.password") "context" $) }}
   {{- end }}
-  {{- if and (.Values.discourse.smtp.password) (.Values.discourse.smtp.enabled) (not .Values.discourse.smtp.existingSecret) }}
-  smtp-password: {{ .Values.discourse.smtp.password | b64enc | quote }}
+  {{- if and .Values.smtp.enabled .Values.smtp.password (not .Values.smtp.existingSecret) }}
+  smtp-password: {{ .Values.smtp.password | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/bitnami/discourse/templates/secrets-redis.yaml
+++ b/bitnami/discourse/templates/secrets-redis.yaml
@@ -1,8 +1,9 @@
-{{- if (include "discourse.redis.createSecret" .) }}
+{{- if and (not .Values.redis.enabled) (not .Values.externalRedis.existingSecret) .Values.externalRedis.password }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "common.names.fullname" . }}-redis
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -12,5 +13,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  redis-password: {{ .Values.externalRedis.password | b64enc | quote }}
+  {{ include "discourse.redis.secretPasswordKey" . }}: {{ .Values.externalRedis.password | b64enc | quote }}
 {{- end }}

--- a/bitnami/discourse/templates/service.yaml
+++ b/bitnami/discourse/templates/service.yaml
@@ -2,34 +2,41 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-  {{- if .Values.commonLabels }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-  {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if or .Values.service.annotations .Values.commonAnnotations }}
   annotations:
-  {{- if .Values.service.annotations }}
-  {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
-  {{- end }}
-  {{- if .Values.commonAnnotations }}
-  {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
-  {{- end }}
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if (and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges) }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   {{- if (and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
-  {{- if (and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges) }}
-  loadBalancerSourceRanges:
-  {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
-  {{- end }}
   ports:
     - name: http
-      port: {{ .Values.service.port }}
+      port: {{ .Values.service.ports.http }}
+      protocol: TCP
       targetPort: http
       {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http))) }}
       nodePort: {{ .Values.service.nodePorts.http }}

--- a/bitnami/discourse/templates/serviceaccount.yaml
+++ b/bitnami/discourse/templates/serviceaccount.yaml
@@ -3,17 +3,19 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "discourse.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-  {{- if .Values.commonLabels }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-  {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
   annotations:
-  {{- if .Values.serviceAccount.annotations }}
-  {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
+    {{- end }}
   {{- end }}
-  {{- if .Values.commonAnnotations }}
-  {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
-  {{- end }}
-  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/bitnami/discourse/templates/tls-secrets.yaml
+++ b/bitnami/discourse/templates/tls-secrets.yaml
@@ -1,19 +1,45 @@
 {{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
 {{- range .Values.ingress.secrets }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
-  {{- if $.Values.commonLabels }}
-  {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-  {{- end }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if $.Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 type: kubernetes.io/tls
 data:
   tls.crt: {{ .certificate | b64enc }}
   tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- $ca := genCA "discourse-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+---
 {{- end }}
 {{- end }}

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -68,7 +68,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/discourse
-  tag: 2.7.13-debian-10-r21
+  tag: 2.7.13-debian-10-r25
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -27,6 +27,9 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override discourse.fullname template
 ##
 fullnameOverride: ""
+## @param clusterDomain Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
 ## @param commonLabels Labels to be added to all deployed resources
 ##
 commonLabels: {}
@@ -36,47 +39,22 @@ commonAnnotations: {}
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
-
-## @section Service parameters
-
-## Kubernetes service configuration. For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
+## Enable diagnostic mode in the deployment(s)/statefulset(s)
 ##
-service:
-  ## @param service.type Kubernetes Service type
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
   ##
-  type: LoadBalancer
-  ## @param service.port Service HTTP port
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the the deployment(s)/statefulset(s)
   ##
-  port: 80
-  ## @param service.nodePort Node Ports to expose
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the the deployment(s)/statefulset(s)
   ##
-  nodePort: ""
-  ## @param service.loadBalancerIP Use loadBalancerIP to request a specific static IP
-  ##
-  loadBalancerIP: ""
-  ## @param service.externalTrafficPolicy Enable client source IP preservation
-  ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
-  ##
-  externalTrafficPolicy: Cluster
-  ## @param service.annotations Service annotations
-  ##
-  annotations: {}
-  ## @param service.loadBalancerSourceRanges Limits which cidr blocks can connect to service's load balancer
-  ## Only valid if service.type: LoadBalancer
-  ##
-  loadBalancerSourceRanges: []
-  ## @param service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
-  ##
-  extraPorts: []
-  ## @param service.nodePorts.http Kubernetes http node port
-  ## Example:
-  ##  nodePorts:
-  ##   http: <to set explicitly, choose port between 30000-32767>
-  ##
-  nodePorts:
-    http: ""
+  args:
+    - infinity
 
-## @section Discourse parameters
+## @section Discourse Common parameters
 
 ## Bitnami Discourse image version
 ## ref: https://hub.docker.com/r/bitnami/discourse/tags/
@@ -85,7 +63,7 @@ service:
 ## @param image.tag Discourse image tag
 ## @param image.pullPolicy Discourse image pull policy
 ## @param image.pullSecrets Discourse image pull secrets
-## @param image.debug Specify if debug logs should be enabled
+## @param image.debug Enable image debug mode
 ##
 image:
   registry: docker.io
@@ -107,256 +85,67 @@ image:
   ## Set to true if you would like to see extra information on logs
   ##
   debug: false
-## @param imagePullSecrets Specify docker-registry secret names as an array
+## Authentication parameters
+## ref: https://github.com/bitnami/bitnami-docker-discourse#user-and-site-configuration
 ##
-imagePullSecrets: []
-## Discourse configuration parameters
-## ref: https://github.com/bitnami/bitnami-docker-discourse#configuration
-##
-discourse:
-  ## @param discourse.host Discourse host to create application URLs (include the port if =/= 80)
+auth:
+  ## @param auth.email Discourse admin user email
   ##
-  host: ""
-  ## @param discourse.siteName Discourse site name
-  ##
-  siteName: 'My Site!'
-  ## @param discourse.username Admin user of the application
+  email: user@example.com
+  ## @param auth.username Discourse admin user
   ##
   username: user
-  ## @param discourse.password password. WARNING: Minimum length of 10 characters
+  ## @param auth.password Discourse admin password. WARNING: Minimum length of 10 characters
   ## Defaults to a random 10-character alphanumeric string if not set
   ##
   password: ""
-  ## @param discourse.existingSecret Name of an existing secret containing the password (ignores previous password)
-  ## The secret should contain the following key:
-  ## discourse-password
+  ## @param auth.existingSecret Name of an existing secret to use for Discourse credentials
+  ## `auth.password` will be ignored and picked up from this secret
+  ## The secret must contain the key `discourse-password`
+  ## The value is evaluated as a template
   ##
   existingSecret: ""
-  ## @param discourse.email Admin user email of the application
-  ##
-  email: user@example.com
-  ## @param discourse.command Custom command to override image cmd
-  ##
-  command: []
-  ## @param discourse.args Custom args for the custom command
-  ##
-  args: []
-  ## @param discourse.containerSecurityContext Container security context specification
-  ## Example:
-  ## capabilities:
-  ##   drop:
-  ##   - ALL
-  ## readOnlyRootFilesystem: true
-  ## runAsNonRoot: true
-  ## runAsUser: 1000
-  ##
-  containerSecurityContext: {}
-  ## Discourse container's resource requests and limits
-  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param discourse.resources.limits The resources limits for the container
-  ## @param discourse.resources.requests The requested resources for the container
-  ##
-  resources:
-    ## Example:
-    ## limits:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    requests: {}
-  ## Discourse extra options for liveness probe
-  ## WARNING: Discourse installation process may take up some time and
-  ## setting inappropriate values here may lead to pods failure.
-  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
-  ## @param discourse.livenessProbe.enabled Enable/disable livenessProbe
-  ## @param discourse.livenessProbe.initialDelaySeconds Delay before liveness probe is initiated
-  ## @param discourse.livenessProbe.periodSeconds How often to perform the probe
-  ## @param discourse.livenessProbe.timeoutSeconds When the probe times out
-  ## @param discourse.livenessProbe.failureThreshold Minimum consecutive failures for the probe
-  ## @param discourse.livenessProbe.successThreshold Minimum consecutive successes for the probe
-  ##
-  livenessProbe:
-    enabled: true
-    initialDelaySeconds: 500
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
-    successThreshold: 1
-  ## Discourse extra options for readiness probe
-  ## WARNING: Discourse installation process may take up some time and
-  ## setting inappropriate values here may lead to pods failure.
-  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
-  ## @param discourse.readinessProbe.enabled Enable/disable readinessProbe
-  ## @param discourse.readinessProbe.initialDelaySeconds Delay before readiness probe is initiated
-  ## @param discourse.readinessProbe.periodSeconds How often to perform the probe
-  ## @param discourse.readinessProbe.timeoutSeconds When the probe times out
-  ## @param discourse.readinessProbe.failureThreshold Minimum consecutive failures for the probe
-  ## @param discourse.readinessProbe.successThreshold Minimum consecutive successes for the probe
-  ##
-  readinessProbe:
-    enabled: true
-    initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
-    successThreshold: 1
-  ## @param discourse.customLivenessProbe Custom liveness probe to execute (when the main one is disabled)
-  ##
-  customLivenessProbe: {}
-  ## @param discourse.customReadinessProbe Custom readiness probe to execute (when the main one is disabled)
-  ##
-  customReadinessProbe: {}
-  ## Discourse SMTP settings
-  ## @param discourse.smtp.enabled Enable/disable SMTP
-  ## @param discourse.smtp.host SMTP host name
-  ## @param discourse.smtp.port SMTP port number
-  ## @param discourse.smtp.user SMTP account user name
-  ## @param discourse.smtp.password SMTP account password
-  ## @param discourse.smtp.protocol SMTP protocol (Allowed values: tls, ssl)
-  ## @param discourse.smtp.auth SMTP authentication method
-  ## @param discourse.smtp.existingSecret Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password`
-  ##
-  smtp:
-    enabled: false
-    host: ""
-    port: ""
-    user: ""
-    password: ""
-    protocol: ""
-    auth: ""
-    existingSecret: ""
-  ## @param discourse.extraEnvVars An array to add extra env vars
-  ## For example:
-  ## extraEnvVars:
-  ##   discourse:
-  ##   - name: DISCOURSE_ELASTICSEARCH_URL
-  ##     value: test
-  ##
-  extraEnvVars: []
-  ## @param discourse.extraEnvVarsCM Array to add extra configmaps
-  ##
-  extraEnvVarsCM: []
-  ## @param discourse.extraEnvVarsSecret Array to add extra environment variables from a secret
-  ##
-  extraEnvVarsSecret: ""
-  ## @param discourse.extraVolumeMounts Additional volume mounts (used along with `extraVolumes`)
-  ## Example: Mount CA file
-  ## extraVolumeMounts
-  ##   - name: ca-cert
-  ##     subPath: ca_cert
-  ##     mountPath: /path/to/ca_cert
-  ##
-  extraVolumeMounts: []
-  ## @param discourse.skipInstall Do not run the Discourse installation wizard
-  ## Use only in case you are importing an existing database.
-  ##
-  skipInstall: false
+## @param host Hostname to create application URLs (include the port if =/= 80)
+##
+host: ""
+## @param siteName Discourse site name
+##
+siteName: 'My Site!'
+## Discourse SMTP settings
+## @param smtp.enabled Enable/disable SMTP
+## @param smtp.host SMTP host name
+## @param smtp.port SMTP port number
+## @param smtp.user SMTP account user name
+## @param smtp.password SMTP account password
+## @param smtp.protocol SMTP protocol (Allowed values: tls, ssl)
+## @param smtp.auth SMTP authentication method
+## @param smtp.existingSecret Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password`
+##
+smtp:
+  enabled: false
+  host: ""
+  port: ""
+  user: ""
+  password: ""
+  protocol: ""
+  auth: ""
+  existingSecret: ""
 ## @param replicaCount Number of Discourse & Sidekiq replicas
-## (Note that you will need ReadWriteMany PVCs for this to work properly)
+## Note: ReadWriteMany PVCs are required to scale
 ##
 replicaCount: 1
-## @param extraVolumes Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`
-## Example: Add secret volume
-## extraVolumes:
-##  - name: ca-cert
-##    secret:
-##      secretName: ca-cert
-##      items:
-##        - key: ca-cert
-##          path: ca_cert
+## Configure Discourse pods Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param podSecurityContext.enabled Enabled Discourse pods' Security Context
+## @param podSecurityContext.fsGroup Set Discourse pod's Security Context fsGroup
 ##
-extraVolumes: []
-## @param sidecars Attach additional sidecar containers to the pod
-## Example:
-## sidecars:
-##   - name: your-image-name
-##     image: your-image
-##     imagePullPolicy: Always
-##     ports:
-##       - name: portname
-##         containerPort: 1234
-##
-sidecars: []
-## @param initContainers Additional init containers to add to the pods
-##
-## e.g.
-## initContainers:
-##   - name: your-image-name
-##     image: your-image
-##     imagePullPolicy: Always
-##     ports:
-##       - name: portname
-##       containerPort: 1234
-##
-initContainers: []
-## @param serviceAccount.create Whether the service account should be created
-## @param serviceAccount.annotations Annotations to add to the service account
-## @param serviceAccount.name Name to be used for the service account
-##
-serviceAccount:
-  create: false
-  annotations: {}
-  ## If not set and create is true, a name is generated using the fullname template
-  ##
-  name: ""
-## @param podSecurityContext Pod security context specification
-## Example:
-##  fsGroup: 2000
-##
-##
-podSecurityContext: {}
+podSecurityContext:
+  enabled: false
+  fsGroup: 0
 ## @param hostAliases Add deployment host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##
 hostAliases: []
-## Enable persistence using Persistent Volume Claims
-## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
-##
-persistence:
-  ## @param persistence.enabled Whether to enable persistence based on Persistent Volume Claims
-  ##
-  enabled: true
-  ## @param persistence.storageClass discourse & sidekiq data Persistent Volume Storage Class
-  ## If defined, storageClassName: <storageClass>
-  ## If set to "-", storageClassName: "", which disables dynamic provisioning
-  ## If undefined (the default) or set to null, no storageClassName spec is
-  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-  ##   GKE, AWS & OpenStack)
-  ##
-  storageClass: ""
-  ## @param persistence.existingClaim Use a existing PVC which must be created manually before bound
-  ##
-  existingClaim: ""
-  ## @param persistence.accessMode PVC Access Mode (RWO, ROX, RWX)
-  ##
-  accessMode: ReadWriteOnce
-  ## @param persistence.size Size of the PVC to request
-  ##
-  size: 10Gi
-  ## @param persistence.selector Selector to match an existing Persistent Volume (this value is evaluated as a template)
-  ## selector:
-  ##   matchLabels:
-  ##     app: my-app
-  selector: {}
-## @param updateStrategy.type Update strategy type. Only really applicable for deployments with RWO PVs attached
-## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
-## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
-## terminate the single previous pod, so that the new, incoming pod can attach to the PV
-## Example:
-## updateStrategy:
-##  type: RollingUpdate
-##  rollingUpdate:
-##    maxSurge: 25%
-##    maxUnavailable: 25%
-updateStrategy:
-  type: RollingUpdate
 ## @param podAnnotations Additional pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
@@ -404,36 +193,218 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+##
+topologySpreadConstraints: {}
+## @param priorityClassName Priority Class Name
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+##
+priorityClassName: ""
+## @param schedulerName Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+schedulerName: ""
+## @param terminationGracePeriodSeconds Seconds Discourse pod needs to terminate gracefully
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+##
+terminationGracePeriodSeconds: ""
+## @param updateStrategy.type Discourse deployment strategy type
+## @param updateStrategy.rollingUpdate Discourse deployment rolling update configuration parameters
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+##
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate: {}
+## @param sidecars Add additional sidecar containers to the Discourse pods
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: []
+## @param initContainers Add additional init containers to the Discourse pods
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: []
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Discourse pods
+##
+extraVolumeMounts: []
+## @param extraVolumes Optionally specify extra list of additional volumes for the Discourse pods
+##
+extraVolumes: []
 
-## @section Sidekiq parameters
+## @section Discourse container parameters
+
+discourse:
+  ## @param discourse.skipInstall Do not run the Discourse installation wizard
+  ## Use only in case you are importing an existing database.
+  ##
+  skipInstall: false
+  ## @param discourse.command Custom command to override image cmd
+  ##
+  command: []
+  ## @param discourse.args Custom args for the custom command
+  ##
+  args: []
+  ## @param discourse.extraEnvVars Array with extra environment variables to add Discourse pods
+  ##
+  extraEnvVars: []
+  ## @param discourse.extraEnvVarsCM ConfigMap containing extra environment variables for Discourse pods
+  ##
+  extraEnvVarsCM: ""
+  ## @param discourse.extraEnvVarsSecret Secret containing extra environment variables (in case of sensitive data) for Discourse pods
+  ##
+  extraEnvVarsSecret: ""
+  ## @param discourse.containerPorts.http Discourse HTTP container port
+  ##
+  containerPorts:
+    http: 8080
+  ## Configure extra options for Discourse containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param discourse.livenessProbe.enabled Enable livenessProbe on Discourse containers
+  ## @param discourse.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param discourse.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param discourse.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param discourse.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param discourse.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 500
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param discourse.readinessProbe.enabled Enable readinessProbe on Discourse containers
+  ## @param discourse.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param discourse.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param discourse.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param discourse.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param discourse.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param discourse.startupProbe.enabled Enable startupProbe on Discourse containers
+  ## @param discourse.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param discourse.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param discourse.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param discourse.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param discourse.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 15
+    successThreshold: 1
+  ## @param discourse.customLivenessProbe Custom livenessProbe that overrides the default one
+  ##
+  customLivenessProbe: {}
+  ## @param discourse.customReadinessProbe Custom readinessProbe that overrides the default one
+  ##
+  customReadinessProbe: {}
+  ## @param discourse.customStartupProbe Custom startupProbe that overrides the default one
+  ##
+  customStartupProbe: {}
+  ## Discourse resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param discourse.resources.limits The resources limits for the Discourse containers
+  ## @param discourse.resources.requests The requested resources for the Discourse containers
+  ##
+  resources:
+    limits: {}
+    requests: {}
+  ## Configure Discourse containers (only main one) Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param discourse.containerSecurityContext.enabled Enabled Discourse containers' Security Context
+  ## @param discourse.containerSecurityContext.runAsUser Set Discourse containers' Security Context runAsUser
+  ## @param discourse.containerSecurityContext.runAsNonRoot Set Discourse containers' Security Context runAsNonRoot
+  ##
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 0
+    runAsNonRoot: false
+  ## @param discourse.lifecycleHooks for the Discourse container(s) to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+  ## @param discourse.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Discourse pods
+  ##
+  extraVolumeMounts: []
+
+## Persistence Parameters
+## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  ## @param persistence.enabled Enable persistence using Persistent Volume Claims
+  ##
+  enabled: true
+  ## @param persistence.storageClass Persistent Volume storage class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+  ##
+  storageClass: ""
+  ## @param persistence.accessModes [array] Persistent Volume access modes
+  ##
+  accessModes:
+    - ReadWriteOnce
+  ## @param persistence.accessMode Persistent Volume access mode (DEPRECATED: use `persistence.accessModes` instead)
+  ##
+  accessMode: ReadWriteOnce
+  ## @param persistence.size Persistent Volume size
+  ##
+  size: 10Gi
+  ## @param persistence.existingClaim The name of an existing PVC to use for persistence
+  ##
+  existingClaim: ""
+  ## @param persistence.selector Selector to match an existing Persistent Volume for Discourse data PVC
+  ## If set, the PVC can't have a PV dynamically provisioned for it
+  ## E.g.
+  ## selector:
+  ##   matchLabels:
+  ##     app: my-app
+  ##
+  selector: {}
+
+## @section Sidekiq container parameters
 
 sidekiq:
-  ## @param sidekiq.containerSecurityContext Container security context specification
-  ## capabilities:
-  ##   drop:
-  ##   - ALL
-  ## readOnlyRootFilesystem: true
-  ## runAsNonRoot: true
-  ## runAsUser: 1000
-  ##
-  containerSecurityContext: {}
   ## @param sidekiq.command Custom command to override image cmd (evaluated as a template)
   ##
   command: ['/opt/bitnami/scripts/discourse/entrypoint.sh']
   ## @param sidekiq.args Custom args for the custom command (evaluated as a template)
   ##
   args: ['/opt/bitnami/scripts/discourse-sidekiq/run.sh']
-  ## @param sidekiq.resources Sidekiq container resource requests and limits
-  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param sidekiq.extraEnvVars Array with extra environment variables to add Sidekiq pods
   ##
-  resources: {}
-  ## Sidekiq extra options for liveness probe
-  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
-  ## @param sidekiq.livenessProbe.enabled Enable/disable livenessProbe
+  extraEnvVars: []
+  ## @param sidekiq.extraEnvVarsCM ConfigMap containing extra environment variables for Sidekiq pods
+  ##
+  extraEnvVarsCM: ""
+  ## @param sidekiq.extraEnvVarsSecret Secret containing extra environment variables (in case of sensitive data) for Sidekiq pods
+  ##
+  extraEnvVarsSecret: ""
+  ## Configure extra options for Sidekiq containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param sidekiq.livenessProbe.enabled Enable livenessProbe on Sidekiq containers
   ## @param sidekiq.livenessProbe.initialDelaySeconds Delay before liveness probe is initiated
   ## @param sidekiq.livenessProbe.periodSeconds How often to perform the probe
   ## @param sidekiq.livenessProbe.timeoutSeconds When the probe times out
@@ -448,8 +419,7 @@ sidekiq:
     failureThreshold: 6
     successThreshold: 1
   ## Sidekiq extra options for readiness probe
-  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
-  ## @param sidekiq.readinessProbe.enabled Enable/disable readinessProbe
+  ## @param sidekiq.readinessProbe.enabled Enable readinessProbe on Sidekiq containers
   ## @param sidekiq.readinessProbe.initialDelaySeconds Delay before readiness probe is initiated
   ## @param sidekiq.readinessProbe.periodSeconds How often to perform the probe
   ## @param sidekiq.readinessProbe.timeoutSeconds When the probe times out
@@ -463,251 +433,259 @@ sidekiq:
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
-  ## @param sidekiq.customLivenessProbe Custom liveness probe to execute (when the main one is disabled)
+  ## @param sidekiq.startupProbe.enabled Enable startupProbe on Sidekiq containers
+  ## @param sidekiq.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param sidekiq.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param sidekiq.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param sidekiq.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param sidekiq.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 15
+    successThreshold: 1
+  ## @param sidekiq.customLivenessProbe Custom livenessProbe that overrides the default one
   ##
   customLivenessProbe: {}
-  ## @param sidekiq.customReadinessProbe Custom readiness probe to execute (when the main one is disabled)
+  ## @param sidekiq.customReadinessProbe Custom readinessProbe that overrides the default one
   ##
   customReadinessProbe: {}
-  ## @param sidekiq.extraEnvVars An array to add extra env vars
-  ## For example:
-  ## extraEnvVars:
-  ##   - name: DISCOURSE_ELASTICSEARCH_URL
-  ##     value: test
+  ## @param sidekiq.customStartupProbe Custom startupProbe that overrides the default one
   ##
-  extraEnvVars: []
-  ## @param sidekiq.extraEnvVarsCM Array to add extra configmaps
+  customStartupProbe: {}
+  ## Sidekiq resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param sidekiq.resources.limits The resources limits for the Sidekiq containers
+  ## @param sidekiq.resources.requests The requested resources for the Sidekiq containers
   ##
-  extraEnvVarsCM: []
-  ## @param sidekiq.extraEnvVarsSecret Name of the secret that holds extra env vars
+  resources:
+    limits: {}
+    requests: {}
+  ## Configure Sidekiq containers (only main one) Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param sidekiq.containerSecurityContext.enabled Enabled Sidekiq containers' Security Context
+  ## @param sidekiq.containerSecurityContext.runAsUser Set Sidekiq containers' Security Context runAsUser
+  ## @param sidekiq.containerSecurityContext.runAsNonRoot Set Sidekiq containers' Security Context runAsNonRoot
   ##
-  extraEnvVarsSecret: ""
-  ## @param sidekiq.extraVolumeMounts Additional volume mounts
-  ## Example: Mount CA file
-  ## extraVolumeMounts
-  ##   - name: ca-cert
-  ##     subPath: ca_cert
-  ##     mountPath: /path/to/ca_cert
+  containerSecurityContext:
+    enabled: false
+    runAsUser: 0
+    runAsNonRoot: false
+  ## @param sidekiq.lifecycleHooks for the Sidekiq container(s) to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+  ## @param sidekiq.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the Sidekiq pods
   ##
   extraVolumeMounts: []
 
-## @section Volume Permissions parameters
+## @section Traffic Exposure Parameters
 
-## Init containers parameters:
-## volumePermissions: Change the owner and group of the persistent volume mountpoint to runAsUser:fsGroup
-## values from the securityContext section.
+## Discourse service parameters
 ##
-volumePermissions:
-  ## @param volumePermissions.enabled Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work)
+service:
+  ## @param service.type Discourse service type
   ##
-  enabled: false
-  ## Init containers' resource requests and limits
-  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param volumePermissions.resources.limits The resources limits for the init container
-  ## @param volumePermissions.resources.requests The requested resources for the init container
+  type: ClusterIP
+  ## @param service.ports.http Discourse service HTTP port
   ##
-  resources:
-    ## Example:
-    ## limits:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    requests: {}
+  ports:
+    http: 80
+  ## Node ports to expose
+  ## @param service.nodePorts.http Node port for HTTP
+  ## NOTE: choose port between <30000-32767>
+  ##
+  nodePorts:
+    http: ""
+  ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
+  ## Values: ClientIP or None
+  ## ref: https://kubernetes.io/docs/user-guide/services/
+  ##
+  sessionAffinity: None
+  ## @param service.clusterIP Discourse service Cluster IP
+  ## e.g.:
+  ## clusterIP: None
+  ##
+  clusterIP: ""
+  ## @param service.loadBalancerIP Discourse service Load Balancer IP
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+  ##
+  loadBalancerIP: ""
+  ## @param service.loadBalancerSourceRanges Discourse service Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## @param service.externalTrafficPolicy Discourse service external traffic policy
+  ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+  ## @param service.annotations Additional custom annotations for Discourse service
+  ##
+  annotations: {}
+  ## @param service.extraPorts Extra port to expose on Discourse service
+  ##
+  extraPorts: []
 
-## @section Ingress parameters
-
-## Ingress parameters
+## Discourse ingress parameters
+## ref: https://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
-  ## @param ingress.enabled Enable ingress controller resource
+  ## @param ingress.enabled Enable ingress record generation for Discourse
   ##
   enabled: false
-  ## DEPRECATED: Use ingress.annotations instead of ingress.certManager
-  ## certManager: false
+  ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
   ##
-
-  ## @param ingress.hostname Default host for the ingress resource
-  ##
-  hostname: discourse.local
-  ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
-  ##
-  apiVersion: ""
-  ## @param ingress.path Ingress path
-  ##
-  path: /
+  ingressClassName: ""
   ## @param ingress.pathType Ingress path type
   ##
   pathType: ImplementationSpecific
-  ## @param ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
+  ##
+  apiVersion: ""
+  ## @param ingress.hostname Default host for the ingress record
+  ##
+  hostname: discourse.local
+  ## @param ingress.path Default path for the ingress record
+  ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
+  ##
+  path: /
+  ## @param ingress.annotations [object] Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
   ## Use this parameter to set the required annotations for cert-manager, see
   ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
-  ##
   ## e.g:
   ## annotations:
   ##   kubernetes.io/ingress.class: nginx
   ##   cert-manager.io/cluster-issuer: cluster-issuer-name
   ##
   annotations: {}
-  ## @param ingress.tls Enable TLS configuration for the hostname defined at ingress.hostname parameter
-  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
-  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
+  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting the corresponding annotations
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
   ##
   tls: false
-  ## @param ingress.extraHosts The list of additional hostnames to be covered with this ingress record.
-  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+  ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+  ##
+  selfSigned: false
+  ## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
+  ## e.g:
   ## extraHosts:
-  ## - name: discourse.local
-  ##   path: /
+  ##   - name: discourse.local
+  ##     path: /
+  ##
   extraHosts: []
-  ## @param ingress.extraTls The tls configuration for additional hostnames to be covered with this ingress record.
-  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## @param ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  ## e.g:
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## e.g:
   ## extraTls:
   ## - hosts:
   ##     - discourse.local
   ##   secretName: discourse.local-tls
+  ##
   extraTls: []
-  ## @param ingress.secrets If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
-  ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
+  ## @param ingress.secrets Custom TLS certificates as secrets
+  ## NOTE: 'key' and 'certificate' are expected in PEM format
+  ## NOTE: 'name' should line up with a 'secretName' set further up
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
   ## It is also possible to create and manage the certificates outside of this helm chart
   ## Please see README.md for more information
-  ## Example:
-  ## - name: discourse.local-tls
-  ##   key:
-  ##   certificate:
+  ## e.g:
+  ## secrets:
+  ##   - name: discourse.local-tls
+  ##     key: |-
+  ##       -----BEGIN RSA PRIVATE KEY-----
+  ##       ...
+  ##       -----END RSA PRIVATE KEY-----
+  ##     certificate: |-
+  ##       -----BEGIN CERTIFICATE-----
+  ##       ...
+  ##       -----END CERTIFICATE-----
+  ##
   secrets: []
 
-## @section Database parameters
+## @section Volume Permissions parameters
 
-## PostgreSQL chart configuration
-## https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+## Init containers parameters:
+## volumePermissions: Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each node
 ##
-postgresql:
-  ## @param postgresql.enabled Deploy PostgreSQL container(s)
+volumePermissions:
+  ## @param volumePermissions.enabled Enable init container that changes the owner and group of the persistent volume
   ##
-  enabled: true
-  ## @param postgresql.postgresqlUsername PostgreSQL user to create (used by Discourse). Has superuser privileges if username is `postgres`.
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
+  enabled: false
+  ## @param volumePermissions.image.registry Init container volume-permissions image registry
+  ## @param volumePermissions.image.repository Init container volume-permissions image repository
+  ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+  ## @param volumePermissions.image.pullSecrets Init container volume-permissions image pull secrets
   ##
-  postgresqlUsername: bn_discourse
-  ## @param postgresql.postgresqlPassword PostgreSQL password
-  ## Defaults to a random 10-character alphanumeric string if not set
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
+  image:
+    registry: docker.io
+    repository: bitnami/bitnami-shell
+    tag: 10-debian-10-r312
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## Example:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+  ## Init container resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param volumePermissions.resources.limits Init container volume-permissions resource limits
+  ## @param volumePermissions.resources.requests Init container volume-permissions resource requests
   ##
-  postgresqlPassword: ""
-  ## @param postgresql.postgresqlPostgresPassword PostgreSQL admin password (used when `postgresqlUsername` is not `postgres`)
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-user-on-first-run (see note!)
+  resources:
+    limits: {}
+    requests: {}
+  ## Init container' Security Context
+  ## Note: the chown of the data folder is done to containerSecurityContext.runAsUser
+  ## and not the below volumePermissions.containerSecurityContext.runAsUser
+  ## @param volumePermissions.containerSecurityContext.runAsUser User ID for the init container
   ##
-  postgresqlPostgresPassword: 'bitnami'
-  ## @param postgresql.existingSecret Name of existing secret object
-  ## The secret should contain the following keys:
-  ## postgresql-postgres-password (for root user)
-  ## postgresql-password (for the unprivileged user)
-  ##
-  existingSecret: ""
-  ## @param postgresql.postgresqlDatabase Name of the database to create
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run
-  ##
-  postgresqlDatabase: bitnami_application
-  ## @param postgresql.persistence.enabled Enable database persistence using PVC
-  ##
-  persistence:
-    enabled: true
-## External database configuration
-##
-externalDatabase:
-  ## @param externalDatabase.host Host of the external database
-  ##
-  host: ""
-  ## @param externalDatabase.port Database port number (when using an external db)
-  ##
-  port: 5432
-  ## @param externalDatabase.user Non-root PostgreSQL username (when using an external db)
-  ##
-  user: bn_discourse
-  ## @param externalDatabase.password Password for the above username (when using an external db)
-  ##
-  password: ""
-  ## @param externalDatabase.create PostgreSQL create user/database
-  ## If true it will add POSTGRESQL_CLIENT_* env vars to the deployment which will create the PostgreSQL user & database using the provided admin credentials
-  ##
-  create: true
-  ## @param externalDatabase.postgresqlPostgresUser PostgreSQL admin user, used during the installation stage (when using an external db)
-  ##
-  postgresqlPostgresUser: ""
-  ## @param externalDatabase.postgresqlPostgresPassword PostgreSQL admin password used in the installation stage (when using an external db)
-  ##
-  postgresqlPostgresPassword: ""
-  ## @param externalDatabase.existingSecret Name of existing secret object
-  ## The secret should contain the following keys:
-  ## postgresql-postgres-password (for root user)
-  ## postgresql-password (for the unprivileged user)
-  ##
-  existingSecret: ""
-  ## @param externalDatabase.database Name of the existing database (when using an external db)
-  ##
-  database: bitnami_application
+  containerSecurityContext:
+    runAsUser: 0
 
-## @section Redis&trade; parameters
+## @section Other Parameters
 
-## Redis&trade; chart configuration
-## https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
+## Service account for Discourse pods to use.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 ##
-redis:
-  ## @param redis.enabled Whether to deploy a redis server to satisfy the applications requirements. To use an external redis instance set this to false and configure the externalRedis parameters
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Discourse pods
   ##
-  enabled: true
-  ## Use password authentication
-  ## @param redis.auth.enabled Use password authentication
-  ## @param redis.auth.password Redis&trade; password (both master and replica)
-  ## @param redis.auth.existingSecret Name of an existing Kubernetes secret object containing the password
-  ## @param redis.auth.existingSecretPasswordKey Name of the key pointing to the password in your Kubernetes secret
+  create: false
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
   ##
-  auth:
-    enabled: false
-    ## Defaults to a random 10-character alphanumeric string if not set and auth.enabled is true.
-    ## It should always be set using the password value or in the existingSecret to avoid issues
-    ## with Discourse.
-    ## The password value is ignored if existingSecret is set
-    password: ""
-    existingSecret: ""
-    existingSecretPasswordKey: 'redis-password'
-  ## @param redis.architecture Cluster settings
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
   ##
-  architecture: standalone
-  ## Redis&trade; Master parameters
-  ## @param redis.master.persistence.enabled Enable database persistence using PVC
+  automountServiceAccountToken: true
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
   ##
-  master:
-    persistence:
-      enabled: true
-## External Redis&trade;
-## @param externalRedis.host Host of the external database
-## @param externalRedis.port Database port number
-## @param externalRedis.password Password for the external Redis. Ignored if existingSecret is set
-## @param externalRedis.existingSecret Name of an existing Kubernetes secret object containing the password
-## @param externalRedis.existingSecretPasswordKey Name of the key pointing to the password in your Kubernetes secret
-##
-externalRedis:
-  host: ""
-  port: 6379
-  password: ""
-  existingSecret: ""
-  existingSecretPasswordKey: 'redis-password'
+  annotations: {}
 
 ## @section NetworkPolicy parameters
 
@@ -783,3 +761,94 @@ networkPolicy:
     ##             label: example
     ##
     customRules: {}
+
+## @section Discourse database parameters
+
+## PostgreSQL chart configuration
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+## @param postgresql.enabled Switch to enable or disable the PostgreSQL helm chart
+## @param postgresql.auth.enablePostgresUser Assign a password to the "postgres" admin user. Otherwise, remote access will be blocked for this user
+## @param postgresql.auth.postgresPassword Password for the "postgres" admin user
+## @param postgresql.auth.username Name for a custom user to create
+## @param postgresql.auth.password Password for the custom user to create
+## @param postgresql.auth.database Name for a custom database to create
+## @param postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials
+## @param postgresql.architecture PostgreSQL architecture (`standalone` or `replication`)
+##
+postgresql:
+  enabled: true
+  auth:
+    enablePostgresUser: true
+    postgresPassword: bitnami
+    username: bn_discourse
+    password: ""
+    database: bitnami_application
+    existingSecret: ""
+  architecture: standalone
+## External PostgreSQL configuration
+## All of these values are only used when postgresql.enabled is set to false
+## @param externalDatabase.host Database host
+## @param externalDatabase.port Database port number
+## @param externalDatabase.user Non-root username for Discourse
+## @param externalDatabase.password Password for the non-root username for Discourse
+## @param externalDatabase.database Discourse database name
+## @param externalDatabase.create Switch to enable user/database creation during the installation stage
+## @param externalDatabase.postgresUser PostgreSQL admin user, used during the installation stage
+## @param externalDatabase.postgresPassword PostgreSQL admin password, used during the installation stage
+## @param externalDatabase.existingSecret Name of an existing secret resource containing the database credentials
+## @param externalDatabase.existingSecretPasswordKey Name of an existing secret key containing the database credentials
+## @param externalDatabase.existingSecretPostgresPasswordKey Name of an existing secret key containing the database admin user credentials
+##
+externalDatabase:
+  host: localhost
+  port: 5432
+  user: bn_discourse
+  database: bitnami_application
+  password: ""
+  create: true
+  postgresUser: ""
+  postgresPassword: ""
+  existingSecret: ""
+  existingSecretPasswordKey: "password"
+  existingSecretPostgresPasswordKey: "postgres-password"
+
+## @section Redis&trade; parameters
+
+## Redis&trade; chart configuration
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
+## @param redis.enabled Switch to enable or disable the Redis&trade; helm
+## @param redis.auth.enabled Enable password authentication
+## @param redis.auth.password Redis&trade; password
+## @param redis.auth.existingSecret The name of an existing secret with Redis&trade; credentials
+## @param redis.architecture Redis&trade; architecture. Allowed values: `standalone` or `replication`
+##
+redis:
+  enabled: true
+  auth:
+    enabled: true
+    ## Redis&trade; password (both master and slave). Defaults to a random 10-character alphanumeric string if not set and auth.enabled is true.
+    ## It should always be set using the password value or in the existingSecret to avoid issues
+    ## with Discourse.
+    ## The password value is ignored if existingSecret is set
+    password: ""
+    existingSecret: ""
+  architecture: standalone
+
+## External Redis&trade; configuration
+## All of these values are only used when redis.enabled is set to false
+## @param externalRedis.host Redis&trade; host
+## @param externalRedis.port Redis&trade; port number
+## @param externalRedis.username Redis&trade; username
+## @param externalRedis.password Redis&trade; password
+## @param externalRedis.existingSecret Name of an existing secret resource containing the Redis&trade credentials
+## @param externalRedis.existingSecretPasswordKey Name of an existing secret key containing the Redis&trade credentials
+##
+externalRedis:
+  host: localhost
+  port: 6379
+  ## Most Redis&trade; implementations do not require a username
+  ## to authenticate and it should be enough with the password
+  username: ""
+  password: ""
+  existingSecret: ""
+  existingSecretPasswordKey: "redis-password"


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR standardizes the `bitnami/discourse` chart to be in line with the rest of the catalog.

**Benefits**

Standardization.

**Possible drawbacks**

Changes the values structure forcing a major bump, check the README.md for more information.

**Applicable issues**

N/A

**Additional information**

Triggered after https://github.com/bitnami/charts/pull/8827 (major bump in PostgreSQL)

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])