### PR TITLE
Point workflows to the new VIB GH repository

### DIFF
--- a/.github/workflows/vib-early-feedback.yaml
+++ b/.github/workflows/vib-early-feedback.yaml
@@ -73,7 +73,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - uses: vmware-samples/vmware-image-builder-examples/vib-action@main
+      - uses: vmware-labs/vmware-image-builder-action@main
         name: 'Package, Lint and Trivy scan'
         with:
           pipeline: vib-early-feedback.json

--- a/.github/workflows/vib-redis.yaml
+++ b/.github/workflows/vib-redis.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - uses: vmware-samples/vmware-image-builder-examples/vib-action@main
+      - uses: vmware-labs/vmware-image-builder-action@main
         with:
           pipeline: redis/standalone/vib-platform-verify.json
         env:
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - uses: vmware-samples/vmware-image-builder-examples/vib-action@main
+      - uses: vmware-labs/vmware-image-builder-action@main
         with:
           pipeline: redis/sentinel/vib-platform-verify.json
         env:
@@ -49,7 +49,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - uses: vmware-samples/vmware-image-builder-examples/vib-action@main
+      - uses: vmware-labs/vmware-image-builder-action@main
         with:
           pipeline: redis/replicas/vib-platform-verify.json
         env:

--- a/.github/workflows/vib.yaml
+++ b/.github/workflows/vib.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
-      - uses: vmware-samples/vmware-image-builder-examples/vib-action@main
+      - uses: vmware-labs/vmware-image-builder-action@main
         with:
           pipeline: vib-platform-verify.json
         env:


### PR DESCRIPTION
Signed-off-by: Martin Perez <martinpe@vmware.com>


**Description of the change**

Points the GitHub workflows to the new repository that we allocated for the GH action in vmware-labs organization.

**Benefits**

Use the latest and greatest. 

**Possible drawbacks**

None
