### PR TITLE
[bitnami/redis-cluster] Fix readiness script typo

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 7.2.8
+version: 7.2.9

--- a/bitnami/redis-cluster/templates/scripts-configmap.yaml
+++ b/bitnami/redis-cluster/templates/scripts-configmap.yaml
@@ -38,7 +38,7 @@ data:
 {{- end }}
         ping
     )
-    if [ $? == 124 ]; then
+    if [ "$?" -eq "124" ]; then
       echo "Timed out"
       exit 1
     fi
@@ -63,7 +63,7 @@ data:
   {{- end }}
           CLUSTER INFO | grep cluster_state | tr -d '[:space:]'
       )
-      if [ $? == 124 ]; then
+      if [ "$?" -eq "124" ]; then
         echo "Timed out"
         exit 1
       fi
@@ -100,7 +100,7 @@ data:
 {{- end }}
         ping
     )
-    if [ $? == 124 ]; then
+    if [ "$?" -eq "124" ]; then
       echo "Timed out"
       exit 1
     fi


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

**Description of the change**

Fixes typo in in the readiness scripts that caused the following error message when `cluster_state:fail`:

```
/scripts/ping_readiness_local.sh: 13: [: 0: unexpected operator
/scripts/ping_readiness_local.sh: 29: [: 0: unexpected operator
```

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)