### PR TITLE
[bitnami/jupyterhub] Chart standardized

### DIFF
--- a/bitnami/jupyterhub/Chart.lock
+++ b/bitnami/jupyterhub/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.3
+  version: 11.1.4
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.11.3
-digest: sha256:59d28ebb1e7caa4862a9892c8eebf2f28e593292d756c5e48b4ec12d7e4c0571
-generated: "2022-03-04T15:37:28.696424984Z"
+digest: sha256:0fc4c1a4f98fe10a226266b775c3a3feec858336fce8bc89dc7502c680a9ad97
+generated: "2022-03-08T10:28:09.616286+01:00"

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -26,4 +26,4 @@ name: jupyterhub
 sources:
   - https://github.com/bitnami/bitnami-docker-jupyterhub
   - https://github.com/jupyterhub/jupyterhub
-version: 1.0.2
+version: 1.1.0

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -64,193 +64,222 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
+
 ### Common parameters
 
-| Name                | Description                                                                         | Value |
-| ------------------- | ----------------------------------------------------------------------------------- | ----- |
-| `kubeVersion`       | Override Kubernetes version                                                         | `""`  |
-| `nameOverride`      | String to partially override common.names.fullname (will maintain the release name) | `""`  |
-| `fullnameOverride`  | String to fully override common.names.fullname                                      | `""`  |
-| `commonLabels`      | Labels to add to all deployed objects                                               | `{}`  |
-| `commonAnnotations` | Annotations to add to all deployed objects                                          | `{}`  |
-| `extraDeploy`       | Array of extra objects to deploy with the release                                   | `[]`  |
+| Name                     | Description                                                                             | Value           |
+| ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
+| `nameOverride`           | String to partially override common.names.fullname (will maintain the release name)     | `""`            |
+| `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
+| `clusterDomain`          | Kubernetes Cluster Domain                                                               | `cluster.local` |
+| `commonLabels`           | Labels to add to all deployed objects                                                   | `{}`            |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the the deployment(s)/daemonset(s)                | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the the deployment(s)/daemonset(s)                   | `["infinity"]`  |
+
 
 ### Hub deployment parameters
 
-| Name                                        | Description                                                                               | Value                  |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------- |
-| `hub.image.registry`                        | Hub image registry                                                                        | `docker.io`            |
-| `hub.image.repository`                      | Hub image repository                                                                      | `bitnami/jupyterhub`   |
-| `hub.image.tag`                             | Hub image tag (immutabe tags are recommended)                                             | `1.5.0-debian-10-r105` |
-| `hub.image.pullPolicy`                      | Hub image pull policy                                                                     | `IfNotPresent`         |
-| `hub.image.pullSecrets`                     | Hub image pull secrets                                                                    | `[]`                   |
-| `hub.startupProbe.enabled`                  | Enable startupProbe                                                                       | `true`                 |
-| `hub.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                    | `10`                   |
-| `hub.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                           | `10`                   |
-| `hub.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                          | `3`                    |
-| `hub.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                        | `30`                   |
-| `hub.startupProbe.successThreshold`         | Success threshold for startupProbe                                                        | `1`                    |
-| `hub.livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`                 |
-| `hub.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                   | `10`                   |
-| `hub.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                          | `10`                   |
-| `hub.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                         | `3`                    |
-| `hub.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                       | `30`                   |
-| `hub.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                       | `1`                    |
-| `hub.readinessProbe.enabled`                | Enable readinessProbe                                                                     | `true`                 |
-| `hub.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                  | `10`                   |
-| `hub.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                         | `10`                   |
-| `hub.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                        | `3`                    |
-| `hub.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                      | `30`                   |
-| `hub.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                      | `1`                    |
-| `hub.baseUrl`                               | Hub base URL                                                                              | `/`                    |
-| `hub.adminUser`                             | Hub Dummy authenticator admin user                                                        | `user`                 |
-| `hub.password`                              | Hub Dummy authenticator password                                                          | `""`                   |
-| `hub.configuration`                         | Hub configuration file (to be used by jupyterhub_config.py)                               | `""`                   |
-| `hub.containerPort`                         | Hub container port                                                                        | `8081`                 |
-| `hub.existingConfigmap`                     | Configmap with Hub init scripts (replaces the scripts in templates/hub/configmap.yml)     | `""`                   |
-| `hub.existingSecret`                        | Secret with hub configuration (replaces the hub.configuration value) and proxy token      | `""`                   |
-| `hub.command`                               | Override Hub default command                                                              | `[]`                   |
-| `hub.args`                                  | Override Hub default args                                                                 | `[]`                   |
-| `hub.pdb.create`                            | Deploy Hub PodDisruptionBudget                                                            | `false`                |
-| `hub.pdb.minAvailable`                      | Set minimum available hub instances                                                       | `""`                   |
-| `hub.pdb.maxUnavailable`                    | Set maximum available hub instances                                                       | `""`                   |
-| `hub.priorityClassName`                     | Hub pod priority class name                                                               | `""`                   |
-| `hub.hostAliases`                           | Add deployment host aliases                                                               | `[]`                   |
-| `hub.resources.limits`                      | The resources limits for the container                                                    | `{}`                   |
-| `hub.resources.requests`                    | The requested resources for the container                                                 | `{}`                   |
-| `hub.containerSecurityContext.enabled`      | Enabled Hub containers' Security Context                                                  | `true`                 |
-| `hub.containerSecurityContext.runAsUser`    | Set Hub container's Security Context runAsUser                                            | `1000`                 |
-| `hub.containerSecurityContext.runAsNonRoot` | Set Hub container's Security Context runAsNonRoot                                         | `true`                 |
-| `hub.podSecurityContext.enabled`            | Enabled Hub pods' Security Context                                                        | `true`                 |
-| `hub.podSecurityContext.fsGroup`            | Set Hub pod's Security Context fsGroup                                                    | `1001`                 |
-| `hub.podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                   |
-| `hub.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                 |
-| `hub.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                   |
-| `hub.nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set                                     | `""`                   |
-| `hub.nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set                                  | `[]`                   |
-| `hub.affinity`                              | Affinity for pod assignment.                                                              | `{}`                   |
-| `hub.nodeSelector`                          | Node labels for pod assignment.                                                           | `{}`                   |
-| `hub.tolerations`                           | Tolerations for pod assignment.                                                           | `[]`                   |
-| `hub.podLabels`                             | Pod extra labels                                                                          | `{}`                   |
-| `hub.podAnnotations`                        | Annotations for server pods.                                                              | `{}`                   |
-| `hub.lifecycleHooks`                        | LifecycleHooks for the hub container to automate configuration before or after startup    | `{}`                   |
-| `hub.customStartupProbe`                    | Override default startup probe                                                            | `{}`                   |
-| `hub.customLivenessProbe`                   | Override default liveness probe                                                           | `{}`                   |
-| `hub.customReadinessProbe`                  | Override default readiness probe                                                          | `{}`                   |
-| `hub.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached            | `RollingUpdate`        |
-| `hub.extraEnvVars`                          | Add extra environment variables to the Hub container                                      | `[]`                   |
-| `hub.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                      | `""`                   |
-| `hub.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                         | `""`                   |
-| `hub.extraVolumes`                          | Optionally specify extra list of additional volumes for Hub pods                          | `[]`                   |
-| `hub.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for Hub container(s)             | `[]`                   |
-| `hub.initContainers`                        | Add additional init containers to the Hub pods                                            | `[]`                   |
-| `hub.sidecars`                              | Add additional sidecar containers to the Hub pod                                          | `[]`                   |
+| Name                                        | Description                                                                                                              | Value                  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| `hub.image.registry`                        | Hub image registry                                                                                                       | `docker.io`            |
+| `hub.image.repository`                      | Hub image repository                                                                                                     | `bitnami/jupyterhub`   |
+| `hub.image.tag`                             | Hub image tag (immutable tags are recommended)                                                                           | `1.5.0-debian-10-r107` |
+| `hub.image.pullPolicy`                      | Hub image pull policy                                                                                                    | `IfNotPresent`         |
+| `hub.image.pullSecrets`                     | Hub image pull secrets                                                                                                   | `[]`                   |
+| `hub.baseUrl`                               | Hub base URL                                                                                                             | `/`                    |
+| `hub.adminUser`                             | Hub Dummy authenticator admin user                                                                                       | `user`                 |
+| `hub.password`                              | Hub Dummy authenticator password                                                                                         | `""`                   |
+| `hub.configuration`                         | Hub configuration file (to be used by jupyterhub_config.py)                                                              | `""`                   |
+| `hub.existingConfigmap`                     | Configmap with Hub init scripts (replaces the scripts in templates/hub/configmap.yml)                                    | `""`                   |
+| `hub.existingSecret`                        | Secret with hub configuration (replaces the hub.configuration value) and proxy token                                     | `""`                   |
+| `hub.command`                               | Override Hub default command                                                                                             | `[]`                   |
+| `hub.args`                                  | Override Hub default args                                                                                                | `[]`                   |
+| `hub.extraEnvVars`                          | Add extra environment variables to the Hub container                                                                     | `[]`                   |
+| `hub.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                                                     | `""`                   |
+| `hub.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                                                        | `""`                   |
+| `hub.containerPorts.http`                   | Hub container port                                                                                                       | `8081`                 |
+| `hub.startupProbe.enabled`                  | Enable startupProbe on Hub containers                                                                                    | `true`                 |
+| `hub.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `10`                   |
+| `hub.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `10`                   |
+| `hub.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `3`                    |
+| `hub.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `30`                   |
+| `hub.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                    |
+| `hub.livenessProbe.enabled`                 | Enable livenessProbe on Hub containers                                                                                   | `true`                 |
+| `hub.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `10`                   |
+| `hub.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `10`                   |
+| `hub.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `3`                    |
+| `hub.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `30`                   |
+| `hub.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                    |
+| `hub.readinessProbe.enabled`                | Enable readinessProbe on Hub containers                                                                                  | `true`                 |
+| `hub.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `10`                   |
+| `hub.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                   |
+| `hub.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `3`                    |
+| `hub.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `30`                   |
+| `hub.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                    |
+| `hub.customStartupProbe`                    | Override default startup probe                                                                                           | `{}`                   |
+| `hub.customLivenessProbe`                   | Override default liveness probe                                                                                          | `{}`                   |
+| `hub.customReadinessProbe`                  | Override default readiness probe                                                                                         | `{}`                   |
+| `hub.resources.limits`                      | The resources limits for the Hub containers                                                                              | `{}`                   |
+| `hub.resources.requests`                    | The requested resources for the Hub containers                                                                           | `{}`                   |
+| `hub.containerSecurityContext.enabled`      | Enabled Hub containers' Security Context                                                                                 | `true`                 |
+| `hub.containerSecurityContext.runAsUser`    | Set Hub container's Security Context runAsUser                                                                           | `1000`                 |
+| `hub.containerSecurityContext.runAsNonRoot` | Set Hub container's Security Context runAsNonRoot                                                                        | `true`                 |
+| `hub.podSecurityContext.enabled`            | Enabled Hub pods' Security Context                                                                                       | `true`                 |
+| `hub.podSecurityContext.fsGroup`            | Set Hub pod's Security Context fsGroup                                                                                   | `1001`                 |
+| `hub.lifecycleHooks`                        | LifecycleHooks for the Hub container to automate configuration before or after startup                                   | `{}`                   |
+| `hub.hostAliases`                           | Add deployment host aliases                                                                                              | `[]`                   |
+| `hub.podLabels`                             | Add extra labels to the Hub pods                                                                                         | `{}`                   |
+| `hub.podAnnotations`                        | Add extra annotations to the Hub pods                                                                                    | `{}`                   |
+| `hub.podAffinityPreset`                     | Pod affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                   |
+| `hub.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                             | `soft`                 |
+| `hub.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                            | `""`                   |
+| `hub.nodeAffinityPreset.key`                | Node label key to match. Ignored if `hub.affinity` is set                                                                | `""`                   |
+| `hub.nodeAffinityPreset.values`             | Node label values to match. Ignored if `hub.affinity` is set                                                             | `[]`                   |
+| `hub.affinity`                              | Affinity for pod assignment.                                                                                             | `{}`                   |
+| `hub.nodeSelector`                          | Node labels for pod assignment.                                                                                          | `{}`                   |
+| `hub.tolerations`                           | Tolerations for pod assignment.                                                                                          | `[]`                   |
+| `hub.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                   |
+| `hub.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                   |
+| `hub.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                   |
+| `hub.terminationGracePeriodSeconds`         | Seconds Hub pod needs to terminate gracefully                                                                            | `""`                   |
+| `hub.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                           | `RollingUpdate`        |
+| `hub.updateStrategy.rollingUpdate`          | Hub deployment rolling update configuration parameters                                                                   | `{}`                   |
+| `hub.extraVolumes`                          | Optionally specify extra list of additional volumes for Hub pods                                                         | `[]`                   |
+| `hub.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for Hub container(s)                                            | `[]`                   |
+| `hub.initContainers`                        | Add additional init containers to the Hub pods                                                                           | `[]`                   |
+| `hub.sidecars`                              | Add additional sidecar containers to the Hub pod                                                                         | `[]`                   |
+| `hub.pdb.create`                            | Deploy Hub PodDisruptionBudget                                                                                           | `false`                |
+| `hub.pdb.minAvailable`                      | Set minimum available hub instances                                                                                      | `""`                   |
+| `hub.pdb.maxUnavailable`                    | Set maximum available hub instances                                                                                      | `""`                   |
+
 
 ### Hub RBAC parameters
 
-| Name                        | Description                                          | Value  |
-| --------------------------- | ---------------------------------------------------- | ------ |
-| `hub.serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
-| `hub.serviceAccount.name`   | Override Hub service account name                    | `""`   |
-| `hub.rbac.create`           | Specifies whether RBAC resources should be created   | `true` |
+| Name                                              | Description                                                            | Value  |
+| ------------------------------------------------- | ---------------------------------------------------------------------- | ------ |
+| `hub.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                   | `true` |
+| `hub.serviceAccount.name`                         | Override Hub service account name                                      | `""`   |
+| `hub.serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created | `true` |
+| `hub.serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                   | `{}`   |
+| `hub.rbac.create`                                 | Specifies whether RBAC resources should be created                     | `true` |
+| `hub.rbac.rules`                                  | Custom RBAC rules to set                                               | `[]`   |
+
 
 ### Hub Traffic Exposure Parameters
 
-| Name                                      | Description                                              | Value       |
-| ----------------------------------------- | -------------------------------------------------------- | ----------- |
-| `hub.networkPolicy.enabled`               | Deploy Hub network policies                              | `true`      |
-| `hub.networkPolicy.allowInterspaceAccess` | Allow communication between pods in different namespaces | `true`      |
-| `hub.networkPolicy.extraIngress`          | Add extra ingress rules to the NetworkPolicy             | `""`        |
-| `hub.networkPolicy.extraEgress`           | Add extra ingress rules to the NetworkPolicy             | `""`        |
-| `hub.service.type`                        | Hub service type                                         | `ClusterIP` |
-| `hub.service.port`                        | Hub service HTTP port                                    | `8081`      |
-| `hub.service.loadBalancerIP`              | Hub service LoadBalancer IP (optional, cloud specific)   | `""`        |
-| `hub.service.loadBalancerSourceRanges`    | loadBalancerIP source ranges for the Service             | `[]`        |
-| `hub.service.nodePorts.http`              | NodePort for the HTTP endpoint                           | `""`        |
-| `hub.service.externalTrafficPolicy`       | External traffic policy for the service                  | `Cluster`   |
+| Name                                      | Description                                                      | Value       |
+| ----------------------------------------- | ---------------------------------------------------------------- | ----------- |
+| `hub.networkPolicy.enabled`               | Deploy Hub network policies                                      | `true`      |
+| `hub.networkPolicy.allowInterspaceAccess` | Allow communication between pods in different namespaces         | `true`      |
+| `hub.networkPolicy.extraIngress`          | Add extra ingress rules to the NetworkPolicy                     | `""`        |
+| `hub.networkPolicy.extraEgress`           | Add extra ingress rules to the NetworkPolicy                     | `""`        |
+| `hub.service.type`                        | Hub service type                                                 | `ClusterIP` |
+| `hub.service.ports.http`                  | Hub service HTTP port                                            | `8081`      |
+| `hub.service.nodePorts.http`              | NodePort for the HTTP endpoint                                   | `""`        |
+| `hub.service.sessionAffinity`             | Control where client requests go, to the same pod or round-robin | `None`      |
+| `hub.service.clusterIP`                   | Hub service Cluster IP                                           | `""`        |
+| `hub.service.loadBalancerIP`              | Hub service Load Balancer IP                                     | `""`        |
+| `hub.service.loadBalancerSourceRanges`    | Hub service Load Balancer sources                                | `[]`        |
+| `hub.service.externalTrafficPolicy`       | Hub service external traffic policy                              | `Cluster`   |
+| `hub.service.annotations`                 | Additional custom annotations for Hub service                    | `{}`        |
+| `hub.service.extraPorts`                  | Extra port to expose on Hub service                              | `[]`        |
+
 
 ### Hub Metrics parameters
 
-| Name                                          | Description                                                                                 | Value          |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------- | -------------- |
-| `hub.metrics.authenticatePrometheus`          | Use authentication for Prometheus                                                           | `false`        |
-| `hub.metrics.serviceMonitor.enabled`          | If the operator is installed in your cluster, set to true to create a Service Monitor Entry | `false`        |
-| `hub.metrics.serviceMonitor.namespace`        | Namespace which Prometheus is running in                                                    | `""`           |
-| `hub.metrics.serviceMonitor.path`             | HTTP path to scrape for metrics                                                             | `/hub/metrics` |
-| `hub.metrics.serviceMonitor.interval`         | Interval at which metrics should be scraped                                                 | `30s`          |
-| `hub.metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                         | `""`           |
-| `hub.metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                                   | `[]`           |
-| `hub.metrics.serviceMonitor.honorLabels`      | Specify honorLabels parameter to add the scrape endpoint                                    | `false`        |
-| `hub.metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the installed Prometheus Operator                  | `{}`           |
+| Name                                           | Description                                                                                 | Value          |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------- | -------------- |
+| `hub.metrics.authenticatePrometheus`           | Use authentication for Prometheus                                                           | `false`        |
+| `hub.metrics.serviceMonitor.enabled`           | If the operator is installed in your cluster, set to true to create a Service Monitor Entry | `false`        |
+| `hub.metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                                    | `""`           |
+| `hub.metrics.serviceMonitor.path`              | HTTP path to scrape for metrics                                                             | `/hub/metrics` |
+| `hub.metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                                 | `30s`          |
+| `hub.metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                         | `""`           |
+| `hub.metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus       | `{}`           |
+| `hub.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                         | `{}`           |
+| `hub.metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                          | `[]`           |
+| `hub.metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                   | `[]`           |
+| `hub.metrics.serviceMonitor.honorLabels`       | Specify honorLabels parameter to add the scrape endpoint                                    | `false`        |
+| `hub.metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.           | `""`           |
+
 
 ### Proxy deployment parameters
 
-| Name                                          | Description                                                                               | Value                             |
-| --------------------------------------------- | ----------------------------------------------------------------------------------------- | --------------------------------- |
-| `proxy.image.registry`                        | Proxy image registry                                                                      | `docker.io`                       |
-| `proxy.image.repository`                      | Proxy image repository                                                                    | `bitnami/configurable-http-proxy` |
-| `proxy.image.tag`                             | Proxy image tag (immutable tags are recommended)                                          | `4.5.1-debian-10-r7`              |
-| `proxy.image.pullPolicy`                      | Proxy image pull policy                                                                   | `IfNotPresent`                    |
-| `proxy.image.pullSecrets`                     | Proxy image pull secrets                                                                  | `[]`                              |
-| `proxy.image.debug`                           | Activate verbose output                                                                   | `false`                           |
-| `proxy.startupProbe.enabled`                  | Enable startupProbe                                                                       | `true`                            |
-| `proxy.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                    | `10`                              |
-| `proxy.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                           | `10`                              |
-| `proxy.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                          | `3`                               |
-| `proxy.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                        | `30`                              |
-| `proxy.startupProbe.successThreshold`         | Success threshold for startupProbe                                                        | `1`                               |
-| `proxy.livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`                            |
-| `proxy.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                   | `10`                              |
-| `proxy.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                          | `10`                              |
-| `proxy.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                         | `3`                               |
-| `proxy.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                       | `30`                              |
-| `proxy.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                       | `1`                               |
-| `proxy.readinessProbe.enabled`                | Enable readinessProbe                                                                     | `true`                            |
-| `proxy.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                  | `10`                              |
-| `proxy.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                         | `10`                              |
-| `proxy.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                        | `3`                               |
-| `proxy.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                      | `30`                              |
-| `proxy.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                      | `1`                               |
-| `proxy.command`                               | Override Proxy default command                                                            | `[]`                              |
-| `proxy.args`                                  | Override Proxy default args                                                               | `[]`                              |
-| `proxy.secretToken`                           | Proxy secret token (used for communication with the Hub)                                  | `""`                              |
-| `proxy.hostAliases`                           | Add deployment host aliases                                                               | `[]`                              |
-| `proxy.pdb.create`                            | Deploy Proxy PodDisruptionBudget                                                          | `false`                           |
-| `proxy.pdb.minAvailable`                      | Set minimum available proxy instances                                                     | `""`                              |
-| `proxy.pdb.maxUnavailable`                    | Set maximum available proxy instances                                                     | `""`                              |
-| `proxy.containerPort.api`                     | Proxy api container port                                                                  | `8001`                            |
-| `proxy.containerPort.metrics`                 | Proxy metrics container port                                                              | `8002`                            |
-| `proxy.containerPort.http`                    | Proxy http container port                                                                 | `8000`                            |
-| `proxy.priorityClassName`                     | Proxy pod priority class name                                                             | `""`                              |
-| `proxy.resources.limits`                      | The resources limits for the container                                                    | `{}`                              |
-| `proxy.resources.requests`                    | The requested resources for the container                                                 | `{}`                              |
-| `proxy.containerSecurityContext.enabled`      | Enabled Proxy containers' Security Context                                                | `true`                            |
-| `proxy.containerSecurityContext.runAsUser`    | Set Proxy container's Security Context runAsUser                                          | `1001`                            |
-| `proxy.containerSecurityContext.runAsNonRoot` | Set Proxy container's Security Context runAsNonRoot                                       | `true`                            |
-| `proxy.podSecurityContext.enabled`            | Enabled Proxy pods' Security Context                                                      | `true`                            |
-| `proxy.podSecurityContext.fsGroup`            | Set Proxy pod's Security Context fsGroup                                                  | `1001`                            |
-| `proxy.podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                              |
-| `proxy.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                            |
-| `proxy.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                              |
-| `proxy.nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set                                     | `""`                              |
-| `proxy.nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set                                  | `[]`                              |
-| `proxy.affinity`                              | Affinity for pod assignment. Evaluated as a template.                                     | `{}`                              |
-| `proxy.nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                  | `{}`                              |
-| `proxy.tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                  | `[]`                              |
-| `proxy.podLabels`                             | Extra labels for Proxy pods                                                               | `{}`                              |
-| `proxy.podAnnotations`                        | Annotations for Proxy pods                                                                | `{}`                              |
-| `proxy.lifecycleHooks`                        | Add lifecycle hooks to the Proxy deployment                                               | `{}`                              |
-| `proxy.customStartupProbe`                    | Override default startup probe                                                            | `{}`                              |
-| `proxy.customLivenessProbe`                   | Override default liveness probe                                                           | `{}`                              |
-| `proxy.customReadinessProbe`                  | Override default readiness probe                                                          | `{}`                              |
-| `proxy.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached            | `RollingUpdate`                   |
-| `proxy.extraEnvVars`                          | Add extra environment variables to the Proxy container                                    | `[]`                              |
-| `proxy.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                      | `""`                              |
-| `proxy.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                         | `""`                              |
-| `proxy.extraVolumes`                          | Optionally specify extra list of additional volumes for Proxy pods                        | `[]`                              |
-| `proxy.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for Proxy container(s)           | `[]`                              |
-| `proxy.initContainers`                        | Add additional init containers to the Proxy pods                                          | `[]`                              |
-| `proxy.sidecars`                              | Add additional sidecar containers to the Proxy pod                                        | `[]`                              |
+| Name                                          | Description                                                                                                              | Value                             |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
+| `proxy.image.registry`                        | Proxy image registry                                                                                                     | `docker.io`                       |
+| `proxy.image.repository`                      | Proxy image repository                                                                                                   | `bitnami/configurable-http-proxy` |
+| `proxy.image.tag`                             | Proxy image tag (immutable tags are recommended)                                                                         | `4.5.1-debian-10-r8`              |
+| `proxy.image.pullPolicy`                      | Proxy image pull policy                                                                                                  | `IfNotPresent`                    |
+| `proxy.image.pullSecrets`                     | Proxy image pull secrets                                                                                                 | `[]`                              |
+| `proxy.image.debug`                           | Activate verbose output                                                                                                  | `false`                           |
+| `proxy.secretToken`                           | Proxy secret token (used for communication with the Hub)                                                                 | `""`                              |
+| `proxy.command`                               | Override Proxy default command                                                                                           | `[]`                              |
+| `proxy.args`                                  | Override Proxy default args                                                                                              | `[]`                              |
+| `proxy.extraEnvVars`                          | Add extra environment variables to the Proxy container                                                                   | `[]`                              |
+| `proxy.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                                                     | `""`                              |
+| `proxy.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                                                        | `""`                              |
+| `proxy.containerPort.api`                     | Proxy api container port                                                                                                 | `8001`                            |
+| `proxy.containerPort.metrics`                 | Proxy metrics container port                                                                                             | `8002`                            |
+| `proxy.containerPort.http`                    | Proxy http container port                                                                                                | `8000`                            |
+| `proxy.startupProbe.enabled`                  | Enable startupProbe on Proxy containers                                                                                  | `true`                            |
+| `proxy.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `10`                              |
+| `proxy.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `10`                              |
+| `proxy.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `3`                               |
+| `proxy.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `30`                              |
+| `proxy.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                               |
+| `proxy.livenessProbe.enabled`                 | Enable livenessProbe on Proxy containers                                                                                 | `true`                            |
+| `proxy.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `10`                              |
+| `proxy.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `10`                              |
+| `proxy.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `3`                               |
+| `proxy.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `30`                              |
+| `proxy.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                               |
+| `proxy.readinessProbe.enabled`                | Enable readinessProbe on Proxy containers                                                                                | `true`                            |
+| `proxy.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `10`                              |
+| `proxy.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                              |
+| `proxy.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `3`                               |
+| `proxy.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `30`                              |
+| `proxy.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                               |
+| `proxy.customStartupProbe`                    | Override default startup probe                                                                                           | `{}`                              |
+| `proxy.customLivenessProbe`                   | Override default liveness probe                                                                                          | `{}`                              |
+| `proxy.customReadinessProbe`                  | Override default readiness probe                                                                                         | `{}`                              |
+| `proxy.resources.limits`                      | The resources limits for the Proxy containers                                                                            | `{}`                              |
+| `proxy.resources.requests`                    | The requested resources for the Proxy containers                                                                         | `{}`                              |
+| `proxy.containerSecurityContext.enabled`      | Enabled Proxy containers' Security Context                                                                               | `true`                            |
+| `proxy.containerSecurityContext.runAsUser`    | Set Proxy container's Security Context runAsUser                                                                         | `1001`                            |
+| `proxy.containerSecurityContext.runAsNonRoot` | Set Proxy container's Security Context runAsNonRoot                                                                      | `true`                            |
+| `proxy.podSecurityContext.enabled`            | Enabled Proxy pods' Security Context                                                                                     | `true`                            |
+| `proxy.podSecurityContext.fsGroup`            | Set Proxy pod's Security Context fsGroup                                                                                 | `1001`                            |
+| `proxy.lifecycleHooks`                        | Add lifecycle hooks to the Proxy deployment                                                                              | `{}`                              |
+| `proxy.hostAliases`                           | Add deployment host aliases                                                                                              | `[]`                              |
+| `proxy.podLabels`                             | Add extra labels to the Proxy pods                                                                                       | `{}`                              |
+| `proxy.podAnnotations`                        | Add extra annotations to the Proxy pods                                                                                  | `{}`                              |
+| `proxy.podAffinityPreset`                     | Pod affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`                                | `""`                              |
+| `proxy.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`                           | `soft`                            |
+| `proxy.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`                          | `""`                              |
+| `proxy.nodeAffinityPreset.key`                | Node label key to match. Ignored if `proxy.affinity` is set                                                              | `""`                              |
+| `proxy.nodeAffinityPreset.values`             | Node label values to match. Ignored if `proxy.affinity` is set                                                           | `[]`                              |
+| `proxy.affinity`                              | Affinity for pod assignment. Evaluated as a template.                                                                    | `{}`                              |
+| `proxy.nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                                                 | `{}`                              |
+| `proxy.tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                                                 | `[]`                              |
+| `proxy.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                              |
+| `proxy.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                              |
+| `proxy.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                              |
+| `proxy.terminationGracePeriodSeconds`         | Seconds Proxy pod needs to terminate gracefully                                                                          | `""`                              |
+| `proxy.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                           | `RollingUpdate`                   |
+| `proxy.updateStrategy.rollingUpdate`          | Proxy deployment rolling update configuration parameters                                                                 | `{}`                              |
+| `proxy.extraVolumes`                          | Optionally specify extra list of additional volumes for Proxy pods                                                       | `[]`                              |
+| `proxy.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for Proxy container(s)                                          | `[]`                              |
+| `proxy.initContainers`                        | Add additional init containers to the Proxy pods                                                                         | `[]`                              |
+| `proxy.sidecars`                              | Add additional sidecar containers to the Proxy pod                                                                       | `[]`                              |
+| `proxy.pdb.create`                            | Deploy Proxy PodDisruptionBudget                                                                                         | `false`                           |
+| `proxy.pdb.minAvailable`                      | Set minimum available proxy instances                                                                                    | `""`                              |
+| `proxy.pdb.maxUnavailable`                    | Set maximum available proxy instances                                                                                    | `""`                              |
+
 
 ### Proxy Traffic Exposure Parameters
 
@@ -261,88 +290,110 @@ The command removes all the Kubernetes components associated with the chart and 
 | `proxy.networkPolicy.extraIngress`               | Add extra ingress rules to the NetworkPolicy                                                                                     | `""`                     |
 | `proxy.networkPolicy.extraEgress`                | Add extra egress rules to the NetworkPolicy                                                                                      | `""`                     |
 | `proxy.service.api.type`                         | API service type                                                                                                                 | `ClusterIP`              |
-| `proxy.service.api.port`                         | API service port                                                                                                                 | `8001`                   |
-| `proxy.service.api.loadBalancerIP`               | API service LoadBalancer IP (optional, cloud specific)                                                                           | `""`                     |
-| `proxy.service.api.loadBalancerSourceRanges`     | loadBalancerIP source ranges for the Service                                                                                     | `[]`                     |
+| `proxy.service.api.ports.http`                   | API service HTTP port                                                                                                            | `8001`                   |
 | `proxy.service.api.nodePorts.http`               | NodePort for the HTTP endpoint                                                                                                   | `""`                     |
-| `proxy.service.api.externalTrafficPolicy`        | External traffic policy for the service                                                                                          | `Cluster`                |
+| `proxy.service.api.sessionAffinity`              | Control where client requests go, to the same pod or round-robin                                                                 | `None`                   |
+| `proxy.service.api.clusterIP`                    | Hub service Cluster IP                                                                                                           | `""`                     |
+| `proxy.service.api.loadBalancerIP`               | Hub service Load Balancer IP                                                                                                     | `""`                     |
+| `proxy.service.api.loadBalancerSourceRanges`     | Hub service Load Balancer sources                                                                                                | `[]`                     |
+| `proxy.service.api.externalTrafficPolicy`        | Hub service external traffic policy                                                                                              | `Cluster`                |
+| `proxy.service.api.annotations`                  | Additional custom annotations for Hub service                                                                                    | `{}`                     |
+| `proxy.service.api.extraPorts`                   | Extra port to expose on Hub service                                                                                              | `[]`                     |
 | `proxy.service.metrics.type`                     | Metrics service type                                                                                                             | `ClusterIP`              |
-| `proxy.service.metrics.port`                     | Metrics service port                                                                                                             | `8002`                   |
-| `proxy.service.metrics.loadBalancerIP`           | Metrics service LoadBalancer IP (optional, cloud specific)                                                                       | `""`                     |
-| `proxy.service.metrics.loadBalancerSourceRanges` | loadBalancerIP source ranges for the Service                                                                                     | `[]`                     |
+| `proxy.service.metrics.ports.http`               | Metrics service port                                                                                                             | `8002`                   |
 | `proxy.service.metrics.nodePorts.http`           | NodePort for the HTTP endpoint                                                                                                   | `""`                     |
-| `proxy.service.metrics.externalTrafficPolicy`    | External traffic policy for the service                                                                                          | `Cluster`                |
+| `proxy.service.metrics.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                                                 | `None`                   |
+| `proxy.service.metrics.clusterIP`                | Hub service Cluster IP                                                                                                           | `""`                     |
+| `proxy.service.metrics.loadBalancerIP`           | Hub service Load Balancer IP                                                                                                     | `""`                     |
+| `proxy.service.metrics.loadBalancerSourceRanges` | Hub service Load Balancer sources                                                                                                | `[]`                     |
+| `proxy.service.metrics.externalTrafficPolicy`    | Hub service external traffic policy                                                                                              | `Cluster`                |
+| `proxy.service.metrics.annotations`              | Additional custom annotations for Hub service                                                                                    | `{}`                     |
+| `proxy.service.metrics.extraPorts`               | Extra port to expose on Hub service                                                                                              | `[]`                     |
 | `proxy.service.public.type`                      | Public service type                                                                                                              | `LoadBalancer`           |
-| `proxy.service.public.port`                      | Public service port                                                                                                              | `80`                     |
-| `proxy.service.public.loadBalancerIP`            | Public service LoadBalancer IP (optional, cloud specific)                                                                        | `""`                     |
-| `proxy.service.public.loadBalancerSourceRanges`  | loadBalancerIP source ranges for the Service                                                                                     | `[]`                     |
+| `proxy.service.public.ports.http`                | Public service HTTP port                                                                                                         | `80`                     |
 | `proxy.service.public.nodePorts.http`            | NodePort for the HTTP endpoint                                                                                                   | `""`                     |
-| `proxy.service.public.externalTrafficPolicy`     | External traffic policy for the service                                                                                          | `Cluster`                |
+| `proxy.service.public.sessionAffinity`           | Control where client requests go, to the same pod or round-robin                                                                 | `None`                   |
+| `proxy.service.public.clusterIP`                 | Hub service Cluster IP                                                                                                           | `""`                     |
+| `proxy.service.public.loadBalancerIP`            | Hub service Load Balancer IP                                                                                                     | `""`                     |
+| `proxy.service.public.loadBalancerSourceRanges`  | Hub service Load Balancer sources                                                                                                | `[]`                     |
+| `proxy.service.public.externalTrafficPolicy`     | Hub service external traffic policy                                                                                              | `Cluster`                |
+| `proxy.service.public.annotations`               | Additional custom annotations for Hub service                                                                                    | `{}`                     |
+| `proxy.service.public.extraPorts`                | Extra port to expose on Hub service                                                                                              | `[]`                     |
 | `proxy.ingress.enabled`                          | Set to true to enable ingress record generation                                                                                  | `false`                  |
 | `proxy.ingress.apiVersion`                       | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
 | `proxy.ingress.ingressClassName`                 | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
-| `proxy.ingress.path`                             | Path to the Proxy pod.                                                                                                           | `/`                      |
 | `proxy.ingress.pathType`                         | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `proxy.ingress.hostname`                         | Set ingress rule hostname                                                                                                        | `jupyterhub.local`       |
+| `proxy.ingress.path`                             | Path to the Proxy pod                                                                                                            | `/`                      |
 | `proxy.ingress.annotations`                      | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
-| `proxy.ingress.tls`                              | Enable ingress tls configuration for the hostname defined at proxy.ingress.hostname                                              | `false`                  |
+| `proxy.ingress.tls`                              | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |
 | `proxy.ingress.selfSigned`                       | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
-| `proxy.ingress.extraHosts`                       | The list of additional hostnames to be covered with this ingress record.                                                         | `[]`                     |
+| `proxy.ingress.extraHosts`                       | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                     |
+| `proxy.ingress.extraPaths`                       | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                     |
 | `proxy.ingress.extraTls`                         | The tls configuration for additional hostnames to be covered with this ingress record.                                           | `[]`                     |
-| `proxy.ingress.extraPaths`                       | Any additional arbitrary paths that may need to be added to the ingress under the main host.                                     | `[]`                     |
-| `proxy.ingress.secrets`                          | Add extra secrets for the tls configuration                                                                                      | `[]`                     |
+| `proxy.ingress.secrets`                          | Custom TLS certificates as secrets                                                                                               | `[]`                     |
+
 
 ### Proxy Metrics parameters
 
-| Name                                            | Description                                                                                 | Value      |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------- | ---------- |
-| `proxy.metrics.serviceMonitor.enabled`          | If the operator is installed in your cluster, set to true to create a Service Monitor Entry | `false`    |
-| `proxy.metrics.serviceMonitor.namespace`        | Namespace which Prometheus is running in                                                    | `""`       |
-| `proxy.metrics.serviceMonitor.path`             | HTTP path to scrape for metrics                                                             | `/metrics` |
-| `proxy.metrics.serviceMonitor.interval`         | Interval at which metrics should be scraped                                                 | `30s`      |
-| `proxy.metrics.serviceMonitor.scrapeTimeout`    | Specify the timeout after which the scrape is ended                                         | `""`       |
-| `proxy.metrics.serviceMonitor.relabellings`     | Specify Metric Relabellings to add to the scrape endpoint                                   | `[]`       |
-| `proxy.metrics.serviceMonitor.honorLabels`      | Specify honorLabels parameter to add the scrape endpoint                                    | `false`    |
-| `proxy.metrics.serviceMonitor.additionalLabels` | Used to pass Labels that are required by the installed Prometheus Operator                  | `{}`       |
+| Name                                             | Description                                                                                 | Value      |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------- | ---------- |
+| `proxy.metrics.serviceMonitor.enabled`           | If the operator is installed in your cluster, set to true to create a Service Monitor Entry | `false`    |
+| `proxy.metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                                    | `""`       |
+| `proxy.metrics.serviceMonitor.path`              | HTTP path to scrape for metrics                                                             | `/metrics` |
+| `proxy.metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                                 | `30s`      |
+| `proxy.metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                         | `""`       |
+| `proxy.metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus       | `{}`       |
+| `proxy.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                         | `{}`       |
+| `proxy.metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                          | `[]`       |
+| `proxy.metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                   | `[]`       |
+| `proxy.metrics.serviceMonitor.honorLabels`       | Specify honorLabels parameter to add the scrape endpoint                                    | `false`    |
+| `proxy.metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.           | `""`       |
+
 
 ### Image puller deployment parameters
 
-| Name                                                | Description                                                                               | Value           |
-| --------------------------------------------------- | ----------------------------------------------------------------------------------------- | --------------- |
-| `imagePuller.enabled`                               | Deploy ImagePuller daemonset                                                              | `true`          |
-| `imagePuller.command`                               | Override ImagePuller default command                                                      | `[]`            |
-| `imagePuller.args`                                  | Override ImagePuller default args                                                         | `[]`            |
-| `imagePuller.hostAliases`                           | Add deployment host aliases                                                               | `[]`            |
-| `imagePuller.resources.limits`                      | The resources limits for the container                                                    | `{}`            |
-| `imagePuller.resources.requests`                    | The requested resources for the container                                                 | `{}`            |
-| `imagePuller.containerSecurityContext.enabled`      | Enabled ImagePuller containers' Security Context                                          | `true`          |
-| `imagePuller.containerSecurityContext.runAsUser`    | Set ImagePuller container's Security Context runAsUser                                    | `1001`          |
-| `imagePuller.containerSecurityContext.runAsNonRoot` | Set ImagePuller container's Security Context runAsNonRoot                                 | `true`          |
-| `imagePuller.podSecurityContext.enabled`            | Enabled ImagePuller pods' Security Context                                                | `true`          |
-| `imagePuller.podSecurityContext.fsGroup`            | Set ImagePuller pod's Security Context fsGroup                                            | `1001`          |
-| `imagePuller.podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
-| `imagePuller.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
-| `imagePuller.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`            |
-| `imagePuller.nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set                                     | `""`            |
-| `imagePuller.nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set                                  | `[]`            |
-| `imagePuller.affinity`                              | Affinity for pod assignment. Evaluated as a template.                                     | `{}`            |
-| `imagePuller.nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                  | `{}`            |
-| `imagePuller.tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                  | `[]`            |
-| `imagePuller.podLabels`                             | Pod extra labels                                                                          | `{}`            |
-| `imagePuller.podAnnotations`                        | Annotations for ImagePuller pods                                                          | `{}`            |
-| `imagePuller.priorityClassName`                     | ImagePuller pod priority class name                                                       | `""`            |
-| `imagePuller.lifecycleHooks`                        | Add lifecycle hooks to the ImagePuller deployment                                         | `{}`            |
-| `imagePuller.customStartupProbe`                    | Override default startup probe                                                            | `{}`            |
-| `imagePuller.customLivenessProbe`                   | Override default liveness probe                                                           | `{}`            |
-| `imagePuller.customReadinessProbe`                  | Override default readiness probe                                                          | `{}`            |
-| `imagePuller.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached            | `RollingUpdate` |
-| `imagePuller.extraEnvVars`                          | Add extra environment variables to the ImagePuller container                              | `[]`            |
-| `imagePuller.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                      | `""`            |
-| `imagePuller.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                         | `""`            |
-| `imagePuller.extraVolumes`                          | Optionally specify extra list of additional volumes for ImagePuller pods                  | `[]`            |
-| `imagePuller.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for ImagePuller container(s)     | `[]`            |
-| `imagePuller.initContainers`                        | Add additional init containers to the ImagePuller pods                                    | `[]`            |
-| `imagePuller.sidecars`                              | Add additional sidecar containers to the ImagePuller pod                                  | `[]`            |
+| Name                                                | Description                                                                                                              | Value           |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------- |
+| `imagePuller.enabled`                               | Deploy ImagePuller daemonset                                                                                             | `true`          |
+| `imagePuller.command`                               | Override ImagePuller default command                                                                                     | `[]`            |
+| `imagePuller.args`                                  | Override ImagePuller default args                                                                                        | `[]`            |
+| `imagePuller.extraEnvVars`                          | Add extra environment variables to the ImagePuller container                                                             | `[]`            |
+| `imagePuller.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                                                     | `""`            |
+| `imagePuller.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                                                        | `""`            |
+| `imagePuller.customStartupProbe`                    | Override default startup probe                                                                                           | `{}`            |
+| `imagePuller.customLivenessProbe`                   | Override default liveness probe                                                                                          | `{}`            |
+| `imagePuller.customReadinessProbe`                  | Override default readiness probe                                                                                         | `{}`            |
+| `imagePuller.resources.limits`                      | The resources limits for the ImagePuller containers                                                                      | `{}`            |
+| `imagePuller.resources.requests`                    | The requested resources for the ImagePuller containers                                                                   | `{}`            |
+| `imagePuller.containerSecurityContext.enabled`      | Enabled ImagePuller containers' Security Context                                                                         | `true`          |
+| `imagePuller.containerSecurityContext.runAsUser`    | Set ImagePuller container's Security Context runAsUser                                                                   | `1001`          |
+| `imagePuller.containerSecurityContext.runAsNonRoot` | Set ImagePuller container's Security Context runAsNonRoot                                                                | `true`          |
+| `imagePuller.podSecurityContext.enabled`            | Enabled ImagePuller pods' Security Context                                                                               | `true`          |
+| `imagePuller.podSecurityContext.fsGroup`            | Set ImagePuller pod's Security Context fsGroup                                                                           | `1001`          |
+| `imagePuller.lifecycleHooks`                        | Add lifecycle hooks to the ImagePuller deployment                                                                        | `{}`            |
+| `imagePuller.hostAliases`                           | Add deployment host aliases                                                                                              | `[]`            |
+| `imagePuller.podLabels`                             | Pod extra labels                                                                                                         | `{}`            |
+| `imagePuller.podAnnotations`                        | Annotations for ImagePuller pods                                                                                         | `{}`            |
+| `imagePuller.podAffinityPreset`                     | Pod affinity preset. Ignored if `imagePuller.affinity` is set. Allowed values: `soft` or `hard`                          | `""`            |
+| `imagePuller.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `imagePuller.affinity` is set. Allowed values: `soft` or `hard`                     | `soft`          |
+| `imagePuller.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `imagePuller.affinity` is set. Allowed values: `soft` or `hard`                    | `""`            |
+| `imagePuller.nodeAffinityPreset.key`                | Node label key to match. Ignored if `imagePuller.affinity` is set                                                        | `""`            |
+| `imagePuller.nodeAffinityPreset.values`             | Node label values to match. Ignored if `imagePuller.affinity` is set                                                     | `[]`            |
+| `imagePuller.affinity`                              | Affinity for pod assignment. Evaluated as a template.                                                                    | `{}`            |
+| `imagePuller.nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                                                 | `{}`            |
+| `imagePuller.tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                                                 | `[]`            |
+| `imagePuller.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`            |
+| `imagePuller.priorityClassName`                     | Priority Class Name                                                                                                      | `""`            |
+| `imagePuller.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`            |
+| `imagePuller.terminationGracePeriodSeconds`         | Seconds ImagePuller pod needs to terminate gracefully                                                                    | `""`            |
+| `imagePuller.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                           | `RollingUpdate` |
+| `imagePuller.updateStrategy.rollingUpdate`          | ImagePuller deployment rolling update configuration parameters                                                           | `{}`            |
+| `imagePuller.extraVolumes`                          | Optionally specify extra list of additional volumes for ImagePuller pods                                                 | `[]`            |
+| `imagePuller.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for ImagePuller container(s)                                    | `[]`            |
+| `imagePuller.initContainers`                        | Add additional init containers to the ImagePuller pods                                                                   | `[]`            |
+| `imagePuller.sidecars`                              | Add additional sidecar containers to the ImagePuller pod                                                                 | `[]`            |
+
 
 ### Singleuser deployment parameters
 
@@ -350,36 +401,40 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------ |
 | `singleuser.image.registry`                     | Single User image registry                                                                          | `docker.io`                          |
 | `singleuser.image.repository`                   | Single User image repository                                                                        | `bitnami/jupyter-base-notebook`      |
-| `singleuser.image.tag`                          | Single User image tag (immutabe tags are recommended)                                               | `1.5.0-debian-10-r104`               |
+| `singleuser.image.tag`                          | Single User image tag (immutabe tags are recommended)                                               | `1.5.0-debian-10-r106`               |
 | `singleuser.image.pullPolicy`                   | Single User image pull policy                                                                       | `IfNotPresent`                       |
 | `singleuser.image.pullSecrets`                  | Single User image pull secrets                                                                      | `[]`                                 |
-| `singleuser.command`                            | Override Single User default command                                                                | `[]`                                 |
-| `singleuser.tolerations`                        | Tolerations for pod assignment. Evaluated as a template.                                            | `[]`                                 |
-| `singleuser.containerPort`                      | Single User container port                                                                          | `8888`                               |
 | `singleuser.notebookDir`                        | Notebook directory (it will be the same as the PVC volume mount)                                    | `/opt/bitnami/jupyterhub-singleuser` |
-| `singleuser.resources.limits`                   | The resources limits for the container                                                              | `{}`                                 |
-| `singleuser.resources.requests`                 | The requested resources for the container                                                           | `{}`                                 |
+| `singleuser.command`                            | Override Single User default command                                                                | `[]`                                 |
+| `singleuser.extraEnvVars`                       | Add extra environment variables to the Single User container                                        | `[]`                                 |
+| `singleuser.containerPort`                      | Single User container port                                                                          | `8888`                               |
+| `singleuser.resources.limits`                   | The resources limits for the Singleuser containers                                                  | `{}`                                 |
+| `singleuser.resources.requests`                 | The requested resources for the Singleuser containers                                               | `{}`                                 |
 | `singleuser.containerSecurityContext.enabled`   | Enabled Single User containers' Security Context                                                    | `true`                               |
 | `singleuser.containerSecurityContext.runAsUser` | Set Single User container's Security Context runAsUser                                              | `1001`                               |
 | `singleuser.podSecurityContext.enabled`         | Enabled Single User pods' Security Context                                                          | `true`                               |
 | `singleuser.podSecurityContext.fsGroup`         | Set Single User pod's Security Context fsGroup                                                      | `1001`                               |
-| `singleuser.nodeSelector`                       | Node labels for pod assignment. Evaluated as a template.                                            | `{}`                                 |
 | `singleuser.podLabels`                          | Extra labels for Single User pods                                                                   | `{}`                                 |
 | `singleuser.podAnnotations`                     | Annotations for Single User pods                                                                    | `{}`                                 |
+| `singleuser.nodeSelector`                       | Node labels for pod assignment. Evaluated as a template.                                            | `{}`                                 |
+| `singleuser.tolerations`                        | Tolerations for pod assignment. Evaluated as a template.                                            | `[]`                                 |
 | `singleuser.priorityClassName`                  | Single User pod priority class name                                                                 | `""`                                 |
 | `singleuser.lifecycleHooks`                     | Add lifecycle hooks to the Single User deployment to automate configuration before or after startup | `{}`                                 |
-| `singleuser.extraEnvVars`                       | Add extra environment variables to the Single User container                                        | `[]`                                 |
 | `singleuser.extraVolumes`                       | Optionally specify extra list of additional volumes for Single User pods                            | `[]`                                 |
 | `singleuser.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for Single User container(s)               | `[]`                                 |
 | `singleuser.initContainers`                     | Add additional init containers to the Single User pods                                              | `[]`                                 |
 | `singleuser.sidecars`                           | Add additional sidecar containers to the Single User pod                                            | `[]`                                 |
 
+
 ### Single User RBAC parameters
 
-| Name                               | Description                                          | Value  |
-| ---------------------------------- | ---------------------------------------------------- | ------ |
-| `singleuser.serviceAccount.create` | Specifies whether a ServiceAccount should be created | `true` |
-| `singleuser.serviceAccount.name`   | Override Single User service account name            | `""`   |
+| Name                                                     | Description                                                            | Value  |
+| -------------------------------------------------------- | ---------------------------------------------------------------------- | ------ |
+| `singleuser.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                   | `true` |
+| `singleuser.serviceAccount.name`                         | Override Single User service account name                              | `""`   |
+| `singleuser.serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created | `true` |
+| `singleuser.serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                   | `{}`   |
+
 
 ### Single User Persistence parameters
 
@@ -389,6 +444,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `singleuser.persistence.storageClass` | Persistent Volumes storage class                           | `""`                |
 | `singleuser.persistence.accessModes`  | Persistent Volumes access modes                            | `["ReadWriteOnce"]` |
 | `singleuser.persistence.size`         | Persistent Volumes size                                    | `10Gi`              |
+
 
 ### Traffic exposure parameters
 
@@ -400,43 +456,37 @@ The command removes all the Kubernetes components associated with the chart and 
 | `singleuser.networkPolicy.extraIngress`             | Add extra ingress rules to the NetworkPolicy             | `""`    |
 | `singleuser.networkPolicy.extraEgress`              | Add extra egress rules to the NetworkPolicy              | `""`    |
 
+
 ### Auxiliary image parameters
 
 | Name                         | Description                                         | Value                   |
 | ---------------------------- | --------------------------------------------------- | ----------------------- |
 | `auxiliaryImage.registry`    | Auxiliary image registry                            | `docker.io`             |
 | `auxiliaryImage.repository`  | Auxiliary image repository                          | `bitnami/bitnami-shell` |
-| `auxiliaryImage.tag`         | Auxiliary image tag (immutabe tags are recommended) | `10-debian-10-r351`     |
+| `auxiliaryImage.tag`         | Auxiliary image tag (immutabe tags are recommended) | `10-debian-10-r353`     |
 | `auxiliaryImage.pullPolicy`  | Auxiliary image pull policy                         | `IfNotPresent`          |
 | `auxiliaryImage.pullSecrets` | Auxiliary image pull secrets                        | `[]`                    |
 
-### External Database settings
 
-| Name                              | Description                                                                                                     | Value        |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------ |
-| `externalDatabase.host`           | Host of an external PostgreSQL instance to connect (only if postgresql.enabled=false)                           | `""`         |
-| `externalDatabase.user`           | User of an external PostgreSQL instance to connect (only if postgresql.enabled=false)                           | `postgres`   |
-| `externalDatabase.password`       | Password of an external PostgreSQL instance to connect (only if postgresql.enabled=false)                       | `""`         |
-| `externalDatabase.existingSecret` | Secret containing the password of an external PostgreSQL instance to connect (only if postgresql.enabled=false) | `""`         |
-| `externalDatabase.database`       | Database inside an external PostgreSQL to connect (only if postgresql.enabled=false)                            | `jupyterhub` |
-| `externalDatabase.port`           | Port of an external PostgreSQL to connect (only if postgresql.enabled=false)                                    | `5432`       |
+### JupyterHub database parameters
 
-### PostgreSQL subchart settings
+| Name                                         | Description                                                             | Value                |
+| -------------------------------------------- | ----------------------------------------------------------------------- | -------------------- |
+| `postgresql.enabled`                         | Switch to enable or disable the PostgreSQL helm chart                   | `true`               |
+| `postgresql.auth.username`                   | Name for a custom user to create                                        | `bn_jupyterhub`      |
+| `postgresql.auth.password`                   | Password for the custom user to create                                  | `""`                 |
+| `postgresql.auth.database`                   | Name for a custom database to create                                    | `bitnami_jupyterhub` |
+| `postgresql.auth.existingSecret`             | Name of existing secret to use for PostgreSQL credentials               | `""`                 |
+| `postgresql.architecture`                    | PostgreSQL architecture (`standalone` or `replication`)                 | `standalone`         |
+| `postgresql.service.ports.postgresql`        | PostgreSQL service port                                                 | `5432`               |
+| `externalDatabase.host`                      | Database host                                                           | `""`                 |
+| `externalDatabase.port`                      | Database port number                                                    | `5432`               |
+| `externalDatabase.user`                      | Non-root username for JupyterHub                                        | `postgres`           |
+| `externalDatabase.password`                  | Password for the non-root username for JupyterHub                       | `""`                 |
+| `externalDatabase.database`                  | JupyterHub database name                                                | `jupyterhub`         |
+| `externalDatabase.existingSecret`            | Name of an existing secret resource containing the database credentials | `""`                 |
+| `externalDatabase.existingSecretPasswordKey` | Name of an existing secret key containing the database credentials      | `""`                 |
 
-| Name                                   | Description                                                                        | Value                |
-| -------------------------------------- | ---------------------------------------------------------------------------------- | -------------------- |
-| `postgresql.enabled`                   | Deploy PostgreSQL subchart                                                         | `true`               |
-| `postgresql.nameOverride`              | Override name of the PostgreSQL chart                                              | `""`                 |
-| `postgresql.existingSecret`            | Existing secret containing the password of the PostgreSQL chart                    | `""`                 |
-| `postgresql.auth.password`             | Password for the postgres user of the PostgreSQL chart (auto-generated if not set) | `""`                 |
-| `postgresql.auth.username`             | Username to create when deploying the PostgreSQL chart                             | `bn_jupyterhub`      |
-| `postgresql.auth.database`             | Database to create when deploying the PostgreSQL chart                             | `bitnami_jupyterhub` |
-| `postgresql.service.ports.postgresql`  | PostgreSQL service port                                                            | `5432`               |
-| `postgresql.persistence.enabled`       | Use PVCs when deploying the PostgreSQL chart                                       | `true`               |
-| `postgresql.persistence.existingClaim` | Use an existing PVC when deploying the PostgreSQL chart                            | `""`                 |
-| `postgresql.persistence.storageClass`  | storageClass of the created PVCs                                                   | `""`                 |
-| `postgresql.persistence.accessMode`    | Access mode of the created PVCs                                                    | `ReadWriteOnce`      |
-| `postgresql.persistence.size`          | Size of the created PVCs                                                           | `8Gi`                |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/jupyterhub/templates/NOTES.txt
+++ b/bitnami/jupyterhub/templates/NOTES.txt
@@ -17,6 +17,7 @@ APP VERSION: {{ .Chart.AppVersion }}
 
 1. Get the JupyterHub URL by running:
 
+{{- $port := coalesce .Values.proxy.service.public.ports.http .Values.proxy.service.public.port | toString }}
 {{- if eq .Values.proxy.service.public.type "NodePort" }}
 
   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }}-proxy-public)
@@ -29,13 +30,12 @@ APP VERSION: {{ .Chart.AppVersion }}
 ** Watch the status using: kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}-proxy-public **
 
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }}-proxy-public --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  echo "JupyterHub URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ $port }}{{ end }}/"
 
-{{- $port:=.Values.proxy.service.public.port | toString }}
-  echo "JupyterHub URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.proxy.service.public.port }}{{ end }}/"
 {{- else if eq .Values.proxy.service.public.type "ClusterIP" }}
 
   echo "JupyterHub URL: http://127.0.0.1:8080/"
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }}-proxy-public 8080:{{ .Values.proxy.service.public.port }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }}-proxy-public 8080:{{ $port }}
 
 {{- end }}
 {{- end }}

--- a/bitnami/jupyterhub/templates/_helpers.tpl
+++ b/bitnami/jupyterhub/templates/_helpers.tpl
@@ -169,6 +169,25 @@ Get the Postgresql credentials secret.
 {{- end -}}
 
 {{/*
+Add environment variables to configure database values
+*/}}
+{{- define "jupyterhub.databaseSecretKey" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- print "password" -}}
+{{- else -}}
+    {{- if .Values.externalDatabase.existingSecret -}}
+        {{- if .Values.externalDatabase.existingSecretPasswordKey -}}
+            {{- printf "%s" .Values.externalDatabase.existingSecretPasswordKey -}}
+        {{- else -}}
+            {{- print "db-password" -}}
+        {{- end -}}
+    {{- else -}}
+        {{- print "db-password" -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get the Postgresql credentials secret.
 */}}
 {{- define "jupyterhub.hubSecretName" -}}

--- a/bitnami/jupyterhub/templates/hub/configmap.yaml
+++ b/bitnami/jupyterhub/templates/hub/configmap.yaml
@@ -101,7 +101,7 @@ data:
 
     # hub_bind_url configures what the JupyterHub process within the hub pod's
     # container should listen to.
-    hub_container_port = {{ .Values.hub.containerPort }}
+    hub_container_port = {{ coalesce .Values.hub.containerPorts.http .Values.hub.containerPort }}
     c.JupyterHub.hub_bind_url = f"http://:{hub_container_port}"
 
     # hub_connect_url is the URL for connecting to the hub for use by external

--- a/bitnami/jupyterhub/templates/hub/deployment.yaml
+++ b/bitnami/jupyterhub/templates/hub/deployment.yaml
@@ -1,13 +1,13 @@
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
+  name: {{ include "jupyterhub.hub.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: hub
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ include "jupyterhub.hub.name" . }}
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -58,11 +58,20 @@ spec:
       {{- if .Values.hub.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.hub.tolerations "context" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.hub.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.hub.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.hub.priorityClassName }}
       priorityClassName: {{ .Values.hub.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.hub.schedulerName }}
+      schedulerName: {{ .Values.hub.schedulerName }}
+      {{- end }}
       {{- if .Values.hub.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.hub.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hub.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.hub.terminationGracePeriodSeconds }}
       {{- end }}
       initContainers:
         {{- if .Values.postgresql.enabled }}
@@ -112,7 +121,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "jupyterhub.databaseSecretName" . }}
-                  key: "password"
+                  key: {{ include "jupyterhub.databaseSecretKey" . }}
             - name: POSTGRESQL_CLIENT_POSTGRES_USER
               value: {{ ternary .Values.postgresql.auth.username .Values.externalDatabase.host .Values.postgresql.enabled | quote }}
         {{- end }}
@@ -129,13 +138,17 @@ spec:
           {{- if .Values.hub.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.hub.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.hub.command }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.hub.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.hub.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - jupyterhub
           {{- end }}
-          {{- if .Values.hub.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.hub.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.hub.args "context" $) | nindent 12 }}
           {{- else }}
           args:
@@ -148,16 +161,16 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ .Values.hub.containerPort }}
+              containerPort: {{ coalesce .Values.hub.containerPorts.http .Values.hub.containerPort }}
           env:
             - name: PYTHONUNBUFFERED
               value: "1"
             - name: HELM_RELEASE_NAME
               value: {{ .Release.Name | quote }}
             - name: PROXY_API_SERVICE_PORT
-              value: {{ .Values.proxy.service.api.port | quote }}
+              value: {{ coalesce .Values.proxy.service.api.ports.http .Values.proxy.service.api.port | quote }}
             - name: HUB_SERVICE_PORT
-              value: {{ .Values.hub.service.port | quote }}
+              value: {{  coalesce .Values.hub.service.ports.http .Values.hub.service.port  | quote }}
             - name: POD_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -171,7 +184,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "jupyterhub.databaseSecretName" . }}
-                  key: {{ ternary "password" "db-password" .Values.postgresql.enabled | quote }}
+                  key: {{ include "jupyterhub.databaseSecretKey" . }}
             {{- if .Values.hub.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.hub.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -187,44 +200,31 @@ spec:
           {{- if .Values.hub.resources }}
           resources: {{- toYaml .Values.hub.resources | nindent 12 }}
           {{- end }}
+          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.hub.startupProbe.enabled }}
-          startupProbe:
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.hub.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
               port: http
-            initialDelaySeconds: {{ .Values.hub.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.hub.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.hub.startupProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.hub.startupProbe.failureThreshold }}
-            successThreshold: {{ .Values.hub.startupProbe.successThreshold }}
           {{- else if .Values.hub.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.hub.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.hub.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.hub.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
               port: http
-            initialDelaySeconds: {{ .Values.hub.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.hub.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.hub.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.hub.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.hub.livenessProbe.successThreshold }}
           {{- else if .Values.hub.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.hub.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.hub.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.hub.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: {{ .Values.hub.baseUrl | trimSuffix "/" }}/hub/health
               port: http
-            initialDelaySeconds: {{ .Values.hub.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.hub.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.hub.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.hub.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.hub.readinessProbe.successThreshold }}
           {{- else if .Values.hub.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.hub.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           volumeMounts:
             - mountPath: /etc/jupyterhub/jupyterhub_config.py

--- a/bitnami/jupyterhub/templates/hub/networkpolicy.yaml
+++ b/bitnami/jupyterhub/templates/hub/networkpolicy.yaml
@@ -33,7 +33,7 @@ spec:
     {{- end }}
     # Pods with label "hub.jupyter.org/network-access-hub" --> Hub
     - ports:
-        - port: {{ .Values.hub.containerPort }}
+        - port: {{ coalesce .Values.hub.containerPorts.http .Values.hub.containerPort }}
       from:
         - podSelector:
             matchLabels:

--- a/bitnami/jupyterhub/templates/hub/pdb.yaml
+++ b/bitnami/jupyterhub/templates/hub/pdb.yaml
@@ -2,18 +2,20 @@
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
+  name: {{ include "jupyterhub.hub.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: hub
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ include "jupyterhub.hub.name" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
   minAvailable: {{ .Values.hub.pdb.minAvailable }}
   maxUnavailable: {{ .Values.hub.pdb.maxUnavailable }}
   selector:
-    matchLabels:
-      {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: hub
 {{- end }}

--- a/bitnami/jupyterhub/templates/hub/role.yaml
+++ b/bitnami/jupyterhub/templates/hub/role.yaml
@@ -2,16 +2,16 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: {{ printf "%s-hub" (include "common.names.fullname" .) }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: hub
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ include "jupyterhub.hub.name" . }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace | quote }}
 rules:
   - apiGroups: [""]
     resources: ["pods", "persistentvolumeclaims"]
@@ -19,4 +19,7 @@ rules:
   - apiGroups: [""]       # "" indicates the core API group
     resources: ["events"]
     verbs: ["get", "watch", "list"]
+  {{- if .Values.hub.rbac.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.hub.rbac.rules "context" $ ) | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/bitnami/jupyterhub/templates/hub/rolebinding.yaml
+++ b/bitnami/jupyterhub/templates/hub/rolebinding.yaml
@@ -2,19 +2,22 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: {{ include "jupyterhub.hub.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: hub
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ include "jupyterhub.hub.name" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "jupyterhub.hubServiceAccountName" . }}
+    name: {{ include "jupyterhub.hubServiceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ template "common.names.fullname" . }}-hub
+  name: {{ printf "%s-hub" (include "common.names.fullname" .) }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/bitnami/jupyterhub/templates/hub/secret.yaml
+++ b/bitnami/jupyterhub/templates/hub/secret.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ include "jupyterhub.hub.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: hub
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ include "jupyterhub.hub.name" . }}
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/jupyterhub/templates/hub/service-account.yaml
+++ b/bitnami/jupyterhub/templates/hub/service-account.yaml
@@ -2,14 +2,19 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: {{ template "jupyterhub.hubServiceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: hub
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ template "jupyterhub.hubServiceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.hub.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.hub.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ .Values.hub.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/bitnami/jupyterhub/templates/hub/service.yaml
+++ b/bitnami/jupyterhub/templates/hub/service.yaml
@@ -1,36 +1,49 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ include "jupyterhub.hub.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: hub
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ include "jupyterhub.hub.name" . }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.hub.service.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.hub.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.hub.service.type }}
+  sessionAffinity: {{ .Values.hub.service.sessionAffinity }}
+  {{- if and .Values.hub.service.clusterIP (eq .Values.hub.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.hub.service.clusterIP }}
+  {{- end }}
   {{- if (or (eq .Values.hub.service.type "LoadBalancer") (eq .Values.hub.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.hub.service.externalTrafficPolicy | quote }}
   {{- end }}
-  {{ if eq .Values.hub.service.type "LoadBalancer" }}
-  loadBalancerSourceRanges: {{ .Values.hub.service.loadBalancerSourceRanges }}
-  {{ end }}
+  {{- if (and (eq .Values.hub.service.type "LoadBalancer") .Values.hub.service.loadBalancerSourceRanges) }}
+  {{- with .Values.hub.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{- if (and (eq .Values.hub.service.type "LoadBalancer") (not (empty .Values.hub.service.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.hub.service.loadBalancerIP }}
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.hub.service.port }}
+      port: {{ coalesce .Values.hub.service.ports.http .Values.hub.service.port }}
       targetPort: http
       protocol: TCP
-      {{- if (and (or (eq .Values.hub.service.type "NodePort") (eq .Values.hub.service.type "LoadBalancer")) (not (empty .Values.hub.service.nodePorts.http))) }}
+      {{- if and (or (eq .Values.hub.service.type "NodePort") (eq .Values.hub.service.type "LoadBalancer")) (not (empty .Values.hub.service.nodePorts.http)) }}
       nodePort: {{ .Values.hub.service.nodePorts.http }}
       {{- else if eq .Values.hub.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.hub.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.hub.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: hub

--- a/bitnami/jupyterhub/templates/hub/servicemonitor.yaml
+++ b/bitnami/jupyterhub/templates/hub/servicemonitor.yaml
@@ -21,6 +21,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.hub.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.hub.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   endpoints:
     - port: http
       path: {{ .Values.hub.metrics.serviceMonitor.path }}
@@ -33,8 +36,11 @@ spec:
       {{- if .Values.hub.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.hub.metrics.serviceMonitor.honorLabels }}
       {{- end }}
-      {{- if .Values.hub.metrics.serviceMonitor.relabellings }}
-      metricRelabelings: {{- toYaml .Values.hub.metrics.serviceMonitor.relabellings | nindent 6 }}
+      {{- if .Values.hub.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.hub.metrics.serviceMonitor.relabelings "context" $) | nindent 6 }}
+      {{- end }}
+      {{- if .Values.hub.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.hub.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/jupyterhub/templates/image-puller/daemonset.yaml
+++ b/bitnami/jupyterhub/templates/image-puller/daemonset.yaml
@@ -2,13 +2,13 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  name: {{ printf "%s-image-puller" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: image-puller
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ printf "%s-image-puller" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -48,11 +48,20 @@ spec:
       {{- if .Values.imagePuller.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.imagePuller.tolerations "context" .) | nindent 8 }}
       {{- end }}
-      {{- if .Values.imagePuller.priorityClassName }}
+      {{- if .Values.imagePuller.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.imagePuller.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hub.priorityClassName }}
       priorityClassName: {{ .Values.imagePuller.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.imagePuller.schedulerName }}
+      schedulerName: {{ .Values.imagePuller.schedulerName }}
       {{- end }}
       {{- if .Values.imagePuller.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.imagePuller.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.imagePuller.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.imagePuller.terminationGracePeriodSeconds }}
       {{- end }}
       initContainers:
       {{- range $index, $image := (list .Values.singleuser.image .Values.auxiliaryImage) }}
@@ -80,7 +89,9 @@ spec:
           {{- if .Values.imagePuller.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.imagePuller.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.imagePuller.command }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.imagePuller.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.imagePuller.command "context" $) | nindent 12 }}
           {{- else }}
           command:
@@ -88,7 +99,9 @@ spec:
             - -c
             - sleep infinity
           {{- end }}
-          {{- if .Values.imagePuller.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.imagePuller.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.imagePuller.args "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.imagePuller.extraEnvVars }}

--- a/bitnami/jupyterhub/templates/proxy/deployment.yaml
+++ b/bitnami/jupyterhub/templates/proxy/deployment.yaml
@@ -1,13 +1,13 @@
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
+  name: {{ include "jupyterhub.proxy.name" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: proxy
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ include "jupyterhub.proxy.name" . }}
-  namespace: {{ .Release.Namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -20,10 +20,11 @@ spec:
       app.kubernetes.io/component: proxy
   template:
     metadata:
-      {{- if .Values.proxy.podAnnotations }}
-      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.podAnnotations "context" $) | nindent 8 }}
+      annotations:
+        {{- if .Values.proxy.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.proxy.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
         checksum/hub-secret: {{ include (print $.Template.BasePath "/hub/secret.yaml") . | sha256sum }}
-      {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: proxy
         hub.jupyter.org/network-access-hub: "true"
@@ -50,11 +51,20 @@ spec:
       {{- if .Values.proxy.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.tolerations "context" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.proxy.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.proxy.priorityClassName }}
       priorityClassName: {{ .Values.proxy.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.proxy.schedulerName }}
+      schedulerName: {{ .Values.proxy.schedulerName }}
+      {{- end }}
       {{- if .Values.proxy.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.proxy.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.proxy.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.proxy.terminationGracePeriodSeconds }}
       {{- end }}
       {{- if .Values.proxy.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.initContainers "context" $) | nindent 8 }}
@@ -69,10 +79,14 @@ spec:
           {{- if .Values.proxy.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.proxy.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.proxy.command }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.proxy.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.command "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.proxy.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.proxy.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.args "context" $) | nindent 12 }}
           {{- else }}
           args:
@@ -80,8 +94,8 @@ spec:
             - "--ip=::"
             - "--api-ip=::"
             - --api-port={{ .Values.proxy.containerPort.api }}
-            - --default-target=http://{{ template "common.names.fullname" . }}-hub:{{ .Values.hub.service.port }}
-            - --error-target=http://{{ template "common.names.fullname" . }}-hub:{{ .Values.hub.service.port }}/hub/error
+            - --default-target=http://{{ template "common.names.fullname" . }}-hub:{{ coalesce .Values.hub.service.ports.http .Values.hub.service.port }}
+            - --error-target=http://{{ template "common.names.fullname" . }}-hub:{{ coalesce .Values.hub.service.ports.http .Values.hub.service.port }}/hub/error
             - --port={{ .Values.proxy.containerPort.http }}
             {{- if .Values.proxy.metrics.serviceMonitor.enabled }}
             - "--metrics-ip=::"
@@ -124,44 +138,31 @@ spec:
           {{- if .Values.proxy.resources }}
           resources: {{- toYaml .Values.proxy.resources | nindent 12 }}
           {{- end }}
+          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.proxy.startupProbe.enabled }}
-          startupProbe:
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.proxy.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /_chp_healthz
               port: http
-            initialDelaySeconds: {{ .Values.proxy.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.proxy.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.proxy.startupProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.proxy.startupProbe.successThreshold }}
-            failureThreshold: {{ .Values.proxy.startupProbe.failureThreshold }}
           {{- else if .Values.proxy.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.proxy.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.proxy.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /_chp_healthz
               port: http
-            initialDelaySeconds: {{ .Values.proxy.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.proxy.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.proxy.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.proxy.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.proxy.livenessProbe.failureThreshold }}
           {{- else if .Values.proxy.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.proxy.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.proxy.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /_chp_healthz
               port: http
-            initialDelaySeconds: {{ .Values.proxy.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.proxy.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.proxy.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.proxy.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.proxy.readinessProbe.failureThreshold }}
           {{- else if .Values.proxy.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           volumeMounts:
           {{- if .Values.proxy.extraVolumeMounts }}

--- a/bitnami/jupyterhub/templates/proxy/networkpolicy.yaml
+++ b/bitnami/jupyterhub/templates/proxy/networkpolicy.yaml
@@ -40,7 +40,7 @@ spec:
   egress:
     # Proxy --> Hub
     - ports:
-        - port: {{ .Values.hub.containerPort }}
+        - port: {{ coalesce .Values.hub.containerPorts.http .Values.hub.containerPort }}
       to:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" . | nindent 14 }}

--- a/bitnami/jupyterhub/templates/proxy/service-api.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-api.yaml
@@ -1,30 +1,40 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ printf "%s-proxy-api" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: proxy
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ printf "%s-proxy-api" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.proxy.service.api.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.proxy.service.api.annotations "context" $) | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.proxy.service.api.type }}
+  sessionAffinity: {{ .Values.proxy.service.api.sessionAffinity }}
+  {{- if and .Values.proxy.service.api.clusterIP (eq .Values.proxy.service.api.type "ClusterIP") }}
+  clusterIP: {{ .Values.proxy.service.api.clusterIP }}
+  {{- end }}
   {{- if (or (eq .Values.proxy.service.api.type "LoadBalancer") (eq .Values.proxy.service.api.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.proxy.service.api.externalTrafficPolicy | quote }}
   {{- end }}
-  {{ if eq .Values.proxy.service.api.type "LoadBalancer" }}
-  loadBalancerSourceRanges: {{ .Values.proxy.service.api.loadBalancerSourceRanges }}
-  {{ end }}
+  {{- if (and (eq .Values.proxy.service.api.type "LoadBalancer") .Values.proxy.service.api.loadBalancerSourceRanges) }}
+  {{- with .Values.proxy.service.api.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{- if (and (eq .Values.proxy.service.api.type "LoadBalancer") (not (empty .Values.proxy.service.api.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.proxy.service.api.loadBalancerIP }}
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.proxy.service.api.port }}
+      port: {{ coalesce .Values.proxy.service.api.ports.http .Values.proxy.service.api.port }}
       targetPort: api
       protocol: TCP
       {{- if (and (or (eq .Values.proxy.service.api.type "NodePort") (eq .Values.proxy.service.api.type "LoadBalancer")) (not (empty .Values.proxy.service.api.nodePorts.http))) }}
@@ -32,5 +42,8 @@ spec:
       {{- else if eq .Values.proxy.service.api.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.proxy.service.api.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.proxy.service.api.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: proxy

--- a/bitnami/jupyterhub/templates/proxy/service-metrics.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-metrics.yaml
@@ -3,30 +3,40 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ printf "%s-proxy-metrics" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: proxy
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ printf "%s-proxy-metrics" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.proxy.service.metrics.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.proxy.service.metrics.annotations "context" $) | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.proxy.service.metrics.type }}
+  sessionAffinity: {{ .Values.proxy.service.metrics.sessionAffinity }}
+  {{- if and .Values.proxy.service.metrics.clusterIP (eq .Values.proxy.service.metrics.type "ClusterIP") }}
+  clusterIP: {{ .Values.proxy.service.metrics.clusterIP }}
+  {{- end }}
   {{- if (or (eq .Values.proxy.service.metrics.type "LoadBalancer") (eq .Values.proxy.service.metrics.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.proxy.service.metrics.externalTrafficPolicy | quote }}
   {{- end }}
-  {{ if eq .Values.proxy.service.metrics.type "LoadBalancer" }}
-  loadBalancerSourceRanges: {{ .Values.proxy.service.metrics.loadBalancerSourceRanges }}
-  {{ end }}
+  {{- if (and (eq .Values.proxy.service.metrics.type "LoadBalancer") .Values.proxy.service.metrics.loadBalancerSourceRanges) }}
+  {{- with .Values.proxy.service.metrics.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{- if (and (eq .Values.proxy.service.metrics.type "LoadBalancer") (not (empty .Values.proxy.service.metrics.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.proxy.service.metrics.loadBalancerIP }}
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.proxy.service.metrics.port }}
+      port: {{ coalesce .Values.proxy.service.metrics.ports.http .Values.proxy.service.metrics.port }}
       targetPort: metrics
       protocol: TCP
       {{- if (and (or (eq .Values.proxy.service.metrics.type "NodePort") (eq .Values.proxy.service.metrics.type "LoadBalancer")) (not (empty .Values.proxy.service.metrics.nodePorts.http))) }}
@@ -34,6 +44,9 @@ spec:
       {{- else if eq .Values.proxy.service.metrics.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.proxy.service.metrics.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.proxy.service.metrics.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: proxy
 {{- end }}

--- a/bitnami/jupyterhub/templates/proxy/service-public.yaml
+++ b/bitnami/jupyterhub/templates/proxy/service-public.yaml
@@ -1,30 +1,40 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ printf "%s-proxy-public" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: proxy
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ printf "%s-proxy-public" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.proxy.service.public.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.proxy.service.public.annotations "context" $) | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.proxy.service.public.type }}
+  sessionAffinity: {{ .Values.proxy.service.public.sessionAffinity }}
+  {{- if and .Values.proxy.service.public.clusterIP (eq .Values.proxy.service.public.type "ClusterIP") }}
+  clusterIP: {{ .Values.proxy.service.public.clusterIP }}
+  {{- end }}
   {{- if (or (eq .Values.proxy.service.public.type "LoadBalancer") (eq .Values.proxy.service.public.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.proxy.service.public.externalTrafficPolicy | quote }}
   {{- end }}
-  {{ if eq .Values.proxy.service.public.type "LoadBalancer" }}
-  loadBalancerSourceRanges: {{ .Values.proxy.service.public.loadBalancerSourceRanges }}
-  {{ end }}
+  {{- if (and (eq .Values.proxy.service.public.type "LoadBalancer") .Values.proxy.service.public.loadBalancerSourceRanges) }}
+  {{- with .Values.proxy.service.public.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{- if (and (eq .Values.proxy.service.public.type "LoadBalancer") (not (empty .Values.proxy.service.public.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.proxy.service.public.loadBalancerIP }}
   {{- end }}
   ports:
     - name: http
-      port: {{ .Values.proxy.service.public.port }}
+      port: {{ coalesce .Values.proxy.service.public.ports.http .Values.proxy.service.public.port }}
       targetPort: http
       protocol: TCP
       {{- if (and (or (eq .Values.proxy.service.public.type "NodePort") (eq .Values.proxy.service.public.type "LoadBalancer")) (not (empty .Values.proxy.service.public.nodePorts.http))) }}
@@ -32,5 +42,8 @@ spec:
       {{- else if eq .Values.proxy.service.public.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.proxy.service.public.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.proxy.service.public.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: proxy

--- a/bitnami/jupyterhub/templates/proxy/servicemonitor.yaml
+++ b/bitnami/jupyterhub/templates/proxy/servicemonitor.yaml
@@ -21,6 +21,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.proxy.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.proxy.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   endpoints:
     - port: metrics
       path: {{ .Values.proxy.metrics.serviceMonitor.path }}
@@ -33,8 +36,11 @@ spec:
       {{- if .Values.proxy.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.proxy.metrics.serviceMonitor.honorLabels }}
       {{- end }}
-      {{- if .Values.proxy.metrics.serviceMonitor.relabellings }}
-      metricRelabelings: {{- toYaml .Values.proxy.metrics.serviceMonitor.relabellings | nindent 6 }}
+      {{- if .Values.proxy.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.proxy.metrics.serviceMonitor.relabelings "context" $) | nindent 6 }}
+      {{- end }}
+      {{- if .Values.proxy.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- toYaml .Values.proxy.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:

--- a/bitnami/jupyterhub/templates/proxy/tls-secret.yaml
+++ b/bitnami/jupyterhub/templates/proxy/tls-secret.yaml
@@ -41,5 +41,6 @@ data:
   tls.crt: {{ $cert.Cert | b64enc | quote }}
   tls.key: {{ $cert.Key | b64enc | quote }}
   ca.crt: {{ $ca.Cert | b64enc | quote }}
+---
 {{- end }}
 {{- end }}

--- a/bitnami/jupyterhub/templates/singleuser/networkpolicy.yaml
+++ b/bitnami/jupyterhub/templates/singleuser/networkpolicy.yaml
@@ -40,7 +40,7 @@ spec:
   egress:
     # Single User --> Hub
     - ports:
-        - port: {{ .Values.hub.containerPort }}
+        - port: {{ coalesce .Values.hub.containerPorts.http .Values.hub.containerPort }}
       to:
         - podSelector:
             matchLabels: {{- include "common.labels.matchLabels" . | nindent 14 }}

--- a/bitnami/jupyterhub/templates/singleuser/service-account.yaml
+++ b/bitnami/jupyterhub/templates/singleuser/service-account.yaml
@@ -2,14 +2,19 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: {{ template "jupyterhub.singleuserServiceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: singleuser
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ template "jupyterhub.singleuserServiceAccountName" . }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
-  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.singleuser.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.singleuser.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ .Values.singleuser.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -2,7 +2,6 @@
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
-##
 
 ## @param global.imageRegistry Global Docker image registry
 ## @param global.imagePullSecrets Global Docker registry secret names as an array
@@ -29,6 +28,9 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override common.names.fullname
 ##
 fullnameOverride: ""
+## @param clusterDomain Kubernetes Cluster Domain
+##
+clusterDomain: cluster.local
 ## @param commonLabels  Labels to add to all deployed objects
 ##
 commonLabels: {}
@@ -38,28 +40,37 @@ commonAnnotations: {}
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## Enable diagnostic mode in the deployment(s)/daemonset(s)
+##
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ##
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the the deployment(s)/daemonset(s)
+  ##
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the the deployment(s)/daemonset(s)
+  ##
+  args:
+    - infinity
 
 ## @section Hub deployment parameters
-##
 
-## Hub deployment parameters
-##
 hub:
+  ## @param hub.image.registry Hub image registry
+  ## @param hub.image.repository Hub image repository
+  ## @param hub.image.tag Hub image tag (immutable tags are recommended)
+  ## @param hub.image.pullPolicy Hub image pull policy
+  ## @param hub.image.pullSecrets Hub image pull secrets
+  ##
   image:
-    ## @param hub.image.registry Hub image registry
-    ##
     registry: docker.io
-    ## @param hub.image.repository Hub image repository
-    ##
     repository: bitnami/jupyterhub
-    ## @param hub.image.tag Hub image tag (immutabe tags are recommended)
-    ##
     tag: 1.5.0-debian-10-r107
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    ## @param hub.image.pullPolicy Hub image pull policy
     ##
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -68,55 +79,8 @@ hub:
     ## e.g:
     ## pullSecrets:
     ##  - myRegistryKeySecretName
-    ## @param hub.image.pullSecrets Hub image pull secrets
     ##
     pullSecrets: []
-  ## Configure extra options for startup probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-startup-readiness-probes/#configure-probes
-  ## @param hub.startupProbe.enabled Enable startupProbe
-  ## @param hub.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
-  ## @param hub.startupProbe.periodSeconds Period seconds for startupProbe
-  ## @param hub.startupProbe.timeoutSeconds Timeout seconds for startupProbe
-  ## @param hub.startupProbe.failureThreshold Failure threshold for startupProbe
-  ## @param hub.startupProbe.successThreshold Success threshold for startupProbe
-  ##
-  startupProbe:
-    enabled: true
-    initialDelaySeconds: 10
-    periodSeconds: 10
-    failureThreshold: 30
-    timeoutSeconds: 3
-    successThreshold: 1
-  ## Configure extra options for liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param hub.livenessProbe.enabled Enable livenessProbe
-  ## @param hub.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
-  ## @param hub.livenessProbe.periodSeconds Period seconds for livenessProbe
-  ## @param hub.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
-  ## @param hub.livenessProbe.failureThreshold Failure threshold for livenessProbe
-  ## @param hub.livenessProbe.successThreshold Success threshold for livenessProbe
-  ##
-  livenessProbe:
-    enabled: true
-    initialDelaySeconds: 10
-    periodSeconds: 10
-    failureThreshold: 30
-    timeoutSeconds: 3
-    successThreshold: 1
-  ## @param hub.readinessProbe.enabled Enable readinessProbe
-  ## @param hub.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
-  ## @param hub.readinessProbe.periodSeconds Period seconds for readinessProbe
-  ## @param hub.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
-  ## @param hub.readinessProbe.failureThreshold Failure threshold for readinessProbe
-  ## @param hub.readinessProbe.successThreshold Success threshold for readinessProbe
-  ##
-  readinessProbe:
-    enabled: true
-    initialDelaySeconds: 10
-    periodSeconds: 10
-    failureThreshold: 30
-    timeoutSeconds: 3
-    successThreshold: 1
   ## @param hub.baseUrl Hub base URL
   ##
   baseUrl: /
@@ -272,9 +236,6 @@ hub:
       every: 600
       concurrency: 10
       maxAge: 0
-  ## @param hub.containerPort Hub container port
-  ##
-  containerPort: 8081
   ## @param hub.existingConfigmap Configmap with Hub init scripts (replaces the scripts in templates/hub/configmap.yml)
   ##
   existingConfigmap: ""
@@ -287,44 +248,83 @@ hub:
   ## @param hub.args Override Hub default args
   ##
   args: []
-  pdb:
-    ## @param hub.pdb.create Deploy Hub PodDisruptionBudget
-    ##
-    create: false
-    ## @param hub.pdb.minAvailable Set minimum available hub instances
-    ##
-    minAvailable: ""
-    ## @param hub.pdb.maxUnavailable Set maximum available hub instances
-    ##
-    maxUnavailable: ""
-  ## @param hub.priorityClassName Hub pod priority class name
+  ## @param hub.extraEnvVars Add extra environment variables to the Hub container
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
   ##
-  priorityClassName: ""
-  ## @param hub.hostAliases Add deployment host aliases
-  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  extraEnvVars: []
+  ## @param hub.extraEnvVarsCM Name of existing ConfigMap containing extra env vars
   ##
-  hostAliases: []
-  ## hub resource requests and limits
+  extraEnvVarsCM: ""
+  ## @param hub.extraEnvVarsSecret Name of existing Secret containing extra env vars
+  ##
+  extraEnvVarsSecret: ""
+  ## @param hub.containerPorts.http Hub container port
+  ##
+  containerPorts:
+    http: 8081
+  ## Configure extra options for Hub containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param hub.startupProbe.enabled Enable startupProbe on Hub containers
+  ## @param hub.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param hub.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param hub.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param hub.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param hub.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 3
+    successThreshold: 1
+  ## @param hub.livenessProbe.enabled Enable livenessProbe on Hub containers
+  ## @param hub.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param hub.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param hub.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param hub.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param hub.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 3
+    successThreshold: 1
+  ## @param hub.readinessProbe.enabled Enable readinessProbe on Hub containers
+  ## @param hub.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param hub.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param hub.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param hub.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param hub.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 30
+    timeoutSeconds: 3
+    successThreshold: 1
+  ## @param hub.customStartupProbe Override default startup probe
+  ##
+  customStartupProbe: {}
+  ## @param hub.customLivenessProbe Override default liveness probe
+  ##
+  customLivenessProbe: {}
+  ## @param hub.customReadinessProbe Override default readiness probe
+  ##
+  customReadinessProbe: {}
+  ## Hub resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param hub.resources.limits The resources limits for the container
-  ## @param hub.resources.requests The requested resources for the container
+  ## @param hub.resources.limits The resources limits for the Hub containers
+  ## @param hub.resources.requests The requested resources for the Hub containers
   ##
   resources:
-    ## Example:
-    ## limits:
-    ##   cpu: 200m
-    ##   memory: 256Mi
-    ##
     limits: {}
-    ## Examples:
-    ## requests:
-    ##   cpu: 200m
-    ##   memory: 10Mi
-    ##
     requests: {}
   ## hub containers' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
@@ -344,22 +344,37 @@ hub:
   podSecurityContext:
     enabled: true
     fsGroup: 1001
+  ## @param hub.lifecycleHooks LifecycleHooks for the Hub container to automate configuration before or after startup
+  ##
+  lifecycleHooks: {}
+  ## @param hub.hostAliases Add deployment host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param hub.podLabels Add extra labels to the Hub pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param hub.podAnnotations Add extra annotations to the Hub pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
   ## Pod affinity preset
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ## Allowed values: soft, hard
-  ## @param hub.podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## @param hub.podAffinityPreset Pod affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`
   ##
   podAffinityPreset: ""
   ## Pod anti-affinity preset
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-  ## @param hub.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## @param hub.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`
   ##
   podAntiAffinityPreset: soft
   ## Node affinity preset
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-  ## @param hub.nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
-  ## @param hub.nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
-  ## @param hub.nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
+  ## @param hub.nodeAffinityPreset.type Node affinity preset type. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`
+  ## @param hub.nodeAffinityPreset.key Node label key to match. Ignored if `hub.affinity` is set
+  ## @param hub.nodeAffinityPreset.values Node label values to match. Ignored if `hub.affinity` is set
   ##
   nodeAffinityPreset:
     type: ""
@@ -385,46 +400,31 @@ hub:
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param hub.podLabels Pod extra labels
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ## @param hub.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
-  podLabels: {}
-  ## @param hub.podAnnotations Annotations for server pods.
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  topologySpreadConstraints: {}
+  ## @param hub.priorityClassName Priority Class Name
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##
-  podAnnotations: {}
-  ## @param hub.lifecycleHooks LifecycleHooks for the hub container to automate configuration before or after startup
+  priorityClassName: ""
+  ## @param hub.schedulerName Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
-  lifecycleHooks: {}
-  ## @param hub.customStartupProbe Override default startup probe
+  schedulerName: ""
+  ## @param hub.terminationGracePeriodSeconds Seconds Hub pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   ##
-  customStartupProbe: {}
-  ## @param hub.customLivenessProbe Override default liveness probe
-  ##
-  customLivenessProbe: {}
-  ## @param hub.customReadinessProbe Override default readiness probe
-  ##
-  customReadinessProbe: {}
+  terminationGracePeriodSeconds: ""
   ## @param hub.updateStrategy.type Update strategy - only really applicable for deployments with RWO PVs attached
+  ## @param hub.updateStrategy.rollingUpdate Hub deployment rolling update configuration parameters
   ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
   ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
   ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
   ##
   updateStrategy:
     type: RollingUpdate
-  ## @param hub.extraEnvVars Add extra environment variables to the Hub container
-  ## Example:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
-  ##
-  extraEnvVars: []
-  ## @param hub.extraEnvVarsCM Name of existing ConfigMap containing extra env vars
-  ##
-  extraEnvVarsCM: ""
-  ## @param hub.extraEnvVarsSecret Name of existing Secret containing extra env vars
-  ##
-  extraEnvVarsSecret: ""
+    rollingUpdate: {}
   ## @param hub.extraVolumes Optionally specify extra list of additional volumes for Hub pods
   ##
   extraVolumes: []
@@ -453,9 +453,16 @@ hub:
   ##         containerPort: 1234
   ##
   sidecars: []
+  ## @param hub.pdb.create Deploy Hub PodDisruptionBudget
+  ## @param hub.pdb.minAvailable Set minimum available hub instances
+  ## @param hub.pdb.maxUnavailable Set maximum available hub instances
+  ##
+  pdb:
+    create: false
+    minAvailable: ""
+    maxUnavailable: ""
 
   ## @section Hub RBAC parameters
-  ##
 
   ## ServiceAccount parameters
   ##
@@ -467,15 +474,33 @@ hub:
     ## If not set and create is true, a name is generated using the fullname template
     ##
     name: ""
+    ## @param hub.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+    ##
+    automountServiceAccountToken: true
+    ## @param hub.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
   ## RBAC resources
   ##
   rbac:
     ## @param hub.rbac.create Specifies whether RBAC resources should be created
     ##
     create: true
+    ## @param hub.rbac.rules Custom RBAC rules to set
+    ## e.g:
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - get
+    ##       - list
+    ##
+    rules: []
 
   ## @section Hub Traffic Exposure Parameters
-  ##
 
   ## Network policy
   ##
@@ -499,28 +524,46 @@ hub:
     ## @param hub.service.type Hub service type
     ##
     type: ClusterIP
-    ## @param hub.service.port Hub service HTTP port
+    ## @param hub.service.ports.http Hub service HTTP port
     ##
-    port: 8081
-    ## @param hub.service.loadBalancerIP Hub service LoadBalancer IP (optional, cloud specific)
-    ## ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer
-    ##
-    loadBalancerIP: ""
-    ## @param hub.service.loadBalancerSourceRanges loadBalancerIP source ranges for the Service
-    ##
-    loadBalancerSourceRanges: []
+    ports:
+      http: 8081
     ## @param hub.service.nodePorts.http NodePort for the HTTP endpoint
-    ## nodePorts:
-    ##   http: <to set explicitly, choose port between 30000-32767>
-    ##   https: <to set explicitly, choose port between 30000-32767>
+    ## NOTE: choose port between <30000-32767>
     ##
     nodePorts:
       http: ""
-    ## @param hub.service.externalTrafficPolicy External traffic policy for the service
-    ## Enable client source IP preservation
+    ## @param hub.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
+    ## @param hub.service.clusterIP Hub service Cluster IP
+    ## e.g.:
+    ## clusterIP: None
+    ##
+    clusterIP: ""
+    ## @param hub.service.loadBalancerIP Hub service Load Balancer IP
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+    ##
+    loadBalancerIP: ""
+    ## @param hub.service.loadBalancerSourceRanges Hub service Load Balancer sources
+    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ## e.g:
+    ## loadBalancerSourceRanges:
+    ##   - 10.10.10.0/24
+    ##
+    loadBalancerSourceRanges: []
+    ## @param hub.service.externalTrafficPolicy Hub service external traffic policy
     ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
     externalTrafficPolicy: Cluster
+    ## @param hub.service.annotations Additional custom annotations for Hub service
+    ##
+    annotations: {}
+    ## @param hub.service.extraPorts Extra port to expose on Hub service
+    ##
+    extraPorts: []
 
   ## @section Hub Metrics parameters
   ##
@@ -550,22 +593,28 @@ hub:
       ## scrapeTimeout: 30s
       ##
       scrapeTimeout: ""
-      ## @param hub.metrics.serviceMonitor.relabellings Specify Metric Relabellings to add to the scrape endpoint
+      ## @param hub.metrics.serviceMonitor.labels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
       ##
-      relabellings: []
+      labels: {}
+      ## @param hub.metrics.serviceMonitor.selector Prometheus instance selector labels
+      ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+      ##
+      selector: {}
+      ## @param hub.metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+      ##
+      relabelings: []
+      ## @param hub.metrics.serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
+      ##
+      metricRelabelings: []
       ## @param hub.metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
       ##
       honorLabels: false
-      ## @param hub.metrics.serviceMonitor.additionalLabels Used to pass Labels that are required by the installed Prometheus Operator
-      ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+      ## @param hub.metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
       ##
-      additionalLabels: {}
+      jobLabel: ""
 
 ## @section Proxy deployment parameters
-##
 
-## Proxy deployment parameters
-##
 proxy:
   ## @param proxy.image.registry Proxy image registry
   ## @param proxy.image.repository Proxy image repository
@@ -594,9 +643,40 @@ proxy:
     ## Enable debug mode
     ##
     debug: false
-  ## Configure extra options for startup probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-startup-readiness-probes/#configure-probes
-  ## @param proxy.startupProbe.enabled Enable startupProbe
+  ## @param proxy.secretToken Proxy secret token (used for communication with the Hub)
+  ##
+  secretToken: ""
+  ## @param proxy.command Override Proxy default command
+  ##
+  command: []
+  ## @param proxy.args Override Proxy default args
+  ##
+  args: []
+  ## @param proxy.extraEnvVars Add extra environment variables to the Proxy container
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+  ## @param proxy.extraEnvVarsCM Name of existing ConfigMap containing extra env vars
+  ##
+  extraEnvVarsCM: ""
+  ## @param proxy.extraEnvVarsSecret Name of existing Secret containing extra env vars
+  ##
+  extraEnvVarsSecret: ""
+  ## Container ports
+  ## @param proxy.containerPort.api Proxy api container port
+  ## @param proxy.containerPort.metrics Proxy metrics container port
+  ## @param proxy.containerPort.http Proxy http container port
+  ##
+  containerPort:
+    api: 8001
+    metrics: 8002
+    http: 8000
+  ## Configure extra options for Proxy containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param proxy.startupProbe.enabled Enable startupProbe on Proxy containers
   ## @param proxy.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
   ## @param proxy.startupProbe.periodSeconds Period seconds for startupProbe
   ## @param proxy.startupProbe.timeoutSeconds Timeout seconds for startupProbe
@@ -610,9 +690,7 @@ proxy:
     failureThreshold: 30
     timeoutSeconds: 3
     successThreshold: 1
-  ## Configure extra options for liveness and readiness probes
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param proxy.livenessProbe.enabled Enable livenessProbe
+  ## @param proxy.livenessProbe.enabled Enable livenessProbe on Proxy containers
   ## @param proxy.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param proxy.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param proxy.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -626,7 +704,7 @@ proxy:
     failureThreshold: 30
     timeoutSeconds: 3
     successThreshold: 1
-  ## @param proxy.readinessProbe.enabled Enable readinessProbe
+  ## @param proxy.readinessProbe.enabled Enable readinessProbe on Proxy containers
   ## @param proxy.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param proxy.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param proxy.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -640,70 +718,24 @@ proxy:
     failureThreshold: 30
     timeoutSeconds: 3
     successThreshold: 1
-  ## @param proxy.command Override Proxy default command
+  ## @param proxy.customStartupProbe Override default startup probe
   ##
-  command: []
-  ## @param proxy.args Override Proxy default args
+  customStartupProbe: {}
+  ## @param proxy.customLivenessProbe Override default liveness probe
   ##
-  args: []
-  ## @param proxy.secretToken Proxy secret token (used for communication with the Hub)
+  customLivenessProbe: {}
+  ## @param proxy.customReadinessProbe Override default readiness probe
   ##
-  secretToken: ""
-  ## Deployment pod host aliases
-  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
-  ## @param proxy.hostAliases Add deployment host aliases
-  ##
-  hostAliases: []
-  ## PodDisruptionBudget settings
-  ##
-  pdb:
-    ## @param proxy.pdb.create Deploy Proxy PodDisruptionBudget
-    ##
-    create: false
-    ## @param proxy.pdb.minAvailable Set minimum available proxy instances
-    ##
-    minAvailable: ""
-    ## @param proxy.pdb.maxUnavailable Set maximum available proxy instances
-    ##
-    maxUnavailable: ""
-  ## Container ports
-  ##
-  containerPort:
-    ## @param proxy.containerPort.api Proxy api container port
-    ##
-    api: 8001
-    ## @param proxy.containerPort.metrics Proxy metrics container port
-    ##
-    metrics: 8002
-    ## @param proxy.containerPort.http Proxy http container port
-    ##
-    http: 8000
-  ## @param proxy.priorityClassName Proxy pod priority class name
-  ##
-  priorityClassName: ""
-  ## proxy resource requests and limits
+  customReadinessProbe: {}
+  ## Proxy resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param proxy.resources.limits The resources limits for the container
-  ## @param proxy.resources.requests The requested resources for the container
+  ## @param proxy.resources.limits The resources limits for the Proxy containers
+  ## @param proxy.resources.requests The requested resources for the Proxy containers
   ##
   resources:
-    ## Example:
-    ## limits:
-    ##   cpu: 200m
-    ##   memory: 256Mi
-    ##
     limits: {}
-    ## Examples:
-    ## requests:
-    ##   cpu: 200m
-    ##   memory: 10Mi
-    ##
     requests: {}
-  ## proxy containers' Security Context
+  ## Proxy containers' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param proxy.containerSecurityContext.enabled Enabled Proxy containers' Security Context
   ## @param proxy.containerSecurityContext.runAsUser Set Proxy container's Security Context runAsUser
@@ -721,20 +753,36 @@ proxy:
   podSecurityContext:
     enabled: true
     fsGroup: 1001
-  ## @param proxy.podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## @param proxy.lifecycleHooks Add lifecycle hooks to the Proxy deployment
+  ##
+  lifecycleHooks: {}
+  ## Deployment pod host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ## @param proxy.hostAliases Add deployment host aliases
+  ##
+  hostAliases: []
+  ## @param proxy.podLabels Add extra labels to the Proxy pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param proxy.podAnnotations Add extra annotations to the Proxy pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param proxy.podAffinityPreset Pod affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAffinityPreset: ""
-  ## @param proxy.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## @param proxy.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAntiAffinityPreset: soft
   ## Node affinity preset
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
   ## Allowed values: soft, hard
-  ## @param proxy.nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
-  ## @param proxy.nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
-  ## @param proxy.nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
+  ## @param proxy.nodeAffinityPreset.type Node affinity preset type. Ignored if `proxy.affinity` is set. Allowed values: `soft` or `hard`
+  ## @param proxy.nodeAffinityPreset.key Node label key to match. Ignored if `proxy.affinity` is set
+  ## @param proxy.nodeAffinityPreset.values Node label values to match. Ignored if `proxy.affinity` is set
   ##
   nodeAffinityPreset:
     type: ""
@@ -760,46 +808,31 @@ proxy:
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param proxy.podLabels Extra labels for Proxy pods
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ## @param proxy.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
-  podLabels: {}
-  ## @param proxy.podAnnotations Annotations for Proxy pods
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  topologySpreadConstraints: {}
+  ## @param proxy.priorityClassName Priority Class Name
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##
-  podAnnotations: {}
-  ## @param proxy.lifecycleHooks Add lifecycle hooks to the Proxy deployment
+  priorityClassName: ""
+  ## @param proxy.schedulerName Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
-  lifecycleHooks: {}
-  ## @param proxy.customStartupProbe Override default startup probe
+  schedulerName: ""
+  ## @param proxy.terminationGracePeriodSeconds Seconds Proxy pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   ##
-  customStartupProbe: {}
-  ## @param proxy.customLivenessProbe Override default liveness probe
-  ##
-  customLivenessProbe: {}
-  ## @param proxy.customReadinessProbe Override default readiness probe
-  ##
-  customReadinessProbe: {}
+  terminationGracePeriodSeconds: ""
   ## @param proxy.updateStrategy.type Update strategy - only really applicable for deployments with RWO PVs attached
+  ## @param proxy.updateStrategy.rollingUpdate Proxy deployment rolling update configuration parameters
   ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
   ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
   ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
   ##
   updateStrategy:
     type: RollingUpdate
-  ## @param proxy.extraEnvVars Add extra environment variables to the Proxy container
-  ## Example:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
-  ##
-  extraEnvVars: []
-  ## @param proxy.extraEnvVarsCM Name of existing ConfigMap containing extra env vars
-  ##
-  extraEnvVarsCM: ""
-  ## @param proxy.extraEnvVarsSecret Name of existing Secret containing extra env vars
-  ##
-  extraEnvVarsSecret: ""
+    rollingUpdate: {}
   ## @param proxy.extraVolumes Optionally specify extra list of additional volumes for Proxy pods
   ##
   extraVolumes: []
@@ -828,6 +861,18 @@ proxy:
   ##         containerPort: 1234
   ##
   sidecars: []
+  ## PodDisruptionBudget settings
+  ##
+  pdb:
+    ## @param proxy.pdb.create Deploy Proxy PodDisruptionBudget
+    ##
+    create: false
+    ## @param proxy.pdb.minAvailable Set minimum available proxy instances
+    ##
+    minAvailable: ""
+    ## @param proxy.pdb.maxUnavailable Set maximum available proxy instances
+    ##
+    maxUnavailable: ""
 
   ## @section Proxy Traffic Exposure Parameters
   ##
@@ -856,81 +901,135 @@ proxy:
       ## @param proxy.service.api.type API service type
       ##
       type: ClusterIP
-      ## @param proxy.service.api.port API service port
+      ## @param proxy.service.api.ports.http API service HTTP port
       ##
-      port: 8001
-      ## @param proxy.service.api.loadBalancerIP API service LoadBalancer IP (optional, cloud specific)
-      ## ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer
-      ##
-      loadBalancerIP: ""
-      ## @param proxy.service.api.loadBalancerSourceRanges loadBalancerIP source ranges for the Service
-      ##
-      loadBalancerSourceRanges: []
+      ports:
+        http: 8001
       ## @param proxy.service.api.nodePorts.http NodePort for the HTTP endpoint
-      ## nodePorts:
-      ##   http: <to set explicitly, choose port between 30000-32767>
-      ##   https: <to set explicitly, choose port between 30000-32767>
+      ## NOTE: choose port between <30000-32767>
       ##
       nodePorts:
         http: ""
-      ## @param proxy.service.api.externalTrafficPolicy External traffic policy for the service
-      ## Enable client source IP preservation
+      ## @param proxy.service.api.sessionAffinity Control where client requests go, to the same pod or round-robin
+      ## Values: ClientIP or None
+      ## ref: https://kubernetes.io/docs/user-guide/services/
+      ##
+      sessionAffinity: None
+      ## @param proxy.service.api.clusterIP Hub service Cluster IP
+      ## e.g.:
+      ## clusterIP: None
+      ##
+      clusterIP: ""
+      ## @param proxy.service.api.loadBalancerIP Hub service Load Balancer IP
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+      ##
+      loadBalancerIP: ""
+      ## @param proxy.service.api.loadBalancerSourceRanges Hub service Load Balancer sources
+      ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+      ## e.g:
+      ## loadBalancerSourceRanges:
+      ##   - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []
+      ## @param proxy.service.api.externalTrafficPolicy Hub service external traffic policy
       ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
       ##
       externalTrafficPolicy: Cluster
+      ## @param proxy.service.api.annotations Additional custom annotations for Hub service
+      ##
+      annotations: {}
+      ## @param proxy.service.api.extraPorts Extra port to expose on Hub service
+      ##
+      extraPorts: []
     metrics:
       ## @param proxy.service.metrics.type Metrics service type
       ##
       type: ClusterIP
-      ## @param proxy.service.metrics.port Metrics service port
+      ## @param proxy.service.metrics.ports.http Metrics service port
       ##
-      port: 8002
-      ## @param proxy.service.metrics.loadBalancerIP Metrics service LoadBalancer IP (optional, cloud specific)
-      ## ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer
-      ##
-      loadBalancerIP: ""
-      ## @param proxy.service.metrics.loadBalancerSourceRanges loadBalancerIP source ranges for the Service
-      ##
-      loadBalancerSourceRanges: []
+      ports:
+        http: 8002
       ## @param proxy.service.metrics.nodePorts.http NodePort for the HTTP endpoint
-      ## nodePorts:
-      ##   http: <to set explicitly, choose port between 30000-32767>
-      ##   https: <to set explicitly, choose port between 30000-32767>
+      ## NOTE: choose port between <30000-32767>
       ##
       nodePorts:
         http: ""
-      ## @param proxy.service.metrics.externalTrafficPolicy External traffic policy for the service
-      ## Enable client source IP preservation
+      ## @param proxy.service.metrics.sessionAffinity Control where client requests go, to the same pod or round-robin
+      ## Values: ClientIP or None
+      ## ref: https://kubernetes.io/docs/user-guide/services/
+      ##
+      sessionAffinity: None
+      ## @param proxy.service.metrics.clusterIP Hub service Cluster IP
+      ## e.g.:
+      ## clusterIP: None
+      ##
+      clusterIP: ""
+      ## @param proxy.service.metrics.loadBalancerIP Hub service Load Balancer IP
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+      ##
+      loadBalancerIP: ""
+      ## @param proxy.service.metrics.loadBalancerSourceRanges Hub service Load Balancer sources
+      ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+      ## e.g:
+      ## loadBalancerSourceRanges:
+      ##   - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []
+      ## @param proxy.service.metrics.externalTrafficPolicy Hub service external traffic policy
       ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
       ##
       externalTrafficPolicy: Cluster
+      ## @param proxy.service.metrics.annotations Additional custom annotations for Hub service
+      ##
+      annotations: {}
+      ## @param proxy.service.metrics.extraPorts Extra port to expose on Hub service
+      ##
+      extraPorts: []
     public:
       ## @param proxy.service.public.type Public service type
       ##
       type: LoadBalancer
       # HTTP Port
-      ## @param proxy.service.public.port Public service port
+      ## @param proxy.service.public.ports.http Public service HTTP port
       ##
-      port: 80
-      ## @param proxy.service.public.loadBalancerIP Public service LoadBalancer IP (optional, cloud specific)
-      ## ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer
-      ##
-      loadBalancerIP: ""
-      ## @param proxy.service.public.loadBalancerSourceRanges loadBalancerIP source ranges for the Service
-      ##
-      loadBalancerSourceRanges: []
+      ports:
+        http: 80
       ## @param proxy.service.public.nodePorts.http NodePort for the HTTP endpoint
-      ## nodePorts:
-      ##   http: <to set explicitly, choose port between 30000-32767>
-      ##   https: <to set explicitly, choose port between 30000-32767>
+      ## NOTE: choose port between <30000-32767>
       ##
       nodePorts:
         http: ""
-      ## @param proxy.service.public.externalTrafficPolicy External traffic policy for the service
-      ## Enable client source IP preservation
+      ## @param proxy.service.public.sessionAffinity Control where client requests go, to the same pod or round-robin
+      ## Values: ClientIP or None
+      ## ref: https://kubernetes.io/docs/user-guide/services/
+      ##
+      sessionAffinity: None
+      ## @param proxy.service.public.clusterIP Hub service Cluster IP
+      ## e.g.:
+      ## clusterIP: None
+      ##
+      clusterIP: ""
+      ## @param proxy.service.public.loadBalancerIP Hub service Load Balancer IP
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+      ##
+      loadBalancerIP: ""
+      ## @param proxy.service.public.loadBalancerSourceRanges Hub service Load Balancer sources
+      ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+      ## e.g:
+      ## loadBalancerSourceRanges:
+      ##   - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []
+      ## @param proxy.service.public.externalTrafficPolicy Hub service external traffic policy
       ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
       ##
       externalTrafficPolicy: Cluster
+      ## @param proxy.service.public.annotations Additional custom annotations for Hub service
+      ##
+      annotations: {}
+      ## @param proxy.service.public.extraPorts Extra port to expose on Hub service
+      ##
+      extraPorts: []
   ## Configure the ingress resource that allows you to access to your JupyterHub instance
   ##
   ingress:
@@ -945,78 +1044,82 @@ proxy:
     ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
     ##
     ingressClassName: ""
-    ## @param proxy.ingress.path Path to the Proxy pod.
-    ##
-    path: /
     ## @param proxy.ingress.pathType Ingress path type
     ##
     pathType: ImplementationSpecific
-    ## DEPRECATED: Use ingress.annotations instead of ingress.certManager
-    ## certManager: false
-    ##
-
-    ## When the ingress is enabled, a host pointing to this will be created
     ## @param proxy.ingress.hostname Set ingress rule hostname
     ##
     hostname: jupyterhub.local
-    ## @param proxy.ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
-    ## For a full list of possible ingress annotations, please see
-    ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    ## @param proxy.ingress.path Path to the Proxy pod
+    ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
+    ##
+    path: /
+    ## @param proxy.ingress.annotations [object] Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
     ## Use this parameter to set the required annotations for cert-manager, see
     ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
-    ##
     ## e.g:
     ## annotations:
     ##   kubernetes.io/ingress.class: nginx
     ##   cert-manager.io/cluster-issuer: cluster-issuer-name
     ##
     annotations: {}
-    ## @param proxy.ingress.tls Enable ingress tls configuration for the hostname defined at proxy.ingress.hostname
-    ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
-    ## You can use the ingress.secrets parameter to create this TLS secret, relay on cert-manager to create it, or
-    ## let the chart create self-signed certificates for you
+    ## @param proxy.ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+    ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+    ## You can:
+    ##   - Use the `ingress.secrets` parameter to create this TLS secret
+    ##   - Relay on cert-manager to create it by setting the corresponding annotations
+    ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
     ##
     tls: false
     ## @param proxy.ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
     ##
     selfSigned: false
-    ## @param proxy.ingress.extraHosts The list of additional hostnames to be covered with this ingress record.
-    ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
+    ## @param proxy.ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
+    ## e.g:
     ## extraHosts:
-    ## - name: aspnet-core.local
+    ## - name: jupyterhub.local
     ##   path: /
     ##
     extraHosts: []
+    ## @param proxy.ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+    ## e.g:
+    ## extraPaths:
+    ## - path: /*
+    ##   backend:
+    ##     serviceName: ssl-redirect
+    ##     servicePort: use-annotation
+    ##
+    extraPaths: []
     ## @param proxy.ingress.extraTls The tls configuration for additional hostnames to be covered with this ingress record.
     ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
     ## extraTls:
     ## - hosts:
-    ##     - aspnet-core.local
-    ##   secretName: aspnet-core.local-tls
+    ##     - jupyterhub.local
+    ##   secretName: jupyterhub.local-tls
     ##
     extraTls: []
-    ## @param proxy.ingress.extraPaths Any additional arbitrary paths that may need to be added to the ingress under the main host.
-    ## For example: The ALB ingress controller requires a special rule for handling SSL redirection.
-    ##
-    extraPaths: []
-    ## @param proxy.ingress.secrets Add extra secrets for the tls configuration
-    ## If you're providing your own certificates, please use this to add the certificates as secrets
-    ## key and certificate should start with -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
-    ## name should line up with a secretName set further up
-    ##
-    ## If it is not set and you're using cert-manager, this is unneeded, as it will create the secret for you
-    ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created
+    ## @param proxy.ingress.secrets Custom TLS certificates as secrets
+    ## NOTE: 'key' and 'certificate' are expected in PEM format
+    ## NOTE: 'name' should line up with a 'secretName' set further up
+    ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+    ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
     ## It is also possible to create and manage the certificates outside of this helm chart
-    ##
     ## Please see README.md for more information
-    ## - name: aspnet-core.local-tls
-    ##   key:
-    ##   certificate:
+    ## e.g:
+    ## secrets:
+    ##   - name: jupyterhub.local-tls
+    ##     key: |-
+    ##       -----BEGIN RSA PRIVATE KEY-----
+    ##       ...
+    ##       -----END RSA PRIVATE KEY-----
+    ##     certificate: |-
+    ##       -----BEGIN CERTIFICATE-----
+    ##       ...
+    ##       -----END CERTIFICATE-----
     ##
     secrets: []
 
   ## @section Proxy Metrics parameters
-  ##
 
   metrics:
     ## Prometheus Operator ServiceMonitor configuration
@@ -1039,16 +1142,25 @@ proxy:
       ## scrapeTimeout: 30s
       ##
       scrapeTimeout: ""
-      ## @param proxy.metrics.serviceMonitor.relabellings Specify Metric Relabellings to add to the scrape endpoint
+      ## @param proxy.metrics.serviceMonitor.labels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
       ##
-      relabellings: []
+      labels: {}
+      ## @param proxy.metrics.serviceMonitor.selector Prometheus instance selector labels
+      ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
+      ##
+      selector: {}
+      ## @param proxy.metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+      ##
+      relabelings: []
+      ## @param proxy.metrics.serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
+      ##
+      metricRelabelings: []
       ## @param proxy.metrics.serviceMonitor.honorLabels Specify honorLabels parameter to add the scrape endpoint
       ##
       honorLabels: false
-      ## @param proxy.metrics.serviceMonitor.additionalLabels Used to pass Labels that are required by the installed Prometheus Operator
-      ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+      ## @param proxy.metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
       ##
-      additionalLabels: {}
+      jobLabel: ""
 
 ## @section Image puller deployment parameters
 ##
@@ -1065,33 +1177,37 @@ imagePuller:
   ## @param imagePuller.args Override ImagePuller default args
   ##
   args: []
-  ## @param imagePuller.hostAliases Add deployment host aliases
-  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ## @param imagePuller.extraEnvVars Add extra environment variables to the ImagePuller container
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
   ##
-  hostAliases: []
-  ## imagePuller resource requests and limits
+  extraEnvVars: []
+  ## @param imagePuller.extraEnvVarsCM Name of existing ConfigMap containing extra env vars
+  ##
+  extraEnvVarsCM: ""
+  ## @param imagePuller.extraEnvVarsSecret Name of existing Secret containing extra env vars
+  ##
+  extraEnvVarsSecret: ""
+  ## @param imagePuller.customStartupProbe Override default startup probe
+  ##
+  customStartupProbe: {}
+  ## @param imagePuller.customLivenessProbe Override default liveness probe
+  ##
+  customLivenessProbe: {}
+  ## @param imagePuller.customReadinessProbe Override default readiness probe
+  ##
+  customReadinessProbe: {}
+  ## ImagePuller resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param imagePuller.resources.limits The resources limits for the container
-  ## @param imagePuller.resources.requests The requested resources for the container
+  ## @param imagePuller.resources.limits The resources limits for the ImagePuller containers
+  ## @param imagePuller.resources.requests The requested resources for the ImagePuller containers
   ##
   resources:
-    ## Example:
-    ## limits:
-    ##   cpu: 200m
-    ##   memory: 256Mi
-    ##
     limits: {}
-    ## Examples:
-    ## requests:
-    ##   cpu: 200m
-    ##   memory: 10Mi
-    ##
     requests: {}
-  ## imagePuller containers' Security Context
+  ## ImagePuller containers' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   ## @param imagePuller.containerSecurityContext.enabled Enabled ImagePuller containers' Security Context
   ## @param imagePuller.containerSecurityContext.runAsUser Set ImagePuller container's Security Context runAsUser
@@ -1101,7 +1217,7 @@ imagePuller:
     enabled: true
     runAsUser: 1001
     runAsNonRoot: true
-  ## imagePuller pods' Security Context
+  ## ImagePuller pods' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param imagePuller.podSecurityContext.enabled Enabled ImagePuller pods' Security Context
   ## @param imagePuller.podSecurityContext.fsGroup Set ImagePuller pod's Security Context fsGroup
@@ -1109,19 +1225,34 @@ imagePuller:
   podSecurityContext:
     enabled: true
     fsGroup: 1001
-  ## @param imagePuller.podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## @param imagePuller.lifecycleHooks Add lifecycle hooks to the ImagePuller deployment
+  ##
+  lifecycleHooks: {}
+  ## @param imagePuller.hostAliases Add deployment host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param imagePuller.podLabels Pod extra labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param imagePuller.podAnnotations Annotations for ImagePuller pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param imagePuller.podAffinityPreset Pod affinity preset. Ignored if `imagePuller.affinity` is set. Allowed values: `soft` or `hard`
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAffinityPreset: ""
-  ## @param imagePuller.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## @param imagePuller.podAntiAffinityPreset Pod anti-affinity preset. Ignored if `imagePuller.affinity` is set. Allowed values: `soft` or `hard`
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
   ##
   podAntiAffinityPreset: soft
   ## Node affinity preset
   ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
-  ## @param imagePuller.nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
-  ## @param imagePuller.nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
-  ## @param imagePuller.nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
+  ## @param imagePuller.nodeAffinityPreset.type Node affinity preset type. Ignored if `imagePuller.affinity` is set. Allowed values: `soft` or `hard`
+  ## @param imagePuller.nodeAffinityPreset.key Node label key to match. Ignored if `imagePuller.affinity` is set
+  ## @param imagePuller.nodeAffinityPreset.values Node label values to match. Ignored if `imagePuller.affinity` is set
   ##
   nodeAffinityPreset:
     type: ""
@@ -1147,50 +1278,31 @@ imagePuller:
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
   tolerations: []
-  ## @param imagePuller.podLabels Pod extra labels
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ## @param imagePuller.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
-  podLabels: {}
-  ## @param imagePuller.podAnnotations Annotations for ImagePuller pods
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-  ##
-  podAnnotations: {}
-  ## @param imagePuller.priorityClassName ImagePuller pod priority class name
-  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  topologySpreadConstraints: {}
+  ## @param imagePuller.priorityClassName Priority Class Name
+  ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##
   priorityClassName: ""
-  ## @param imagePuller.lifecycleHooks Add lifecycle hooks to the ImagePuller deployment
+  ## @param imagePuller.schedulerName Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
-  lifecycleHooks: {}
-  ## @param imagePuller.customStartupProbe  Override default startup probe
+  schedulerName: ""
+  ## @param imagePuller.terminationGracePeriodSeconds Seconds ImagePuller pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   ##
-  customStartupProbe: {}
-  ## @param imagePuller.customLivenessProbe  Override default liveness probe
-  ##
-  customLivenessProbe: {}
-  ## @param imagePuller.customReadinessProbe  Override default readiness probe
-  ##
-  customReadinessProbe: {}
+  terminationGracePeriodSeconds: ""
   ## @param imagePuller.updateStrategy.type Update strategy - only really applicable for deployments with RWO PVs attached
+  ## @param imagePuller.updateStrategy.rollingUpdate ImagePuller deployment rolling update configuration parameters
   ## If replicas = 1, an update can get "stuck", as the previous pod remains attached to the
   ## PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will
   ## terminate the single previous pod, so that the new, incoming pod can attach to the PV
   ##
   updateStrategy:
     type: RollingUpdate
-  ## @param imagePuller.extraEnvVars Add extra environment variables to the ImagePuller container
-  ## Example:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
-  ##
-  extraEnvVars: []
-  ## @param imagePuller.extraEnvVarsCM Name of existing ConfigMap containing extra env vars
-  ##
-  extraEnvVarsCM: ""
-  ## @param imagePuller.extraEnvVarsSecret Name of existing Secret containing extra env vars
-  ##
-  extraEnvVarsSecret: ""
+    rollingUpdate: {}
   ## @param imagePuller.extraVolumes  Optionally specify extra list of additional volumes for ImagePuller pods
   ##
   extraVolumes: []
@@ -1251,41 +1363,30 @@ singleuser:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
+  ## @param singleuser.notebookDir Notebook directory (it will be the same as the PVC volume mount)
+  ##
+  notebookDir: /opt/bitnami/jupyterhub-singleuser
   ## Command for running the container (set to default if not set). Use array form
   ## @param singleuser.command Override Single User default command
   ##
   command: []
-  ## @param singleuser.tolerations Tolerations for pod assignment. Evaluated as a template.
-  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ## @param singleuser.extraEnvVars Add extra environment variables to the Single User container
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
   ##
-  tolerations: []
+  extraEnvVars: []
   ## @param singleuser.containerPort Single User container port
   ##
   containerPort: 8888
-  ## @param singleuser.notebookDir Notebook directory (it will be the same as the PVC volume mount)
-  ##
-  notebookDir: /opt/bitnami/jupyterhub-singleuser
-  ## singleuser resource requests and limits
+  ## Singleuser resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param singleuser.resources.limits The resources limits for the container
-  ## @param singleuser.resources.requests The requested resources for the container
+  ## @param singleuser.resources.limits The resources limits for the Singleuser containers
+  ## @param singleuser.resources.requests The requested resources for the Singleuser containers
   ##
   resources:
-    ## Example:
-    ## limits:
-    ##   cpu: 200m
-    ##   memory: 256Mi
-    ##
     limits: {}
-    ## Examples:
-    ## requests:
-    ##   cpu: 200m
-    ##   memory: 10Mi
-    ##
     requests: {}
   ## singleuser containers' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
@@ -1303,10 +1404,6 @@ singleuser:
   podSecurityContext:
     enabled: true
     fsGroup: 1001
-  ## @param singleuser.nodeSelector Node labels for pod assignment. Evaluated as a template.
-  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
-  ##
-  nodeSelector: {}
   ## @param singleuser.podLabels Extra labels for Single User pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   ##
@@ -1315,6 +1412,14 @@ singleuser:
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations: {}
+  ## @param singleuser.nodeSelector Node labels for pod assignment. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param singleuser.tolerations Tolerations for pod assignment. Evaluated as a template.
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
   ## @param singleuser.priorityClassName Single User pod priority class name
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   ##
@@ -1322,13 +1427,6 @@ singleuser:
   ## @param singleuser.lifecycleHooks Add lifecycle hooks to the Single User deployment to automate configuration before or after startup
   ##
   lifecycleHooks: {}
-  ## @param singleuser.extraEnvVars Add extra environment variables to the Single User container
-  ## Example:
-  ## extraEnvVars:
-  ##   - name: FOO
-  ##     value: "bar"
-  ##
-  extraEnvVars: []
   ## @param singleuser.extraVolumes Optionally specify extra list of additional volumes for Single User pods
   ##
   extraVolumes: []
@@ -1359,10 +1457,7 @@ singleuser:
   sidecars: []
 
   ## @section Single User RBAC parameters
-  ##
 
-  ## Service account parameters
-  ##
   serviceAccount:
     ## @param singleuser.serviceAccount.create Specifies whether a ServiceAccount should be created
     ##
@@ -1371,13 +1466,18 @@ singleuser:
     ## If not set and create is true, a name is generated using the fullname template
     ##
     name: ""
+    ## @param singleuser.serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+    ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+    ##
+    automountServiceAccountToken: true
+    ## @param singleuser.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+    ##
+    annotations: {}
 
   ## @section Single User Persistence parameters
-  ##
-
   ## Enable persistence using Persistent Volume Claims
   ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
+
   persistence:
     ## @param singleuser.persistence.enabled Enable persistent volume creation on Single User instances
     ## If true, use a Persistent Volume Claim, If false, use emptyDir
@@ -1400,10 +1500,7 @@ singleuser:
     size: 10Gi
 
   ## @section Traffic exposure parameters
-  ##
 
-  ## Network policy
-  ##
   networkPolicy:
     ## @param singleuser.networkPolicy.enabled Deploy Single User network policies
     ##
@@ -1444,89 +1541,45 @@ auxiliaryImage:
   ##
   pullSecrets: []
 
-## @section External Database settings
-##
-
-## External Database Configuration
-## All of these values are only used when postgresql.enabled is set to false
-##
-externalDatabase:
-  ## @param externalDatabase.host Host of an external PostgreSQL instance to connect (only if postgresql.enabled=false)
-  ##
-  host: ""
-  ## @param externalDatabase.user User of an external PostgreSQL instance to connect (only if postgresql.enabled=false)
-  ##
-  user: postgres
-  ## @param externalDatabase.password Password of an external PostgreSQL instance to connect (only if postgresql.enabled=false)
-  ##
-  password: ""
-  ## @param externalDatabase.existingSecret Secret containing the password of an external PostgreSQL instance to connect (only if postgresql.enabled=false)
-  ## Name of an existing secret resource containing the DB password in a 'password' key
-  ##
-  existingSecret: ""
-  ## @param externalDatabase.database Database inside an external PostgreSQL to connect (only if postgresql.enabled=false)
-  ##
-  database: jupyterhub
-  ## @param externalDatabase.port Port of an external PostgreSQL to connect (only if postgresql.enabled=false)
-  ##
-  port: 5432
-
-## @section PostgreSQL subchart settings
-##
+## @section JupyterHub database parameters
 
 ## PostgreSQL chart configuration
-## https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+## @param postgresql.enabled Switch to enable or disable the PostgreSQL helm chart
+## @param postgresql.auth.username Name for a custom user to create
+## @param postgresql.auth.password Password for the custom user to create
+## @param postgresql.auth.database Name for a custom database to create
+## @param postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials
+## @param postgresql.architecture PostgreSQL architecture (`standalone` or `replication`)
+## @param postgresql.service.ports.postgresql PostgreSQL service port
 ##
 postgresql:
-  ## @param postgresql.enabled Deploy PostgreSQL subchart
-  ##
   enabled: true
-  ## @param postgresql.nameOverride Override name of the PostgreSQL chart
-  ##
-  nameOverride: ""
-  ## @param postgresql.existingSecret Existing secret containing the password of the PostgreSQL chart
-  ##
-  existingSecret: ""
   auth:
-    ## @param postgresql.auth.password Password for the postgres user of the PostgreSQL chart (auto-generated if not set)
-    ## ref: https://hub.docker.com/_/postgres/
-    ##
-    password: ""
-    ## @param postgresql.auth.username Username to create when deploying the PostgreSQL chart
-    ##
     username: bn_jupyterhub
-    ## @param postgresql.auth.database Database to create when deploying the PostgreSQL chart
-    ##
+    password: ""
     database: bitnami_jupyterhub
-  ## PostgreSQL service
-  ##
+    existingSecret: ""
+  architecture: standalone
   service:
-    ## @param postgresql.service.ports.postgresql PostgreSQL service port
-    ##
     ports:
       postgresql: 5432
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  persistence:
-    ## @param postgresql.persistence.enabled Use PVCs when deploying the PostgreSQL chart
-    ##
-    enabled: true
-    ## @param postgresql.persistence.existingClaim Use an existing PVC when deploying the PostgreSQL chart
-    ##
-    existingClaim: ""
-    ## @param postgresql.persistence.storageClass storageClass of the created PVCs
-    ## postgresql data Persistent Volume Storage Class
-    ## If defined, storageClassName: <storageClass>
-    ## If set to "-", storageClassName: "", which disables dynamic provisioning
-    ## If undefined (the default) or set to null, no storageClassName spec is
-    ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    ##   GKE, AWS & OpenStack)
-    ##
-    storageClass: ""
-    ## @param postgresql.persistence.accessMode Access mode of the created PVCs
-    ##
-    accessMode: ReadWriteOnce
-    ## @param postgresql.persistence.size Size of the created PVCs
-    ##
-    size: 8Gi
+
+## External PostgreSQL configuration
+## All of these values are only used when postgresql.enabled is set to false
+## @param externalDatabase.host Database host
+## @param externalDatabase.port Database port number
+## @param externalDatabase.user Non-root username for JupyterHub
+## @param externalDatabase.password Password for the non-root username for JupyterHub
+## @param externalDatabase.database JupyterHub database name
+## @param externalDatabase.existingSecret Name of an existing secret resource containing the database credentials
+## @param externalDatabase.existingSecretPasswordKey Name of an existing secret key containing the database credentials
+##
+externalDatabase:
+  host: ""
+  port: 5432
+  user: postgres
+  database: jupyterhub
+  password: ""
+  existingSecret: ""
+  existingSecretPasswordKey: ""


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR standardizes the `bitnami/jupyterhub` chart to be in line with the rest of the catalog.

**Benefits**

Standardization.

**Possible drawbacks**

None. No major bump is required since breaking changes were added support for deprecated values using `coalesce`.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])