### PR TITLE
[bitnami/redmine] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/bitnami-docker-redmine
   - https://www.redmine.org/
-version: 17.2.5
+version: 17.2.6

--- a/bitnami/redmine/templates/pdb.yaml
+++ b/bitnami/redmine/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)