### PR TITLE
[bitnami/grafana-operator] Include nodeSelector parameter

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 2.2.3
+version: 2.2.4

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -117,7 +117,7 @@ spec:
       nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.grafana.nodeAffinityPreset.type "key" .Values.grafana.nodeAffinityPreset.key "values" .Values.grafana.nodeAffinityPreset.values) | nindent 8 }}
       {{- end }}
     {{- end }}
-    {{- if .Values.grafana.updateStrategy }}
+    {{- if .Values.grafana.nodeSelector }}
     nodeSelector: {{ toYaml .Values.grafana.nodeSelector | nindent 6 }}
     {{- end }}
     {{- if .Values.grafana.updateStrategy }}

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -118,6 +118,9 @@ spec:
       {{- end }}
     {{- end }}
     {{- if .Values.grafana.updateStrategy }}
+    nodeSelector: {{ toYaml .Values.grafana.nodeSelector | nindent 6 }}
+    {{- end }}
+    {{- if .Values.grafana.updateStrategy }}
     strategy: {{ toYaml .Values.grafana.updateStrategy | nindent 6 }}
     {{- end }}
     {{- if .Values.grafana.extraVolumeMounts }}


### PR DESCRIPTION
First time doing a PR to this project - hopefully I did it right?

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Adds a nodeSelector parameter to the grafana CRD

**Benefits**

Unlocks the possibility to contain grafana-deployment pods in certain nodepools.

**Possible drawbacks**

N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #8987 (https://github.com/bitnami/charts/issues/8987)

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)