### PR TITLE
[bitnami/keycloak] Remove unused 'database-password' key

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 7.1.0
+version: 7.1.1

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -113,7 +113,6 @@ auth:
   ##   keyMapping:
   ##     admin-password: myPasswordKey
   ##     management-password: myManagementPasswordKey
-  ##     database-password: myDatabasePasswordKey
   ##     tls-keystore-password: myTlsKeystorePasswordKey
   ##     tls-truestore-password: myTlsTruestorePasswordKey
   ##


### PR DESCRIPTION
Remove unused 'database-password' key commented example
in values.yaml.

Closes #9274.