### PR TITLE
[bitnami/mariadb] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 10.3.5
+version: 10.3.6

--- a/bitnami/mariadb/templates/primary/pdb.yaml
+++ b/bitnami/mariadb/templates/primary/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.primary.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mariadb.primary.fullname" . }}

--- a/bitnami/mariadb/templates/secondary/pdb.yaml
+++ b/bitnami/mariadb/templates/secondary/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.architecture "replication") .Values.secondary.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mariadb.secondary.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)