### PR TITLE
bitnami/kubeapps Improved handling of packaging options for Kubeapps

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami
     version: 15.x.x
-    condition: redis.enabled
+    condition: packaging.flux.enabled
 description: Kubeapps is a web-based UI for launching and managing applications on Kubernetes. It allows users to deploy trusted applications and operators to control users access to the cluster.
 home: https://kubeapps.com
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/main/docs/img/logo.png
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.8.0
+version: 7.8.1

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -102,13 +102,22 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `ingress.secrets`     | Custom TLS certificates as secrets                                                                                               | `[]`                     |
 
 
+### Kubeapps packaging options
+
+| Name                       | Description                                                | Value   |
+| -------------------------- | ---------------------------------------------------------- | ------- |
+| `packaging.helm.enabled`   | Enable the standard Helm packaging.                        | `true`  |
+| `packaging.carvel.enabled` | Enable support for the Carvel (kapp-controller) packaging. | `false` |
+| `packaging.flux.enabled`   | Enable support for Flux (v2) packaging.                    | `false` |
+
+
 ### Frontend parameters
 
 | Name                                             | Description                                                                               | Value                  |
 | ------------------------------------------------ | ----------------------------------------------------------------------------------------- | ---------------------- |
 | `frontend.image.registry`                        | NGINX image registry                                                                      | `docker.io`            |
 | `frontend.image.repository`                      | NGINX image repository                                                                    | `bitnami/nginx`        |
-| `frontend.image.tag`                             | NGINX image tag (immutable tags are recommended)                                          | `1.21.6-debian-10-r13` |
+| `frontend.image.tag`                             | NGINX image tag (immutable tags are recommended)                                          | `1.21.6-debian-10-r21` |
 | `frontend.image.pullPolicy`                      | NGINX image pull policy                                                                   | `IfNotPresent`         |
 | `frontend.image.pullSecrets`                     | NGINX image pull secrets                                                                  | `[]`                   |
 | `frontend.image.debug`                           | Enable image debug mode                                                                   | `false`                |
@@ -176,7 +185,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | ------------------------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------- |
 | `dashboard.image.registry`                        | Dashboard image registry                                                                     | `docker.io`                  |
 | `dashboard.image.repository`                      | Dashboard image repository                                                                   | `bitnami/kubeapps-dashboard` |
-| `dashboard.image.tag`                             | Dashboard image tag (immutable tags are recommended)                                         | `2.4.2-debian-10-r66`        |
+| `dashboard.image.tag`                             | Dashboard image tag (immutable tags are recommended)                                         | `2.4.3-debian-10-r0`         |
 | `dashboard.image.pullPolicy`                      | Dashboard image pull policy                                                                  | `IfNotPresent`               |
 | `dashboard.image.pullSecrets`                     | Dashboard image pull secrets                                                                 | `[]`                         |
 | `dashboard.image.debug`                           | Enable image debug mode                                                                      | `false`                      |
@@ -242,12 +251,12 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | ----------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------- |
 | `apprepository.image.registry`                        | Kubeapps AppRepository Controller image registry                                          | `docker.io`                                 |
 | `apprepository.image.repository`                      | Kubeapps AppRepository Controller image repository                                        | `bitnami/kubeapps-apprepository-controller` |
-| `apprepository.image.tag`                             | Kubeapps AppRepository Controller image tag (immutable tags are recommended)              | `2.4.2-scratch-r1`                          |
+| `apprepository.image.tag`                             | Kubeapps AppRepository Controller image tag (immutable tags are recommended)              | `2.4.3-scratch-r1`                          |
 | `apprepository.image.pullPolicy`                      | Kubeapps AppRepository Controller image pull policy                                       | `IfNotPresent`                              |
 | `apprepository.image.pullSecrets`                     | Kubeapps AppRepository Controller image pull secrets                                      | `[]`                                        |
 | `apprepository.syncImage.registry`                    | Kubeapps Asset Syncer image registry                                                      | `docker.io`                                 |
 | `apprepository.syncImage.repository`                  | Kubeapps Asset Syncer image repository                                                    | `bitnami/kubeapps-asset-syncer`             |
-| `apprepository.syncImage.tag`                         | Kubeapps Asset Syncer image tag (immutable tags are recommended)                          | `2.4.2-scratch-r1`                          |
+| `apprepository.syncImage.tag`                         | Kubeapps Asset Syncer image tag (immutable tags are recommended)                          | `2.4.3-scratch-r1`                          |
 | `apprepository.syncImage.pullPolicy`                  | Kubeapps Asset Syncer image pull policy                                                   | `IfNotPresent`                              |
 | `apprepository.syncImage.pullSecrets`                 | Kubeapps Asset Syncer image pull secrets                                                  | `[]`                                        |
 | `apprepository.globalReposNamespaceSuffix`            | Suffix for the namespace of global repos. Defaults to empty for backwards compatibility.  | `""`                                        |
@@ -292,7 +301,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `kubeops.enabled`                               | Specifies whether this component should be installed.                                     | `true`                     |
 | `kubeops.image.registry`                        | Kubeops image registry                                                                    | `docker.io`                |
 | `kubeops.image.repository`                      | Kubeops image repository                                                                  | `bitnami/kubeapps-kubeops` |
-| `kubeops.image.tag`                             | Kubeops image tag (immutable tags are recommended)                                        | `2.4.2-scratch-r1`         |
+| `kubeops.image.tag`                             | Kubeops image tag (immutable tags are recommended)                                        | `2.4.3-scratch-r1`         |
 | `kubeops.image.pullPolicy`                      | Kubeops image pull policy                                                                 | `IfNotPresent`             |
 | `kubeops.image.pullSecrets`                     | Kubeops image pull secrets                                                                | `[]`                       |
 | `kubeops.namespaceHeaderName`                   | Additional header name for trusted namespaces                                             | `""`                       |
@@ -352,7 +361,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `assetsvc.enabled`                               | Specifies whether this deprecated component should be installed.                          | `false`                     |
 | `assetsvc.image.registry`                        | Kubeapps Assetsvc image registry                                                          | `docker.io`                 |
 | `assetsvc.image.repository`                      | Kubeapps Assetsvc image repository                                                        | `bitnami/kubeapps-assetsvc` |
-| `assetsvc.image.tag`                             | Kubeapps Assetsvc image tag (immutable tags are recommended)                              | `2.4.2-scratch-r1`          |
+| `assetsvc.image.tag`                             | Kubeapps Assetsvc image tag (immutable tags are recommended)                              | `2.4.3-scratch-r1`          |
 | `assetsvc.image.pullPolicy`                      | Kubeapps Assetsvc image pull policy                                                       | `IfNotPresent`              |
 | `assetsvc.image.pullSecrets`                     | Kubeapps Assetsvc image pull secrets                                                      | `[]`                        |
 | `assetsvc.replicaCount`                          | Number of Assetsvc replicas to deploy                                                     | `1`                         |
@@ -407,7 +416,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `authProxy.enabled`                               | Specifies whether Kubeapps should configure OAuth login/logout                | `false`                |
 | `authProxy.image.registry`                        | OAuth2 Proxy image registry                                                   | `docker.io`            |
 | `authProxy.image.repository`                      | OAuth2 Proxy image repository                                                 | `bitnami/oauth2-proxy` |
-| `authProxy.image.tag`                             | OAuth2 Proxy image tag (immutable tags are recommended)                       | `7.2.1-debian-10-r49`  |
+| `authProxy.image.tag`                             | OAuth2 Proxy image tag (immutable tags are recommended)                       | `7.2.1-debian-10-r56`  |
 | `authProxy.image.pullPolicy`                      | OAuth2 Proxy image pull policy                                                | `IfNotPresent`         |
 | `authProxy.image.pullSecrets`                     | OAuth2 Proxy image pull secrets                                               | `[]`                   |
 | `authProxy.external`                              | Use an external Auth Proxy instead of deploying its own one                   | `false`                |
@@ -440,7 +449,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `pinnipedProxy.enabled`                               | Specifies whether Kubeapps should configure Pinniped Proxy               | `false`                           |
 | `pinnipedProxy.image.registry`                        | Pinniped Proxy image registry                                            | `docker.io`                       |
 | `pinnipedProxy.image.repository`                      | Pinniped Proxy image repository                                          | `bitnami/kubeapps-pinniped-proxy` |
-| `pinnipedProxy.image.tag`                             | Pinniped Proxy image tag (immutable tags are recommended)                | `2.4.2-debian-10-r69`             |
+| `pinnipedProxy.image.tag`                             | Pinniped Proxy image tag (immutable tags are recommended)                | `2.4.3-debian-10-r4`              |
 | `pinnipedProxy.image.pullPolicy`                      | Pinniped Proxy image pull policy                                         | `IfNotPresent`                    |
 | `pinnipedProxy.image.pullSecrets`                     | Pinniped Proxy image pull secrets                                        | `[]`                              |
 | `pinnipedProxy.defaultPinnipedNamespace`              | Specify the (default) namespace in which pinniped concierge is installed | `pinniped-concierge`              |
@@ -467,7 +476,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `rbac.create`             | Specifies whether RBAC resources should be created                            | `true`                 |
 | `testImage.registry`      | NGINX image registry                                                          | `docker.io`            |
 | `testImage.repository`    | NGINX image repository                                                        | `bitnami/nginx`        |
-| `testImage.tag`           | NGINX image tag (immutable tags are recommended)                              | `1.21.6-debian-10-r13` |
+| `testImage.tag`           | NGINX image tag (immutable tags are recommended)                              | `1.21.6-debian-10-r21` |
 | `testImage.pullPolicy`    | NGINX image pull policy                                                       | `IfNotPresent`         |
 | `testImage.pullSecrets`   | NGINX image pull secrets                                                      | `[]`                   |
 
@@ -492,7 +501,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 
 | Name                                                                                            | Description                                                                               | Value                   |
 | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------- |
-| `kubeappsapis.enabledPlugins`                                                                   | Enabled plugins for the Kubeapps-APIs service                                             | `["helm","resources"]`  |
+| `kubeappsapis.enabledPlugins`                                                                   | Manually override which plugins are enabled for the Kubeapps-APIs service                 | `nil`                   |
 | `kubeappsapis.pluginConfig.core.packages.v1alpha1.versionsInSummary.major`                      | Number of major versions to display in the summary                                        | `3`                     |
 | `kubeappsapis.pluginConfig.core.packages.v1alpha1.versionsInSummary.minor`                      | Number of minor versions to display in the summary                                        | `3`                     |
 | `kubeappsapis.pluginConfig.core.packages.v1alpha1.versionsInSummary.patch`                      | Number of patch versions to display in the summary                                        | `3`                     |
@@ -502,7 +511,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `kubeappsapis.pluginConfig.kappController.packages.v1alpha1.defaultAllowDowngrades`             | Default policy for allowing applications to be downgraded to previous versions            | `false`                 |
 | `kubeappsapis.image.registry`                                                                   | Kubeapps-APIs image registry                                                              | `docker.io`             |
 | `kubeappsapis.image.repository`                                                                 | Kubeapps-APIs image repository                                                            | `bitnami/kubeapps-apis` |
-| `kubeappsapis.image.tag`                                                                        | Kubeapps-APIs image tag (immutable tags are recommended)                                  | `2.4.2-debian-10-r68`   |
+| `kubeappsapis.image.tag`                                                                        | Kubeapps-APIs image tag (immutable tags are recommended)                                  | `2.4.3-debian-10-r7`    |
 | `kubeappsapis.image.pullPolicy`                                                                 | Kubeapps-APIs image pull policy                                                           | `IfNotPresent`          |
 | `kubeappsapis.image.pullSecrets`                                                                | Kubeapps-APIs image pull secrets                                                          | `[]`                    |
 | `kubeappsapis.replicaCount`                                                                     | Number of frontend replicas to deploy                                                     | `2`                     |
@@ -558,7 +567,6 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | Name                            | Description                                                        | Value                                                    |
 | ------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------- |
 | `redis.redisPassword`           | Password used in Redis&trade;                                      | `""`                                                     |
-| `redis.enabled`                 | Enable the Redis&trade; deployment when deploying Kubeapps APIs.   | `false`                                                  |
 | `redis.master.extraFlags`       | Array with additional command line flags for Redis&trade; master   | `["--maxmemory 200mb","--maxmemory-policy allkeys-lru"]` |
 | `redis.master.disableCommands`  | Array with commands to deactivate on Redis&trade                   | `[]`                                                     |
 | `redis.replica.replicaCount`    | Number of Redis&trade; replicas to deploy                          | `1`                                                      |

--- a/bitnami/kubeapps/templates/NOTES.txt
+++ b/bitnami/kubeapps/templates/NOTES.txt
@@ -71,7 +71,7 @@ To access Kubeapps from outside your K8s cluster, follow the steps below:
 ##########################################################################################################
 {{- end }}
 
-{{ if and (.Values.redis.enabled) (not .Values.redis.existingSecret) (empty .Values.redis.redisPassword) -}}
+{{ if and (.Values.packaging.flux.enabled) (not .Values.redis.existingSecret) (empty .Values.redis.redisPassword) -}}
 ##########################################################################################################
 ### WARNING: You did not provide a value for the redisPassword so one has been generated randomly      ###
 ##########################################################################################################

--- a/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -68,7 +68,8 @@ spec:
           command:
             - /kubeapps-apis
           args:
-            {{- range .Values.kubeappsapis.enabledPlugins }}
+            {{- $enabledPlugins := include "kubeapps.kubeappsapis.enabledPlugins" . | fromJsonArray }}
+            {{- range $enabledPlugins }}
             - --plugin-dir
             - /plugins/{{ . }}
             {{- end }}
@@ -90,7 +91,7 @@ spec:
             {{- end }}
           env:
             - name: GOGC
-              value: "50" # default is 100. 50 means increasing x2 the frequency of GC 
+              value: "50" # default is 100. 50 means increasing x2 the frequency of GC
             - name: PORT
               value: {{ .Values.kubeappsapis.containerPort | quote }}
             {{- if .Values.redis.enabled }}

--- a/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -94,7 +94,7 @@ spec:
               value: "50" # default is 100. 50 means increasing x2 the frequency of GC
             - name: PORT
               value: {{ .Values.kubeappsapis.containerPort | quote }}
-            {{- if .Values.redis.enabled }}
+            {{- if .Values.packaging.flux.enabled }}
             # REDIS-* vars are required by the plugins for caching functionality
             # TODO (gfichtenolt) this as required by the kubeapps apis service (which will
             # longer-term pass something to the plugins so that the plugins won't need to

--- a/bitnami/kubeapps/templates/kubeappsapis/rbac_fluxv2.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/rbac_fluxv2.yaml
@@ -1,4 +1,4 @@
-{{- if has "fluxv2" .Values.kubeappsapis.enabledPlugins }}
+{{- if .Values.packaging.flux.enabled }}
 {{- if .Values.rbac.create -}}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -136,6 +136,26 @@ ingress:
   ##
   secrets: []
 
+## @section Kubeapps packaging options
+## Note: the helm and flux plugins are mutually exclusive, you can only
+## enable one or the other since they both operate on Helm release objects.
+## Enabling carvel or flux does *not* install the required related Carvel or
+## Flux controllers on your cluster. Please read the documentation for running
+## Kubeapps with Carvel or Flux support.
+packaging:
+  ## Default helm packaging
+  ## @param packaging.helm.enabled Enable the standard Helm packaging.
+  helm:
+    enabled: true
+  ## Carvel packaging
+  ## @param packaging.carvel.enabled Enable support for the Carvel (kapp-controller) packaging.
+  carvel:
+    enabled: false
+  ## Flux (v2) packaging
+  ## @param packaging.flux.enabled Enable support for Flux (v2) packaging.
+  flux:
+    enabled: false
+
 ## @section Frontend parameters
 
 ## Frontend parameters
@@ -1609,16 +1629,15 @@ postgresql:
 
 ## @section kubeappsapis parameters
 kubeappsapis:
-  ## @param kubeappsapis.enabledPlugins Enabled plugins for the Kubeapps-APIs service
-  ## e.g:
-  ## enabledPlugins:
-  ## - helm
-  ## - fluxv2
-  ## - kapp-controller
+  ## @param kubeappsapis.enabledPlugins Manually override which plugins are
+  ## enabled for the Kubeapps-APIs service
+  ##
+  ## NOTE: normally this should remain blank, with the top-level `packaging`
+  ## value automatically determining which plugins should be enabled. Only
+  ## set this value if you want to manually override the list of plugins
+  ## enabled for the service.
   ##
   enabledPlugins:
-    - helm
-    - resources
   pluginConfig:
     core:
       packages:
@@ -1848,18 +1867,12 @@ kubeappsapis:
 ## @section Redis&trade; chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
 ##
+## Redis will be enabled and installed if `packages.flux.enabled` is true.
 redis:
   ## @param redis.redisPassword Password used in Redis&trade;
   ## ref: https://github.com/bitnami/bitnami-docker-redis/blob/master/README.md#setting-the-server-password-on-first-run
   ##
   redisPassword: ""
-  ## @param redis.enabled Enable the Redis&trade; deployment when deploying Kubeapps APIs.
-  ## We currently have the situation that Redis is required for the fluxv2 plugin only.
-  ## Until such a point that we're releasing with the fluxv2 plugin enabled, or the
-  ## plugin cache support has been generalised so all plugins use Redis, we'll need
-  ## to manually enable this in dev while ensuring it is false for releases (as it
-  ## is a conditional dependency in the Chart.yaml).
-  enabled: false
   master:
     ## @param redis.master.extraFlags Array with additional command line flags for Redis&trade; master
     extraFlags:

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1629,8 +1629,7 @@ postgresql:
 
 ## @section kubeappsapis parameters
 kubeappsapis:
-  ## @param kubeappsapis.enabledPlugins Manually override which plugins are
-  ## enabled for the Kubeapps-APIs service
+  ## @param kubeappsapis.enabledPlugins Manually override which plugins are enabled for the Kubeapps-APIs service
   ##
   ## NOTE: normally this should remain blank, with the top-level `packaging`
   ## value automatically determining which plugins should be enabled. Only


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
This change contains the changes landed in our Kubeapps chart at https://github.com/kubeapps/kubeapps/pull/4265 , but without the update to the plugin paths for now.

Adding Antonio and Rafa as reviewers just to ensure we're on the same page about landing this change now.

**Benefits**

<!-- What benefits will be realized by the code change? -->
It gives us a better UX for choosing which packaging system to use with Kubeapps, by allowing the user to choose just the packaging system, while the chart then calculates the required plugins. It also allows the chart to conditionally enable/disable chart dependencies based on the chosen packaging.

Backwards compatible as setting the `kubeappsapis.enabledPlugins` will override (see paste below)
**Possible drawbacks**

I understand the readme-generator-for-helm check failure is known (it doesn't deal with nil values yet), but I'm confused about the ```Error: Detected changes in charts without version bump in Chart.yaml.
Charts changed: 1
bitnami/kubeapps
Version bumps detected: 99```
error, given that I have bumped the patch version of the chart?
<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

Here's the output from testing the change by comparing the output of helm template:

```
# Default plugins are helm and resources:
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 5              
            - /kubeapps-apis
          args:
            - --plugin-dir
            - /plugins/helm
            - --plugin-dir
            - /plugins/resources

# Enabling carvel updates the enabled plugins.
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
diff --git a/docs/user/manifests/kubeapps-local-dev-values.yaml b/docs/user/manifests/kubeapps-local-dev-values.yaml
index 3b7518cc..ff73074b 100644
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -30,3 +30,6 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  carvel:
+    enabled: true
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 7
            - /kubeapps-apis
          args:
            - --plugin-dir
            - /plugins/kapp-controller
            - --plugin-dir
            - /plugins/helm
            - --plugin-dir
            - /plugins/resources

# Enabling flux results in an error as helm is also enabled:
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
diff --git a/docs/user/manifests/kubeapps-local-dev-values.yaml b/docs/user/manifests/kubeapps-local-dev-values.yaml
index 3b7518cc..7117cbaa 100644
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -30,3 +30,8 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  carvel:
+    enabled: true
+  flux:
+    enabled: true
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 7              
Error: execution error at (kubeapps/templates/kubeappsapis/deployment.yaml:71:35): packaging: Please enable only one of the flux and helm plugins, since they both operate on Helm releases.

Use --debug flag to render out invalid YAML
make: *** [script/makefiles/deploy-dev.mk:40: deploy-dev-kubeapps] Error 1

# Disabling helm gets things going as expected:
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
diff --git a/docs/user/manifests/kubeapps-local-dev-values.yaml b/docs/user/manifests/kubeapps-local-dev-values.yaml
index 3b7518cc..ba928fcc 100644
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -30,3 +30,10 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  carvel:
+    enabled: true
+  flux:
+    enabled: true
+  helm:
+    enabled: false
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 7              
            - /kubeapps-apis
          args:
            - --plugin-dir
            - /plugins/kapp-controller
            - --plugin-dir
            - /plugins/fluxv2
            - --plugin-dir
            - /plugins/resources

# Adding some other key to the packaging value causes a fail:
Use --debug flag to render out invalid YAML
make: *** [script/makefiles/deploy-dev.mk:40: deploy-dev-kubeapps] Error 1
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
diff --git a/docs/user/manifests/kubeapps-local-dev-values.yaml b/docs/user/manifests/kubeapps-local-dev-values.yaml
index 3b7518cc..c3a43886 100644
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -30,3 +30,12 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  carvel:
+    enabled: true
+  flux:
+    enabled: true
+  helm:
+    enabled: false
+  unknownpkg:
+    enabled: true
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 7              
Error: execution error at (kubeapps/templates/kubeappsapis/deployment.yaml:71:35): packaging: Unsupported packaging option: unknownpkg

Use --debug flag to render out invalid YAML
make: *** [script/makefiles/deploy-dev.mk:40: deploy-dev-kubeapps] Error 1

# Manually overriding the enabled plugins is still possible:
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ git --no-pager diff docs/user/manifests/kubeapps-local-dev-values.yaml
diff --git a/docs/user/manifests/kubeapps-local-dev-values.yaml b/docs/user/manifests/kubeapps-local-dev-values.yaml
index 3b7518cc..e1fe4b91 100644
--- a/docs/user/manifests/kubeapps-local-dev-values.yaml
+++ b/docs/user/manifests/kubeapps-local-dev-values.yaml
@@ -18,6 +18,9 @@ postgresql:
   existingSecret: postgresql-db
 kubeappsapis:
   replicaCount: 1
+  enabledPlugins:
+  - unknownpkg
+  - anotherunknownpkg
 ingress:
   enabled: true
   hostname: localhost
@@ -30,3 +33,12 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
     # Required for ingress-nginx 1.0.0 for a valid ingress.
     kubernetes.io/ingress.class: nginx
+packaging:
+  carvel:
+    enabled: true
+  flux:
+    enabled: true
+  helm:
+    enabled: false
+  unknownpkg:
+    enabled: true
➜  kubeapps git:(3695-dont-require-explicit-enable-redis-2) ✗ make deploy-dev-kubeapps | grep "\- /kubeapps-apis" -A 7              
            - /kubeapps-apis
          args:
            - --plugin-dir
            - /plugins/unknownpkg
            - --plugin-dir
            - /plugins/anotherunknownpkg
            - --clusters-config-path=/config/clusters.conf
            - --plugin-config-path=/config/kubeapps-apis/plugins.conf
```

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)