### PR TITLE
[bitnami/elasticsearch] fix use the correct elasticsearch port for exporter.

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.9.4
+version: 17.9.5

--- a/bitnami/elasticsearch/templates/metrics-deploy.yaml
+++ b/bitnami/elasticsearch/templates/metrics-deploy.yaml
@@ -43,10 +43,10 @@ spec:
           args:
             {{- if gt (int .Values.coordinating.replicas) 0 }}
             # Prefer coordinating only nodes to do the initial metrics query
-            - --es.uri=http://{{- if .Values.security.enabled }}elastic:{{ .Values.security.elasticPassword }}@{{- end }}{{ template "elasticsearch.coordinating.fullname" . }}:{{ .Values.coordinating.service.port }}
+            - --es.uri=http://{{- if .Values.security.enabled }}elastic:{{ .Values.security.elasticPassword }}@{{- end }}{{ template "elasticsearch.coordinating.fullname" . }}:9200
             {{- else }}
             # Using master nodes as there are no coordinating only nodes
-            - --es.uri=http://{{- if .Values.security.enabled }}elastic:{{ .Values.security.elasticPassword }}@{{- end }}{{ include "elasticsearch.master.fullname" . }}:{{ .Values.master.service.port }}
+            - --es.uri=http://{{- if .Values.security.enabled }}elastic:{{ .Values.security.elasticPassword }}@{{- end }}{{ include "elasticsearch.master.fullname" . }}:9200
             {{- end }}
             - --es.all
             {{- if .Values.metrics.extraArgs }}

--- a/bitnami/elasticsearch/templates/metrics-deploy.yaml
+++ b/bitnami/elasticsearch/templates/metrics-deploy.yaml
@@ -43,7 +43,7 @@ spec:
           args:
             {{- if gt (int .Values.coordinating.replicas) 0 }}
             # Prefer coordinating only nodes to do the initial metrics query
-            - --es.uri=http://{{- if .Values.security.enabled }}elastic:{{ .Values.security.elasticPassword }}@{{- end }}{{ template "elasticsearch.coordinating.fullname" . }}:9200
+            - --es.uri=http://{{- if .Values.security.enabled }}elastic:{{ .Values.security.elasticPassword }}@{{- end }}{{ template "elasticsearch.coordinating.fullname" . }}:{{ .Values.coordinating.service.port }}
             {{- else }}
             # Using master nodes as there are no coordinating only nodes
             - --es.uri=http://{{- if .Values.security.enabled }}elastic:{{ .Values.security.elasticPassword }}@{{- end }}{{ include "elasticsearch.master.fullname" . }}:9200


### PR DESCRIPTION
**Description of the change**

Always use the correct elasticsearch port for the exporter.

**Benefits**

With this change, the exporter is able to scrape the elasticsearch cluster regardless of the nodes configuration.

**Possible drawbacks**

None.

**Applicable issues**

  - fixes #https://github.com/bitnami/charts/issues/9182

**Additional information**

Remove the usage of parameter chart and use a hardcoded value.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)