### PR TITLE
[bitnami/redis-cluster] Fix namespace issue with externalAccess

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 7.2.2
+version: 7.2.3

--- a/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml
+++ b/bitnami/redis-cluster/templates/svc-cluster-external-access.yaml
@@ -12,7 +12,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" $ }}-{{ $i }}-svc
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     pod: {{ $targetPod }}
     {{- if $root.Values.commonLabels }}


### PR DESCRIPTION
**Description of the change**

As reported at https://github.com/bitnami/charts/issues/8917#issuecomment-1039677569, this PR https://github.com/bitnami/charts/pull/8821 introduced a bug when using `externalAccess.enabled=true`.

The issue was caused because of the `.Release.namespace` being used inside a `range` loop.

**Benefits**

Fixes issue with manifest when using `externalAccess`.

**Possible drawbacks**

None known

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)