### PR TITLE
[bitnami/argo-cd] Fix svc wrong indentation

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/bitnami-docker-dex
   - https://github.com/dexidp/dex
-version: 3.0.10
+version: 3.0.11

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -76,14 +76,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Argo CD image parameters
 
-| Name                | Description                                        | Value                |
-| ------------------- | -------------------------------------------------- | -------------------- |
-| `image.registry`    | Argo CD image registry                             | `docker.io`          |
-| `image.repository`  | Argo CD image repository                           | `bitnami/argo-cd`    |
-| `image.tag`         | Argo CD image tag (immutable tags are recommended) | `2.2.3-debian-10-r1` |
-| `image.pullPolicy`  | Argo CD image pull policy                          | `IfNotPresent`       |
-| `image.pullSecrets` | Argo CD image pull secrets                         | `[]`                 |
-| `image.debug`       | Enable Argo CD image debug mode                    | `false`              |
+| Name                | Description                                        | Value                 |
+| ------------------- | -------------------------------------------------- | --------------------- |
+| `image.registry`    | Argo CD image registry                             | `docker.io`           |
+| `image.repository`  | Argo CD image repository                           | `bitnami/argo-cd`     |
+| `image.tag`         | Argo CD image tag (immutable tags are recommended) | `2.2.5-debian-10-r19` |
+| `image.pullPolicy`  | Argo CD image pull policy                          | `IfNotPresent`        |
+| `image.pullSecrets` | Argo CD image pull secrets                         | `[]`                  |
+| `image.debug`       | Enable Argo CD image debug mode                    | `false`               |
 
 
 ### Argo CD application controller parameters
@@ -446,7 +446,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------- |
 | `dex.image.registry`                              | Dex image registry                                                                            | `docker.io`            |
 | `dex.image.repository`                            | Dex image repository                                                                          | `bitnami/dex`          |
-| `dex.image.tag`                                   | Dex image tag (immutable tags are recommended)                                                | `2.30.2-debian-10-r59` |
+| `dex.image.tag`                                   | Dex image tag (immutable tags are recommended)                                                | `2.31.0-debian-10-r16` |
 | `dex.image.pullPolicy`                            | Dex image pull policy                                                                         | `IfNotPresent`         |
 | `dex.image.pullSecrets`                           | Dex image pull secrets                                                                        | `[]`                   |
 | `dex.image.debug`                                 | Enable Dex image debug mode                                                                   | `false`                |
@@ -581,7 +581,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                    | `docker.io`             |
 | `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r312`     |
+| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r351`     |
 | `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                | `[]`                    |
 | `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                    |
@@ -596,7 +596,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.create`                             | Specifies whether RBAC resources should be created                          | `true`                 |
 | `redis.image.registry`                    | Argo CD controller image registry                                           | `docker.io`            |
 | `redis.image.repository`                  | Argo CD controller image repository                                         | `bitnami/redis`        |
-| `redis.image.tag`                         | Argo CD controller image tag (immutable tags are recommended)               | `6.2.6-debian-10-r103` |
+| `redis.image.tag`                         | Argo CD controller image tag (immutable tags are recommended)               | `6.2.6-debian-10-r142` |
 | `redis.image.pullPolicy`                  | Argo CD controller image pull policy                                        | `IfNotPresent`         |
 | `redis.image.pullSecrets`                 | Argo CD controller image pull secrets                                       | `[]`                   |
 | `redis.enabled`                           | Enable Redis dependency                                                     | `true`                 |
@@ -605,6 +605,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `redis.auth.enabled`                      | Enable Redis dependency authentication                                      | `true`                 |
 | `redis.auth.existingSecret`               | Existing secret to load redis dependency password                           | `""`                   |
 | `redis.auth.existingSecretPasswordKey`    | Pasword key name inside the existing secret                                 | `redis-password`       |
+| `redis.architecture`                      | Redis&trade; architecture. Allowed values: `standalone` or `replication`    | `standalone`           |
 | `externalRedis.host`                      | External Redis host                                                         | `""`                   |
 | `externalRedis.port`                      | External Redis port                                                         | `6379`                 |
 | `externalRedis.password`                  | External Redis password                                                     | `""`                   |

--- a/bitnami/argo-cd/templates/repo-server/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/repo-server/metrics-svc.yaml
@@ -17,7 +17,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
-type: {{ .Values.repoServer.metrics.service.type }}
+  type: {{ .Values.repoServer.metrics.service.type }}
   {{- if and .Values.repoServer.metrics.service.clusterIP (eq .Values.repoServer.metrics.service.type "ClusterIP") }}
   clusterIP: {{ .Values.repoServer.metrics.service.clusterIP }}
   {{- end }}

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -2336,7 +2336,7 @@ redis:
   ## @disabled-param redis.architecture Redis dependency architecture. Either 'standalone' or 'replicaset'
   ## TODO(miguelaeh): We need to test the chart with redis sentinel, it seems to be supported at: https://github.com/argoproj/argo-cd/blob/2a410187565e15633b6f2a8c8d8da22cf02b257d/util/cache/cache.go#L40
   ##
-  ## architecture: standalone
+  architecture: standalone
 
 ##
 ## External Redis&trade;

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -2333,7 +2333,7 @@ redis:
     existingSecretPasswordKey: 'redis-password'
 
   ## Cluster settings
-  ## @disabled-param redis.architecture Redis dependency architecture. Either 'standalone' or 'replicaset'
+  ## @param redis.architecture Redis&trade; architecture. Allowed values: `standalone` or `replication`
   ## TODO(miguelaeh): We need to test the chart with redis sentinel, it seems to be supported at: https://github.com/argoproj/argo-cd/blob/2a410187565e15633b6f2a8c8d8da22cf02b257d/util/cache/cache.go#L40
   ##
   architecture: standalone


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR fixes a typo in the metrics service.

**Benefits**

Users can enable metrics (`--set repoServer.metrics.enabled=true`).

**Possible drawbacks**

None

**Applicable issues**

  - fixes #9241

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)