### PR TITLE
[bitnami/contour-operator] Fix contour-operator icon

### DIFF
--- a/bitnami/contour-operator/Chart.yaml
+++ b/bitnami/contour-operator/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
 description: The Contour Operator extends the Kubernetes API to create, configure and manage instances of Contour on behalf of users.
 engine: gotpl
 home: https://github.com/projectcontour/contour-operator
-icon: https://bitnami.com/assets/stacks/contour-operator/img/contour-operator-stack-220.2.5.png
+icon: https://bitnami.com/assets/stacks/contour-operator/img/contour-operator-stack-220x234.png
 keywords:
   - contour
   - operator
@@ -24,4 +24,4 @@ name: contour-operator
 sources:
   - https://github.com/projectcontour/contour-operator
   - https://github.com/bitnami/bitnami-docker-contour-operator
-version: 0.2.6
+version: 0.2.7


### PR DESCRIPTION
**Description of the change**

This trivial PR just fixes a wrong icon in the `contour-operator` chart as the current one yields a 404.

**Benefits**

This asset will have an icon again.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)