### PR TITLE
Update readme-generator command in github-actions

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -51,4 +51,4 @@ jobs:
           cat raw-inputs | sed 's/bitnami/charts\/bitnami/' > prepared-inputs
 
       - name: Execute readme-generator-for-helm
-        run: readme-generator-for-helm/bin/index.js --values $(cat prepared-inputs | grep values) --metadata /tmp/chart-schema.json
+        run: readme-generator-for-helm/bin/index.js --values $(cat prepared-inputs | grep values) --schema /tmp/chart-schema.json


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

**Description of the change**

The readme-generator command `--metadata` was renamed as `--schema`. The readme generator commit-id was recently updated here: https://github.com/bitnami/charts/pull/9181 but the command wasn't, leading to this error:

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/37381070/155476420-85c79449-5d18-4859-96ec-b2da6d5ea50c.png">