### PR TITLE
[bitnami/node] Bump bundled MongoDB subchart

### DIFF
--- a/bitnami/node/Chart.lock
+++ b/bitnami/node/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.31.5
+  version: 11.0.3
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.11.1
-digest: sha256:c37303d8de07f9b04c66affbd70de3b0301cbed5102fd908dbfe4333e77a5dde
-generated: "2022-02-08T22:29:39.720202162Z"
+digest: sha256:72a12ba5eb42be11eaffc70d1a16cf792c6e114f4f1e4575f22c816f22dfe43d
+generated: "2022-02-21T13:06:42.235351351Z"

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   - condition: mongodb.enabled
     name: mongodb
     repository: https://charts.bitnami.com/bitnami
-    version: 10.x.x
+    version: 11.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
@@ -28,4 +28,4 @@ name: node
 sources:
   - https://github.com/bitnami/bitnami-docker-node
   - http://nodejs.org/
-version: 16.3.2
+version: 17.0.0

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -376,6 +376,12 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 17.0.0
+
+In this version, the mongodb-exporter bundled as part of the bitnami/mongodb dependency was updated to a new version which, even it is not a major change, can contain breaking changes (from `0.11.X` to `0.30.X`).
+
+Please visit the release notes from the upstream project at https://github.com/percona/mongodb_exporter/releases
+
 ### To 15.0.0
 
 This version standardizes the way of defining Ingress rules. When configuring a single hostname for the Ingress rule, set the `ingress.hostname` value. When defining more than one, set the `ingress.extraHosts` array. Apart from this case, no issues are expected to appear when upgrading.


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <carlosrh@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

In this version, the mongodb-exporter bundled as part of the bitnami/mongodb dependency was updated to a new version which, even it is not a major change, can contain breaking changes (from `0.11.X` to `0.30.X`).

Please visit the release notes from the upstream project at https://github.com/percona/mongodb_exporter/releases