### PR TITLE
[bitnami/contour] Support Gateway API v1alpha2 resources and API groups

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 7.3.5
+version: 7.3.6

--- a/bitnami/contour/templates/contour/rbac.yaml
+++ b/bitnami/contour/templates/contour/rbac.yaml
@@ -78,6 +78,7 @@ rules:
       - update
   - apiGroups:
       - networking.x-k8s.io
+      - gateway.networking.k8s.io
     resources:
       - gatewayclasses
       - gateways
@@ -85,12 +86,14 @@ rules:
       - tcproutes
       - tlsroutes
       - udproutes
+      - referencepolicies
     verbs:
       - get
       - list
       - watch
   - apiGroups:
       - networking.x-k8s.io
+      - gateway.networking.k8s.io
     resources:
       - gatewayclasses/status
       - gateways/status


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This change adds support for [Kubernetes Gateway API v1alpha2](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/). This API version migrates to a new API group (`gateway.networking.k8s.io`), and from `BackendPolicy` to `ReferencePolicy`.

**Benefits**

Users of this chart will be able to use the new version of the Gateway API, as supported by Contour v1.20.0.

**Possible drawbacks**

The resource name change coupled with how we phrase this rule means that we support both resource name for both API groups. I'd be happy to change this to be more explicit, this just seemed cleaner and more concise.

**Applicable issues**

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)