### PR TITLE
[bitnami/grafana-tempo] Reorder subcharts

### DIFF
--- a/bitnami/grafana-tempo/Chart.lock
+++ b/bitnami/grafana-tempo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.1
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
   version: 6.0.5
-digest: sha256:1cf24c8cbffcd8534eb01118fa0cc37226e86cdebc4ddfb7cfea445ba795c611
-generated: "2022-02-28T13:53:54.597842651Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:6543d168cdd2e5cec838ad059f9fe62cec14fbb7921081613ba3a491dbd5bc4b
+generated: "2022-03-04T14:03:06.655840091Z"

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -3,15 +3,15 @@ annotations:
 apiVersion: v2
 appVersion: 1.3.2
 dependencies:
+  - condition: memcached.enabled
+    name: memcached
+    repository: https://charts.bitnami.com/bitnami
+    version: 6.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - condition: memcached.enabled
-    name: memcached
-    repository: https://charts.bitnami.com/bitnami
-    version: 6.x.x
 description: Grafana Tempo is a distributed tracing system that has out-of-the-box integration with Grafana. It is highly scalable and works with many popular tracing protocols.
 engine: gotpl
 home: https://github.com/grafana/tempo/
@@ -28,4 +28,4 @@ name: grafana-tempo
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana-tempo
   - https://github.com/grafana/tempo/
-version: 1.0.8
+version: 1.0.9


### PR DESCRIPTION
**Description of the change**

It seems there is an issue when working with OCI registries and the definition order of the subcharts.
While the issue is solved in the Helm CLI, we are reordering the dependencies.

The upstream issue is to be created.