### PR TITLE
bitnami/wordpress - simple fix w3 cache post init wp-config save path

### DIFF
--- a/bitnami/wordpress/templates/postinit-configmap.yaml
+++ b/bitnami/wordpress/templates/postinit-configmap.yaml
@@ -36,7 +36,7 @@ data:
     wp total-cache flush all
 
     # Revoke permissions to edit wp-config.php
-    chmod a-w bitnami/wordpress/wp-config.php
+    chmod a-w /bitnami/wordpress/wp-config.php
   {{- end }}
   {{- if .Values.customPostInitScripts }}
   {{- include "common.tplvalues.render" (dict "value" .Values.customPostInitScripts "context" $) | nindent 2 }}


### PR DESCRIPTION
**Description of the change**

Fixes the bash script created by the ConfigMap that enables w3 cache. Simple change to point to the right file uses the same path in line 22 

**Benefits**

script actually works and doesn't error out and makes the wp-config.php locked again 

**Possible drawbacks**

NA

**Applicable issues**

fixes issue reported #9146

**Additional information**

Nope pretty straight forward. I was using kustomize to patch this but decided to submit a proper PR and log the issue 

First PR so I might be doing it wrong 

**Checklist**

- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
