### PR TITLE
[bitnami/thanos] Properly name HPA for receive-distributor

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 9.0.4
+version: 9.0.5

--- a/bitnami/thanos/templates/receive-distributor/hpa.yaml
+++ b/bitnami/thanos/templates/receive-distributor/hpa.yaml
@@ -16,7 +16,7 @@ spec:
   scaleTargetRef:
     apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
     kind: Deployment
-    name: {{ include "common.capabilities.deployment.apiVersion" . }}
+    name: {{ include "common.names.fullname" . }}-receive-distributor
   minReplicas: {{ .Values.receiveDistributor.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.receiveDistributor.autoscaling.maxReplicas }}
   metrics:


### PR DESCRIPTION
Signed-off-by: Stefan Steinert <ststefa@heldenzeit.net>

**Description of the change**

The change fixes a faulty naming in the HorizontalPodAutoscaler (HPA) of the Thanos receive-distributor component, making it impossible to enable HPA for that component. K8s will reject the manifest with:

`Error: HorizontalPodAutoscaler.autoscaling "thanos-receive-distributor" is invalid: spec.scaleTargetRef.name: Invalid value: "apps/v1": may not contain '/'`

The change mimics the naming scheme for the other Thanos components and should be simple enough to not require any more prose.

**Benefits**

Ability to enable HPA for Thanos receive-distributor

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)