### PR TITLE
[bitnami/logstash] Adding service account config for workload identity integration

### DIFF
--- a/bitnami/logstash/Chart.lock
+++ b/bitnami/logstash/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.2
-digest: sha256:eda6c82c39104cba0d9522be8ed6316d0bedae75d36deb778ed7f97ff2217aca
-generated: "2022-02-28T18:53:45.037144588Z"
+  version: 1.11.3
+digest: sha256:d5f850d857edd58b32c0e10652f6ec3ce5018def5542f2bcef38fd7fa0079d6b
+generated: "2022-03-08T21:27:00.950997969Z"

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -23,4 +23,4 @@ name: logstash
 sources:
   - https://github.com/bitnami/bitnami-docker-logstash
   - https://www.elastic.co/products/logstash
-version: 3.7.8
+version: 3.8.0

--- a/bitnami/logstash/templates/_helpers.tpl
+++ b/bitnami/logstash/templates/_helpers.tpl
@@ -33,6 +33,17 @@ Return the Logstash configuration configmap.
 {{- end -}}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "logstash.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Check if there are rolling tags in the images
 */}}
 {{- define "logstash.checkRollingTags" -}}

--- a/bitnami/logstash/templates/serviceaccount.yaml
+++ b/bitnami/logstash/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "logstash.serviceAccountName" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
+  annotations:
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end -}}

--- a/bitnami/logstash/templates/serviceaccount.yaml
+++ b/bitnami/logstash/templates/serviceaccount.yaml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "logstash.serviceAccountName" . }}
+  name: {{ template "logstash.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -61,7 +61,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/logstash
-  tag: 7.17.1-debian-10-r0
+  tag: 7.17.1-debian-10-r9
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -434,7 +434,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r351
+    tag: 10-debian-10-r359
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -564,7 +564,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/logstash-exporter
-    tag: 7.3.0-debian-10-r454
+    tag: 7.3.0-debian-10-r461
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -166,21 +166,21 @@ extraVolumeMounts: []
  ## ServiceAccount for Logstash
  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
  ##
- serviceAccount:
-   ## @param serviceAccount.create Enable creation of ServiceAccount for Logstash pods
-   ##
-   create: true
-   ## @param serviceAccount.name The name of the service account to use. If not set and `create` is `true`, a name is generated
-   ## If not set and create is true, a name is generated using the logstash.serviceAccountName template
-   ##
-   name: ""
-   ## @param serviceAccount.automountServiceAccountToken Allows automount of ServiceAccountToken on the serviceAccount created
-   ## Can be set to false if pods using this serviceAccount do not need to use K8s API
-   ##
-   automountServiceAccountToken: true
-   ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
-   ##
-   annotations: {}
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for Logstash pods
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the service account to use. If not set and `create` is `true`, a name is generated
+  ## If not set and create is true, a name is generated using the logstash.serviceAccountName template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows automount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: true
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
 
 ## @param containerPorts [array] Array containing the ports to open in the Logstash container
 ##

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -163,11 +163,24 @@ extraVolumes: []
 ##
 extraVolumeMounts: []
 
-## @param serviceAccount.create If true, create a service account object on Kubernetes.
-# serviceAccount:
-#   create: false
-serviceAccount: 
-  create: false
+ ## ServiceAccount for Logstash
+ ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+ ##
+ serviceAccount:
+   ## @param serviceAccount.create Enable creation of ServiceAccount for Logstash pods
+   ##
+   create: true
+   ## @param serviceAccount.name The name of the service account to use. If not set and `create` is `true`, a name is generated
+   ## If not set and create is true, a name is generated using the logstash.serviceAccountName template
+   ##
+   name: ""
+   ## @param serviceAccount.automountServiceAccountToken Allows automount of ServiceAccountToken on the serviceAccount created
+   ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+   ##
+   automountServiceAccountToken: true
+   ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+   ##
+   annotations: {}
 
 ## @param containerPorts [array] Array containing the ports to open in the Logstash container
 ##

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -164,9 +164,13 @@ extraVolumes: []
 extraVolumeMounts: []
 
 ## @param serviceAccount Containing the creation of ServiceAccount Object on Kubernetes
-serviceAccount:
+## @param serviceAccount.create If true, create a service account.
+## @param serviceAccount.annotations Annotations for the service account
+# serviceAccount:
+#   create: false
+#   annotations: {}
+serviceAccount: 
   create: false
-  annotations: []
 
 ## @param containerPorts [array] Array containing the ports to open in the Logstash container
 ##

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -163,12 +163,9 @@ extraVolumes: []
 ##
 extraVolumeMounts: []
 
-## @param serviceAccount Containing the creation of ServiceAccount Object on Kubernetes
-## @param serviceAccount.create If true, create a service account.
-## @param serviceAccount.annotations Annotations for the service account
+## @param serviceAccount.create If true, create a service account object on Kubernetes.
 # serviceAccount:
 #   create: false
-#   annotations: {}
 serviceAccount: 
   create: false
 

--- a/bitnami/logstash/values.yaml
+++ b/bitnami/logstash/values.yaml
@@ -162,6 +162,12 @@ extraVolumes: []
 ##     readOnly: true
 ##
 extraVolumeMounts: []
+
+## @param serviceAccount Containing the creation of ServiceAccount Object on Kubernetes
+serviceAccount:
+  create: false
+  annotations: []
+
 ## @param containerPorts [array] Array containing the ports to open in the Logstash container
 ##
 containerPorts:


### PR DESCRIPTION
…y integration

Signed-off-by: Luiz Ferreira <luiz.ferreira@idwall.co>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

This config enables the logstash chart to integrate with workload identity of GCP, useful when you need to use a cloud permission on your config, like, buckets, pubsub, etc..

**Benefits**

This change implements a cleaner config of permissions when installing on a GKE cluster, with that you don't need to create a JSON Key for the logstash service acount with the cloud permission and put it inside the pod, you can config that easily using workload identity(https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)

**Possible drawbacks**

This is a simply configuration, doesn't affect anything related to how things work right now.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

I created this PR because i was integrating this logstash chart on my cluster and i needed a special permission for using a custom plugin of pubsub(https://www.elastic.co/guide/en/logstash/current/plugins-inputs-google_pubsub.html), so, instead of creating a new service account on GCP project, download de jsonkey, and put it in a volume of pod, i created this config for easily set this permission using workload identity, using that, all i need to do is add an annotation on service account inside the cluster, pointing to the service account created on GCP project. 

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)