### PR TITLE
[bitnami/Thanos] Add volumePermission initContainer for receive.statefulset

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 9.0.5
+version: 9.0.6

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -72,8 +72,27 @@ spec:
       {{- if .Values.receive.topologySpreadConstraints }}
       topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.receive.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}
-      {{- if .Values.receive.initContainers }}
-      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.receive.initContainers "context" $) | nindent 8 }}
+      {{- if or .Values.receive.initContainers (and .Values.volumePermissions.enabled .Values.receive.persistence.enabled) }}
+      initContainers:
+        {{- if and .Values.volumePermissions.enabled .Values.receive.persistence.enabled }}
+        - name: init-chmod-data
+          image: {{ include "thanos.volumePermissions.image" . }}
+          imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /var/thanos/receive
+              chown -R "{{ .Values.receive.containerSecurityContext.runAsUser }}:{{ .Values.receive.podSecurityContext.fsGroup }}" /var/thanos/receive
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /var/thanos/receive
+        {{- end }}
+        {{- if .Values.receive.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.receive.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         {{- if .Values.receive.sidecars }}


### PR DESCRIPTION

**Description of the change**

 Add volumePermission initContainer for Thanos Receive `statefulset.yaml`

**Benefits**

Fix the issue with k8s securityContext in some Cloud Providers. 

**Possible drawbacks**

No drawbacks as my understanding, just copy the configs from other component.


**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)