### PR TITLE
[bitnami/contour] Add support for changing lifetime for tls certificate generated by contour certgen

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 7.3.11
+version: 7.4.0

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -148,6 +148,7 @@ $ helm uninstall my-release
 | `contour.startupProbe.successThreshold`         | Minimum consecutive successes for the probe to be considered successful after having failed.                                       | `1`                    |
 | `contour.certgen.serviceAccount.create`         | Create a serviceAccount for the Contour pod                                                                                        | `true`                 |
 | `contour.certgen.serviceAccount.name`           | Use the serviceAccount with the specified name, a name is generated using the fullname template                                    | `""`                   |
+| `contour.certgen.certificateLifetime`           | Generated certificate lifetime (in days).                                                                                          | `365`                  |
 | `contour.tlsExistingSecret`                     | Name of the existingSecret to be use in Contour deployment. If it is not nil `contour.certgen` will be disabled.                   | `""`                   |
 | `contour.service.type`                          | Service type                                                                                                                       | `ClusterIP`            |
 | `contour.service.ports.xds`                     | Contour service xds port                                                                                                           | `8001`                 |

--- a/bitnami/contour/templates/certgen/job.yaml
+++ b/bitnami/contour/templates/certgen/job.yaml
@@ -49,7 +49,7 @@ spec:
             - --overwrite
             - --secrets-format=compact
             - --namespace=$(CONTOUR_NAMESPACE)
-            - --certificate-lifetime {{ .Values.contour.certgen.certificateLifetime }}
+            - --certificate-lifetime={{ .Values.contour.certgen.certificateLifetime }}
           env:
             - name: CONTOUR_NAMESPACE
               valueFrom:

--- a/bitnami/contour/templates/certgen/job.yaml
+++ b/bitnami/contour/templates/certgen/job.yaml
@@ -49,6 +49,7 @@ spec:
             - --overwrite
             - --secrets-format=compact
             - --namespace=$(CONTOUR_NAMESPACE)
+            - --certificate-lifetime {{ .Values.contour.certgen.certificateLifetime }}
           env:
             - name: CONTOUR_NAMESPACE
               valueFrom:

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -289,13 +289,18 @@ contour:
     timeoutSeconds: 5
     failureThreshold: 3
     successThreshold: 1
-  ## @param contour.certgen.serviceAccount.create Create a serviceAccount for the Contour pod
-  ## @param contour.certgen.serviceAccount.name Use the serviceAccount with the specified name, a name is generated using the fullname template
+  ## Contour certgen configs
   ##
   certgen:
+    ## @param contour.certgen.serviceAccount.create Create a serviceAccount for the Contour pod
+    ## @param contour.certgen.serviceAccount.name Use the serviceAccount with the specified name, a name is generated using the fullname template
+    ##
     serviceAccount:
       create: true
       name: ""
+    ## @param contour.certgen.certificateLifetime Generated certificate lifetime (in days).
+    ##
+    certificateLifetime: 365
   ## @param contour.tlsExistingSecret Name of the existingSecret to be use in Contour deployment. If it is not nil `contour.certgen` will be disabled.
   ## It will override `tlsExistingSecret`
   ##


### PR DESCRIPTION
**Description of the change**

This PR adds a way to change the lifetime (in days) of the TLS cert generated by contour certgen for communication b/w contour and envoy services.

**Benefits**

Allows to extend the lifetime of the generated certificated and hence reduce the need to refresh the certificate.

**Possible drawbacks**


**Applicable issues**

  - fixes #9224 

**Additional information**

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
    - Running `readme-generator-for-helm` was generating too many unrelated changes, so skipped for this PR, can take it up as a separate one.
    - README updated manually for now
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)