### PR TITLE
[bitnami/kube-prometheus] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 6.6.5
+version: 6.6.6

--- a/bitnami/kube-prometheus/crds/crd-alertmanager-config.yaml
+++ b/bitnami/kube-prometheus/crds/crd-alertmanager-config.yaml
@@ -2629,7 +2629,7 @@ spec:
                       seconds minutes hours).
                     type: string
                   matchers:
-                    description: 'List of matchers that the alert's labels should
+                    description: 'List of matchers that the alert labels should
                       match. For the first level route, the operator removes any existing
                       equality and regexp matcher on the `namespace` label and adds
                       a `namespace: <object namespace>` matcher.'

--- a/bitnami/kube-prometheus/templates/alertmanager/pdb.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.alertmanager.enabled .Values.alertmanager.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}

--- a/bitnami/kube-prometheus/templates/prometheus/pdb.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.prometheus.enabled .Values.prometheus.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)