### PR TITLE
[bitnami/thanos] Fix: use name passed to receive.existingConfigmap if set

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 9.0.5
+version: 9.0.6

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -325,6 +325,17 @@ Return true if a hashring configmap object should be created
 {{- end -}}
 
 
+{{/*
+Return the Thanos receive hashring configuration configmap.
+*/}}
+{{- define "thanos.receive.configmapName" -}}
+{{- if .Values.receive.existingConfigmap -}}
+    {{- printf "%s" (tpl .Values.receive.existingConfigmap $) -}}
+{{- else -}}
+    {{- printf "%s-receive" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Return the proper pod fqdn of the replica.
 Usage:
 {{ include "thanos.receive.podFqdn" (dict "root" . "extra" $suffix ) }}

--- a/bitnami/thanos/templates/receive-distributor/deployment.yaml
+++ b/bitnami/thanos/templates/receive-distributor/deployment.yaml
@@ -180,7 +180,7 @@ spec:
       volumes:
         - name: hashring-config
           configMap:
-            name: {{ include "common.names.fullname" . }}-receive
+            name: {{ include "thanos.receive.configmapName" . }}
         {{- if .Values.receiveDistributor.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -204,7 +204,7 @@ spec:
       volumes:
         - name: hashring-config
           configMap:
-            name: {{ include "common.names.fullname" . }}-receive
+            name: {{ include "thanos.receive.configmapName" . }}
         {{- if .Values.receive.grpc.server.tls.enabled }}
         - name: grpc-server-tls
           secret:


### PR DESCRIPTION
**Description of the change**

This fixes an issue with `.Values.receive.existingConfigmap`.
The receive statefulset and receive-distributor deployment were always pointing to the auto-generated configmap name, even if it was not generated due to `existingConfigmap` being set.
The implemented fix uses an adjusted copy of same function already in use for e.g. storegateway.

**Possible drawbacks**

There might be people relying on the current behavior.

**Applicable issues**

Could not find any

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)