### PR TITLE
[bitnami/dataplatform-*] Bump Kafka subchart

### DIFF
--- a/bitnami/dataplatform-bp1/Chart.lock
+++ b/bitnami/dataplatform-bp1/Chart.lock
@@ -10,12 +10,12 @@ dependencies:
   version: 7.6.2
 - name: wavefront
   repository: https://charts.bitnami.com/bitnami
-  version: 3.1.29
+  version: 3.1.30
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 14.9.3
+  version: 15.3.6
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.11.3
-digest: sha256:11e9de81d072c02ef7f9a4af2c239b4c66af6d3f4993b2c5c52b35af17fde4e4
-generated: "2022-03-04T15:33:07.142092084Z"
+digest: sha256:c54ea21e7871572a9d3e0d5ee780314675c5f77c87c313eae5aba548038cabab
+generated: "2022-03-07T14:00:09.28609+01:00"

--- a/bitnami/dataplatform-bp1/Chart.yaml
+++ b/bitnami/dataplatform-bp1/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
   - condition: kafka.enabled
     name: kafka
     repository: https://charts.bitnami.com/bitnami
-    version: 14.x.x
+    version: 15.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
@@ -59,4 +59,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 9.0.10
+version: 10.0.0

--- a/bitnami/dataplatform-bp1/README.md
+++ b/bitnami/dataplatform-bp1/README.md
@@ -6,8 +6,6 @@ This Helm chart can be used for the automated deployment of a data platform blue
 
 [Overview of Data Platform Blueprint 1](https://github.com/bitnami/dataplatform-exporter)
 
-
-                           
 ## TL;DR
 
 ```console
@@ -487,6 +485,18 @@ Find more information about how to deal with common errors related to Bitnami's 
 In order to render complete information about the deployment including all the sub-charts, please use --render-subchart-notes flag while installing the chart.
 
 ## Upgrading
+
+### To 10.0.0
+
+This major release updates the Kafka subchart to its newest major `15.x.x`, which contain several changes in the supported values and bumps Kafka major version to `3.x` series (check the [upgrade notes](https://github.com/bitnami/charts/blob/master/bitnami/kafka/README.md#to-1500) to obtain more information).
+
+To upgrade to *10.0.0* from *9.x* it's recommended to maintain the Kafka `2.x` series (to avoid incompatibility issues). To do so, follow the instructions below (the following example assumes that the release name is *dataplatform* and the release namespace *default*):
+
+```bash
+export CURRENT_KAFKA_VERSION=$(kubectl exec dataplatform-kafka-0 -- bash -c 'echo $BITNAMI_IMAGE_VERSION')
+helm upgrade dataplatform bitnami/dataplatform-bp1 \
+  --set kafka.image.tag=$CURRENT_KAFKA_VERSION
+```
 
 ### To 9.0.0
 

--- a/bitnami/dataplatform-bp2/Chart.lock
+++ b/bitnami/dataplatform-bp2/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: wavefront
   repository: https://charts.bitnami.com/bitnami
-  version: 3.1.29
+  version: 3.1.30
 - name: spark
   repository: https://charts.bitnami.com/bitnami
   version: 5.9.3
@@ -10,12 +10,12 @@ dependencies:
   version: 3.7.8
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 14.9.3
+  version: 15.3.6
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 17.9.7
+  version: 17.9.8
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.11.3
-digest: sha256:ee19966ac964551d1cb9d3d81d73ae16811e01bbf2f8c77792775decd018061a
-generated: "2022-03-04T15:34:07.255694241Z"
+digest: sha256:1c0f5b128f50729715d224d061f2cbe146fd22d7b582f6adef9d24d62e0cfcf5
+generated: "2022-03-07T13:59:47.914138+01:00"

--- a/bitnami/dataplatform-bp2/Chart.yaml
+++ b/bitnami/dataplatform-bp2/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
   - condition: kafka.enabled
     name: kafka
     repository: https://charts.bitnami.com/bitnami
-    version: 14.x.x
+    version: 15.x.x
   - condition: elasticsearch.enabled
     name: elasticsearch
     repository: https://charts.bitnami.com/bitnami
@@ -58,4 +58,4 @@ sources:
   - https://www.elastic.co/products/logstash
   - https://zookeeper.apache.org/
   - https://github.com/bitnami/bitnami-docker-zookeeper
-version: 10.0.10
+version: 11.0.0

--- a/bitnami/dataplatform-bp2/README.md
+++ b/bitnami/dataplatform-bp2/README.md
@@ -7,7 +7,7 @@ This Helm chart can be used for the automated deployment of a data platform blue
 [Overview of Data Platform Blueprint 2](https://github.com/bitnami/dataplatform-emitter)
 
 
-                           
+
 ## TL;DR
 
 ```console
@@ -541,6 +541,18 @@ Elasticsearch dependency version was bumped to a new major version changing the 
 Regular upgrade is compatible from previous versions.
 
 ## Upgrading
+
+### To 10.0.0
+
+This major release updates the Kafka subchart to its newest major `15.x.x`, which contain several changes in the supported values and bumps Kafka major version to `3.x` series (check the [upgrade notes](https://github.com/bitnami/charts/blob/master/bitnami/kafka/README.md#to-1500) to obtain more information).
+
+To upgrade to *10.0.0* from *9.x* it's recommended to maintain the Kafka `2.x` series (to avoid incompatibility issues). To do so, follow the instructions below (the following example assumes that the release name is *dataplatform* and the release namespace *default*):
+
+```bash
+export CURRENT_KAFKA_VERSION=$(kubectl exec dataplatform-kafka-0 -- bash -c 'echo $BITNAMI_IMAGE_VERSION')
+helm upgrade dataplatform bitnami/dataplatform-bp2 \
+  --set kafka.image.tag=$CURRENT_KAFKA_VERSION
+```
 
 ### To 9.0.0
 


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR bumps the Kafka subchart version to its latest major.

**Benefits**

Use latest chart features

**Possible drawbacks**

None. Upgrading from previous versions is a possibility.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)