### PR TITLE
[bitnami/mongodb] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 11.0.3
+version: 11.0.4

--- a/bitnami/mongodb/templates/arbiter/pdb.yaml
+++ b/bitnami/mongodb/templates/arbiter/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (include "mongodb.arbiter.enabled" .) .Values.arbiter.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mongodb.fullname" . }}-arbiter

--- a/bitnami/mongodb/templates/hidden/pdb.yaml
+++ b/bitnami/mongodb/templates/hidden/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (include "mongodb.hidden.enabled" .) .Values.hidden.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mongodb.fullname" . }}-hidden

--- a/bitnami/mongodb/templates/replicaset/pdb.yaml
+++ b/bitnami/mongodb/templates/replicaset/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.architecture "replicaset") .Values.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mongodb.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)