### PR TITLE
bitnami/influxdb: fix reference to read/writeUser

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/bitnami-docker-influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 4.0.0
+version: 4.0.1

--- a/bitnami/influxdb/templates/NOTES.txt
+++ b/bitnami/influxdb/templates/NOTES.txt
@@ -49,16 +49,16 @@ To get the password for the {{ .Values.auth.user.username }} user, run:
     export USER_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.user-password}" | base64 --decode)
 
 {{- end }}
-{{- if .Values.readUser.name }}
+{{- if .Values.auth.readUser.username }}
 
-To get the password for the {{ .Values.readUser.name }} user, run:
+To get the password for the {{ .Values.auth.readUser.username }} user, run:
 
     export READ_USER_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.read-user-password}" | base64 --decode)
 
 {{- end }}
-{{- if .Values.writeUser.name }}
+{{- if .Values.auth.writeUser.username }}
 
-To get the password for the {{ .Values.writeUser.name }} user, run:
+To get the password for the {{ .Values.auth.writeUser.username }} user, run:
 
     export WRITE_USER_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "influxdb.secretName" . }} -o jsonpath="{.data.write-user-password}" | base64 --decode)
 


### PR DESCRIPTION
**Description of the change**

Fix bug: reference to old yaml object `readUser` and `writeUser`

**Benefits**

Chart works again without setting old values.

**Possible drawbacks**

I may have missed other places.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)