### PR TITLE
[bitnami/airflow] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 12.0.4
+version: 12.0.5

--- a/bitnami/airflow/templates/scheduler/poddisruptionbudget.yaml
+++ b/bitnami/airflow/templates/scheduler/poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.scheduler.pdb.create }}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 metadata:
   name: {{ printf "%s-scheduler" (include "common.names.fullname" .) }}
   namespace: {{ .Release.Namespace }}

--- a/bitnami/airflow/templates/web/poddisruptionbudget.yaml
+++ b/bitnami/airflow/templates/web/poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.web.pdb.enabled }}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 metadata:
   name: {{ printf "%s-web" (include "common.names.fullname" .) }}
   namespace: {{ .Release.Namespace }}

--- a/bitnami/airflow/templates/worker/poddisruptionbudget.yaml
+++ b/bitnami/airflow/templates/worker/poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.worker.pdb.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 metadata:
   name: {{ printf "%s-worker" (include "common.names.fullname" .) }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)