### PR TITLE
[bitnami/several] Reorder subcharts

### DIFF
--- a/bitnami/airflow/Chart.lock
+++ b/bitnami/airflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: common
+- name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
+  version: 16.4.5
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.3
-- name: redis
+- name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 16.4.4
-digest: sha256:fa517ca53fab22b3c57590b5514b26395f02b1fac336127c39f7c01823e31ba6
-generated: "2022-03-01T09:48:39.789152117Z"
+  version: 1.11.3
+digest: sha256:224a946d23e0ed2c300ccbc9bf88c8ea3c4ea5f2cd2703a1c8d84f15ea945701
+generated: "2022-03-04T15:32:18.242647715Z"

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -3,19 +3,19 @@ annotations:
 apiVersion: v2
 appVersion: 2.2.3
 dependencies:
+  - condition: redis.enabled
+    name: redis
+    repository: https://charts.bitnami.com/bitnami
+    version: 16.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 11.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - condition: postgresql.enabled
-    name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 11.x.x
-  - condition: redis.enabled
-    name: redis
-    repository: https://charts.bitnami.com/bitnami
-    version: 16.x.x
 description: Apache Airflow is a tool to express and execute workflows as directed acyclic graphs (DAGs). It includes utilities to schedule tasks, monitor task progress and handle task dependencies.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/airflow
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 12.0.7
+version: 12.0.8

--- a/bitnami/dataplatform-bp1/Chart.lock
+++ b/bitnami/dataplatform-bp1/Chart.lock
@@ -1,10 +1,7 @@
 dependencies:
-- name: kafka
-  repository: https://charts.bitnami.com/bitnami
-  version: 14.9.3
 - name: spark
   repository: https://charts.bitnami.com/bitnami
-  version: 5.9.2
+  version: 5.9.3
 - name: solr
   repository: https://charts.bitnami.com/bitnami
   version: 2.4.2
@@ -13,9 +10,12 @@ dependencies:
   version: 7.6.2
 - name: wavefront
   repository: https://charts.bitnami.com/bitnami
-  version: 3.1.26
+  version: 3.1.29
+- name: kafka
+  repository: https://charts.bitnami.com/bitnami
+  version: 14.9.3
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.1
-digest: sha256:7304826926127290b0e10bea9bde6823e375ff71c35b464c182955ce4403b3a6
-generated: "2022-02-23T20:50:09.540266515Z"
+  version: 1.11.3
+digest: sha256:11e9de81d072c02ef7f9a4af2c239b4c66af6d3f4993b2c5c52b35af17fde4e4
+generated: "2022-03-04T15:33:07.142092084Z"

--- a/bitnami/dataplatform-bp1/Chart.yaml
+++ b/bitnami/dataplatform-bp1/Chart.yaml
@@ -3,10 +3,6 @@ annotations:
 apiVersion: v2
 appVersion: 1.0.1
 dependencies:
-  - condition: kafka.enabled
-    name: kafka
-    repository: https://charts.bitnami.com/bitnami
-    version: 14.x.x
   - condition: spark.enabled
     name: spark
     repository: https://charts.bitnami.com/bitnami
@@ -23,6 +19,10 @@ dependencies:
     name: wavefront
     repository: https://charts.bitnami.com/bitnami
     version: 3.x.x
+  - condition: kafka.enabled
+    name: kafka
+    repository: https://charts.bitnami.com/bitnami
+    version: 14.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
@@ -59,4 +59,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 9.0.9
+version: 9.0.10

--- a/bitnami/dataplatform-bp2/Chart.lock
+++ b/bitnami/dataplatform-bp2/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
+- name: wavefront
+  repository: https://charts.bitnami.com/bitnami
+  version: 3.1.29
+- name: spark
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.9.3
+- name: logstash
+  repository: https://charts.bitnami.com/bitnami
+  version: 3.7.8
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
   version: 14.9.3
-- name: spark
-  repository: https://charts.bitnami.com/bitnami
-  version: 5.9.2
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 17.9.2
-- name: logstash
-  repository: https://charts.bitnami.com/bitnami
-  version: 3.7.4
-- name: wavefront
-  repository: https://charts.bitnami.com/bitnami
-  version: 3.1.25
+  version: 17.9.7
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.1
-digest: sha256:6af1584ce71536d2a4296bbd72a62c52ea50749c53ef0d682a68615d61153866
-generated: "2022-02-16T03:34:18.652982641Z"
+  version: 1.11.3
+digest: sha256:ee19966ac964551d1cb9d3d81d73ae16811e01bbf2f8c77792775decd018061a
+generated: "2022-03-04T15:34:07.255694241Z"

--- a/bitnami/dataplatform-bp2/Chart.yaml
+++ b/bitnami/dataplatform-bp2/Chart.yaml
@@ -3,26 +3,26 @@ annotations:
 apiVersion: v2
 appVersion: 1.0.1
 dependencies:
-  - condition: kafka.enabled
-    name: kafka
-    repository: https://charts.bitnami.com/bitnami
-    version: 14.x.x
-  - condition: spark.enabled
-    name: spark
-    repository: https://charts.bitnami.com/bitnami
-    version: 5.x.x
-  - condition: elasticsearch.enabled
-    name: elasticsearch
-    repository: https://charts.bitnami.com/bitnami
-    version: 17.x.x
-  - condition: logstash.enabled
-    name: logstash
-    repository: https://charts.bitnami.com/bitnami
-    version: 3.x.x
   - condition: wavefront.enabled
     name: wavefront
     repository: https://charts.bitnami.com/bitnami
     version: 3.x.x
+  - condition: spark.enabled
+    name: spark
+    repository: https://charts.bitnami.com/bitnami
+    version: 5.x.x
+  - condition: logstash.enabled
+    name: logstash
+    repository: https://charts.bitnami.com/bitnami
+    version: 3.x.x
+  - condition: kafka.enabled
+    name: kafka
+    repository: https://charts.bitnami.com/bitnami
+    version: 14.x.x
+  - condition: elasticsearch.enabled
+    name: elasticsearch
+    repository: https://charts.bitnami.com/bitnami
+    version: 17.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
@@ -58,4 +58,4 @@ sources:
   - https://www.elastic.co/products/logstash
   - https://zookeeper.apache.org/
   - https://github.com/bitnami/bitnami-docker-zookeeper
-version: 10.0.9
+version: 10.0.10

--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.1
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 11.1.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.4.3
-digest: sha256:80b3d3296813665c83909d4c7d403ace5c08e358c68477b86d04200cf39cf299
-generated: "2022-02-27T07:14:04.861873116Z"
+  version: 16.4.5
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 11.1.3
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:42feffba50eaf078c8980d7e1141a1d884a4e716ca7deb1f8d4f80e28b4deb80
+generated: "2022-03-04T15:34:51.30337566Z"

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -3,19 +3,19 @@ annotations:
 apiVersion: v2
 appVersion: 2.7.13
 dependencies:
+  - condition: redis.enabled
+    name: redis
+    repository: https://charts.bitnami.com/bitnami
+    version: 16.X.X
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 11.X.X
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - condition: postgresql.enabled
-    name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 11.X.X
-  - condition: redis.enabled
-    name: redis
-    repository: https://charts.bitnami.com/bitnami
-    version: 16.X.X
 description: Discourse is an open source discussion platform with built-in moderation and governance systems that let discussion communities protect themselves from bad actors even without official moderators.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/discourse
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 6.0.3
+version: 6.0.4

--- a/bitnami/ejbca/Chart.lock
+++ b/bitnami/ejbca/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 10.3.7
-digest: sha256:6bd433f2cca2bb85883c8af61b89d6d8012da64c7ac8e56cf4e08d0a3ffd8ce1
-generated: "2022-03-02T19:43:49.744547944Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:ddd45c41a7cba70bbae65a1fe6c26d559c3be555ee9e49dc522f453cbba7dbed
+generated: "2022-03-04T15:35:20.440255665Z"

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -3,17 +3,17 @@ annotations:
 apiVersion: v2
 appVersion: 7.4.3-2
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
     tags:
       - ejbca-database
     version: 10.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: EJBCA is an enterprise class PKI Certificate Authority software, built using Java (JEE) technology.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/ejbca
@@ -30,4 +30,4 @@ name: ejbca
 sources:
   - https://github.com/bitnami/bitnami-docker-ejbca
   - https://www.ejbca.org/
-version: 5.1.3
+version: 5.1.4

--- a/bitnami/elasticsearch/Chart.lock
+++ b/bitnami/elasticsearch/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: kibana
   repository: https://charts.bitnami.com/bitnami
   version: 9.3.7
-digest: sha256:3a32aaf4c7cd2de7df6ca56b5e5983d94b21451def221502e1c273744829e19a
-generated: "2022-03-01T04:15:20.372270484Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:5991e38539f21ed771767e82a8f03d7d12adb09cfd6c532e8aea84d8bd3e9364
+generated: "2022-03-04T15:35:47.1240902Z"

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -3,15 +3,15 @@ annotations:
 apiVersion: v2
 appVersion: 7.17.0
 dependencies:
+  - condition: global.kibanaEnabled
+    name: kibana
+    repository: https://charts.bitnami.com/bitnami
+    version: 9.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - condition: global.kibanaEnabled
-    name: kibana
-    repository: https://charts.bitnami.com/bitnami
-    version: 9.x.x
 description: Elasticsearch is a distributed search and analytics engine. It is used for web search, log monitoring, and real-time analytics. Ideal for Big Data applications.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/elasticsearch
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.9.7
+version: 17.9.8

--- a/bitnami/ghost/Chart.lock
+++ b/bitnami/ghost/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 10.3.7
-digest: sha256:a2aa29842c702bd2cf4a3f97a2135607cc04678f5ac0bedd7ef3e111ad42ce63
-generated: "2022-02-28T21:17:45.410842568Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:638cb3d5ce4fa114c3a1f5e3e927de8c0ea7be375093bd379f4c150db5d58db9
+generated: "2022-03-04T15:36:23.108112054Z"

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -3,17 +3,17 @@ annotations:
 apiVersion: v2
 appVersion: 4.37.0
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
     tags:
       - ghost-database
     version: 10.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Ghost is an open source publishing platform designed to create blogs, magazines, and news sites. It includes a simple markdown editor with preview, theming, and SEO built-in to simplify editing.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/ghost
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/bitnami-docker-ghost
   - https://www.ghost.org/
-version: 16.1.0
+version: 16.1.1

--- a/bitnami/harbor/Chart.lock
+++ b/bitnami/harbor/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.16.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 15.7.6
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.16.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.11.3
-digest: sha256:d9877ec1161f3c0d6d5f2c8ae7520838a872091ae031cda7d2d67c7454e5a8f0
-generated: "2022-03-04T11:41:54.3259555Z"
+digest: sha256:1f02461905972fa5b358f14eb441ac4558d26a9a3c9c1fb26df3c6da6e807057
+generated: "2022-03-04T15:36:54.029938649Z"

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -3,14 +3,14 @@ annotations:
 apiVersion: v2
 appVersion: 2.4.1
 dependencies:
-  - condition: postgresql.enabled
-    name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 10.x.x
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
     version: 15.x.x
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 10.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     version: 1.x.x
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 11.2.5
+version: 11.2.6

--- a/bitnami/jupyterhub/Chart.lock
+++ b/bitnami/jupyterhub/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.3
-digest: sha256:c6a21515c91cb28d190f049bb2f1642772d7e2d8e5c83b10220b46c399422c74
-generated: "2022-03-02T12:43:11.595981+01:00"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:59d28ebb1e7caa4862a9892c8eebf2f28e593292d756c5e48b4ec12d7e4c0571
+generated: "2022-03-04T15:37:28.696424984Z"

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -3,15 +3,15 @@ annotations:
 apiVersion: v2
 appVersion: 1.5.0
 dependencies:
+  - name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+    version: 11.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled
-    version: 11.x.x
 description: JupyterHub brings the power of notebooks to groups of users. It gives users access to computational environments and resources without burdening the users with installation and maintenance tasks.
 engine: gotpl
 home: https://jupyter.org/hub
@@ -26,4 +26,4 @@ name: jupyterhub
 sources:
   - https://github.com/bitnami/bitnami-docker-jupyterhub
   - https://github.com/jupyterhub/jupyterhub
-version: 1.0.0
+version: 1.0.1

--- a/bitnami/kafka/Chart.lock
+++ b/bitnami/kafka/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
   version: 8.1.1
-digest: sha256:27365bfc14ef2cf7ae76c4cdd1f79235ac3e5b1ab8bfeabc91dc249bab317d97
-generated: "2022-02-28T22:25:10.818653011Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:95bd34ff3834f3f58aa7fb22d001314de23c13588758876d6b4893efea8e2f11
+generated: "2022-03-04T15:37:59.558282784Z"

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -3,15 +3,15 @@ annotations:
 apiVersion: v2
 appVersion: 3.1.0
 dependencies:
+  - condition: zookeeper.enabled
+    name: zookeeper
+    repository: https://charts.bitnami.com/bitnami
+    version: 8.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - condition: zookeeper.enabled
-    name: zookeeper
-    repository: https://charts.bitnami.com/bitnami
-    version: 8.x.x
 description: Apache Kafka is a distributed streaming platform designed to build real-time pipelines and can be used as a message broker or as a replacement for a log aggregation solution for big data applications.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/kafka
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 15.3.4
+version: 15.3.5

--- a/bitnami/keycloak/Chart.lock
+++ b/bitnami/keycloak/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.3
-digest: sha256:c6a21515c91cb28d190f049bb2f1642772d7e2d8e5c83b10220b46c399422c74
-generated: "2022-03-02T13:12:57.786314+01:00"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:59d28ebb1e7caa4862a9892c8eebf2f28e593292d756c5e48b4ec12d7e4c0571
+generated: "2022-03-04T15:38:25.331170061Z"

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -3,16 +3,16 @@ annotations:
 apiVersion: v2
 appVersion: 16.1.1
 dependencies:
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 11.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - condition: postgresql.enabled
-    name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 11.x.x
-description: Keycloak is a high performance Java-based identity and access management solution. It lets developers add an authentication layer to their applications with minimum effort. 
+description: Keycloak is a high performance Java-based identity and access management solution. It lets developers add an authentication layer to their applications with minimum effort.
 engine: gotpl
 home: https://www.keycloak.org
 icon: https://bitnami.com/assets/stacks/keycloak/img/keycloak-stack-220x234.png
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 7.0.0
+version: 7.0.1

--- a/bitnami/kong/Chart.lock
+++ b/bitnami/kong/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.2
-- name: cassandra
-  repository: https://charts.bitnami.com/bitnami
-  version: 9.1.7
+  version: 11.1.3
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.1
-digest: sha256:dd583d66f248f7c79b38bc5c04fa1ca7464daeaad27bc7a870d7dd795d698e42
-generated: "2022-02-26T09:53:54.661244715Z"
+  version: 1.11.3
+- name: cassandra
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.1.8
+digest: sha256:c3015c160b6aa8096402b02ef926054010c7abf3100b32a6a1fb57eb0e162a59
+generated: "2022-03-04T15:39:01.294999811Z"

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -7,13 +7,13 @@ dependencies:
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
     version: 11.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    version: 1.x.x
   - condition: cassandra.enabled
     name: cassandra
     repository: https://charts.bitnami.com/bitnami
     version: 9.x.x
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    version: 1.x.x
 description: Kong is an open source Microservice API gateway and platform designed for managing microservices requests of high-availability, fault-tolerance, and distributed systems.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/kong
@@ -34,4 +34,4 @@ name: kong
 sources:
   - https://github.com/bitnami/bitnami-docker-kong
   - https://konghq.com/
-version: 6.0.1
+version: 6.0.2

--- a/bitnami/kube-prometheus/Chart.lock
+++ b/bitnami/kube-prometheus/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: node-exporter
   repository: https://charts.bitnami.com/bitnami
   version: 2.4.4
 - name: kube-state-metrics
   repository: https://charts.bitnami.com/bitnami
   version: 2.2.11
-digest: sha256:57aacd82a8a1973635d29627986e7cc4ecaaec7405c66c059e146156e50a47b0
-generated: "2022-03-01T11:27:24.332045465Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:0ca6f75626784ec979cc02b44267d6c0a21c33bbd375e888653d917657fe4696
+generated: "2022-03-04T15:39:38.492545018Z"

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -3,11 +3,6 @@ annotations:
 apiVersion: v2
 appVersion: 0.54.1
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
   - condition: exporters.enabled,exporters.node-exporter.enabled
     name: node-exporter
     repository: https://charts.bitnami.com/bitnami
@@ -16,6 +11,11 @@ dependencies:
     name: kube-state-metrics
     repository: https://charts.bitnami.com/bitnami
     version: 2.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Prometheus Operator provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/kube-prometheus
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 6.6.10
+version: 6.6.11

--- a/bitnami/kubeapps/Chart.lock
+++ b/bitnami/kubeapps/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.16.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 15.7.6
-digest: sha256:e2fbacc0528c8d10ce61014c4cbaf52186dbcf66d09c1d05fe0a8078f7f6bcda
-generated: "2022-02-28T17:17:52.62446066Z"
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.16.2
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:2966ff9867eda79c880633ed9d924b5ead4a9f4e503e25938dd8e2b98a643b6b
+generated: "2022-03-04T15:40:13.042952348Z"

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -3,14 +3,6 @@ annotations:
 apiVersion: v2
 appVersion: 2.4.3
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
-  - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 10.x.x
   # Currently redis is only used for an in-progress plugin for flux support.
   # Our upstream bitnami/kubeapps chart should not include redis as a
   # dependency yet, and in development we can set redis.enabled if developing
@@ -19,6 +11,14 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 15.x.x
     condition: packaging.flux.enabled
+  - name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 10.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Kubeapps is a web-based UI for launching and managing applications on Kubernetes. It allows users to deploy trusted applications and operators to control users access to the cluster.
 home: https://kubeapps.com
 icon: https://raw.githubusercontent.com/kubeapps/kubeapps/main/docs/img/logo.png
@@ -33,4 +33,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 7.8.6
+version: 7.8.7

--- a/bitnami/magento/Chart.lock
+++ b/bitnami/magento/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 9.8.1
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 17.9.6
-digest: sha256:55c29e6b64f7ee3e3cdd365f30ce85dce4e979ed82b3f2f1d2d3c4f7514e2f5a
-generated: "2022-03-01T06:28:24.969382907Z"
+  version: 17.9.7
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:85390f583ea373d66a0245b9a42be17852fa25dda3f6cd31675498dce478228f
+generated: "2022-03-04T15:40:48.076934202Z"

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -3,11 +3,6 @@ annotations:
 apiVersion: v2
 appVersion: 2.4.3
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
@@ -18,6 +13,11 @@ dependencies:
     name: elasticsearch
     repository: https://charts.bitnami.com/bitnami
     version: 17.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Magento is a powerful open source e-commerce platform. With easy customizations and rich features, it allows retailers to grow their online businesses in a cost-effective way.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/magento
@@ -35,4 +35,4 @@ name: magento
 sources:
   - https://github.com/bitnami/bitnami-docker-magento
   - https://magento.com/
-version: 19.2.8
+version: 19.2.9

--- a/bitnami/mediawiki/Chart.lock
+++ b/bitnami/mediawiki/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 10.3.7
-digest: sha256:41b7cf164d49dacc82f2cd535e333b672a8f222d9f7ad0435fa44be94940994d
-generated: "2022-03-01T01:26:18.508817968Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:1fd3790b3e7292d305b0d9a01156f5c36517483ea0cbdb8ea28aebdb9fe8104b
+generated: "2022-03-04T15:41:15.904724265Z"

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -3,17 +3,17 @@ annotations:
 apiVersion: v2
 appVersion: 1.37.1
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
     tags:
       - mediawiki-database
     version: 10.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: MediaWiki is the free and open source wiki software that powers Wikipedia. Used by thousands of organizations, it is extremely powerful, scalable software and a feature-rich wiki implementation.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/mediawiki
@@ -32,4 +32,4 @@ name: mediawiki
 sources:
   - https://github.com/bitnami/bitnami-docker-mediawiki
   - https://www.mediawiki.org/
-version: 13.0.8
+version: 13.0.9

--- a/bitnami/oauth2-proxy/Chart.lock
+++ b/bitnami/oauth2-proxy/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.4.4
-digest: sha256:3ca6f5c0762c7800b13488818186eca7e6b2ead2c0e76094c6d5db903b675326
-generated: "2022-02-28T20:46:41.443878789Z"
+  version: 16.4.5
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:234dcc1221ea640791cf8c1d226eba441c528a24d17a892ff2091826023069a8
+generated: "2022-03-04T15:41:38.609238129Z"

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -3,15 +3,15 @@ annotations:
 apiVersion: v2
 appVersion: 7.2.1
 dependencies:
+  - name: redis
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
+    version: 16.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - name: redis
-    repository: https://charts.bitnami.com/bitnami
-    condition: redis.enabled
-    version: 16.x.x
 description: A reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/oauth2-proxy
@@ -30,4 +30,4 @@ name: oauth2-proxy
 sources:
   - https://github.com/bitnami/bitnami-docker-oauth2-proxy
   - https://github.com/oauth2-proxy/oauth2-proxy
-version: 2.0.7
+version: 2.0.8

--- a/bitnami/osclass/Chart.lock
+++ b/bitnami/osclass/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 10.3.7
-digest: sha256:ebfd3a907f2d9b8038acb709e18537e8652777a8dc1a5bf2366359452749ed44
-generated: "2022-02-28T22:04:49.721918654Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:2ce7f666d92c60c740480db468565076c80b2f25f80a8e15dff1b22c28c94264
+generated: "2022-03-04T15:42:11.891248091Z"

--- a/bitnami/osclass/Chart.yaml
+++ b/bitnami/osclass/Chart.yaml
@@ -3,17 +3,17 @@ annotations:
 apiVersion: v2
 appVersion: 8.0.1
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
     tags:
       - osclass-database
     version: 10.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Osclass allows you to easily create a classifieds site without any technical knowledge. It provides support for presenting general ads or specialized ads, is customizable, extensible and multilingual.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/osclass
@@ -31,4 +31,4 @@ name: osclass
 sources:
   - https://github.com/bitnami/bitnami-docker-osclass
   - https://osclass.org/
-version: 13.0.11
+version: 13.0.12

--- a/bitnami/owncloud/Chart.lock
+++ b/bitnami/owncloud/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 10.3.7
-digest: sha256:121154ad2a646bbba480e085f0c8e7d6a8be1b6cae25d484d70e7948c61312c9
-generated: "2022-03-01T05:01:55.512092565Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:e8992e29f625c4ba2ef28fe4c7cb55e1dbc7b36749c5ad02221c34ffe3a670d9
+generated: "2022-03-04T15:42:37.402310641Z"

--- a/bitnami/owncloud/Chart.yaml
+++ b/bitnami/owncloud/Chart.yaml
@@ -3,17 +3,17 @@ annotations:
 apiVersion: v2
 appVersion: 10.9.1
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
     tags:
       - owncloud-database
     version: 10.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: ownCloud is an open source content collaboration platform used to store and share files from any device. It grants data privacy, synchronization between devices, and file access control.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/owncloud
@@ -31,4 +31,4 @@ name: owncloud
 sources:
   - https://github.com/bitnami/bitnami-docker-owncloud
   - https://owncloud.org/
-version: 11.0.12
+version: 11.0.13

--- a/bitnami/phpmyadmin/Chart.lock
+++ b/bitnami/phpmyadmin/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 10.3.7
-digest: sha256:e1a43276b806d2dfa5a26fabfde252157e521fed227a2ec09a9d70629054dc04
-generated: "2022-03-01T01:04:36.686700574Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:c839600f817f8e25cae481abbe40828b75f1d038aacb386f6b4fe97d2deee839
+generated: "2022-03-04T15:43:03.323613082Z"

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -3,17 +3,17 @@ annotations:
 apiVersion: v2
 appVersion: 5.1.3
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
   - condition: db.bundleTestDB
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
     tags:
       - phpmyadmin-database
     version: 10.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: phpMyAdmin is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/phpmyadmin
@@ -29,4 +29,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/bitnami-docker-phpmyadmin
   - https://www.phpmyadmin.net/
-version: 9.0.8
+version: 9.0.9

--- a/bitnami/redmine/Chart.lock
+++ b/bitnami/redmine/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.3.7
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.3
-digest: sha256:d3338af0e2d7d75ac4632228d48a8efed407434a4354c7eafafe5cad5ecaa50d
-generated: "2022-03-02T17:21:43.419448+01:00"
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.3.7
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:6054e0e84d0077cf1c5e2ea3ff12dcd36d2f06e26c5d1966c601bd7a32173893
+generated: "2022-03-04T15:43:30.404500007Z"

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -3,19 +3,19 @@ annotations:
 apiVersion: v2
 appVersion: 4.2.4
 dependencies:
+  - condition: postgresql.enabled
+    name: postgresql
+    repository: https://charts.bitnami.com/bitnami
+    version: 11.x.x
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 10.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - condition: mariadb.enabled
-    name: mariadb
-    repository: https://charts.bitnami.com/bitnami
-    version: 10.x.x
-  - condition: postgresql.enabled
-    name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    version: 11.x.x
 description: Redmine is an open source management application. It includes a tracking issue system, Gantt charts for a visual view of projects and deadlines, and supports SCM integration for version control.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/redmine
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/bitnami-docker-redmine
   - https://www.redmine.org/
-version: 18.0.1
+version: 18.0.2

--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.1
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.3.6
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 8.29.2
+  version: 8.30.0
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.3.7
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
   version: 14.9.3
-digest: sha256:1d39115adf7a9d0808b6b975e3e4a9a982f081ba32130508547ebd7fa61f1a5a
-generated: "2022-02-27T04:23:04.487064192Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:28cc8ffad3f09f741f5f1019765f06ea4e5192bfe1cd6f216f8f598cbf4ff0bf
+generated: "2022-03-04T15:44:09.662486536Z"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -3,25 +3,25 @@ annotations:
 apiVersion: v2
 appVersion: 2.9.2
 dependencies:
-  - name: common
+  - condition: rabbitmq.enabled
+    name: rabbitmq
     repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
+    version: 8.x.x
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
     tags:
       - dataflow-database
     version: 10.x.x
-  - condition: rabbitmq.enabled
-    name: rabbitmq
-    repository: https://charts.bitnami.com/bitnami
-    version: 8.x.x
   - condition: kafka.enabled
     name: kafka
     repository: https://charts.bitnami.com/bitnami
     version: 14.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/spring-cloud-dataflow
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 5.2.2
+version: 5.2.3

--- a/bitnami/thanos/Chart.lock
+++ b/bitnami/thanos/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
+- name: minio
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.1.15
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.11.3
-- name: minio
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.1.14
-digest: sha256:9aa7d3264ea213e513c847e2009462bc18ebfa05ffc2babd17aac263caef2b84
-generated: "2022-03-03T18:33:03.719576829Z"
+digest: sha256:422d8ab9bf5994c8660f072b59621399dca60b9ada9eb065def2a363c92f3024
+generated: "2022-03-04T15:44:39.305470924Z"

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -3,15 +3,15 @@ annotations:
 apiVersion: v2
 appVersion: 0.25.0
 dependencies:
+  - condition: minio.enabled
+    name: minio
+    repository: https://charts.bitnami.com/bitnami
+    version: 10.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - condition: minio.enabled
-    name: minio
-    repository: https://charts.bitnami.com/bitnami
-    version: 10.x.x
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/thanos
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 9.0.12
+version: 9.0.13

--- a/bitnami/wavefront/Chart.lock
+++ b/bitnami/wavefront/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
 - name: kube-state-metrics
   repository: https://charts.bitnami.com/bitnami
   version: 2.2.11
-digest: sha256:ada7afa8a2b5832630f849c73f5cd54c7d328c498611b70d7a180116cd791927
-generated: "2022-03-02T08:55:34.370712169Z"
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.11.3
+digest: sha256:7cbb2ac347a4e81e6ccbe7e2cdf31b86feb99cba12d0e3d0d161ac84c29b77e8
+generated: "2022-03-04T15:45:04.155298431Z"

--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -3,15 +3,15 @@ annotations:
 apiVersion: v2
 appVersion: 1.9.0
 dependencies:
+  - condition: kube-state-metrics.enabled
+    name: kube-state-metrics
+    repository: https://charts.bitnami.com/bitnami
+    version: 2.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 1.x.x
-  - condition: kube-state-metrics.enabled
-    name: kube-state-metrics
-    repository: https://charts.bitnami.com/bitnami
-    version: 2.x.x
 description: Wavefront is a high-performance streaming analytics platform for monitoring and optimizing your environment and applications.
 engine: gotpl
 home: https://www.wavefront.com
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 3.1.29
+version: 3.1.30

--- a/bitnami/wordpress-intel/Chart.lock
+++ b/bitnami/wordpress-intel/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.3.7
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
   version: 6.0.5
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.3.7
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
-digest: sha256:3ae99e5ea6895333ceadd1f0d664c6bd40c90d2ecc04d5d321afc7cdb742a3b3
-generated: "2022-03-01T00:10:26.093109284Z"
+  version: 1.11.3
+digest: sha256:5315b4a38c897006555a959372d50646af6204b1aeff5fed0949f34742772240
+generated: "2022-03-04T15:45:37.004243914Z"

--- a/bitnami/wordpress-intel/Chart.yaml
+++ b/bitnami/wordpress-intel/Chart.yaml
@@ -3,14 +3,14 @@ annotations:
 apiVersion: v2
 appVersion: 5.9.1
 dependencies:
-  - condition: mariadb.enabled
-    name: mariadb
-    repository: https://charts.bitnami.com/bitnami
-    version: 10.x.x
   - condition: memcached.enabled
     name: memcached
     repository: https://charts.bitnami.com/bitnami
     version: 6.x.x
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 10.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
@@ -35,4 +35,4 @@ name: wordpress-intel
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress-intel
   - https://wordpress.org/
-version: 0.1.12
+version: 0.1.13

--- a/bitnami/wordpress/Chart.lock
+++ b/bitnami/wordpress/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
-- name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.3.7
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
   version: 6.0.5
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.3.7
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
-digest: sha256:3ae99e5ea6895333ceadd1f0d664c6bd40c90d2ecc04d5d321afc7cdb742a3b3
-generated: "2022-03-01T10:14:41.851043215Z"
+  version: 1.11.3
+digest: sha256:5315b4a38c897006555a959372d50646af6204b1aeff5fed0949f34742772240
+generated: "2022-03-04T15:46:17.511878624Z"

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -3,14 +3,14 @@ annotations:
 apiVersion: v2
 appVersion: 5.9.1
 dependencies:
-  - condition: mariadb.enabled
-    name: mariadb
-    repository: https://charts.bitnami.com/bitnami
-    version: 10.x.x
   - condition: memcached.enabled
     name: memcached
     repository: https://charts.bitnami.com/bitnami
     version: 6.x.x
+  - condition: mariadb.enabled
+    name: mariadb
+    repository: https://charts.bitnami.com/bitnami
+    version: 10.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - https://wordpress.org/
-version: 13.0.21
+version: 13.0.22


### PR DESCRIPTION
**Description of the change**

It seems there is an issue when working with OCI registries and the definition order of the subcharts.
While the issue is solved in the Helm CLI, we are reordering the dependencies.

The upstream issue is to be created.

Continuation of https://github.com/bitnami/charts/pull/9297 once checked everything works fine and charts are pushed to OCI registries without issues.