### PR TITLE
[bitnami/wordpress] WordPress test update to follow Test Strategy

### DIFF
--- a/.vib/wordpress/cypress/cypress/integration/utils.js
+++ b/.vib/wordpress/cypress/cypress/integration/utils.js
@@ -1,0 +1,5 @@
+
+/// <reference types="cypress" />
+
+export let random = (Math.random() + 1).toString(36).substring(7);
+console.log("random", random);

--- a/.vib/wordpress/cypress/cypress/integration/wordpress_spec.js
+++ b/.vib/wordpress/cypress/cypress/integration/wordpress_spec.js
@@ -36,8 +36,8 @@ it('disallows login to an invalid user', () => {
   cy.clearCookies();
   cy.visit('/wp-login.php')
   cy.fixture('user').then((user) => {
-    cy.get('#user_login').should('not.be.disabled').type(user.username);
-    cy.get('#user_pass').should('not.be.disabled').type(user.password);
+    cy.get('#user_login').should('not.be.disabled').type(user.username).should('have.value', user.username);
+    cy.get('#user_pass').should('not.be.disabled').type(user.password).should('have.value', user.password);
   })
   cy.get('#wp-submit').click();
   cy.fixture('user').then((user) => {
@@ -80,7 +80,7 @@ it('checks if admin can create a post', () => {
   cy.contains('button[type="button"]',"Publish").click();
   cy.get('h1[aria-label="Add title"]').should('be.visible').clear().type(`Test Hello World!${random}`);
   cy.get('.editor-post-save-draft').should('be.visible').click();
-  cy.get('.editor-post-saved-state').should('exist');
+  cy.get('.editor-post-saved-state').should('be.visible').and('have.text','Saved');
 
 })
 
@@ -112,9 +112,7 @@ it('allows the upload of a file',() => {
 
 it('allows to log out', () => {
   cy.login();
-  cy.get("#wp-admin-bar-logout .ab-item").should('exist').click({
-    force: true
-  });
+  cy.visit('wp-login.php?loggedout=true&wp_lang=en_US');
   cy.contains('.message','logged out');
 })
 

--- a/.vib/wordpress/cypress/cypress/integration/wordpress_spec.js
+++ b/.vib/wordpress/cypress/cypress/integration/wordpress_spec.js
@@ -1,12 +1,16 @@
 /// <reference types="cypress" />
 
+import {
+  random,
+} from './utils'
+
 it('contains the sample blogpost and a comment', () => {
   cy.visit('/');
   cy.get('.wp-block-query').should('exist');
-  cy.get('.wp-block-post-title a').click();
+  cy.contains('.wp-block-post-title a','Hello World').click();
   cy.fixture('helloworld').then((hw) => {
-    cy.get('.wp-block-post-title').should('have.text', hw.title);
-    cy.get('.wp-block-post-content').should('contain.text', hw.content);
+    cy.contains('.wp-block-post-title', hw.title);
+    cy.contains('.wp-block-post-content',hw.content);
   })
 
   cy.get('.wp-block-post-title').click();
@@ -32,8 +36,8 @@ it('disallows login to an invalid user', () => {
   cy.clearCookies();
   cy.visit('/wp-login.php')
   cy.fixture('user').then((user) => {
-    cy.get('#user_login').type(user.username).should('have.value', user.username);
-    cy.get('#user_pass').type(user.password).should('have.value', user.password);
+    cy.get('#user_login').should('not.be.disabled').type(user.username);
+    cy.get('#user_pass').should('not.be.disabled').type(user.password);
   })
   cy.get('#wp-submit').click();
   cy.fixture('user').then((user) => {
@@ -68,13 +72,16 @@ it('checks if admin can edit a site', () => {
   cy.url().should('include', '/wp-admin/site-editor.php');
 })
 
-it('checks if admin can edit a post', () => {
+it('checks if admin can create a post', () => {
   cy.login();
-  cy.visit('/wp-admin/edit.php');
-  cy.get('#bulk-action-selector-top').should('exist');
-  cy.get('#post-1 .row-title').should('exist').click();
-  cy.url().should('include', '/post.php?post=1&action=edit');
-  cy.get('#editor').should('exist');
+  cy.visit('/wp-admin/post-new.php');
+  cy.get('.components-modal__header > .components-button').click();
+  cy.get('#editor').should('be.visible');
+  cy.contains('button[type="button"]',"Publish").click();
+  cy.get('h1[aria-label="Add title"]').should('be.visible').clear().type(`Test Hello World!${random}`);
+  cy.get('.editor-post-save-draft').should('be.visible').click();
+  cy.get('.editor-post-saved-state').should('exist');
+
 })
 
 it('checks the SMTP configuration', () => {
@@ -96,8 +103,8 @@ it('checks the value of auto update status', () => {
 it('allows the upload of a file',() => {
   cy.login();
   cy.visit("wp-admin/upload.php");
-  cy.get("[role='button']").contains('Add New').click();
-  cy.get("[aria-labelledby]").contains('Select Files').should('be.visible');
+  cy.contains("[role='button']",'Add New').should('be.visible').click();
+  cy.contains("[aria-labelledby]",'Select Files').should('be.visible');
   cy.get('input[type=file]').selectFile('cypress/fixtures/images/test_image.jpeg',
     {force:true});
   cy.get('.attachment').should('be.visible');
@@ -105,8 +112,9 @@ it('allows the upload of a file',() => {
 
 it('allows to log out', () => {
   cy.login();
-  cy.get("#wp-admin-bar-logout .ab-item").click({
+  cy.get("#wp-admin-bar-logout .ab-item").should('exist').click({
     force: true
   });
-  cy.get('.message').contains('logged out');
+  cy.contains('.message','logged out');
 })
+

--- a/.vib/wordpress/cypress/cypress/integration/wordpress_spec.js
+++ b/.vib/wordpress/cypress/cypress/integration/wordpress_spec.js
@@ -7,7 +7,7 @@ import {
 it('contains the sample blogpost and a comment', () => {
   cy.visit('/');
   cy.get('.wp-block-query').should('exist');
-  cy.contains('.wp-block-post-title a','Hello World').click();
+  cy.get('.wp-block-post-title a').click();
   cy.fixture('helloworld').then((hw) => {
     cy.contains('.wp-block-post-title', hw.title);
     cy.contains('.wp-block-post-content',hw.content);

--- a/.vib/wordpress/cypress/cypress/support/commands.js
+++ b/.vib/wordpress/cypress/cypress/support/commands.js
@@ -1,17 +1,17 @@
-// Added to slow down Cypress test execution without using hardcoded waits. If removed, there will be false positives.
+// Added to slow down Cypress test execution without using hardcoded waits. If removed, there will be false positives. 
 
-const COMMAND_DELAY = 500;
+const COMMAND_DELAY = 200;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
     const origVal = originalFn(...args);
 
-      return new Promise((resolve) => {
-          setTimeout(() => {
-              resolve(origVal);
-           }, COMMAND_DELAY);
-        });
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(origVal);
+      }, COMMAND_DELAY);
     });
+  });
 }
 
 Cypress.Commands.add("login", (

--- a/.vib/wordpress/cypress/cypress/support/commands.js
+++ b/.vib/wordpress/cypress/cypress/support/commands.js
@@ -1,24 +1,24 @@
 const COMMAND_DELAY = 500;
 
 for (const command of ['click']) {
-    Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-        const origVal = originalFn(...args);
+  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
+      const origVal = originalFn(...args);
 
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve(origVal);
-            }, COMMAND_DELAY);
+      return new Promise((resolve) => {
+          setTimeout(() => {
+              resolve(origVal);
+           }, COMMAND_DELAY);
         });
     });
 }
 
 Cypress.Commands.add("login", (
-    username = Cypress.env("username"),
-    password = Cypress.env("password")
+  username = Cypress.env("username"),
+  password = Cypress.env("password")
 ) => {
-    cy.clearCookies();
-    cy.visit('/wp-login.php')
-    cy.get('#user_login').should('not.be.disabled').type(username);
-    cy.get('#user_pass').should('not.be.disabled').type(password);
-    cy.get('#wp-submit').should('be.visible').click();
+  cy.clearCookies();
+  cy.visit('/wp-login.php')
+  cy.get('#user_login').should('not.be.disabled').type(username);
+  cy.get('#user_pass').should('not.be.disabled').type(password);
+  cy.get('#wp-submit').should('be.visible').click();
 });

--- a/.vib/wordpress/cypress/cypress/support/commands.js
+++ b/.vib/wordpress/cypress/cypress/support/commands.js
@@ -1,26 +1,24 @@
-// Added to slow down Cypress test execution without using hardcoded waits. If removed, there will be false positives. 
-
-const COMMAND_DELAY = 200;
+const COMMAND_DELAY = 500;
 
 for (const command of ['click']) {
-  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-    const origVal = originalFn(...args);
+    Cypress.Commands.overwrite(command, (originalFn, ...args) => {
+        const origVal = originalFn(...args);
 
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(origVal);
-      }, COMMAND_DELAY);
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve(origVal);
+            }, COMMAND_DELAY);
+        });
     });
-  });
 }
 
 Cypress.Commands.add("login", (
-  username = Cypress.env("username"),
-  password = Cypress.env("password")
+    username = Cypress.env("username"),
+    password = Cypress.env("password")
 ) => {
-  cy.clearCookies();
-  cy.visit('/wp-login.php')
-  cy.get('#user_login').type(username);
-  cy.get('#user_pass').type(password);
-  cy.get('#wp-submit').click();
+    cy.clearCookies();
+    cy.visit('/wp-login.php')
+    cy.get('#user_login').should('not.be.disabled').type(username);
+    cy.get('#user_pass').should('not.be.disabled').type(password);
+    cy.get('#wp-submit').should('be.visible').click();
 });

--- a/.vib/wordpress/cypress/cypress/support/commands.js
+++ b/.vib/wordpress/cypress/cypress/support/commands.js
@@ -1,3 +1,5 @@
+// Added to slow down Cypress test execution without using hardcoded waits. If removed, there will be false positives.
+
 const COMMAND_DELAY = 500;
 
 for (const command of ['click']) {

--- a/.vib/wordpress/cypress/cypress/support/commands.js
+++ b/.vib/wordpress/cypress/cypress/support/commands.js
@@ -20,7 +20,7 @@ Cypress.Commands.add("login", (
 ) => {
   cy.clearCookies();
   cy.visit('/wp-login.php')
-  cy.get('#user_login').should('not.be.disabled').type(username);
+  cy.get('#user_login').should('not.be.disabled').type(username); //assertion is here to combat flakiness, do not remove
   cy.get('#user_pass').should('not.be.disabled').type(password);
   cy.get('#wp-submit').should('be.visible').click();
 });

--- a/.vib/wordpress/cypress/cypress/support/commands.js
+++ b/.vib/wordpress/cypress/cypress/support/commands.js
@@ -2,7 +2,7 @@ const COMMAND_DELAY = 500;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-      const origVal = originalFn(...args);
+    const origVal = originalFn(...args);
 
       return new Promise((resolve) => {
           setTimeout(() => {


### PR DESCRIPTION
**Description of the change**

Added a dynamic data generator function, used to create a title of the post. Improved some of the locators to avoid flakiness and use a smarter locator strategy. 

**Test results**
Executed successfully 3 different times in a row, total 9 executions. Results of the last one: 

- [GKE](https://cp.production.k.bromelia.bitnami.net/v1/execution-graphs/457a76fb-8eb3-42b9-831c-6f582e62d32b/report) - PASS
- [AKS](https://cp.production.k.bromelia.bitnami.net/v1/execution-graphs/f89dcb60-c8cb-4dfe-8e9d-568d1e8aa655/report) - PASS
- [TKG](https://cp.production.k.bromelia.bitnami.net/v1/execution-graphs/217fa52e-9a39-4364-8f6c-9cd8713367de/report) - PASS

**Benefits**
Less flaky tests that can be run many times in a row and don't generate duplicate data. 

**Possible drawbacks**
As always with UI tests, risk of uncovered flakiness. 

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Test results added - In progress
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)