### PR TITLE
[bitnami/thanos] Do not hardcode PDB apiVersion

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 9.0.4
+version: 9.0.5

--- a/bitnami/thanos/templates/bucketweb/pdb.yaml
+++ b/bitnami/thanos/templates/bucketweb/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.bucketweb.enabled .Values.bucketweb.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}-bucketweb

--- a/bitnami/thanos/templates/query-frontend/pdb.yaml
+++ b/bitnami/thanos/templates/query-frontend/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend

--- a/bitnami/thanos/templates/query/pdb.yaml
+++ b/bitnami/thanos/templates/query/pdb.yaml
@@ -1,6 +1,6 @@
 {{- $query := (include "thanos.query.values" . | fromYaml) -}}
 {{- if and $query.enabled $query.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}-query

--- a/bitnami/thanos/templates/receive-distributor/pdb.yaml
+++ b/bitnami/thanos/templates/receive-distributor/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.receiveDistributor.enabled .Values.receiveDistributor.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}-receive-distributor

--- a/bitnami/thanos/templates/receive/pdb.yaml
+++ b/bitnami/thanos/templates/receive/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.receive.enabled .Values.receive.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}-receive

--- a/bitnami/thanos/templates/ruler/pdb.yaml
+++ b/bitnami/thanos/templates/ruler/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ruler.enabled .Values.ruler.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}-ruler

--- a/bitnami/thanos/templates/storegateway/pdb.yaml
+++ b/bitnami/thanos/templates/storegateway/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.storegateway.enabled .Values.storegateway.pdb.create }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "common.names.fullname" . }}-storegateway


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

Use the helper defined in the common chart to avoid hardcoding the PDB _apiVerison_.

**Benefits**

PDB compatible with different K8s versions.

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)