### PR TITLE
[bitnami/nginx] Fix issue rendering metrics.serviceMonitor.additionalLabels

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 9.9.2
+version: 9.9.3

--- a/bitnami/nginx/templates/prometheusrules.yaml
+++ b/bitnami/nginx/templates/prometheusrules.yaml
@@ -14,7 +14,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.prometheusRule.additionalLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
**Description of the change**

Currently the deployment with the proper values for metrics is failing, see
```console
$ helm template . --set metrics.enabled=true --set metrics.prometheusRule.enabled=true --debug
# Source: nginx/templates/prometheusrules.yaml
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: RELEASE-NAME-nginx
  namespace: default
  labels:
    app.kubernetes.io/name: nginx
    helm.sh/chart: nginx-9.9.2
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: nginx
    app.kubernetes.io/component: metrics
    {}
spec:
  groups:
  - name: RELEASE-NAME-nginx
    rules:
      []
Error: YAML parse error on nginx/templates/prometheusrules.yaml: error converting YAML to JSON: yaml: line 12: did not find expected key
```
with the changes in this diff, everything works as expected
```console
$ helm template . --set metrics.enabled=true --set metrics.prometheusRule.enabled=true --debug
# Source: nginx/templates/prometheusrules.yaml
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: RELEASE-NAME-nginx
  namespace: default
  labels:
    app.kubernetes.io/name: nginx
    helm.sh/chart: nginx-9.9.3
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: nginx
    app.kubernetes.io/component: metrics
spec:
  groups:
  - name: RELEASE-NAME-nginx
    rules:
      []
```