### PR TITLE
[bitnami/nginx-ingress-controller] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 9.1.6
+version: 9.1.7

--- a/bitnami/nginx-ingress-controller/templates/controller-poddisruptionbudget.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.pdb.create (eq .Values.kind "Deployment") }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/nginx-ingress-controller/templates/default-backend-poddisruptionbudget.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.defaultBackend.enabled .Values.defaultBackend.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "nginx-ingress-controller.defaultBackend.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)