### PR TITLE
[bitnami/postgresql] Fix init scripts cm reference

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 11.0.3
+version: 11.0.4

--- a/bitnami/postgresql/templates/_helpers.tpl
+++ b/bitnami/postgresql/templates/_helpers.tpl
@@ -199,7 +199,7 @@ Get the initialization scripts ConfigMap name.
 {{- if .Values.primary.initdb.scriptsConfigMap -}}
     {{- printf "%s" (tpl .Values.primary.initdb.scriptsConfigMap $) -}}
 {{- else -}}
-    {{- printf "%s-init-scripts" (include "common.names.fullname" .) -}}
+    {{- printf "%s-init-scripts" (include "postgresql.primary.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

The referenced init-scripts ConfigMap name isn't correct when using "replication" architecture. This PR address this bug.
 
**Benefits**

Users can actually consume custom init scripts.

**Possible drawbacks**

None

**Applicable issues**

  - fixes #8997

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)