### PR TITLE
[bitnami/sonarqube] Add flag '-r' to xargs in volumePermissions init-…

### DIFF
--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -28,4 +28,4 @@ name: sonarqube
 sources:
   - https://github.com/bitnami/bitnami-docker-sonarqube
   - https://github.com/SonarSource/sonarqube
-version: 0.2.6
+version: 0.2.7

--- a/bitnami/sonarqube/templates/deployment.yaml
+++ b/bitnami/sonarqube/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
             - |
               mkdir -p /bitnami/sonarqube
               chmod 700 /bitnami/sonarqube
-              find /bitnami/sonarqube -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
+              find /bitnami/sonarqube -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
           {{- if .Values.volumePermissions.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.volumePermissions.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

**Description of the change**
The command `xargs` fails with error `missing operand after` if `find` didn't find any coincidence`. This PR adds the flag `-r` to `xargs` to not fail if no args are provided.


**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)