### PR TITLE
[bitnami/jupyterhub] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -26,4 +26,4 @@ name: jupyterhub
 sources:
   - https://github.com/bitnami/bitnami-docker-jupyterhub
   - https://github.com/jupyterhub/jupyterhub
-version: 0.4.6
+version: 0.4.7

--- a/bitnami/jupyterhub/templates/hub/pdb.yaml
+++ b/bitnami/jupyterhub/templates/hub/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.hub.pdb.create -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/bitnami/jupyterhub/templates/proxy/pdb.yaml
+++ b/bitnami/jupyterhub/templates/proxy/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.proxy.pdb.create -}}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)