### PR TITLE
[bitnami/mysql] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.8.24
+version: 8.8.25

--- a/bitnami/mysql/templates/primary/pdb.yaml
+++ b/bitnami/mysql/templates/primary/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.primary.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mysql.primary.fullname" . }}

--- a/bitnami/mysql/templates/secondary/pdb.yaml
+++ b/bitnami/mysql/templates/secondary/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.architecture "replication") .Values.secondary.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "mysql.secondary.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)