### PR TITLE
[bitnami/postgresql] Allow enabling TLS without volume-permissions

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 11.0.4
+version: 11.0.5

--- a/bitnami/postgresql/templates/_helpers.tpl
+++ b/bitnami/postgresql/templates/_helpers.tpl
@@ -226,7 +226,6 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := list -}}
 {{- $messages := append $messages (include "postgresql.validateValues.ldapConfigurationMethod" .) -}}
 {{- $messages := append $messages (include "postgresql.validateValues.psp" .) -}}
-{{- $messages := append $messages (include "postgresql.validateValues.tls" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -255,17 +254,6 @@ Validate values of Postgresql - If PSP is enabled RBAC should be enabled too
 postgresql: psp.create, rbac.create
     RBAC should be enabled if PSP is enabled in order for PSP to work.
     More info at https://kubernetes.io/docs/concepts/policy/pod-security-policy/#authorizing-policies
-{{- end -}}
-{{- end -}}
-
-{{/*
-Validate values of Postgresql TLS - When TLS is enabled, so must be VolumePermissions
-*/}}
-{{- define "postgresql.validateValues.tls" -}}
-{{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
-postgresql: tls.enabled, volumePermissions.enabled
-    When TLS is enabled you must enable volumePermissions as well to ensure certificates files have
-    the right permissions.
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -87,9 +87,30 @@ spec:
       {{- if .Values.primary.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.primary.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
-      {{- if or .Values.primary.initContainers (and .Values.volumePermissions.enabled (or .Values.primary.persistence.enabled .Values.shmVolume.enabled)) }}
       initContainers:
-        {{- if and .Values.volumePermissions.enabled (or .Values.primary.persistence.enabled .Values.shmVolume.enabled .Values.tls.enabled) }}
+      {{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
+        - name: copy-certs
+          image: {{ include "postgresql.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          {{- if .Values.primary.resources }}
+          resources: {{- toYaml .Values.primary.resources | nindent 12 }}
+          {{- end }}
+          # We don't require a privileged container in this case
+          {{- if .Values.primary.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.primary.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              cp /tmp/certs/* /opt/bitnami/postgresql/certs/
+              chmod 600 {{ include "postgresql.tlsCertKey" . }}
+          volumeMounts:
+            - name: raw-certificates
+              mountPath: /tmp/certs
+            - name: postgresql-certificates
+              mountPath: /opt/bitnami/postgresql/certs
+        {{- else if and .Values.volumePermissions.enabled (or .Values.primary.persistence.enabled .Values.shmVolume.enabled .Values.tls.enabled) }}
         - name: init-chmod-data
           image: {{ include "postgresql.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
@@ -98,7 +119,7 @@ spec:
           {{- end }}
           command:
             - /bin/sh
-            - -cx
+            - -ec
             - |
               {{- if .Values.primary.persistence.enabled }}
               {{- if eq ( toString ( .Values.volumePermissions.containerSecurityContext.runAsUser )) "auto" }}
@@ -154,7 +175,6 @@ spec:
         {{- if .Values.primary.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.primary.initContainers "context" $ ) | nindent 8 }}
         {{- end }}
-      {{- end }}
       containers:
         - name: postgresql
           image: {{ include "postgresql.image" . }}

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -88,7 +88,7 @@ spec:
       securityContext: {{- omit .Values.primary.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       initContainers:
-      {{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
+        {{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
         - name: copy-certs
           image: {{ include "postgresql.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
@@ -110,7 +110,7 @@ spec:
               mountPath: /tmp/certs
             - name: postgresql-certificates
               mountPath: /opt/bitnami/postgresql/certs
-        {{- else if and .Values.volumePermissions.enabled (or .Values.primary.persistence.enabled .Values.shmVolume.enabled .Values.tls.enabled) }}
+        {{- else if and .Values.volumePermissions.enabled (or .Values.primary.persistence.enabled .Values.shmVolume.enabled) }}
         - name: init-chmod-data
           image: {{ include "postgresql.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -82,9 +82,30 @@ spec:
       {{- if .Values.readReplicas.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.readReplicas.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
-      {{- if or .Values.readReplicas.initContainers (and .Values.volumePermissions.enabled (or .Values.readReplicas.persistence.enabled .Values.shmVolume.enabled)) }}
       initContainers:
-        {{- if and .Values.volumePermissions.enabled (or .Values.readReplicas.persistence.enabled .Values.shmVolume.enabled .Values.tls.enabled) }}
+        {{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
+        - name: copy-certs
+          image: {{ include "postgresql.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          {{- if .Values.readReplicas.resources }}
+          resources: {{- toYaml .Values.readReplicas.resources | nindent 12 }}
+          {{- end }}
+          # We don't require a privileged container in this case
+          {{- if .Values.readReplicas.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.readReplicas.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              cp /tmp/certs/* /opt/bitnami/postgresql/certs/
+              chmod 600 {{ include "postgresql.tlsCertKey" . }}
+          volumeMounts:
+            - name: raw-certificates
+              mountPath: /tmp/certs
+            - name: postgresql-certificates
+              mountPath: /opt/bitnami/postgresql/certs
+        {{- else if and .Values.volumePermissions.enabled (or .Values.readReplicas.persistence.enabled .Values.shmVolume.enabled) }}
         - name: init-chmod-data
           image: {{ include "postgresql.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
@@ -93,7 +114,7 @@ spec:
           {{- end }}
           command:
             - /bin/sh
-            - -cx
+            - -ec
             - |
               {{- if .Values.readReplicas.persistence.enabled }}
               {{- if eq ( toString ( .Values.volumePermissions.containerSecurityContext.runAsUser )) "auto" }}
@@ -149,7 +170,6 @@ spec:
         {{- if .Values.readReplicas.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.readReplicas.initContainers "context" $ ) | nindent 8 }}
         {{- end }}
-      {{- end }}
       containers:
         - name: postgresql
           image: {{ include "postgresql.image" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

It shouldn't be necessary to run a "root" container to adapt volume permissions to enable TLS. This PR address that.

**Benefits**

TLS without using a "root" container.

**Possible drawbacks**

None

**Applicable issues**

  - fixes #8990

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)