### PR TITLE
[bitnami/mongodb-sharded] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 4.0.4
+version: 4.0.5

--- a/bitnami/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/config-server/config-server-poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 {{- if and (not .Values.configsvr.external.host) .Values.configsvr.pdb.enabled -}}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 metadata:
   name: {{ include "common.names.fullname" . }}-configsvr
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.mongos.pdb.enabled -}}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 metadata:
   name: {{ include "common.names.fullname" . }}-mongos
   labels: {{- include "common.labels.standard" . | nindent 4 }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 {{- $replicas := .Values.shards | int -}}
 {{- range $i, $e := until $replicas -}}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 metadata:
   name: {{ printf "%s-shard%d-data" (include "common.names.fullname" $ ) $i }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)