### PR TITLE
[bitnami/postgresql-ha] fix: :bug: Allow custom postgresql.containerPort

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 8.5.3
+version: 8.5.4

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -268,6 +268,12 @@ spec:
               value: {{ template "postgresql-ha.postgresql.tlsCACert" . }}
             {{- end }}
             {{- end }}
+            - name: POSTGRESQL_PORT_NUMBER
+              value: {{ .Values.postgresql.containerPort | quote }}
+            - name: REPMGR_PORT_NUMBER
+              value: {{ .Values.postgresql.containerPort | quote }}
+            - name: REPMGR_PRIMARY_PORT
+              value: {{ .Values.postgresql.containerPort | quote }}
             # Repmgr configuration
             - name: MY_POD_NAME
               valueFrom:
@@ -348,7 +354,7 @@ spec:
               command:
                 - bash
                 - -ec
-                - '{{ include "postgresql-ha.pgpassword" . }} psql -w -U {{ include "postgresql-ha.postgresqlUsername" . | quote }} -d {{ (include "postgresql-ha.postgresqlDatabase" .) | quote }}  -h 127.0.0.1 -c "SELECT 1"'
+                - '{{ include "postgresql-ha.pgpassword" . }} psql -w -U {{ include "postgresql-ha.postgresqlUsername" . | quote }} -d {{ (include "postgresql-ha.postgresqlDatabase" .) | quote }} -h 127.0.0.1 -p {{ .Values.postgresql.containerPort }} -c "SELECT 1"'
             initialDelaySeconds: {{ .Values.postgresql.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.postgresql.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.postgresql.livenessProbe.timeoutSeconds }}
@@ -365,7 +371,7 @@ spec:
               command:
                 - bash
                 - -ec
-                - '{{ include "postgresql-ha.pgpassword" . }} psql -w -U {{ include "postgresql-ha.postgresqlUsername" . | quote }} -d {{ (include "postgresql-ha.postgresqlDatabase" .) | quote }}  -h 127.0.0.1 -c "SELECT 1"'
+                - '{{ include "postgresql-ha.pgpassword" . }} psql -w -U {{ include "postgresql-ha.postgresqlUsername" . | quote }} -d {{ (include "postgresql-ha.postgresqlDatabase" .) | quote }} -h 127.0.0.1 -p {{ .Values.postgresql.containerPort }} -c "SELECT 1"'
             initialDelaySeconds: {{ .Values.postgresql.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.postgresql.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.postgresql.readinessProbe.timeoutSeconds }}
@@ -382,7 +388,7 @@ spec:
               command:
                 - bash
                 - -ec
-                - '{{ include "postgresql-ha.pgpassword" . }} psql -w -U {{ include "postgresql-ha.postgresqlUsername" . | quote }} -d {{ (include "postgresql-ha.postgresqlDatabase" .) | quote }}  -h 127.0.0.1 -c "SELECT 1"'
+                - '{{ include "postgresql-ha.pgpassword" . }} psql -w -U {{ include "postgresql-ha.postgresqlUsername" . | quote }} -d {{ (include "postgresql-ha.postgresqlDatabase" .) | quote }} -h 127.0.0.1 -p {{ .Values.postgresql.containerPort }} -c "SELECT 1"'
             initialDelaySeconds: {{ .Values.postgresql.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.postgresql.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.postgresql.startupProbe.timeoutSeconds }}


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Currently, if we were using custom container ports for PostgreSQL, these were ignored. This PR adds the proper env vars and fixes the probes.

Test:

```
❯ kubectl get pods
NAME                                        READY   STATUS    RESTARTS   AGE
psql-postgresql-ha-pgpool-ff9cd8944-kp4dj   1/1     Running   1          3m38s
psql-postgresql-ha-postgresql-0             1/1     Running   0          3m38s
psql-postgresql-ha-postgresql-1             1/1     Running   0          3m37s
psql-postgresql-ha-postgresql-2             1/1     Running   0          3m37s

I have no name!@psql-postgresql-ha-pgpool-ff9cd8944-kp4dj:/$ PGCONNECT_TIMEOUT=15 PGPASSWORD="$PGPOOL_POSTGRES_PASSWORD" psql -U "$PGPOOL_POSTGRES_USERNAME"         -d postgres -h "$PGPOOL_TMP_DIR" -p "$PGPOOL_PORT_NUMBER" -h 127.0.0.1 -tA -c "SHOW pool_nodes;"
0|psql-postgresql-ha-postgresql-0.psql-postgresql-ha-postgresql-headless|33442|up|up|0.333333|primary|primary|21|true|0|||2022-03-08 10:58:30
1|psql-postgresql-ha-postgresql-1.psql-postgresql-ha-postgresql-headless|33442|up|up|0.333333|standby|standby|20|false|0|||2022-03-08 10:58:30
2|psql-postgresql-ha-postgresql-2.psql-postgresql-ha-postgresql-headless|33442|up|up|0.333333|standby|standby|18|false|0|||2022-03-08 10:58:30
```

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)