### PR TITLE
[bitnami/geode] Add flag '-r' to xargs in volumePermissions init-cont…

### DIFF
--- a/bitnami/geode/Chart.yaml
+++ b/bitnami/geode/Chart.yaml
@@ -22,4 +22,4 @@ name: geode
 sources:
   - https://github.com/bitnami/bitnami-docker-geode
   - https://github.com/apache/geode
-version: 0.4.5
+version: 0.4.6

--- a/bitnami/geode/templates/locator/statefulset.yaml
+++ b/bitnami/geode/templates/locator/statefulset.yaml
@@ -95,7 +95,7 @@ spec:
             - |
               mkdir -p /bitnami/geode/config /bitnami/geode/data
               chmod 700 /bitnami/geode/config /bitnami/geode/data
-              find /bitnami/geode -mindepth 1 -maxdepth 1 -not -name "config" -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ .Values.locator.containerSecurityContext.runAsUser }}:{{ .Values.locator.podSecurityContext.fsGroup }}
+              find /bitnami/geode -mindepth 1 -maxdepth 1 -not -name "config" -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R {{ .Values.locator.containerSecurityContext.runAsUser }}:{{ .Values.locator.podSecurityContext.fsGroup }}
           {{- if .Values.volumePermissions.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.volumePermissions.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

**Description of the change**
The command `xargs` fails with error `missing operand after` if `find` didn't find any coincidence`. This PR adds the flag `-r` to `xargs` to not fail if no args are provided.


**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)