### PR TITLE
[bitnami/spring-cloud-dataflow] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 5.2.0
+version: 5.2.1

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.metrics.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "scdf.fullname" . }}-prometheus-proxy

--- a/bitnami/spring-cloud-dataflow/templates/server/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.server.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "scdf.fullname" . }}-server

--- a/bitnami/spring-cloud-dataflow/templates/skipper/pdb.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and (or .Values.skipper.enabled .Values.server.configuration.streamingEnabled) .Values.skipper.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "scdf.fullname" . }}-skipper


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)