### PR TITLE
[bitnami/keycloak] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 6.1.5
+version: 6.1.6

--- a/bitnami/keycloak/templates/pdb.yaml
+++ b/bitnami/keycloak/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "keycloak.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)