### PR TITLE
[bitnami/postgresql] Add hostNetwork option for PostgreSQL StatefulSets

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 11.0.7
+version: 11.0.8

--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -205,6 +205,7 @@ kubectl delete pvc -l release=my-release
 | `primary.containerSecurityContext.enabled`   | Enable container security context                                                                                        | `true`                |
 | `primary.containerSecurityContext.runAsUser` | User ID for the container                                                                                                | `1001`                |
 | `primary.hostAliases`                        | PostgreSQL primary pods host aliases                                                                                     | `[]`                  |
+| `primary.hostNetwork`                        | Specify if host network should be enabled for PostgreSQL pod                                                             | `false`               |
 | `primary.labels`                             | Map of labels to add to the statefulset (postgresql primary)                                                             | `{}`                  |
 | `primary.annotations`                        | Annotations for PostgreSQL primary pods                                                                                  | `{}`                  |
 | `primary.podLabels`                          | Map of labels to add to the pods (postgresql primary)                                                                    | `{}`                  |
@@ -289,6 +290,7 @@ kubectl delete pvc -l release=my-release
 | `readReplicas.containerSecurityContext.enabled`   | Enable container security context                                                                                        | `true`                |
 | `readReplicas.containerSecurityContext.runAsUser` | User ID for the container                                                                                                | `1001`                |
 | `readReplicas.hostAliases`                        | PostgreSQL read only pods host aliases                                                                                   | `[]`                  |
+| `readReplicas.hostNetwork`                        | Specify if host network should be enabled for PostgreSQL pod                                                             | `false`               |
 | `readReplicas.labels`                             | Map of labels to add to the statefulset (PostgreSQL read only)                                                           | `{}`                  |
 | `readReplicas.annotations`                        | Annotations for PostgreSQL read only pods                                                                                | `{}`                  |
 | `readReplicas.podLabels`                          | Map of labels to add to the pods (PostgreSQL read only)                                                                  | `{}`                  |

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -87,6 +87,7 @@ spec:
       {{- if .Values.primary.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.primary.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      hostNetwork: {{ .Values.primary.hostNetwork }}
       initContainers:
         {{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
         - name: copy-certs

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -82,6 +82,7 @@ spec:
       {{- if .Values.readReplicas.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.readReplicas.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      hostNetwork: {{ .Values.readReplicas.hostNetwork }}
       initContainers:
         {{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
         - name: copy-certs

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -442,6 +442,9 @@ primary:
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
   hostAliases: []
+  ## @param primary.hostNetwork Specify if host network should be enabled for PostgreSQL pod (postgresql primary)
+  ##
+  hostNetwork: false
   ## @param primary.labels Map of labels to add to the statefulset (postgresql primary)
   ##
   labels: {}
@@ -746,6 +749,9 @@ readReplicas:
   ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
   ##
   hostAliases: []
+  ## @param readReplicas.hostNetwork Specify if host network should be enabled for PostgreSQL pod (PostgreSQL read only)
+  ##
+  hostNetwork: false
   ## @param readReplicas.labels Map of labels to add to the statefulset (PostgreSQL read only)
   ##
   labels: {}


### PR DESCRIPTION
Signed-off-by: Hayden James <hayden.james@gmail.com>

This adds the "hostNetwork" option to the StatefulSets used for the PostgreSQL chart in order to enable/disable that feature.  This allows you to enable host networking for the PostgreSQL pod, instead of only forcing the user to user a network bridge.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)