### PR TITLE
[bitnami/*] test: :children_crossing: Improve "Early Feedback" list of changed files

### DIFF
--- a/.github/workflows/vib-early-feedback.yaml
+++ b/.github/workflows/vib-early-feedback.yaml
@@ -30,7 +30,7 @@ jobs:
           # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
           # and jitterbit/get-changed-files does not support pull_request_target
           URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
-          files_changed="$(curl -s -X GET -G "$URL" | jq -r '.[] | .filename')"
+          files_changed="$(curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -G "$URL" | jq -r '.[] | .filename')"
           # Adding || true to avoid "Process exited with code 1" errors
           charts_dirs_changed="$(echo "$files_changed" | xargs dirname | grep -o "bitnami/[^/]*" | sort | uniq || true)"
           # Using grep -c as a better alternative to wc -l when dealing with empty strings."

--- a/.github/workflows/vib-early-feedback.yaml
+++ b/.github/workflows/vib-early-feedback.yaml
@@ -27,7 +27,10 @@ jobs:
       - id: get-chart
         name: 'Get modified charts'
         run: |
-          files_changed="$(git diff --name-only origin/master HEAD)"
+          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
+          # and jitterbit/get-changed-files does not support pull_request_target
+          URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
+          files_changed="$(curl -s -X GET -G "$URL" | jq -r '.[] | .filename')"
           # Adding || true to avoid "Process exited with code 1" errors
           charts_dirs_changed="$(echo "$files_changed" | xargs dirname | grep -o "bitnami/[^/]*" | sort | uniq || true)"
           # Using grep -c as a better alternative to wc -l when dealing with empty strings."


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Currently, the Github action was obtaining the list of files by executing

```
git diff origin/master HEAD
```

However, this was causing issues with branches that had commits behind master, as the list of changed files was included changes done by other commits. This PR changes the action so it uses the Github API to obtain the list of changed files.

We considered other options like jitterbit/get-changed-files but this does not support pull_request_target actions. We also checked `git merge-base` but it was unable to find the fork-point as soon as the branch had commits behind master.

It was tested successfully in this PR: https://github.com/javsalgar/charts-1/pull/10. In it, we can see commits behind master (one change in pytorch).

```
❯ git diff origin/master  --name-only
bitnami/pytorch/Chart.yaml
bitnami/wordpress/Chart.yaml
bitnami/wordpress/templates/pvc.yaml
bitnami/wordpress/templates/svc.yaml
bitnami/wordpress/templates/tls-secrets.yaml
```

It is not detecting the pytorch change, which is the expected behavior.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->
- Improve in UX

**Possible drawbacks**

- Unlikely API rate limits assuming that we had more than 5000 action triggers in an hour.
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [ ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)