### PR TITLE
[bitnami/elasticsearch] Fix named port in ingress

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.9.3
+version: 17.9.4

--- a/bitnami/elasticsearch/templates/ingress.yaml
+++ b/bitnami/elasticsearch/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
             pathType: {{ .Values.master.ingress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "elasticsearch.master.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "elasticsearch.master.fullname" .) "servicePort" (include "elasticsearch.httpPortName" .) "context" $)  | nindent 14 }}
       {{- if ne .Values.master.ingress.hostname "*" }}
       host: {{ .Values.master.ingress.hostname }}
       {{- end }}
@@ -39,7 +39,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "elasticsearch.master.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "elasticsearch.master.fullname" $) "servicePort" (include "elasticsearch.httpPortName" .) "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.master.ingress.tls .Values.master.ingress.extraTls }}
   tls:


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Fix incorrect port in ingress definition. If we enabled security, `https` is set as name for most of the exposed ports but ingress is using always http. The porpouse of the change is use the same logic in the ingress definition.

**Possible drawbacks**

Not identified

**Applicable issues**

  - fixes #9159

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)