### PR TITLE
[bitnami/nginx] Add hostIPC option for NGINX Deployment

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 9.8.0
+version: 9.9.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -108,6 +108,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                 | `[]`    |
 | `affinity`                              | Affinity for pod assignment                                                               | `{}`    |
 | `hostNetwork`                           | Specify if host network should be enabled for NGINX pod                                   | `false` |
+| `hostIPC`                               | Specify if host IPC should be enabled for NGINX pod                                       | `false` |
 | `nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                  | `{}`    |
 | `tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                  | `{}`    |
 | `priorityClassName`                     | Priority class name                                                                       | `""`    |

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
+      hostIPC: {{ .Values.hostIPC }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -148,6 +148,9 @@ affinity: {}
 ## @param hostNetwork Specify if host network should be enabled for NGINX pod
 ##
 hostNetwork: false
+## @param hostIPC Specify if host IPC should be enabled for NGINX pod
+##
+hostIPC: false
 ## @param nodeSelector Node labels for pod assignment. Evaluated as a template.
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##


### PR DESCRIPTION
Signed-off-by: Hayden James <hayden.james@gmail.com>

This adds the "hostIPC" option to the Deployment used for the NGINX chart in order to enable/disable that feature.  This allows you to enable host IPC (inter-process communication) for the NGINX pods, instead of only forcing the user to use an IPC namespace.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)