### PR TITLE
[bitnami/grafana-tempo] Add flag '-r' to xargs in volumePermissions i…

### DIFF
--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -28,4 +28,4 @@ name: grafana-tempo
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana-tempo
   - https://github.com/grafana/tempo/
-version: 1.0.2
+version: 1.0.3

--- a/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
@@ -80,7 +80,7 @@ spec:
             - |
               mkdir -p {{ .Values.tempo.dataDir }}{{- if .Values.ingester.persistence.subPath }}/{{ .Values.ingester.persistence.subPath }}{{- end }}
               {{- if and .Values.ingester.podSecurityContext.enabled .Values.ingester.containerSecurityContext.enabled }}
-              find {{ .Values.tempo.dataDir }}{{- if .Values.ingester.persistence.subPath }}/{{ .Values.ingester.persistence.subPath }}{{- end }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ .Values.ingester.containerSecurityContext.runAsUser }}:{{ .Values.ingester.podSecurityContext.fsGroup }}
+              find {{ .Values.tempo.dataDir }}{{- if .Values.ingester.persistence.subPath }}/{{ .Values.ingester.persistence.subPath }}{{- end }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R {{ .Values.ingester.containerSecurityContext.runAsUser }}:{{ .Values.ingester.podSecurityContext.fsGroup }}
               {{- end }}
           {{- if eq ( toString ( .Values.volumePermissions.containerSecurityContext.runAsUser )) "auto" }}
           securityContext: {{- omit .Values.volumePermissions.containerSecurityContext "runAsUser" | toYaml | nindent 12 }}


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

**Description of the change**
The command `xargs` fails with error `missing operand after` if `find` didn't find any coincidence`. This PR adds the flag `-r` to `xargs` to not fail if no args are provided.


**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)