### PR TITLE
[bitnami/postgresql-ha] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 8.4.1
+version: 8.4.2

--- a/bitnami/postgresql-ha/templates/pgpool/pdb.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pgpool.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "postgresql-ha.pgpool" . }}

--- a/bitnami/postgresql-ha/templates/postgresql/pdb.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.postgresql.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "postgresql-ha.postgresql" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)