### PR TITLE
[bitnami/postgresql] Add hostIPC option for PostgreSQL StatefulSets

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 11.0.8
+version: 11.1.0

--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -206,6 +206,7 @@ kubectl delete pvc -l release=my-release
 | `primary.containerSecurityContext.runAsUser` | User ID for the container                                                                                                | `1001`                |
 | `primary.hostAliases`                        | PostgreSQL primary pods host aliases                                                                                     | `[]`                  |
 | `primary.hostNetwork`                        | Specify if host network should be enabled for PostgreSQL pod                                                             | `false`               |
+| `primary.hostIPC`                            | Specify if host IPC should be enabled for PostgreSQL pod                                                                 | `false`               |
 | `primary.labels`                             | Map of labels to add to the statefulset (postgresql primary)                                                             | `{}`                  |
 | `primary.annotations`                        | Annotations for PostgreSQL primary pods                                                                                  | `{}`                  |
 | `primary.podLabels`                          | Map of labels to add to the pods (postgresql primary)                                                                    | `{}`                  |
@@ -291,6 +292,7 @@ kubectl delete pvc -l release=my-release
 | `readReplicas.containerSecurityContext.runAsUser` | User ID for the container                                                                                                | `1001`                |
 | `readReplicas.hostAliases`                        | PostgreSQL read only pods host aliases                                                                                   | `[]`                  |
 | `readReplicas.hostNetwork`                        | Specify if host network should be enabled for PostgreSQL pod                                                             | `false`               |
+| `readReplicas.hostIPC`                            | Specify if host IPC should be enabled for PostgreSQL pod                                                                 | `false`               |
 | `readReplicas.labels`                             | Map of labels to add to the statefulset (PostgreSQL read only)                                                           | `{}`                  |
 | `readReplicas.annotations`                        | Annotations for PostgreSQL read only pods                                                                                | `{}`                  |
 | `readReplicas.podLabels`                          | Map of labels to add to the pods (PostgreSQL read only)                                                                  | `{}`                  |

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -88,6 +88,7 @@ spec:
       securityContext: {{- omit .Values.primary.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       hostNetwork: {{ .Values.primary.hostNetwork }}
+      hostIPC: {{ .Values.primary.hostIPC }}
       initContainers:
         {{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
         - name: copy-certs

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -83,6 +83,7 @@ spec:
       securityContext: {{- omit .Values.readReplicas.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       hostNetwork: {{ .Values.readReplicas.hostNetwork }}
+      hostIPC: {{ .Values.readReplicas.hostIPC }}
       initContainers:
         {{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
         - name: copy-certs

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -445,6 +445,9 @@ primary:
   ## @param primary.hostNetwork Specify if host network should be enabled for PostgreSQL pod (postgresql primary)
   ##
   hostNetwork: false
+  ## @param primary.hostIPC Specify if host IPC should be enabled for PostgreSQL pod (postgresql primary)
+  ##
+  hostIPC: false
   ## @param primary.labels Map of labels to add to the statefulset (postgresql primary)
   ##
   labels: {}
@@ -752,6 +755,9 @@ readReplicas:
   ## @param readReplicas.hostNetwork Specify if host network should be enabled for PostgreSQL pod (PostgreSQL read only)
   ##
   hostNetwork: false
+  ## @param readReplicas.hostIPC Specify if host IPC should be enabled for PostgreSQL pod (postgresql primary)
+  ##
+  hostIPC: false
   ## @param readReplicas.labels Map of labels to add to the statefulset (PostgreSQL read only)
   ##
   labels: {}


### PR DESCRIPTION
Signed-off-by: Hayden James <hayden.james@gmail.com>

This adds the "hostIPC" option to the StatefulSets used for the PostgreSQL chart in order to enable/disable that feature.  This allows you to enable host IPC (inter-process communication) for the PostgreSQL pod, instead of only forcing the user to use an IPC namespace.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)