### PR TITLE
[bitnami/grafana] added values for anonymous authentication and allow_embedding

### DIFF
--- a/bitnami/contour/Chart.lock
+++ b/bitnami/contour/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.1
-digest: sha256:a000bcd4d4cdd813c67d633b5523b4a4cd478fb95f1cae665d9b0ba5c45b40e2
-generated: "2022-02-15T11:46:09.482384174Z"
+  version: 1.11.3
+digest: sha256:d5f850d857edd58b32c0e10652f6ec3ce5018def5542f2bcef38fd7fa0079d6b
+generated: "2022-03-09T07:06:40.553678298Z"

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/bitnami-docker-contour
   - https://projectcontour.io
-version: 7.4.1
+version: 7.4.2

--- a/bitnami/contour/resources/contourconfiguration.yaml
+++ b/bitnami/contour/resources/contourconfiguration.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: contourconfigurations.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -13,128 +12,131 @@ spec:
     listKind: ContourConfigurationList
     plural: contourconfigurations
     shortNames:
-    - contourconfig
+      - contourconfig
     singular: contourconfiguration
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ContourConfiguration is the schema for a Contour instance.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ContourConfiguration is the schema for a Contour instance.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ContourConfigurationSpec represents a configuration of a
-              Contour controller. It contains most of all the options that can be
-              customized, the other remaining options being command line flags.
-            properties:
-              debug:
-                default:
-                  kubernetesLogLevel: 0
-                  logLevel: info
-                description: Debug contains parameters to enable debug logging and
-                  debug interfaces inside Contour.
-                properties:
-                  address:
-                    description: Defines the Contour debug address interface.
-                    type: string
-                  kubernetesLogLevel:
-                    default: 0
-                    description: "KubernetesDebugLogLevel defines the log level which
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ContourConfigurationSpec represents a configuration of a
+                Contour controller. It contains most of all the options that can be
+                customized, the other remaining options being command line flags.
+              properties:
+                debug:
+                  default:
+                    kubernetesLogLevel: 0
+                    logLevel: info
+                  description: Debug contains parameters to enable debug logging and
+                    debug interfaces inside Contour.
+                  properties:
+                    address:
+                      description: Defines the Contour debug address interface.
+                      type: string
+                    kubernetesLogLevel:
+                      default: 0
+                      description: "KubernetesDebugLogLevel defines the log level which
                       Contour will use when outputting Kubernetes specific log information.
                       \n Details: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md"
-                    maximum: 9
-                    minimum: 0
-                    type: integer
-                  logLevel:
-                    description: DebugLogLevel defines the log level which Contour
-                      will use when outputting log information.
-                    enum:
-                    - info
-                    - debug
-                    type: string
-                  port:
-                    description: Defines the Contour debug address port.
-                    type: integer
-                required:
-                - logLevel
-                type: object
-              enableExternalNameService:
-                default: false
-                description: EnableExternalNameService allows processing of ExternalNameServices
-                  Defaults to disabled for security reasons.
-                type: boolean
-              envoy:
-                default:
-                  cluster:
-                    dnsLookupFamily: auto
-                  defaultHTTPVersions:
-                  - HTTP/1.1
-                  - HTTP/2
-                  http:
-                    accessLog: /dev/stdout
-                    address: 0.0.0.0
-                    port: 8080
-                  https:
-                    accessLog: /dev/stdout
-                    address: 0.0.0.0
-                    port: 8443
-                  listener:
-                    connectionBalancer: ""
-                    disableAllowChunkedLength: false
-                    tls:
-                      cipherSuites:
-                      - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-                      - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
-                      - ECDHE-ECDSA-AES256-GCM-SHA384
-                      - ECDHE-RSA-AES256-GCM-SHA384
-                      minimumProtocolVersion: "1.2"
-                    useProxyProtocol: false
-                  logging:
-                    accessLogFormat: envoy
-                  metrics:
-                    address: 0.0.0.0
-                    port: 8002
-                  network:
-                    adminPort: 9001
-                  service:
-                    name: envoy
-                    namespace: projectcontour
-                description: Envoy contains parameters for Envoy as well as how to
-                  optionally configure a managed Envoy fleet.
-                properties:
-                  clientCertificate:
-                    description: ClientCertificate defines the namespace/name of the
-                      Kubernetes secret containing the client certificate and private
-                      key to be used when establishing TLS connection to upstream
-                      cluster.
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    - namespace
-                    type: object
-                  cluster:
-                    description: Cluster holds various configurable Envoy cluster
-                      values that can be set in the config file.
-                    properties:
-                      dnsLookupFamily:
-                        default: auto
-                        description: "DNSLookupFamily defines how external names are
+                      maximum: 9
+                      minimum: 0
+                      type: integer
+                    logLevel:
+                      description: DebugLogLevel defines the log level which Contour
+                        will use when outputting log information.
+                      enum:
+                        - info
+                        - debug
+                      type: string
+                    port:
+                      description: Defines the Contour debug address port.
+                      type: integer
+                  required:
+                    - logLevel
+                  type: object
+                enableExternalNameService:
+                  default: false
+                  description: EnableExternalNameService allows processing of ExternalNameServices
+                    Defaults to disabled for security reasons.
+                  type: boolean
+                envoy:
+                  default:
+                    cluster:
+                      dnsLookupFamily: auto
+                    defaultHTTPVersions:
+                      - HTTP/1.1
+                      - HTTP/2
+                    health:
+                      address: 0.0.0.0
+                      port: 8002
+                    http:
+                      accessLog: /dev/stdout
+                      address: 0.0.0.0
+                      port: 8080
+                    https:
+                      accessLog: /dev/stdout
+                      address: 0.0.0.0
+                      port: 8443
+                    listener:
+                      connectionBalancer: ""
+                      disableAllowChunkedLength: false
+                      tls:
+                        cipherSuites:
+                          - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+                          - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+                          - ECDHE-ECDSA-AES256-GCM-SHA384
+                          - ECDHE-RSA-AES256-GCM-SHA384
+                        minimumProtocolVersion: "1.2"
+                      useProxyProtocol: false
+                    logging:
+                      accessLogFormat: envoy
+                    metrics:
+                      address: 0.0.0.0
+                      port: 8002
+                    network:
+                      adminPort: 9001
+                    service:
+                      name: envoy
+                      namespace: projectcontour
+                  description: Envoy contains parameters for Envoy as well as how to
+                    optionally configure a managed Envoy fleet.
+                  properties:
+                    clientCertificate:
+                      description: ClientCertificate defines the namespace/name of the
+                        Kubernetes secret containing the client certificate and private
+                        key to be used when establishing TLS connection to upstream
+                        cluster.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                    cluster:
+                      description: Cluster holds various configurable Envoy cluster
+                        values that can be set in the config file.
+                      properties:
+                        dnsLookupFamily:
+                          default: auto
+                          description: "DNSLookupFamily defines how external names are
                           looked up When configured as V4, the DNS resolver will only
                           perform a lookup for addresses in the IPv4 family. If V6
                           is configured, the DNS resolver will only perform a lookup
@@ -144,98 +146,116 @@ spec:
                           in the IPv4 family. Note: This only applies to externalName
                           clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
                           for more information."
+                          enum:
+                            - auto
+                            - v4
+                            - v6
+                          type: string
+                      required:
+                        - dnsLookupFamily
+                      type: object
+                    defaultHTTPVersions:
+                      description: DefaultHTTPVersions defines the default set of HTTPS
+                        versions the proxy should accept. HTTP versions are strings
+                        of the form "HTTP/xx". Supported versions are "HTTP/1.1" and
+                        "HTTP/2".
+                      items:
+                        description: HTTPVersionType is the name of a supported HTTP
+                          version.
                         enum:
-                        - auto
-                        - v4
-                        - v6
+                          - HTTP/1.1
+                          - HTTP/2
                         type: string
-                    required:
-                    - dnsLookupFamily
-                    type: object
-                  defaultHTTPVersions:
-                    description: DefaultHTTPVersions defines the default set of HTTPS
-                      versions the proxy should accept. HTTP versions are strings
-                      of the form "HTTP/xx". Supported versions are "HTTP/1.1" and
-                      "HTTP/2".
-                    items:
-                      description: HTTPVersionType is the name of a supported HTTP
-                        version.
-                      enum:
-                      - HTTP/1.1
-                      - HTTP/2
-                      type: string
-                    type: array
-                  http:
-                    default:
-                      accessLog: /dev/stdout
-                      address: 0.0.0.0
-                      port: 8080
-                    description: Defines the HTTP Listener for Envoy.
-                    properties:
-                      accessLog:
-                        description: AccessLog defines where Envoy logs are outputted
-                          for this listener.
-                        type: string
-                      address:
-                        description: Defines an Envoy Listener Address.
-                        minLength: 1
-                        type: string
-                      port:
-                        description: Defines an Envoy listener Port.
-                        type: integer
-                    required:
-                    - accessLog
-                    - address
-                    - port
-                    type: object
-                  https:
-                    default:
-                      accessLog: /dev/stdout
-                      address: 0.0.0.0
-                      port: 8443
-                    description: Defines the HTTP Listener for Envoy.
-                    properties:
-                      accessLog:
-                        description: AccessLog defines where Envoy logs are outputted
-                          for this listener.
-                        type: string
-                      address:
-                        description: Defines an Envoy Listener Address.
-                        minLength: 1
-                        type: string
-                      port:
-                        description: Defines an Envoy listener Port.
-                        type: integer
-                    required:
-                    - accessLog
-                    - address
-                    - port
-                    type: object
-                  listener:
-                    description: Listener hold various configurable Envoy listener
-                      values.
-                    properties:
-                      connectionBalancer:
-                        description: ConnectionBalancer. If the value is exact, the
-                          listener will use the exact connection balancer See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
-                          for more information.
-                        enum:
-                        - ""
-                        - exact
-                        type: string
-                      disableAllowChunkedLength:
-                        description: 'DisableAllowChunkedLength disables the RFC-compliant
+                      type: array
+                    health:
+                      default:
+                        address: 0.0.0.0
+                        port: 8002
+                      description: Health defines the endpoint Envoy uses to serve health
+                        checks.
+                      properties:
+                        address:
+                          description: Defines the health address interface.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines the health port.
+                          type: integer
+                      required:
+                        - address
+                        - port
+                      type: object
+                    http:
+                      default:
+                        accessLog: /dev/stdout
+                        address: 0.0.0.0
+                        port: 8080
+                      description: Defines the HTTP Listener for Envoy.
+                      properties:
+                        accessLog:
+                          description: AccessLog defines where Envoy logs are outputted
+                            for this listener.
+                          type: string
+                        address:
+                          description: Defines an Envoy Listener Address.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines an Envoy listener Port.
+                          type: integer
+                      required:
+                        - accessLog
+                        - address
+                        - port
+                      type: object
+                    https:
+                      default:
+                        accessLog: /dev/stdout
+                        address: 0.0.0.0
+                        port: 8443
+                      description: Defines the HTTP Listener for Envoy.
+                      properties:
+                        accessLog:
+                          description: AccessLog defines where Envoy logs are outputted
+                            for this listener.
+                          type: string
+                        address:
+                          description: Defines an Envoy Listener Address.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines an Envoy listener Port.
+                          type: integer
+                      required:
+                        - accessLog
+                        - address
+                        - port
+                      type: object
+                    listener:
+                      description: Listener hold various configurable Envoy listener
+                        values.
+                      properties:
+                        connectionBalancer:
+                          description: ConnectionBalancer. If the value is exact, the
+                            listener will use the exact connection balancer See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
+                            for more information.
+                          enum:
+                            - ""
+                            - exact
+                          type: string
+                        disableAllowChunkedLength:
+                          description: 'DisableAllowChunkedLength disables the RFC-compliant
                           Envoy behavior to strip the "Content-Length" header if "Transfer-Encoding:
                           chunked" is also set. This is an emergency off-switch to
                           revert back to Envoy''s default behavior in case of failures.
                           Please file an issue if failures are encountered. See: https://github.com/projectcontour/contour/issues/3221'
-                        type: boolean
-                      tls:
-                        description: TLS holds various configurable Envoy TLS listener
-                          values.
-                        properties:
-                          cipherSuites:
-                            description: "CipherSuites defines the TLS ciphers to
+                          type: boolean
+                        tls:
+                          description: TLS holds various configurable Envoy TLS listener
+                            values.
+                          properties:
+                            cipherSuites:
+                              description: "CipherSuites defines the TLS ciphers to
                               be supported by Envoy TLS listeners when negotiating
                               TLS 1.2. Ciphers are validated against the set that
                               Envoy supports by default. This parameter should only
@@ -243,138 +263,153 @@ spec:
                               when TLS 1.3 is in use. \n See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
                               Note: This list is a superset of what is valid for stock
                               Envoy builds and those using BoringSSL FIPS."
-                            items:
+                              items:
+                                enum:
+                                  - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+                                  - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+                                  - ECDHE-ECDSA-AES128-GCM-SHA256
+                                  - ECDHE-RSA-AES128-GCM-SHA256
+                                  - ECDHE-ECDSA-AES128-SHA
+                                  - ECDHE-RSA-AES128-SHA
+                                  - AES128-GCM-SHA256
+                                  - AES128-SHA
+                                  - ECDHE-ECDSA-AES256-GCM-SHA384
+                                  - ECDHE-RSA-AES256-GCM-SHA384
+                                  - ECDHE-ECDSA-AES256-SHA
+                                  - ECDHE-RSA-AES256-SHA
+                                  - AES256-GCM-SHA384
+                                  - AES256-SHA
+                                type: string
+                              type: array
+                            minimumProtocolVersion:
+                              description: MinimumProtocolVersion is the minimum TLS
+                                version this vhost should negotiate. Valid options are
+                                `1.2` (default) and `1.3`.
                               enum:
-                              - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-                              - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
-                              - ECDHE-ECDSA-AES128-GCM-SHA256
-                              - ECDHE-RSA-AES128-GCM-SHA256
-                              - ECDHE-ECDSA-AES128-SHA
-                              - ECDHE-RSA-AES128-SHA
-                              - AES128-GCM-SHA256
-                              - AES128-SHA
-                              - ECDHE-ECDSA-AES256-GCM-SHA384
-                              - ECDHE-RSA-AES256-GCM-SHA384
-                              - ECDHE-ECDSA-AES256-SHA
-                              - ECDHE-RSA-AES256-SHA
-                              - AES256-GCM-SHA384
-                              - AES256-SHA
+                                - "1.2"
+                                - "1.3"
                               type: string
-                            type: array
-                          minimumProtocolVersion:
-                            description: MinimumProtocolVersion is the minimum TLS
-                              version this vhost should negotiate. Valid options are
-                              `1.2` (default) and `1.3`.
-                            enum:
-                            - "1.2"
-                            - "1.3"
-                            type: string
-                        required:
-                        - cipherSuites
-                        - minimumProtocolVersion
-                        type: object
-                      useProxyProtocol:
-                        description: Use PROXY protocol for all listeners.
-                        type: boolean
-                    required:
-                    - connectionBalancer
-                    - disableAllowChunkedLength
-                    - tls
-                    - useProxyProtocol
-                    type: object
-                  logging:
-                    description: Logging defines how Envoy's logs can be configured.
-                    properties:
-                      accessLogFormat:
-                        description: AccessLogFormat sets the global access log format.
-                          Valid options are 'envoy' or 'json'
-                        enum:
-                        - envoy
-                        - json
-                        type: string
-                      accessLogFormatString:
-                        description: AccessLogFormatString sets the access log format
-                          when format is set to `envoy`. When empty, Envoy's default
-                          format is used.
-                        type: string
-                      jsonFields:
-                        description: AccessLogFields sets the fields that JSON logging
-                          will output when AccessLogFormat is json.
-                        items:
+                          required:
+                            - cipherSuites
+                            - minimumProtocolVersion
+                          type: object
+                        useProxyProtocol:
+                          description: Use PROXY protocol for all listeners.
+                          type: boolean
+                      required:
+                        - connectionBalancer
+                        - disableAllowChunkedLength
+                        - tls
+                        - useProxyProtocol
+                      type: object
+                    logging:
+                      description: Logging defines how Envoy's logs can be configured.
+                      properties:
+                        accessLogFormat:
+                          description: AccessLogFormat sets the global access log format.
+                            Valid options are 'envoy' or 'json'
+                          enum:
+                            - envoy
+                            - json
                           type: string
-                        type: array
-                    required:
-                    - accessLogFormat
-                    type: object
-                  metrics:
-                    default:
-                      address: 0.0.0.0
-                      port: 8002
-                    description: Metrics defines the endpoints Envoy use to serve
-                      to metrics.
-                    properties:
-                      address:
-                        description: Defines the metrics address interface.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      port:
-                        description: Defines the metrics port.
-                        type: integer
-                    required:
-                    - address
-                    - port
-                    type: object
-                  network:
-                    description: Network holds various configurable Envoy network
-                      values.
-                    properties:
-                      adminPort:
-                        default: 9001
-                        description: Configure the port used to access the Envoy Admin
-                          interface. If configured to port "0" then the admin interface
-                          is disabled.
-                        type: integer
-                      numTrustedHops:
-                        description: "XffNumTrustedHops defines the number of additional
+                        accessLogFormatString:
+                          description: AccessLogFormatString sets the access log format
+                            when format is set to `envoy`. When empty, Envoy's default
+                            format is used.
+                          type: string
+                        jsonFields:
+                          description: AccessLogFields sets the fields that JSON logging
+                            will output when AccessLogFormat is json.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - accessLogFormat
+                      type: object
+                    metrics:
+                      default:
+                        address: 0.0.0.0
+                        port: 8002
+                      description: Metrics defines the endpoint Envoy uses to serve
+                        metrics.
+                      properties:
+                        address:
+                          description: Defines the metrics address interface.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines the metrics port.
+                          type: integer
+                        tls:
+                          description: TLS holds TLS file config details. Metrics and
+                            health endpoints cannot have same port number when metrics
+                            is served over HTTPS.
+                          properties:
+                            caFile:
+                              description: CA filename.
+                              type: string
+                            certFile:
+                              description: Client certificate filename.
+                              type: string
+                            keyFile:
+                              description: Client key filename.
+                              type: string
+                          type: object
+                      required:
+                        - address
+                        - port
+                      type: object
+                    network:
+                      description: Network holds various configurable Envoy network
+                        values.
+                      properties:
+                        adminPort:
+                          default: 9001
+                          description: Configure the port used to access the Envoy Admin
+                            interface. If configured to port "0" then the admin interface
+                            is disabled.
+                          type: integer
+                        numTrustedHops:
+                          description: "XffNumTrustedHops defines the number of additional
                           ingress proxy hops from the right side of the x-forwarded-for
-                          HTTP header to trust when determining the origin client's
+                          HTTP header to trust when determining the origin client’s
                           IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
                           for more information."
-                        format: int32
-                        type: integer
-                    required:
-                    - adminPort
-                    type: object
-                  service:
-                    default:
-                      name: envoy
-                      namespace: projectcontour
-                    description: Service holds Envoy service parameters for setting
-                      Ingress status.
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    - namespace
-                    type: object
-                  timeouts:
-                    description: Timeouts holds various configurable timeouts that
-                      can be set in the config file.
-                    properties:
-                      connectionIdleTimeout:
-                        description: "ConnectionIdleTimeout defines how long the proxy
+                          format: int32
+                          type: integer
+                      required:
+                        - adminPort
+                      type: object
+                    service:
+                      default:
+                        name: envoy
+                        namespace: projectcontour
+                      description: Service holds Envoy service parameters for setting
+                        Ingress status.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                    timeouts:
+                      description: Timeouts holds various configurable timeouts that
+                        can be set in the config file.
+                      properties:
+                        connectionIdleTimeout:
+                          description: "ConnectionIdleTimeout defines how long the proxy
                           should wait while there are no active requests (for HTTP/1.1)
                           or streams (for HTTP/2) before terminating an HTTP connection.
                           Set to \"infinity\" to disable the timeout entirely. \n
                           See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
                           for more information."
-                        type: string
-                      connectionShutdownGracePeriod:
-                        description: "ConnectionShutdownGracePeriod defines how long
+                          type: string
+                        connectionShutdownGracePeriod:
+                          description: "ConnectionShutdownGracePeriod defines how long
                           the proxy will wait between sending an initial GOAWAY frame
                           and a second, final GOAWAY frame when terminating an HTTP/2
                           connection. During this grace period, the proxy will continue
@@ -382,9 +417,9 @@ spec:
                           has been sent, the proxy will refuse new streams. \n See
                           https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-drain-timeout
                           for more information."
-                        type: string
-                      delayedCloseTimeout:
-                        description: "DelayedCloseTimeout defines how long envoy will
+                          type: string
+                        delayedCloseTimeout:
+                          description: "DelayedCloseTimeout defines how long envoy will
                           wait, once connection close processing has been initiated,
                           for the downstream peer to close the connection before Envoy
                           closes the socket associated with the connection. \n Setting
@@ -392,304 +427,282 @@ spec:
                           setting it to '0' in Envoy. Leaving it unset will result
                           in the Envoy default value being used. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-delayed-close-timeout
                           for more information."
-                        type: string
-                      maxConnectionDuration:
-                        description: "MaxConnectionDuration defines the maximum period
+                          type: string
+                        maxConnectionDuration:
+                          description: "MaxConnectionDuration defines the maximum period
                           of time after an HTTP connection has been established from
                           the client to the proxy before it is closed by the proxy,
                           regardless of whether there has been activity or not. Omit
                           or set to \"infinity\" for no max duration. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration
                           for more information."
-                        type: string
-                      requestTimeout:
-                        description: "RequestTimeout sets the client request timeout
+                          type: string
+                        requestTimeout:
+                          description: "RequestTimeout sets the client request timeout
                           globally for Contour. Note that this is a timeout for the
                           entire request, not an idle timeout. Omit or set to \"infinity\"
                           to disable the timeout entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout
                           for more information."
-                        type: string
-                      streamIdleTimeout:
-                        description: "StreamIdleTimeout defines how long the proxy
+                          type: string
+                        streamIdleTimeout:
+                          description: "StreamIdleTimeout defines how long the proxy
                           should wait while there is no request activity (for HTTP/1.1)
                           or stream activity (for HTTP/2) before terminating the HTTP
                           request or stream. Set to \"infinity\" to disable the timeout
                           entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
                           for more information."
-                        type: string
-                    type: object
-                required:
-                - cluster
-                - defaultHTTPVersions
-                - http
-                - https
-                - listener
-                - logging
-                - metrics
-                - network
-                - service
-                type: object
-              gateway:
-                description: Gateway contains parameters for the gateway-api Gateway
-                  that Contour is configured to serve traffic.
-                properties:
-                  controllerName:
-                    default: projectcontour.io/projectcontour/contour
-                    description: ControllerName is used to determine whether Contour
-                      should reconcile a GatewayClass. The string takes the form of
-                      "projectcontour.io/<namespace>/contour". If unset, the gatewayclass
-                      controller will not be started.
-                    type: string
-                required:
-                - controllerName
-                type: object
-              health:
-                default:
-                  address: 0.0.0.0
-                  port: 8000
-                description: Health contains parameters to configure endpoints which
-                  Contour exposes to respond to Kubernetes health checks.
-                properties:
-                  address:
-                    description: Defines the Contour health address interface.
-                    minLength: 1
-                    type: string
-                  port:
-                    description: Defines the Contour health port.
-                    type: integer
-                required:
-                - address
-                - port
-                type: object
-              httpproxy:
-                default:
-                  disablePermitInsecure: false
-                description: HTTPProxy defines parameters on HTTPProxy.
-                properties:
-                  disablePermitInsecure:
-                    description: DisablePermitInsecure disables the use of the permitInsecure
-                      field in HTTPProxy.
-                    type: boolean
-                  fallbackCertificate:
-                    description: FallbackCertificate defines the namespace/name of
-                      the Kubernetes secret to use as fallback when a non-SNI request
-                      is received.
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    - namespace
-                    type: object
-                  rootNamespaces:
-                    description: Restrict Contour to searching these namespaces for
-                      root ingress routes.
-                    items:
+                          type: string
+                      type: object
+                  required:
+                    - cluster
+                    - defaultHTTPVersions
+                    - http
+                    - https
+                    - listener
+                    - logging
+                    - metrics
+                    - network
+                    - service
+                  type: object
+                gateway:
+                  description: Gateway contains parameters for the gateway-api Gateway
+                    that Contour is configured to serve traffic.
+                  properties:
+                    controllerName:
+                      default: projectcontour.io/projectcontour/contour
+                      description: ControllerName is used to determine whether Contour
+                        should reconcile a GatewayClass. The string takes the form of
+                        "projectcontour.io/<namespace>/contour". If unset, the gatewayclass
+                        controller will not be started.
                       type: string
-                    type: array
-                required:
-                - disablePermitInsecure
-                type: object
-              ingress:
-                description: Ingress contains parameters for ingress options.
-                properties:
-                  className:
-                    description: Ingress Class Name Contour should use.
-                    type: string
-                  statusAddress:
-                    description: Address to set in Ingress object status.
-                    type: string
-                type: object
-              leaderElection:
-                default:
-                  configmap:
-                    name: leader-elect
-                    namespace: projectcontour
-                  disableLeaderElection: false
-                  leaseDuration: 15s
-                  renewDeadline: 10s
-                  retryPeriod: 2s
-                description: LeaderElection contains leader election parameters.
-                properties:
-                  configmap:
-                    description: NamespacedName defines the namespace/name of the
-                      Kubernetes resource referred from the config file. Used for
-                      Contour config YAML file parsing, otherwise we could use K8s
-                      types.NamespacedName.
-                    properties:
-                      name:
+                  required:
+                    - controllerName
+                  type: object
+                health:
+                  default:
+                    address: 0.0.0.0
+                    port: 8000
+                  description: Health defines the endpoints Contour uses to serve health
+                    checks.
+                  properties:
+                    address:
+                      description: Defines the health address interface.
+                      minLength: 1
+                      type: string
+                    port:
+                      description: Defines the health port.
+                      type: integer
+                  required:
+                    - address
+                    - port
+                  type: object
+                httpproxy:
+                  default:
+                    disablePermitInsecure: false
+                  description: HTTPProxy defines parameters on HTTPProxy.
+                  properties:
+                    disablePermitInsecure:
+                      description: DisablePermitInsecure disables the use of the permitInsecure
+                        field in HTTPProxy.
+                      type: boolean
+                    fallbackCertificate:
+                      description: FallbackCertificate defines the namespace/name of
+                        the Kubernetes secret to use as fallback when a non-SNI request
+                        is received.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                    rootNamespaces:
+                      description: Restrict Contour to searching these namespaces for
+                        root ingress routes.
+                      items:
                         type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    - namespace
-                    type: object
-                  disableLeaderElection:
-                    type: boolean
-                  leaseDuration:
-                    type: string
-                  renewDeadline:
-                    type: string
-                  retryPeriod:
-                    type: string
-                required:
-                - disableLeaderElection
-                type: object
-              metrics:
-                default:
-                  address: 0.0.0.0
-                  port: 8000
-                description: Metrics defines the endpoints Contour uses to serve to
-                  metrics.
-                properties:
-                  address:
-                    description: Defines the metrics address interface.
-                    maxLength: 253
-                    minLength: 1
-                    type: string
-                  port:
-                    description: Defines the metrics port.
-                    type: integer
-                required:
-                - address
-                - port
-                type: object
-              policy:
-                description: Policy specifies default policy applied if not overridden
-                  by the user
-                properties:
-                  applyToIngress:
-                    description: ApplyToIngress determines if the Policies will apply
-                      to ingress objects
-                    type: boolean
-                  requestHeaders:
-                    description: RequestHeadersPolicy defines the request headers
-                      set/removed on all routes
-                    properties:
-                      remove:
-                        items:
+                      type: array
+                  required:
+                    - disablePermitInsecure
+                  type: object
+                ingress:
+                  description: Ingress contains parameters for ingress options.
+                  properties:
+                    className:
+                      description: Ingress Class Name Contour should use.
+                      type: string
+                    statusAddress:
+                      description: Address to set in Ingress object status.
+                      type: string
+                  type: object
+                metrics:
+                  default:
+                    address: 0.0.0.0
+                    port: 8000
+                  description: Metrics defines the endpoint Contour uses to serve metrics.
+                  properties:
+                    address:
+                      description: Defines the metrics address interface.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    port:
+                      description: Defines the metrics port.
+                      type: integer
+                    tls:
+                      description: TLS holds TLS file config details. Metrics and health
+                        endpoints cannot have same port number when metrics is served
+                        over HTTPS.
+                      properties:
+                        caFile:
+                          description: CA filename.
                           type: string
-                        type: array
-                      set:
-                        additionalProperties:
+                        certFile:
+                          description: Client certificate filename.
                           type: string
-                        type: object
-                    type: object
-                  responseHeaders:
-                    description: ResponseHeadersPolicy defines the response headers
-                      set/removed on all routes
-                    properties:
-                      remove:
-                        items:
+                        keyFile:
+                          description: Client key filename.
                           type: string
-                        type: array
-                      set:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                type: object
-              rateLimitService:
-                description: RateLimitService optionally holds properties of the Rate
-                  Limit Service to be used for global rate limiting.
-                properties:
-                  domain:
-                    description: Domain is passed to the Rate Limit Service.
-                    type: string
-                  enableXRateLimitHeaders:
-                    description: "EnableXRateLimitHeaders defines whether to include
+                      type: object
+                  required:
+                    - address
+                    - port
+                  type: object
+                policy:
+                  description: Policy specifies default policy applied if not overridden
+                    by the user
+                  properties:
+                    applyToIngress:
+                      description: ApplyToIngress determines if the Policies will apply
+                        to ingress objects
+                      type: boolean
+                    requestHeaders:
+                      description: RequestHeadersPolicy defines the request headers
+                        set/removed on all routes
+                      properties:
+                        remove:
+                          items:
+                            type: string
+                          type: array
+                        set:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    responseHeaders:
+                      description: ResponseHeadersPolicy defines the response headers
+                        set/removed on all routes
+                      properties:
+                        remove:
+                          items:
+                            type: string
+                          type: array
+                        set:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                  type: object
+                rateLimitService:
+                  description: RateLimitService optionally holds properties of the Rate
+                    Limit Service to be used for global rate limiting.
+                  properties:
+                    domain:
+                      description: Domain is passed to the Rate Limit Service.
+                      type: string
+                    enableXRateLimitHeaders:
+                      description: "EnableXRateLimitHeaders defines whether to include
                       the X-RateLimit headers X-RateLimit-Limit, X-RateLimit-Remaining,
                       and X-RateLimit-Reset (as defined by the IETF Internet-Draft
                       linked below), on responses to clients when the Rate Limit Service
                       is consulted for a request. \n ref. https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html"
-                    type: boolean
-                  extensionService:
-                    description: ExtensionService identifies the extension service
-                      defining the RLS.
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    - namespace
-                    type: object
-                  failOpen:
-                    description: FailOpen defines whether to allow requests to proceed
-                      when the Rate Limit Service fails to respond with a valid rate
-                      limit decision within the timeout defined on the extension service.
-                    type: boolean
-                required:
-                - domain
-                - enableXRateLimitHeaders
-                - failOpen
-                type: object
-              xdsServer:
-                default:
-                  address: 0.0.0.0
-                  port: 8001
-                  tls:
-                    caFile: /certs/ca.crt
-                    certFile: /certs/tls.crt
-                    insecure: false
-                    keyFile: /certs/tls.key
-                  type: contour
-                description: XDSServer contains parameters for the xDS server.
-                properties:
-                  address:
-                    description: Defines the xDS gRPC API address which Contour will
-                      serve.
-                    minLength: 1
-                    type: string
-                  port:
-                    description: Defines the xDS gRPC API port which Contour will
-                      serve.
-                    type: integer
-                  tls:
-                    description: TLS holds TLS file config details.
-                    properties:
-                      caFile:
-                        description: CA filename.
-                        type: string
-                      certFile:
-                        description: Client certificate filename.
-                        type: string
-                      insecure:
-                        description: Allow serving the xDS gRPC API without TLS.
-                        type: boolean
-                      keyFile:
-                        description: Client key filename.
-                        type: string
-                    required:
-                    - insecure
-                    type: object
-                  type:
-                    description: Defines the XDSServer to use for `contour serve`.
-                    enum:
-                    - contour
-                    - envoy
-                    type: string
-                required:
-                - address
-                - port
-                - type
-                type: object
-            type: object
-          status:
-            description: ContourConfigurationStatus defines the observed state of
-              a ContourConfiguration resource.
-            properties:
-              conditions:
-                description: "Conditions contains the current status of the Contour
+                      type: boolean
+                    extensionService:
+                      description: ExtensionService identifies the extension service
+                        defining the RLS.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                    failOpen:
+                      description: FailOpen defines whether to allow requests to proceed
+                        when the Rate Limit Service fails to respond with a valid rate
+                        limit decision within the timeout defined on the extension service.
+                      type: boolean
+                  required:
+                    - domain
+                    - enableXRateLimitHeaders
+                    - failOpen
+                  type: object
+                xdsServer:
+                  default:
+                    address: 0.0.0.0
+                    port: 8001
+                    tls:
+                      caFile: /certs/ca.crt
+                      certFile: /certs/tls.crt
+                      insecure: false
+                      keyFile: /certs/tls.key
+                    type: contour
+                  description: XDSServer contains parameters for the xDS server.
+                  properties:
+                    address:
+                      description: Defines the xDS gRPC API address which Contour will
+                        serve.
+                      minLength: 1
+                      type: string
+                    port:
+                      description: Defines the xDS gRPC API port which Contour will
+                        serve.
+                      type: integer
+                    tls:
+                      description: TLS holds TLS file config details.
+                      properties:
+                        caFile:
+                          description: CA filename.
+                          type: string
+                        certFile:
+                          description: Client certificate filename.
+                          type: string
+                        insecure:
+                          description: Allow serving the xDS gRPC API without TLS.
+                          type: boolean
+                        keyFile:
+                          description: Client key filename.
+                          type: string
+                      required:
+                        - insecure
+                      type: object
+                    type:
+                      description: Defines the XDSServer to use for `contour serve`.
+                      enum:
+                        - contour
+                        - envoy
+                      type: string
+                  required:
+                    - address
+                    - port
+                    - type
+                  type: object
+              type: object
+            status:
+              description: ContourConfigurationStatus defines the observed state of
+                a ContourConfiguration resource.
+              properties:
+                conditions:
+                  description: "Conditions contains the current status of the Contour
                   resource. \n Contour will update a single condition, `Valid`, that
                   is in normal-true polarity. \n Contour will not modify any other
                   Conditions set in this block, in case some other controller wants
                   to add a Condition."
-                items:
-                  description: "DetailedCondition is an extension of the normal Kubernetes
+                  items:
+                    description: "DetailedCondition is an extension of the normal Kubernetes
                     conditions, with two extra fields to hold sub-conditions, which
                     provide more detailed reasons for the state (True or False) of
                     the condition. \n `errors` holds information about sub-conditions
@@ -718,14 +731,14 @@ spec:
                     the detail of the reason (if there is one and only one entry in
                     total across both the `errors` and `warnings` slices), or `MultipleReasons`
                     if there is more than one entry."
-                  properties:
-                    errors:
-                      description: "Errors contains a slice of relevant error subconditions
+                    properties:
+                      errors:
+                        description: "Errors contains a slice of relevant error subconditions
                         for this object. \n Subconditions are expected to appear when
                         relevant (when there is a error), and disappear when not relevant.
                         An empty slice here indicates no errors."
-                      items:
-                        description: "SubCondition is a Condition-like type intended
+                        items:
+                          description: "SubCondition is a Condition-like type intended
                           for use as a subcondition inside a DetailedCondition. \n
                           It contains a subset of the Condition fields. \n It is intended
                           for warnings and errors, so `type` names should use abnormal-true
@@ -733,103 +746,103 @@ spec:
                           true\". \n The expected lifecycle for these errors is that
                           they should only be present when the error or warning is,
                           and should be removed when they are not relevant."
-                        properties:
-                          message:
-                            description: "Message is a human readable message indicating
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
                               details about the transition. \n This may be an empty
                               string."
-                            maxLength: 32768
-                            type: string
-                          reason:
-                            description: "Reason contains a programmatic identifier
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
                               indicating the reason for the condition's last transition.
                               Producers of specific condition types may define expected
                               values and meanings for this field, and whether the
                               values are considered a guaranteed API. \n The value
                               should be a CamelCase string. \n This field may not
                               be empty."
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
                               \n This must be in abnormal-true polarity, that is,
                               `ErrorFound` or `controller.io/ErrorFound`. \n The regex
                               it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                    warnings:
-                      description: "Warnings contains a slice of relevant warning
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition
+                          transitioned from one status to another. This should be when
+                          the underlying condition changed.  If that is not known, then
+                          using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating
+                          details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if .metadata.generation
+                          is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition. Producers
+                          of specific condition types may define expected values and
+                          meanings for this field, and whether the values are considered
+                          a guaranteed API. The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          --- Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                      warnings:
+                        description: "Warnings contains a slice of relevant warning
                         subconditions for this object. \n Subconditions are expected
                         to appear when relevant (when there is a warning), and disappear
                         when not relevant. An empty slice here indicates no warnings."
-                      items:
-                        description: "SubCondition is a Condition-like type intended
+                        items:
+                          description: "SubCondition is a Condition-like type intended
                           for use as a subcondition inside a DetailedCondition. \n
                           It contains a subset of the Condition fields. \n It is intended
                           for warnings and errors, so `type` names should use abnormal-true
@@ -837,70 +850,64 @@ spec:
                           true\". \n The expected lifecycle for these errors is that
                           they should only be present when the error or warning is,
                           and should be removed when they are not relevant."
-                        properties:
-                          message:
-                            description: "Message is a human readable message indicating
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
                               details about the transition. \n This may be an empty
                               string."
-                            maxLength: 32768
-                            type: string
-                          reason:
-                            description: "Reason contains a programmatic identifier
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
                               indicating the reason for the condition's last transition.
                               Producers of specific condition types may define expected
                               values and meanings for this field, and whether the
                               values are considered a guaranteed API. \n The value
                               should be a CamelCase string. \n This field may not
                               be empty."
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
                               \n This must be in abnormal-true polarity, that is,
                               `ErrorFound` or `controller.io/ErrorFound`. \n The regex
                               it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/bitnami/contour/resources/contourdeployments.yaml
+++ b/bitnami/contour/resources/contourdeployments.yaml
@@ -13,131 +13,134 @@ spec:
     listKind: ContourDeploymentList
     plural: contourdeployments
     shortNames:
-    - contourdeploy
+      - contourdeploy
     singular: contourdeployment
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ContourDeployment is the schema for a Contour Deployment.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ContourDeployment is the schema for a Contour Deployment.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ContourDeploymentSpec defines the parameters of how a Contour
-              instance should be configured.
-            properties:
-              config:
-                description: Config is the config that the instances of Contour are
-                  to utilize.
-                properties:
-                  debug:
-                    default:
-                      kubernetesLogLevel: 0
-                      logLevel: info
-                    description: Debug contains parameters to enable debug logging
-                      and debug interfaces inside Contour.
-                    properties:
-                      address:
-                        description: Defines the Contour debug address interface.
-                        type: string
-                      kubernetesLogLevel:
-                        default: 0
-                        description: "KubernetesDebugLogLevel defines the log level
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ContourDeploymentSpec defines the parameters of how a Contour
+                instance should be configured.
+              properties:
+                config:
+                  description: Config is the config that the instances of Contour are
+                    to utilize.
+                  properties:
+                    debug:
+                      default:
+                        kubernetesLogLevel: 0
+                        logLevel: info
+                      description: Debug contains parameters to enable debug logging
+                        and debug interfaces inside Contour.
+                      properties:
+                        address:
+                          description: Defines the Contour debug address interface.
+                          type: string
+                        kubernetesLogLevel:
+                          default: 0
+                          description: "KubernetesDebugLogLevel defines the log level
                           which Contour will use when outputting Kubernetes specific
                           log information. \n Details: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md"
-                        maximum: 9
-                        minimum: 0
-                        type: integer
-                      logLevel:
-                        description: DebugLogLevel defines the log level which Contour
-                          will use when outputting log information.
-                        enum:
-                        - info
-                        - debug
-                        type: string
-                      port:
-                        description: Defines the Contour debug address port.
-                        type: integer
-                    required:
-                    - logLevel
-                    type: object
-                  enableExternalNameService:
-                    default: false
-                    description: EnableExternalNameService allows processing of ExternalNameServices
-                      Defaults to disabled for security reasons.
-                    type: boolean
-                  envoy:
-                    default:
-                      cluster:
-                        dnsLookupFamily: auto
-                      defaultHTTPVersions:
-                      - HTTP/1.1
-                      - HTTP/2
-                      http:
-                        accessLog: /dev/stdout
-                        address: 0.0.0.0
-                        port: 8080
-                      https:
-                        accessLog: /dev/stdout
-                        address: 0.0.0.0
-                        port: 8443
-                      listener:
-                        connectionBalancer: ""
-                        disableAllowChunkedLength: false
-                        tls:
-                          cipherSuites:
-                          - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-                          - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
-                          - ECDHE-ECDSA-AES256-GCM-SHA384
-                          - ECDHE-RSA-AES256-GCM-SHA384
-                          minimumProtocolVersion: "1.2"
-                        useProxyProtocol: false
-                      logging:
-                        accessLogFormat: envoy
-                      metrics:
-                        address: 0.0.0.0
-                        port: 8002
-                      network:
-                        adminPort: 9001
-                      service:
-                        name: envoy
-                        namespace: projectcontour
-                    description: Envoy contains parameters for Envoy as well as how
-                      to optionally configure a managed Envoy fleet.
-                    properties:
-                      clientCertificate:
-                        description: ClientCertificate defines the namespace/name
-                          of the Kubernetes secret containing the client certificate
-                          and private key to be used when establishing TLS connection
-                          to upstream cluster.
-                        properties:
-                          name:
-                            type: string
-                          namespace:
-                            type: string
-                        required:
-                        - name
-                        - namespace
-                        type: object
-                      cluster:
-                        description: Cluster holds various configurable Envoy cluster
-                          values that can be set in the config file.
-                        properties:
-                          dnsLookupFamily:
-                            default: auto
-                            description: "DNSLookupFamily defines how external names
+                          maximum: 9
+                          minimum: 0
+                          type: integer
+                        logLevel:
+                          description: DebugLogLevel defines the log level which Contour
+                            will use when outputting log information.
+                          enum:
+                            - info
+                            - debug
+                          type: string
+                        port:
+                          description: Defines the Contour debug address port.
+                          type: integer
+                      required:
+                        - logLevel
+                      type: object
+                    enableExternalNameService:
+                      default: false
+                      description: EnableExternalNameService allows processing of ExternalNameServices
+                        Defaults to disabled for security reasons.
+                      type: boolean
+                    envoy:
+                      default:
+                        cluster:
+                          dnsLookupFamily: auto
+                        defaultHTTPVersions:
+                          - HTTP/1.1
+                          - HTTP/2
+                        health:
+                          address: 0.0.0.0
+                          port: 8002
+                        http:
+                          accessLog: /dev/stdout
+                          address: 0.0.0.0
+                          port: 8080
+                        https:
+                          accessLog: /dev/stdout
+                          address: 0.0.0.0
+                          port: 8443
+                        listener:
+                          connectionBalancer: ""
+                          disableAllowChunkedLength: false
+                          tls:
+                            cipherSuites:
+                              - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+                              - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+                              - ECDHE-ECDSA-AES256-GCM-SHA384
+                              - ECDHE-RSA-AES256-GCM-SHA384
+                            minimumProtocolVersion: "1.2"
+                          useProxyProtocol: false
+                        logging:
+                          accessLogFormat: envoy
+                        metrics:
+                          address: 0.0.0.0
+                          port: 8002
+                        network:
+                          adminPort: 9001
+                        service:
+                          name: envoy
+                          namespace: projectcontour
+                      description: Envoy contains parameters for Envoy as well as how
+                        to optionally configure a managed Envoy fleet.
+                      properties:
+                        clientCertificate:
+                          description: ClientCertificate defines the namespace/name
+                            of the Kubernetes secret containing the client certificate
+                            and private key to be used when establishing TLS connection
+                            to upstream cluster.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
+                        cluster:
+                          description: Cluster holds various configurable Envoy cluster
+                            values that can be set in the config file.
+                          properties:
+                            dnsLookupFamily:
+                              default: auto
+                              description: "DNSLookupFamily defines how external names
                               are looked up When configured as V4, the DNS resolver
                               will only perform a lookup for addresses in the IPv4
                               family. If V6 is configured, the DNS resolver will only
@@ -147,100 +150,118 @@ spec:
                               to a lookup for addresses in the IPv4 family. Note:
                               This only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
                               for more information."
+                              enum:
+                                - auto
+                                - v4
+                                - v6
+                              type: string
+                          required:
+                            - dnsLookupFamily
+                          type: object
+                        defaultHTTPVersions:
+                          description: DefaultHTTPVersions defines the default set of
+                            HTTPS versions the proxy should accept. HTTP versions are
+                            strings of the form "HTTP/xx". Supported versions are "HTTP/1.1"
+                            and "HTTP/2".
+                          items:
+                            description: HTTPVersionType is the name of a supported
+                              HTTP version.
                             enum:
-                            - auto
-                            - v4
-                            - v6
+                              - HTTP/1.1
+                              - HTTP/2
                             type: string
-                        required:
-                        - dnsLookupFamily
-                        type: object
-                      defaultHTTPVersions:
-                        description: DefaultHTTPVersions defines the default set of
-                          HTTPS versions the proxy should accept. HTTP versions are
-                          strings of the form "HTTP/xx". Supported versions are "HTTP/1.1"
-                          and "HTTP/2".
-                        items:
-                          description: HTTPVersionType is the name of a supported
-                            HTTP version.
-                          enum:
-                          - HTTP/1.1
-                          - HTTP/2
-                          type: string
-                        type: array
-                      http:
-                        default:
-                          accessLog: /dev/stdout
-                          address: 0.0.0.0
-                          port: 8080
-                        description: Defines the HTTP Listener for Envoy.
-                        properties:
-                          accessLog:
-                            description: AccessLog defines where Envoy logs are outputted
-                              for this listener.
-                            type: string
-                          address:
-                            description: Defines an Envoy Listener Address.
-                            minLength: 1
-                            type: string
-                          port:
-                            description: Defines an Envoy listener Port.
-                            type: integer
-                        required:
-                        - accessLog
-                        - address
-                        - port
-                        type: object
-                      https:
-                        default:
-                          accessLog: /dev/stdout
-                          address: 0.0.0.0
-                          port: 8443
-                        description: Defines the HTTP Listener for Envoy.
-                        properties:
-                          accessLog:
-                            description: AccessLog defines where Envoy logs are outputted
-                              for this listener.
-                            type: string
-                          address:
-                            description: Defines an Envoy Listener Address.
-                            minLength: 1
-                            type: string
-                          port:
-                            description: Defines an Envoy listener Port.
-                            type: integer
-                        required:
-                        - accessLog
-                        - address
-                        - port
-                        type: object
-                      listener:
-                        description: Listener hold various configurable Envoy listener
-                          values.
-                        properties:
-                          connectionBalancer:
-                            description: ConnectionBalancer. If the value is exact,
-                              the listener will use the exact connection balancer
-                              See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
-                              for more information.
-                            enum:
-                            - ""
-                            - exact
-                            type: string
-                          disableAllowChunkedLength:
-                            description: 'DisableAllowChunkedLength disables the RFC-compliant
+                          type: array
+                        health:
+                          default:
+                            address: 0.0.0.0
+                            port: 8002
+                          description: Health defines the endpoint Envoy uses to serve
+                            health checks.
+                          properties:
+                            address:
+                              description: Defines the health address interface.
+                              minLength: 1
+                              type: string
+                            port:
+                              description: Defines the health port.
+                              type: integer
+                          required:
+                            - address
+                            - port
+                          type: object
+                        http:
+                          default:
+                            accessLog: /dev/stdout
+                            address: 0.0.0.0
+                            port: 8080
+                          description: Defines the HTTP Listener for Envoy.
+                          properties:
+                            accessLog:
+                              description: AccessLog defines where Envoy logs are outputted
+                                for this listener.
+                              type: string
+                            address:
+                              description: Defines an Envoy Listener Address.
+                              minLength: 1
+                              type: string
+                            port:
+                              description: Defines an Envoy listener Port.
+                              type: integer
+                          required:
+                            - accessLog
+                            - address
+                            - port
+                          type: object
+                        https:
+                          default:
+                            accessLog: /dev/stdout
+                            address: 0.0.0.0
+                            port: 8443
+                          description: Defines the HTTP Listener for Envoy.
+                          properties:
+                            accessLog:
+                              description: AccessLog defines where Envoy logs are outputted
+                                for this listener.
+                              type: string
+                            address:
+                              description: Defines an Envoy Listener Address.
+                              minLength: 1
+                              type: string
+                            port:
+                              description: Defines an Envoy listener Port.
+                              type: integer
+                          required:
+                            - accessLog
+                            - address
+                            - port
+                          type: object
+                        listener:
+                          description: Listener hold various configurable Envoy listener
+                            values.
+                          properties:
+                            connectionBalancer:
+                              description: ConnectionBalancer. If the value is exact,
+                                the listener will use the exact connection balancer
+                                See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
+                                for more information.
+                              enum:
+                                - ""
+                                - exact
+                              type: string
+                            disableAllowChunkedLength:
+                              description: 'DisableAllowChunkedLength disables the RFC-compliant
                               Envoy behavior to strip the "Content-Length" header
                               if "Transfer-Encoding: chunked" is also set. This is
                               an emergency off-switch to revert back to Envoy''s default
                               behavior in case of failures. Please file an issue if
                               failures are encountered. See: https://github.com/projectcontour/contour/issues/3221'
-                            type: boolean
-                          tls:
-                            description: TLS holds various configurable Envoy TLS
-                              listener values.
-                            properties:
-                              cipherSuites:
-                                description: "CipherSuites defines the TLS ciphers
+                              type: boolean
+                            tls:
+                              description: TLS holds various configurable Envoy TLS
+                                listener values.
+                              properties:
+                                cipherSuites:
+                                  description: "CipherSuites defines the TLS ciphers
                                   to be supported by Envoy TLS listeners when negotiating
                                   TLS 1.2. Ciphers are validated against the set that
                                   Envoy supports by default. This parameter should
@@ -249,138 +270,153 @@ spec:
                                   https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
                                   Note: This list is a superset of what is valid for
                                   stock Envoy builds and those using BoringSSL FIPS."
-                                items:
+                                  items:
+                                    enum:
+                                      - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
+                                      - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
+                                      - ECDHE-ECDSA-AES128-GCM-SHA256
+                                      - ECDHE-RSA-AES128-GCM-SHA256
+                                      - ECDHE-ECDSA-AES128-SHA
+                                      - ECDHE-RSA-AES128-SHA
+                                      - AES128-GCM-SHA256
+                                      - AES128-SHA
+                                      - ECDHE-ECDSA-AES256-GCM-SHA384
+                                      - ECDHE-RSA-AES256-GCM-SHA384
+                                      - ECDHE-ECDSA-AES256-SHA
+                                      - ECDHE-RSA-AES256-SHA
+                                      - AES256-GCM-SHA384
+                                      - AES256-SHA
+                                    type: string
+                                  type: array
+                                minimumProtocolVersion:
+                                  description: MinimumProtocolVersion is the minimum
+                                    TLS version this vhost should negotiate. Valid options
+                                    are `1.2` (default) and `1.3`.
                                   enum:
-                                  - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-                                  - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
-                                  - ECDHE-ECDSA-AES128-GCM-SHA256
-                                  - ECDHE-RSA-AES128-GCM-SHA256
-                                  - ECDHE-ECDSA-AES128-SHA
-                                  - ECDHE-RSA-AES128-SHA
-                                  - AES128-GCM-SHA256
-                                  - AES128-SHA
-                                  - ECDHE-ECDSA-AES256-GCM-SHA384
-                                  - ECDHE-RSA-AES256-GCM-SHA384
-                                  - ECDHE-ECDSA-AES256-SHA
-                                  - ECDHE-RSA-AES256-SHA
-                                  - AES256-GCM-SHA384
-                                  - AES256-SHA
+                                    - "1.2"
+                                    - "1.3"
                                   type: string
-                                type: array
-                              minimumProtocolVersion:
-                                description: MinimumProtocolVersion is the minimum
-                                  TLS version this vhost should negotiate. Valid options
-                                  are `1.2` (default) and `1.3`.
-                                enum:
-                                - "1.2"
-                                - "1.3"
-                                type: string
-                            required:
-                            - cipherSuites
-                            - minimumProtocolVersion
-                            type: object
-                          useProxyProtocol:
-                            description: Use PROXY protocol for all listeners.
-                            type: boolean
-                        required:
-                        - connectionBalancer
-                        - disableAllowChunkedLength
-                        - tls
-                        - useProxyProtocol
-                        type: object
-                      logging:
-                        description: Logging defines how Envoy's logs can be configured.
-                        properties:
-                          accessLogFormat:
-                            description: AccessLogFormat sets the global access log
-                              format. Valid options are 'envoy' or 'json'
-                            enum:
-                            - envoy
-                            - json
-                            type: string
-                          accessLogFormatString:
-                            description: AccessLogFormatString sets the access log
-                              format when format is set to `envoy`. When empty, Envoy's
-                              default format is used.
-                            type: string
-                          jsonFields:
-                            description: AccessLogFields sets the fields that JSON
-                              logging will output when AccessLogFormat is json.
-                            items:
+                              required:
+                                - cipherSuites
+                                - minimumProtocolVersion
+                              type: object
+                            useProxyProtocol:
+                              description: Use PROXY protocol for all listeners.
+                              type: boolean
+                          required:
+                            - connectionBalancer
+                            - disableAllowChunkedLength
+                            - tls
+                            - useProxyProtocol
+                          type: object
+                        logging:
+                          description: Logging defines how Envoy's logs can be configured.
+                          properties:
+                            accessLogFormat:
+                              description: AccessLogFormat sets the global access log
+                                format. Valid options are 'envoy' or 'json'
+                              enum:
+                                - envoy
+                                - json
                               type: string
-                            type: array
-                        required:
-                        - accessLogFormat
-                        type: object
-                      metrics:
-                        default:
-                          address: 0.0.0.0
-                          port: 8002
-                        description: Metrics defines the endpoints Envoy use to serve
-                          to metrics.
-                        properties:
-                          address:
-                            description: Defines the metrics address interface.
-                            maxLength: 253
-                            minLength: 1
-                            type: string
-                          port:
-                            description: Defines the metrics port.
-                            type: integer
-                        required:
-                        - address
-                        - port
-                        type: object
-                      network:
-                        description: Network holds various configurable Envoy network
-                          values.
-                        properties:
-                          adminPort:
-                            default: 9001
-                            description: Configure the port used to access the Envoy
-                              Admin interface. If configured to port "0" then the
-                              admin interface is disabled.
-                            type: integer
-                          numTrustedHops:
-                            description: "XffNumTrustedHops defines the number of
+                            accessLogFormatString:
+                              description: AccessLogFormatString sets the access log
+                                format when format is set to `envoy`. When empty, Envoy's
+                                default format is used.
+                              type: string
+                            jsonFields:
+                              description: AccessLogFields sets the fields that JSON
+                                logging will output when AccessLogFormat is json.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - accessLogFormat
+                          type: object
+                        metrics:
+                          default:
+                            address: 0.0.0.0
+                            port: 8002
+                          description: Metrics defines the endpoint Envoy uses to serve
+                            metrics.
+                          properties:
+                            address:
+                              description: Defines the metrics address interface.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            port:
+                              description: Defines the metrics port.
+                              type: integer
+                            tls:
+                              description: TLS holds TLS file config details. Metrics
+                                and health endpoints cannot have same port number when
+                                metrics is served over HTTPS.
+                              properties:
+                                caFile:
+                                  description: CA filename.
+                                  type: string
+                                certFile:
+                                  description: Client certificate filename.
+                                  type: string
+                                keyFile:
+                                  description: Client key filename.
+                                  type: string
+                              type: object
+                          required:
+                            - address
+                            - port
+                          type: object
+                        network:
+                          description: Network holds various configurable Envoy network
+                            values.
+                          properties:
+                            adminPort:
+                              default: 9001
+                              description: Configure the port used to access the Envoy
+                                Admin interface. If configured to port "0" then the
+                                admin interface is disabled.
+                              type: integer
+                            numTrustedHops:
+                              description: "XffNumTrustedHops defines the number of
                               additional ingress proxy hops from the right side of
                               the x-forwarded-for HTTP header to trust when determining
-                              the origin client's IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
+                              the origin client’s IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
                               for more information."
-                            format: int32
-                            type: integer
-                        required:
-                        - adminPort
-                        type: object
-                      service:
-                        default:
-                          name: envoy
-                          namespace: projectcontour
-                        description: Service holds Envoy service parameters for setting
-                          Ingress status.
-                        properties:
-                          name:
-                            type: string
-                          namespace:
-                            type: string
-                        required:
-                        - name
-                        - namespace
-                        type: object
-                      timeouts:
-                        description: Timeouts holds various configurable timeouts
-                          that can be set in the config file.
-                        properties:
-                          connectionIdleTimeout:
-                            description: "ConnectionIdleTimeout defines how long the
+                              format: int32
+                              type: integer
+                          required:
+                            - adminPort
+                          type: object
+                        service:
+                          default:
+                            name: envoy
+                            namespace: projectcontour
+                          description: Service holds Envoy service parameters for setting
+                            Ingress status.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
+                        timeouts:
+                          description: Timeouts holds various configurable timeouts
+                            that can be set in the config file.
+                          properties:
+                            connectionIdleTimeout:
+                              description: "ConnectionIdleTimeout defines how long the
                               proxy should wait while there are no active requests
                               (for HTTP/1.1) or streams (for HTTP/2) before terminating
                               an HTTP connection. Set to \"infinity\" to disable the
                               timeout entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-idle-timeout
                               for more information."
-                            type: string
-                          connectionShutdownGracePeriod:
-                            description: "ConnectionShutdownGracePeriod defines how
+                              type: string
+                            connectionShutdownGracePeriod:
+                              description: "ConnectionShutdownGracePeriod defines how
                               long the proxy will wait between sending an initial
                               GOAWAY frame and a second, final GOAWAY frame when terminating
                               an HTTP/2 connection. During this grace period, the
@@ -388,9 +424,9 @@ spec:
                               the final GOAWAY frame has been sent, the proxy will
                               refuse new streams. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-drain-timeout
                               for more information."
-                            type: string
-                          delayedCloseTimeout:
-                            description: "DelayedCloseTimeout defines how long envoy
+                              type: string
+                            delayedCloseTimeout:
+                              description: "DelayedCloseTimeout defines how long envoy
                               will wait, once connection close processing has been
                               initiated, for the downstream peer to close the connection
                               before Envoy closes the socket associated with the connection.
@@ -399,317 +435,296 @@ spec:
                               unset will result in the Envoy default value being used.
                               \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-delayed-close-timeout
                               for more information."
-                            type: string
-                          maxConnectionDuration:
-                            description: "MaxConnectionDuration defines the maximum
+                              type: string
+                            maxConnectionDuration:
+                              description: "MaxConnectionDuration defines the maximum
                               period of time after an HTTP connection has been established
                               from the client to the proxy before it is closed by
                               the proxy, regardless of whether there has been activity
                               or not. Omit or set to \"infinity\" for no max duration.
                               \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/protocol.proto#envoy-v3-api-field-config-core-v3-httpprotocoloptions-max-connection-duration
                               for more information."
-                            type: string
-                          requestTimeout:
-                            description: "RequestTimeout sets the client request timeout
+                              type: string
+                            requestTimeout:
+                              description: "RequestTimeout sets the client request timeout
                               globally for Contour. Note that this is a timeout for
                               the entire request, not an idle timeout. Omit or set
                               to \"infinity\" to disable the timeout entirely. \n
                               See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-request-timeout
                               for more information."
-                            type: string
-                          streamIdleTimeout:
-                            description: "StreamIdleTimeout defines how long the proxy
+                              type: string
+                            streamIdleTimeout:
+                              description: "StreamIdleTimeout defines how long the proxy
                               should wait while there is no request activity (for
                               HTTP/1.1) or stream activity (for HTTP/2) before terminating
                               the HTTP request or stream. Set to \"infinity\" to disable
                               the timeout entirely. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-stream-idle-timeout
                               for more information."
-                            type: string
-                        type: object
-                    required:
-                    - cluster
-                    - defaultHTTPVersions
-                    - http
-                    - https
-                    - listener
-                    - logging
-                    - metrics
-                    - network
-                    - service
-                    type: object
-                  gateway:
-                    description: Gateway contains parameters for the gateway-api Gateway
-                      that Contour is configured to serve traffic.
-                    properties:
-                      controllerName:
-                        default: projectcontour.io/projectcontour/contour
-                        description: ControllerName is used to determine whether Contour
-                          should reconcile a GatewayClass. The string takes the form
-                          of "projectcontour.io/<namespace>/contour". If unset, the
-                          gatewayclass controller will not be started.
-                        type: string
-                    required:
-                    - controllerName
-                    type: object
-                  health:
-                    default:
-                      address: 0.0.0.0
-                      port: 8000
-                    description: Health contains parameters to configure endpoints
-                      which Contour exposes to respond to Kubernetes health checks.
-                    properties:
-                      address:
-                        description: Defines the Contour health address interface.
-                        minLength: 1
-                        type: string
-                      port:
-                        description: Defines the Contour health port.
-                        type: integer
-                    required:
-                    - address
-                    - port
-                    type: object
-                  httpproxy:
-                    default:
-                      disablePermitInsecure: false
-                    description: HTTPProxy defines parameters on HTTPProxy.
-                    properties:
-                      disablePermitInsecure:
-                        description: DisablePermitInsecure disables the use of the
-                          permitInsecure field in HTTPProxy.
-                        type: boolean
-                      fallbackCertificate:
-                        description: FallbackCertificate defines the namespace/name
-                          of the Kubernetes secret to use as fallback when a non-SNI
-                          request is received.
-                        properties:
-                          name:
-                            type: string
-                          namespace:
-                            type: string
-                        required:
-                        - name
-                        - namespace
-                        type: object
-                      rootNamespaces:
-                        description: Restrict Contour to searching these namespaces
-                          for root ingress routes.
-                        items:
+                              type: string
+                          type: object
+                      required:
+                        - cluster
+                        - defaultHTTPVersions
+                        - http
+                        - https
+                        - listener
+                        - logging
+                        - metrics
+                        - network
+                        - service
+                      type: object
+                    gateway:
+                      description: Gateway contains parameters for the gateway-api Gateway
+                        that Contour is configured to serve traffic.
+                      properties:
+                        controllerName:
+                          default: projectcontour.io/projectcontour/contour
+                          description: ControllerName is used to determine whether Contour
+                            should reconcile a GatewayClass. The string takes the form
+                            of "projectcontour.io/<namespace>/contour". If unset, the
+                            gatewayclass controller will not be started.
                           type: string
-                        type: array
-                    required:
-                    - disablePermitInsecure
-                    type: object
-                  ingress:
-                    description: Ingress contains parameters for ingress options.
-                    properties:
-                      className:
-                        description: Ingress Class Name Contour should use.
-                        type: string
-                      statusAddress:
-                        description: Address to set in Ingress object status.
-                        type: string
-                    type: object
-                  leaderElection:
-                    default:
-                      configmap:
-                        name: leader-elect
-                        namespace: projectcontour
-                      disableLeaderElection: false
-                      leaseDuration: 15s
-                      renewDeadline: 10s
-                      retryPeriod: 2s
-                    description: LeaderElection contains leader election parameters.
-                    properties:
-                      configmap:
-                        description: NamespacedName defines the namespace/name of
-                          the Kubernetes resource referred from the config file. Used
-                          for Contour config YAML file parsing, otherwise we could
-                          use K8s types.NamespacedName.
-                        properties:
-                          name:
+                      required:
+                        - controllerName
+                      type: object
+                    health:
+                      default:
+                        address: 0.0.0.0
+                        port: 8000
+                      description: Health defines the endpoints Contour uses to serve
+                        health checks.
+                      properties:
+                        address:
+                          description: Defines the health address interface.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines the health port.
+                          type: integer
+                      required:
+                        - address
+                        - port
+                      type: object
+                    httpproxy:
+                      default:
+                        disablePermitInsecure: false
+                      description: HTTPProxy defines parameters on HTTPProxy.
+                      properties:
+                        disablePermitInsecure:
+                          description: DisablePermitInsecure disables the use of the
+                            permitInsecure field in HTTPProxy.
+                          type: boolean
+                        fallbackCertificate:
+                          description: FallbackCertificate defines the namespace/name
+                            of the Kubernetes secret to use as fallback when a non-SNI
+                            request is received.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
+                        rootNamespaces:
+                          description: Restrict Contour to searching these namespaces
+                            for root ingress routes.
+                          items:
                             type: string
-                          namespace:
-                            type: string
-                        required:
-                        - name
-                        - namespace
-                        type: object
-                      disableLeaderElection:
-                        type: boolean
-                      leaseDuration:
-                        type: string
-                      renewDeadline:
-                        type: string
-                      retryPeriod:
-                        type: string
-                    required:
-                    - disableLeaderElection
-                    type: object
-                  metrics:
-                    default:
-                      address: 0.0.0.0
-                      port: 8000
-                    description: Metrics defines the endpoints Contour uses to serve
-                      to metrics.
-                    properties:
-                      address:
-                        description: Defines the metrics address interface.
-                        maxLength: 253
-                        minLength: 1
-                        type: string
-                      port:
-                        description: Defines the metrics port.
-                        type: integer
-                    required:
-                    - address
-                    - port
-                    type: object
-                  policy:
-                    description: Policy specifies default policy applied if not overridden
-                      by the user
-                    properties:
-                      applyToIngress:
-                        description: ApplyToIngress determines if the Policies will
-                          apply to ingress objects
-                        type: boolean
-                      requestHeaders:
-                        description: RequestHeadersPolicy defines the request headers
-                          set/removed on all routes
-                        properties:
-                          remove:
-                            items:
+                          type: array
+                      required:
+                        - disablePermitInsecure
+                      type: object
+                    ingress:
+                      description: Ingress contains parameters for ingress options.
+                      properties:
+                        className:
+                          description: Ingress Class Name Contour should use.
+                          type: string
+                        statusAddress:
+                          description: Address to set in Ingress object status.
+                          type: string
+                      type: object
+                    metrics:
+                      default:
+                        address: 0.0.0.0
+                        port: 8000
+                      description: Metrics defines the endpoint Contour uses to serve
+                        metrics.
+                      properties:
+                        address:
+                          description: Defines the metrics address interface.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines the metrics port.
+                          type: integer
+                        tls:
+                          description: TLS holds TLS file config details. Metrics and
+                            health endpoints cannot have same port number when metrics
+                            is served over HTTPS.
+                          properties:
+                            caFile:
+                              description: CA filename.
                               type: string
-                            type: array
-                          set:
-                            additionalProperties:
+                            certFile:
+                              description: Client certificate filename.
                               type: string
-                            type: object
-                        type: object
-                      responseHeaders:
-                        description: ResponseHeadersPolicy defines the response headers
-                          set/removed on all routes
-                        properties:
-                          remove:
-                            items:
+                            keyFile:
+                              description: Client key filename.
                               type: string
-                            type: array
-                          set:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                    type: object
-                  rateLimitService:
-                    description: RateLimitService optionally holds properties of the
-                      Rate Limit Service to be used for global rate limiting.
-                    properties:
-                      domain:
-                        description: Domain is passed to the Rate Limit Service.
-                        type: string
-                      enableXRateLimitHeaders:
-                        description: "EnableXRateLimitHeaders defines whether to include
+                          type: object
+                      required:
+                        - address
+                        - port
+                      type: object
+                    policy:
+                      description: Policy specifies default policy applied if not overridden
+                        by the user
+                      properties:
+                        applyToIngress:
+                          description: ApplyToIngress determines if the Policies will
+                            apply to ingress objects
+                          type: boolean
+                        requestHeaders:
+                          description: RequestHeadersPolicy defines the request headers
+                            set/removed on all routes
+                          properties:
+                            remove:
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        responseHeaders:
+                          description: ResponseHeadersPolicy defines the response headers
+                            set/removed on all routes
+                          properties:
+                            remove:
+                              items:
+                                type: string
+                              type: array
+                            set:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                      type: object
+                    rateLimitService:
+                      description: RateLimitService optionally holds properties of the
+                        Rate Limit Service to be used for global rate limiting.
+                      properties:
+                        domain:
+                          description: Domain is passed to the Rate Limit Service.
+                          type: string
+                        enableXRateLimitHeaders:
+                          description: "EnableXRateLimitHeaders defines whether to include
                           the X-RateLimit headers X-RateLimit-Limit, X-RateLimit-Remaining,
                           and X-RateLimit-Reset (as defined by the IETF Internet-Draft
                           linked below), on responses to clients when the Rate Limit
                           Service is consulted for a request. \n ref. https://tools.ietf.org/id/draft-polli-ratelimit-headers-03.html"
-                        type: boolean
-                      extensionService:
-                        description: ExtensionService identifies the extension service
-                          defining the RLS.
-                        properties:
-                          name:
-                            type: string
-                          namespace:
-                            type: string
-                        required:
-                        - name
-                        - namespace
-                        type: object
-                      failOpen:
-                        description: FailOpen defines whether to allow requests to
-                          proceed when the Rate Limit Service fails to respond with
-                          a valid rate limit decision within the timeout defined on
-                          the extension service.
-                        type: boolean
-                    required:
-                    - domain
-                    - enableXRateLimitHeaders
-                    - failOpen
-                    type: object
-                  xdsServer:
-                    default:
-                      address: 0.0.0.0
-                      port: 8001
-                      tls:
-                        caFile: /certs/ca.crt
-                        certFile: /certs/tls.crt
-                        insecure: false
-                        keyFile: /certs/tls.key
-                      type: contour
-                    description: XDSServer contains parameters for the xDS server.
-                    properties:
-                      address:
-                        description: Defines the xDS gRPC API address which Contour
-                          will serve.
-                        minLength: 1
-                        type: string
-                      port:
-                        description: Defines the xDS gRPC API port which Contour will
-                          serve.
-                        type: integer
-                      tls:
-                        description: TLS holds TLS file config details.
-                        properties:
-                          caFile:
-                            description: CA filename.
-                            type: string
-                          certFile:
-                            description: Client certificate filename.
-                            type: string
-                          insecure:
-                            description: Allow serving the xDS gRPC API without TLS.
-                            type: boolean
-                          keyFile:
-                            description: Client key filename.
-                            type: string
-                        required:
-                        - insecure
-                        type: object
-                      type:
-                        description: Defines the XDSServer to use for `contour serve`.
-                        enum:
-                        - contour
-                        - envoy
-                        type: string
-                    required:
-                    - address
-                    - port
-                    - type
-                    type: object
-                type: object
-              replicas:
-                default: 2
-                description: Replicas is the desired number of Contour replicas. If
-                  unset, defaults to 2.
-                format: int32
-                minimum: 0
-                type: integer
-            required:
-            - config
-            type: object
-          status:
-            description: ContourDeploymentStatus defines the observed state of a ContourDeployment
-              resource.
-            properties:
-              conditions:
-                description: "Conditions contains the current status of the Contour
+                          type: boolean
+                        extensionService:
+                          description: ExtensionService identifies the extension service
+                            defining the RLS.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
+                        failOpen:
+                          description: FailOpen defines whether to allow requests to
+                            proceed when the Rate Limit Service fails to respond with
+                            a valid rate limit decision within the timeout defined on
+                            the extension service.
+                          type: boolean
+                      required:
+                        - domain
+                        - enableXRateLimitHeaders
+                        - failOpen
+                      type: object
+                    xdsServer:
+                      default:
+                        address: 0.0.0.0
+                        port: 8001
+                        tls:
+                          caFile: /certs/ca.crt
+                          certFile: /certs/tls.crt
+                          insecure: false
+                          keyFile: /certs/tls.key
+                        type: contour
+                      description: XDSServer contains parameters for the xDS server.
+                      properties:
+                        address:
+                          description: Defines the xDS gRPC API address which Contour
+                            will serve.
+                          minLength: 1
+                          type: string
+                        port:
+                          description: Defines the xDS gRPC API port which Contour will
+                            serve.
+                          type: integer
+                        tls:
+                          description: TLS holds TLS file config details.
+                          properties:
+                            caFile:
+                              description: CA filename.
+                              type: string
+                            certFile:
+                              description: Client certificate filename.
+                              type: string
+                            insecure:
+                              description: Allow serving the xDS gRPC API without TLS.
+                              type: boolean
+                            keyFile:
+                              description: Client key filename.
+                              type: string
+                          required:
+                            - insecure
+                          type: object
+                        type:
+                          description: Defines the XDSServer to use for `contour serve`.
+                          enum:
+                            - contour
+                            - envoy
+                          type: string
+                      required:
+                        - address
+                        - port
+                        - type
+                      type: object
+                  type: object
+                replicas:
+                  default: 2
+                  description: Replicas is the desired number of Contour replicas. If
+                    unset, defaults to 2.
+                  format: int32
+                  minimum: 0
+                  type: integer
+              required:
+                - config
+              type: object
+            status:
+              description: ContourDeploymentStatus defines the observed state of a ContourDeployment
+                resource.
+              properties:
+                conditions:
+                  description: "Conditions contains the current status of the Contour
                   resource. \n Contour will update a single condition, `Valid`, that
                   is in normal-true polarity. \n Contour will not modify any other
                   Conditions set in this block, in case some other controller wants
                   to add a Condition."
-                items:
-                  description: "DetailedCondition is an extension of the normal Kubernetes
+                  items:
+                    description: "DetailedCondition is an extension of the normal Kubernetes
                     conditions, with two extra fields to hold sub-conditions, which
                     provide more detailed reasons for the state (True or False) of
                     the condition. \n `errors` holds information about sub-conditions
@@ -738,14 +753,14 @@ spec:
                     the detail of the reason (if there is one and only one entry in
                     total across both the `errors` and `warnings` slices), or `MultipleReasons`
                     if there is more than one entry."
-                  properties:
-                    errors:
-                      description: "Errors contains a slice of relevant error subconditions
+                    properties:
+                      errors:
+                        description: "Errors contains a slice of relevant error subconditions
                         for this object. \n Subconditions are expected to appear when
                         relevant (when there is a error), and disappear when not relevant.
                         An empty slice here indicates no errors."
-                      items:
-                        description: "SubCondition is a Condition-like type intended
+                        items:
+                          description: "SubCondition is a Condition-like type intended
                           for use as a subcondition inside a DetailedCondition. \n
                           It contains a subset of the Condition fields. \n It is intended
                           for warnings and errors, so `type` names should use abnormal-true
@@ -753,103 +768,103 @@ spec:
                           true\". \n The expected lifecycle for these errors is that
                           they should only be present when the error or warning is,
                           and should be removed when they are not relevant."
-                        properties:
-                          message:
-                            description: "Message is a human readable message indicating
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
                               details about the transition. \n This may be an empty
                               string."
-                            maxLength: 32768
-                            type: string
-                          reason:
-                            description: "Reason contains a programmatic identifier
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
                               indicating the reason for the condition's last transition.
                               Producers of specific condition types may define expected
                               values and meanings for this field, and whether the
                               values are considered a guaranteed API. \n The value
                               should be a CamelCase string. \n This field may not
                               be empty."
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
                               \n This must be in abnormal-true polarity, that is,
                               `ErrorFound` or `controller.io/ErrorFound`. \n The regex
                               it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                    warnings:
-                      description: "Warnings contains a slice of relevant warning
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition
+                          transitioned from one status to another. This should be when
+                          the underlying condition changed.  If that is not known, then
+                          using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating
+                          details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if .metadata.generation
+                          is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition. Producers
+                          of specific condition types may define expected values and
+                          meanings for this field, and whether the values are considered
+                          a guaranteed API. The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          --- Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                      warnings:
+                        description: "Warnings contains a slice of relevant warning
                         subconditions for this object. \n Subconditions are expected
                         to appear when relevant (when there is a warning), and disappear
                         when not relevant. An empty slice here indicates no warnings."
-                      items:
-                        description: "SubCondition is a Condition-like type intended
+                        items:
+                          description: "SubCondition is a Condition-like type intended
                           for use as a subcondition inside a DetailedCondition. \n
                           It contains a subset of the Condition fields. \n It is intended
                           for warnings and errors, so `type` names should use abnormal-true
@@ -857,68 +872,62 @@ spec:
                           true\". \n The expected lifecycle for these errors is that
                           they should only be present when the error or warning is,
                           and should be removed when they are not relevant."
-                        properties:
-                          message:
-                            description: "Message is a human readable message indicating
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
                               details about the transition. \n This may be an empty
                               string."
-                            maxLength: 32768
-                            type: string
-                          reason:
-                            description: "Reason contains a programmatic identifier
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
                               indicating the reason for the condition's last transition.
                               Producers of specific condition types may define expected
                               values and meanings for this field, and whether the
                               values are considered a guaranteed API. \n The value
                               should be a CamelCase string. \n This field may not
                               be empty."
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
                               \n This must be in abnormal-true polarity, that is,
                               `ErrorFound` or `controller.io/ErrorFound`. \n The regex
                               it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/bitnami/contour/resources/extensionservices.yaml
+++ b/bitnami/contour/resources/extensionservices.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: extensionservices.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -13,185 +12,185 @@ spec:
     listKind: ExtensionServiceList
     plural: extensionservices
     shortNames:
-    - extensionservice
-    - extensionservices
+      - extensionservice
+      - extensionservices
     singular: extensionservice
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ExtensionService is the schema for the Contour extension services
-          API. An ExtensionService resource binds a network service to the Contour
-          API so that Contour API features can be implemented by collaborating components.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ExtensionService is the schema for the Contour extension services
+            API. An ExtensionService resource binds a network service to the Contour
+            API so that Contour API features can be implemented by collaborating components.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ExtensionServiceSpec defines the desired state of an ExtensionService
-              resource.
-            properties:
-              loadBalancerPolicy:
-                description: The policy for load balancing GRPC service requests.
-                  Note that the `Cookie` and `RequestHash` load balancing strategies
-                  cannot be used here.
-                properties:
-                  requestHashPolicies:
-                    description: RequestHashPolicies contains a list of hash policies
-                      to apply when the `RequestHash` load balancing strategy is chosen.
-                      If an element of the supplied list of hash policies is invalid,
-                      it will be ignored. If the list of hash policies is empty after
-                      validation, the load balancing strategy will fall back the the
-                      default `RoundRobin`.
-                    items:
-                      description: RequestHashPolicy contains configuration for an
-                        individual hash policy on a request attribute.
-                      properties:
-                        hashSourceIP:
-                          description: HashSourceIP should be set to true when request
-                            source IP hash based load balancing is desired. It must
-                            be the only hash option field set, otherwise this request
-                            hash policy object will be ignored.
-                          type: boolean
-                        headerHashOptions:
-                          description: HeaderHashOptions should be set when request
-                            header hash based load balancing is desired. It must be
-                            the only hash option field set, otherwise this request
-                            hash policy object will be ignored.
-                          properties:
-                            headerName:
-                              description: HeaderName is the name of the HTTP request
-                                header that will be used to calculate the hash key.
-                                If the header specified is not present on a request,
-                                no hash will be produced.
-                              minLength: 1
-                              type: string
-                          type: object
-                        terminal:
-                          description: Terminal is a flag that allows for short-circuiting
-                            computing of a hash for a given request. If set to true,
-                            and the request attribute specified in the attribute hash
-                            options is present, no further hash policies will be used
-                            to calculate a hash for the request.
-                          type: boolean
-                      type: object
-                    type: array
-                  strategy:
-                    description: Strategy specifies the policy used to balance requests
-                      across the pool of backend pods. Valid policy names are `Random`,
-                      `RoundRobin`, `WeightedLeastRequest`, `Cookie`, and `RequestHash`.
-                      If an unknown strategy name is specified or no policy is supplied,
-                      the default `RoundRobin` policy is used.
-                    type: string
-                type: object
-              protocol:
-                description: Protocol may be used to specify (or override) the protocol
-                  used to reach this Service. Values may be h2 or h2c. If omitted,
-                  protocol-selection falls back on Service annotations.
-                enum:
-                - h2
-                - h2c
-                type: string
-              protocolVersion:
-                description: This field sets the version of the GRPC protocol that
-                  Envoy uses to send requests to the extension service. Since Contour
-                  always uses the v3 Envoy API, this is currently fixed at "v3". However,
-                  other protocol options will be available in future.
-                enum:
-                - v3
-                type: string
-              services:
-                description: Services specifies the set of Kubernetes Service resources
-                  that receive GRPC extension API requests. If no weights are specified
-                  for any of the entries in this array, traffic will be spread evenly
-                  across all the services. Otherwise, traffic is balanced proportionally
-                  to the Weight field in each entry.
-                items:
-                  description: ExtensionServiceTarget defines an Kubernetes Service
-                    to target with extension service traffic.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ExtensionServiceSpec defines the desired state of an ExtensionService
+                resource.
+              properties:
+                loadBalancerPolicy:
+                  description: The policy for load balancing GRPC service requests.
+                    Note that the `Cookie` and `RequestHash` load balancing strategies
+                    cannot be used here.
                   properties:
-                    name:
-                      description: Name is the name of Kubernetes service that will
-                        accept service traffic.
+                    requestHashPolicies:
+                      description: RequestHashPolicies contains a list of hash policies
+                        to apply when the `RequestHash` load balancing strategy is chosen.
+                        If an element of the supplied list of hash policies is invalid,
+                        it will be ignored. If the list of hash policies is empty after
+                        validation, the load balancing strategy will fall back the the
+                        default `RoundRobin`.
+                      items:
+                        description: RequestHashPolicy contains configuration for an
+                          individual hash policy on a request attribute.
+                        properties:
+                          hashSourceIP:
+                            description: HashSourceIP should be set to true when request
+                              source IP hash based load balancing is desired. It must
+                              be the only hash option field set, otherwise this request
+                              hash policy object will be ignored.
+                            type: boolean
+                          headerHashOptions:
+                            description: HeaderHashOptions should be set when request
+                              header hash based load balancing is desired. It must be
+                              the only hash option field set, otherwise this request
+                              hash policy object will be ignored.
+                            properties:
+                              headerName:
+                                description: HeaderName is the name of the HTTP request
+                                  header that will be used to calculate the hash key.
+                                  If the header specified is not present on a request,
+                                  no hash will be produced.
+                                minLength: 1
+                                type: string
+                            type: object
+                          terminal:
+                            description: Terminal is a flag that allows for short-circuiting
+                              computing of a hash for a given request. If set to true,
+                              and the request attribute specified in the attribute hash
+                              options is present, no further hash policies will be used
+                              to calculate a hash for the request.
+                            type: boolean
+                        type: object
+                      type: array
+                    strategy:
+                      description: Strategy specifies the policy used to balance requests
+                        across the pool of backend pods. Valid policy names are `Random`,
+                        `RoundRobin`, `WeightedLeastRequest`, `Cookie`, and `RequestHash`.
+                        If an unknown strategy name is specified or no policy is supplied,
+                        the default `RoundRobin` policy is used.
                       type: string
-                    port:
-                      description: Port (defined as Integer) to proxy traffic to since
-                        a service can have multiple defined.
-                      exclusiveMaximum: true
-                      maximum: 65536
-                      minimum: 1
-                      type: integer
-                    weight:
-                      description: Weight defines proportion of traffic to balance
-                        to the Kubernetes Service.
-                      format: int32
-                      type: integer
-                  required:
-                  - name
-                  - port
                   type: object
-                minItems: 1
-                type: array
-              timeoutPolicy:
-                description: The timeout policy for requests to the services.
-                properties:
-                  idle:
-                    description: Timeout for how long the proxy should wait while
-                      there is no activity during single request/response (for HTTP/1.1)
-                      or stream (for HTTP/2). Timeout will not trigger while HTTP/1.1
-                      connection is idle between two consecutive requests. If not
-                      specified, there is no per-route idle timeout, though a connection
-                      manager-wide stream_idle_timeout default of 5m still applies.
-                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
-                    type: string
-                  response:
-                    description: Timeout for receiving a response from the server
-                      after processing a request from client. If not supplied, Envoy's
-                      default value of 15s applies.
-                    pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
-                    type: string
-                type: object
-              validation:
-                description: UpstreamValidation defines how to verify the backend
-                  service's certificate
-                properties:
-                  caSecret:
-                    description: Name or namespaced name of the Kubernetes secret
-                      used to validate the certificate presented by the backend
-                    type: string
-                  subjectName:
-                    description: Key which is expected to be present in the 'subjectAltName'
-                      of the presented certificate
-                    type: string
-                required:
-                - caSecret
-                - subjectName
-                type: object
-            required:
-            - services
-            type: object
-          status:
-            description: ExtensionServiceStatus defines the observed state of an ExtensionService
-              resource.
-            properties:
-              conditions:
-                description: "Conditions contains the current status of the ExtensionService
+                protocol:
+                  description: Protocol may be used to specify (or override) the protocol
+                    used to reach this Service. Values may be h2 or h2c. If omitted,
+                    protocol-selection falls back on Service annotations.
+                  enum:
+                    - h2
+                    - h2c
+                  type: string
+                protocolVersion:
+                  description: This field sets the version of the GRPC protocol that
+                    Envoy uses to send requests to the extension service. Since Contour
+                    always uses the v3 Envoy API, this is currently fixed at "v3". However,
+                    other protocol options will be available in future.
+                  enum:
+                    - v3
+                  type: string
+                services:
+                  description: Services specifies the set of Kubernetes Service resources
+                    that receive GRPC extension API requests. If no weights are specified
+                    for any of the entries in this array, traffic will be spread evenly
+                    across all the services. Otherwise, traffic is balanced proportionally
+                    to the Weight field in each entry.
+                  items:
+                    description: ExtensionServiceTarget defines an Kubernetes Service
+                      to target with extension service traffic.
+                    properties:
+                      name:
+                        description: Name is the name of Kubernetes service that will
+                          accept service traffic.
+                        type: string
+                      port:
+                        description: Port (defined as Integer) to proxy traffic to since
+                          a service can have multiple defined.
+                        exclusiveMaximum: true
+                        maximum: 65536
+                        minimum: 1
+                        type: integer
+                      weight:
+                        description: Weight defines proportion of traffic to balance
+                          to the Kubernetes Service.
+                        format: int32
+                        type: integer
+                    required:
+                      - name
+                      - port
+                    type: object
+                  minItems: 1
+                  type: array
+                timeoutPolicy:
+                  description: The timeout policy for requests to the services.
+                  properties:
+                    idle:
+                      description: Timeout for how long the proxy should wait while
+                        there is no activity during single request/response (for HTTP/1.1)
+                        or stream (for HTTP/2). Timeout will not trigger while HTTP/1.1
+                        connection is idle between two consecutive requests. If not
+                        specified, there is no per-route idle timeout, though a connection
+                        manager-wide stream_idle_timeout default of 5m still applies.
+                      pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                      type: string
+                    response:
+                      description: Timeout for receiving a response from the server
+                        after processing a request from client. If not supplied, Envoy's
+                        default value of 15s applies.
+                      pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                      type: string
+                  type: object
+                validation:
+                  description: UpstreamValidation defines how to verify the backend
+                    service's certificate
+                  properties:
+                    caSecret:
+                      description: Name or namespaced name of the Kubernetes secret
+                        used to validate the certificate presented by the backend
+                      type: string
+                    subjectName:
+                      description: Key which is expected to be present in the 'subjectAltName'
+                        of the presented certificate
+                      type: string
+                  required:
+                    - caSecret
+                    - subjectName
+                  type: object
+              required:
+                - services
+              type: object
+            status:
+              description: ExtensionServiceStatus defines the observed state of an ExtensionService
+                resource.
+              properties:
+                conditions:
+                  description: "Conditions contains the current status of the ExtensionService
                   resource. \n Contour will update a single condition, `Valid`, that
                   is in normal-true polarity. \n Contour will not modify any other
                   Conditions set in this block, in case some other controller wants
                   to add a Condition."
-                items:
-                  description: "DetailedCondition is an extension of the normal Kubernetes
+                  items:
+                    description: "DetailedCondition is an extension of the normal Kubernetes
                     conditions, with two extra fields to hold sub-conditions, which
                     provide more detailed reasons for the state (True or False) of
                     the condition. \n `errors` holds information about sub-conditions
@@ -220,14 +219,14 @@ spec:
                     the detail of the reason (if there is one and only one entry in
                     total across both the `errors` and `warnings` slices), or `MultipleReasons`
                     if there is more than one entry."
-                  properties:
-                    errors:
-                      description: "Errors contains a slice of relevant error subconditions
+                    properties:
+                      errors:
+                        description: "Errors contains a slice of relevant error subconditions
                         for this object. \n Subconditions are expected to appear when
                         relevant (when there is a error), and disappear when not relevant.
                         An empty slice here indicates no errors."
-                      items:
-                        description: "SubCondition is a Condition-like type intended
+                        items:
+                          description: "SubCondition is a Condition-like type intended
                           for use as a subcondition inside a DetailedCondition. \n
                           It contains a subset of the Condition fields. \n It is intended
                           for warnings and errors, so `type` names should use abnormal-true
@@ -235,103 +234,103 @@ spec:
                           true\". \n The expected lifecycle for these errors is that
                           they should only be present when the error or warning is,
                           and should be removed when they are not relevant."
-                        properties:
-                          message:
-                            description: "Message is a human readable message indicating
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
                               details about the transition. \n This may be an empty
                               string."
-                            maxLength: 32768
-                            type: string
-                          reason:
-                            description: "Reason contains a programmatic identifier
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
                               indicating the reason for the condition's last transition.
                               Producers of specific condition types may define expected
                               values and meanings for this field, and whether the
                               values are considered a guaranteed API. \n The value
                               should be a CamelCase string. \n This field may not
                               be empty."
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
                               \n This must be in abnormal-true polarity, that is,
                               `ErrorFound` or `controller.io/ErrorFound`. \n The regex
                               it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                    warnings:
-                      description: "Warnings contains a slice of relevant warning
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition
+                          transitioned from one status to another. This should be when
+                          the underlying condition changed.  If that is not known, then
+                          using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating
+                          details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if .metadata.generation
+                          is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition. Producers
+                          of specific condition types may define expected values and
+                          meanings for this field, and whether the values are considered
+                          a guaranteed API. The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          --- Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                      warnings:
+                        description: "Warnings contains a slice of relevant warning
                         subconditions for this object. \n Subconditions are expected
                         to appear when relevant (when there is a warning), and disappear
                         when not relevant. An empty slice here indicates no warnings."
-                      items:
-                        description: "SubCondition is a Condition-like type intended
+                        items:
+                          description: "SubCondition is a Condition-like type intended
                           for use as a subcondition inside a DetailedCondition. \n
                           It contains a subset of the Condition fields. \n It is intended
                           for warnings and errors, so `type` names should use abnormal-true
@@ -339,68 +338,62 @@ spec:
                           true\". \n The expected lifecycle for these errors is that
                           they should only be present when the error or warning is,
                           and should be removed when they are not relevant."
-                        properties:
-                          message:
-                            description: "Message is a human readable message indicating
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
                               details about the transition. \n This may be an empty
                               string."
-                            maxLength: 32768
-                            type: string
-                          reason:
-                            description: "Reason contains a programmatic identifier
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
                               indicating the reason for the condition's last transition.
                               Producers of specific condition types may define expected
                               values and meanings for this field, and whether the
                               values are considered a guaranteed API. \n The value
                               should be a CamelCase string. \n This field may not
                               be empty."
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
                               \n This must be in abnormal-true polarity, that is,
                               `ErrorFound` or `controller.io/ErrorFound`. \n The regex
                               it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/bitnami/contour/resources/httpproxies.yaml
+++ b/bitnami/contour/resources/httpproxies.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: httpproxies.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -13,375 +12,375 @@ spec:
     listKind: HTTPProxyList
     plural: httpproxies
     shortNames:
-    - proxy
-    - proxies
+      - proxy
+      - proxies
     singular: httpproxy
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Fully qualified domain name
-      jsonPath: .spec.virtualhost.fqdn
-      name: FQDN
-      type: string
-    - description: Secret with TLS credentials
-      jsonPath: .spec.virtualhost.tls.secretName
-      name: TLS Secret
-      type: string
-    - description: The current status of the HTTPProxy
-      jsonPath: .status.currentStatus
-      name: Status
-      type: string
-    - description: Description of the current status
-      jsonPath: .status.description
-      name: Status Description
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: HTTPProxy is an Ingress CRD specification.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - additionalPrinterColumns:
+        - description: Fully qualified domain name
+          jsonPath: .spec.virtualhost.fqdn
+          name: FQDN
+          type: string
+        - description: Secret with TLS credentials
+          jsonPath: .spec.virtualhost.tls.secretName
+          name: TLS Secret
+          type: string
+        - description: The current status of the HTTPProxy
+          jsonPath: .status.currentStatus
+          name: Status
+          type: string
+        - description: Description of the current status
+          jsonPath: .status.description
+          name: Status Description
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: HTTPProxy is an Ingress CRD specification.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: HTTPProxySpec defines the spec of the CRD.
-            properties:
-              includes:
-                description: Includes allow for specific routing configuration to
-                  be included from another HTTPProxy, possibly in another namespace.
-                items:
-                  description: Include describes a set of policies that can be applied
-                    to an HTTPProxy in a namespace.
-                  properties:
-                    conditions:
-                      description: 'Conditions are a set of rules that are applied
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HTTPProxySpec defines the spec of the CRD.
+              properties:
+                includes:
+                  description: Includes allow for specific routing configuration to
+                    be included from another HTTPProxy, possibly in another namespace.
+                  items:
+                    description: Include describes a set of policies that can be applied
+                      to an HTTPProxy in a namespace.
+                    properties:
+                      conditions:
+                        description: 'Conditions are a set of rules that are applied
                         to included HTTPProxies. In effect, they are added onto the
                         Conditions of included HTTPProxy Route structs. When applied,
                         they are merged using AND, with one exception: There can be
                         only one Prefix MatchCondition per Conditions slice. More
                         than one Prefix, or contradictory Conditions, will make the
                         include invalid.'
-                      items:
-                        description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix or Header must be provided.
-                        properties:
-                          header:
-                            description: Header specifies the header condition to
-                              match.
-                            properties:
-                              contains:
-                                description: Contains specifies a substring that must
-                                  be present in the header value.
-                                type: string
-                              exact:
-                                description: Exact specifies a string that the header
-                                  value must be equal to.
-                                type: string
-                              name:
-                                description: Name is the name of the header to match
-                                  against. Name is required. Header names are case
-                                  insensitive.
-                                type: string
-                              notcontains:
-                                description: NotContains specifies a substring that
-                                  must not be present in the header value.
-                                type: string
-                              notexact:
-                                description: NoExact specifies a string that the header
-                                  value must not be equal to. The condition is true
-                                  if the header has any other value.
-                                type: string
-                              notpresent:
-                                description: NotPresent specifies that condition is
-                                  true when the named header is not present. Note
-                                  that setting NotPresent to false does not make the
-                                  condition true if the named header is present.
-                                type: boolean
-                              present:
-                                description: Present specifies that condition is true
-                                  when the named header is present, regardless of
-                                  its value. Note that setting Present to false does
-                                  not make the condition true if the named header
-                                  is absent.
-                                type: boolean
-                            required:
-                            - name
-                            type: object
-                          prefix:
-                            description: Prefix defines a prefix match for a request.
-                            type: string
-                        type: object
-                      type: array
-                    name:
-                      description: Name of the HTTPProxy
-                      type: string
-                    namespace:
-                      description: Namespace of the HTTPProxy to include. Defaults
-                        to the current namespace if not supplied.
-                      type: string
-                  required:
-                  - name
-                  type: object
-                type: array
-              ingressClassName:
-                description: IngressClassName optionally specifies the ingress class
-                  to use for this HTTPProxy. This replaces the deprecated `kubernetes.io/ingress.class`
-                  annotation. For backwards compatibility, when that annotation is
-                  set, it is given precedence over this field.
-                type: string
-              routes:
-                description: Routes are the ingress routes. If TCPProxy is present,
-                  Routes is ignored.
-                items:
-                  description: Route contains the set of routes for a virtual host.
-                  properties:
-                    authPolicy:
-                      description: AuthPolicy updates the authorization policy that
-                        was set on the root HTTPProxy object for client requests that
-                        match this route.
-                      properties:
-                        context:
-                          additionalProperties:
-                            type: string
-                          description: Context is a set of key/value pairs that are
-                            sent to the authentication server in the check request.
-                            If a context is provided at an enclosing scope, the entries
-                            are merged such that the inner scope overrides matching
-                            keys from the outer scope.
+                        items:
+                          description: MatchCondition are a general holder for matching
+                            rules for HTTPProxies. One of Prefix or Header must be provided.
+                          properties:
+                            header:
+                              description: Header specifies the header condition to
+                                match.
+                              properties:
+                                contains:
+                                  description: Contains specifies a substring that must
+                                    be present in the header value.
+                                  type: string
+                                exact:
+                                  description: Exact specifies a string that the header
+                                    value must be equal to.
+                                  type: string
+                                name:
+                                  description: Name is the name of the header to match
+                                    against. Name is required. Header names are case
+                                    insensitive.
+                                  type: string
+                                notcontains:
+                                  description: NotContains specifies a substring that
+                                    must not be present in the header value.
+                                  type: string
+                                notexact:
+                                  description: NoExact specifies a string that the header
+                                    value must not be equal to. The condition is true
+                                    if the header has any other value.
+                                  type: string
+                                notpresent:
+                                  description: NotPresent specifies that condition is
+                                    true when the named header is not present. Note
+                                    that setting NotPresent to false does not make the
+                                    condition true if the named header is present.
+                                  type: boolean
+                                present:
+                                  description: Present specifies that condition is true
+                                    when the named header is present, regardless of
+                                    its value. Note that setting Present to false does
+                                    not make the condition true if the named header
+                                    is absent.
+                                  type: boolean
+                              required:
+                                - name
+                              type: object
+                            prefix:
+                              description: Prefix defines a prefix match for a request.
+                              type: string
                           type: object
-                        disabled:
-                          description: When true, this field disables client request
-                            authentication for the scope of the policy.
-                          type: boolean
-                      type: object
-                    conditions:
-                      description: 'Conditions are a set of rules that are applied
+                        type: array
+                      name:
+                        description: Name of the HTTPProxy
+                        type: string
+                      namespace:
+                        description: Namespace of the HTTPProxy to include. Defaults
+                          to the current namespace if not supplied.
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                ingressClassName:
+                  description: IngressClassName optionally specifies the ingress class
+                    to use for this HTTPProxy. This replaces the deprecated `kubernetes.io/ingress.class`
+                    annotation. For backwards compatibility, when that annotation is
+                    set, it is given precedence over this field.
+                  type: string
+                routes:
+                  description: Routes are the ingress routes. If TCPProxy is present,
+                    Routes is ignored.
+                  items:
+                    description: Route contains the set of routes for a virtual host.
+                    properties:
+                      authPolicy:
+                        description: AuthPolicy updates the authorization policy that
+                          was set on the root HTTPProxy object for client requests that
+                          match this route.
+                        properties:
+                          context:
+                            additionalProperties:
+                              type: string
+                            description: Context is a set of key/value pairs that are
+                              sent to the authentication server in the check request.
+                              If a context is provided at an enclosing scope, the entries
+                              are merged such that the inner scope overrides matching
+                              keys from the outer scope.
+                            type: object
+                          disabled:
+                            description: When true, this field disables client request
+                              authentication for the scope of the policy.
+                            type: boolean
+                        type: object
+                      conditions:
+                        description: 'Conditions are a set of rules that are applied
                         to a Route. When applied, they are merged using AND, with
                         one exception: There can be only one Prefix MatchCondition
                         per Conditions slice. More than one Prefix, or contradictory
                         Conditions, will make the route invalid.'
-                      items:
-                        description: MatchCondition are a general holder for matching
-                          rules for HTTPProxies. One of Prefix or Header must be provided.
-                        properties:
-                          header:
-                            description: Header specifies the header condition to
-                              match.
-                            properties:
-                              contains:
-                                description: Contains specifies a substring that must
-                                  be present in the header value.
-                                type: string
-                              exact:
-                                description: Exact specifies a string that the header
-                                  value must be equal to.
-                                type: string
-                              name:
-                                description: Name is the name of the header to match
-                                  against. Name is required. Header names are case
-                                  insensitive.
-                                type: string
-                              notcontains:
-                                description: NotContains specifies a substring that
-                                  must not be present in the header value.
-                                type: string
-                              notexact:
-                                description: NoExact specifies a string that the header
-                                  value must not be equal to. The condition is true
-                                  if the header has any other value.
-                                type: string
-                              notpresent:
-                                description: NotPresent specifies that condition is
-                                  true when the named header is not present. Note
-                                  that setting NotPresent to false does not make the
-                                  condition true if the named header is present.
-                                type: boolean
-                              present:
-                                description: Present specifies that condition is true
-                                  when the named header is present, regardless of
-                                  its value. Note that setting Present to false does
-                                  not make the condition true if the named header
-                                  is absent.
-                                type: boolean
-                            required:
+                        items:
+                          description: MatchCondition are a general holder for matching
+                            rules for HTTPProxies. One of Prefix or Header must be provided.
+                          properties:
+                            header:
+                              description: Header specifies the header condition to
+                                match.
+                              properties:
+                                contains:
+                                  description: Contains specifies a substring that must
+                                    be present in the header value.
+                                  type: string
+                                exact:
+                                  description: Exact specifies a string that the header
+                                    value must be equal to.
+                                  type: string
+                                name:
+                                  description: Name is the name of the header to match
+                                    against. Name is required. Header names are case
+                                    insensitive.
+                                  type: string
+                                notcontains:
+                                  description: NotContains specifies a substring that
+                                    must not be present in the header value.
+                                  type: string
+                                notexact:
+                                  description: NoExact specifies a string that the header
+                                    value must not be equal to. The condition is true
+                                    if the header has any other value.
+                                  type: string
+                                notpresent:
+                                  description: NotPresent specifies that condition is
+                                    true when the named header is not present. Note
+                                    that setting NotPresent to false does not make the
+                                    condition true if the named header is present.
+                                  type: boolean
+                                present:
+                                  description: Present specifies that condition is true
+                                    when the named header is present, regardless of
+                                    its value. Note that setting Present to false does
+                                    not make the condition true if the named header
+                                    is absent.
+                                  type: boolean
+                              required:
+                                - name
+                              type: object
+                            prefix:
+                              description: Prefix defines a prefix match for a request.
+                              type: string
+                          type: object
+                        type: array
+                      cookieRewritePolicies:
+                        description: The policies for rewriting Set-Cookie header attributes.
+                          Note that rewritten cookie names must be unique in this list.
+                          Order rewrite policies are specified in does not matter.
+                        items:
+                          properties:
+                            domainRewrite:
+                              description: DomainRewrite enables rewriting the Set-Cookie
+                                Domain element. If not set, Domain will not be rewritten.
+                              properties:
+                                value:
+                                  description: Value is the value to rewrite the Domain
+                                    attribute to. For now this is required.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                            name:
+                              description: Name is the name of the cookie for which
+                                attributes will be rewritten.
+                              maxLength: 4096
+                              minLength: 1
+                              pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                              type: string
+                            pathRewrite:
+                              description: PathRewrite enables rewriting the Set-Cookie
+                                Path element. If not set, Path will not be rewritten.
+                              properties:
+                                value:
+                                  description: Value is the value to rewrite the Path
+                                    attribute to. For now this is required.
+                                  maxLength: 4096
+                                  minLength: 1
+                                  pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                  type: string
+                              required:
+                                - value
+                              type: object
+                            sameSite:
+                              description: SameSite enables rewriting the Set-Cookie
+                                SameSite element. If not set, SameSite attribute will
+                                not be rewritten.
+                              enum:
+                                - Strict
+                                - Lax
+                                - None
+                              type: string
+                            secure:
+                              description: Secure enables rewriting the Set-Cookie Secure
+                                element. If not set, Secure attribute will not be rewritten.
+                              type: boolean
+                          required:
                             - name
-                            type: object
-                          prefix:
-                            description: Prefix defines a prefix match for a request.
-                            type: string
-                        type: object
-                      type: array
-                    cookieRewritePolicies:
-                      description: The policies for rewriting Set-Cookie header attributes.
-                        Note that rewritten cookie names must be unique in this list.
-                        Order rewrite policies are specified in does not matter.
-                      items:
+                          type: object
+                        type: array
+                      enableWebsockets:
+                        description: Enables websocket support for the route.
+                        type: boolean
+                      healthCheckPolicy:
+                        description: The health check policy for this route.
                         properties:
-                          domainRewrite:
-                            description: DomainRewrite enables rewriting the Set-Cookie
-                              Domain element. If not set, Domain will not be rewritten.
-                            properties:
-                              value:
-                                description: Value is the value to rewrite the Domain
-                                  attribute to. For now this is required.
-                                maxLength: 4096
-                                minLength: 1
-                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                type: string
-                            required:
-                            - value
-                            type: object
-                          name:
-                            description: Name is the name of the cookie for which
-                              attributes will be rewritten.
-                            maxLength: 4096
-                            minLength: 1
-                            pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                          healthyThresholdCount:
+                            description: The number of healthy health checks required
+                              before a host is marked healthy
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          host:
+                            description: The value of the host header in the HTTP health
+                              check request. If left empty (default value), the name
+                              "contour-envoy-healthcheck" will be used.
                             type: string
-                          pathRewrite:
-                            description: PathRewrite enables rewriting the Set-Cookie
-                              Path element. If not set, Path will not be rewritten.
-                            properties:
-                              value:
-                                description: Value is the value to rewrite the Path
-                                  attribute to. For now this is required.
-                                maxLength: 4096
-                                minLength: 1
-                                pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
-                                type: string
-                            required:
-                            - value
-                            type: object
-                          sameSite:
-                            description: SameSite enables rewriting the Set-Cookie
-                              SameSite element. If not set, SameSite attribute will
-                              not be rewritten.
-                            enum:
-                            - Strict
-                            - Lax
-                            - None
+                          intervalSeconds:
+                            description: The interval (seconds) between health checks
+                            format: int64
+                            type: integer
+                          path:
+                            description: HTTP endpoint used to perform health checks
+                              on upstream service
                             type: string
-                          secure:
-                            description: Secure enables rewriting the Set-Cookie Secure
-                              element. If not set, Secure attribute will not be rewritten.
-                            type: boolean
+                          timeoutSeconds:
+                            description: The time to wait (seconds) for a health check
+                              response
+                            format: int64
+                            type: integer
+                          unhealthyThresholdCount:
+                            description: The number of unhealthy health checks required
+                              before a host is marked unhealthy
+                            format: int64
+                            minimum: 0
+                            type: integer
                         required:
-                        - name
+                          - path
                         type: object
-                      type: array
-                    enableWebsockets:
-                      description: Enables websocket support for the route.
-                      type: boolean
-                    healthCheckPolicy:
-                      description: The health check policy for this route.
-                      properties:
-                        healthyThresholdCount:
-                          description: The number of healthy health checks required
-                            before a host is marked healthy
-                          format: int64
-                          minimum: 0
-                          type: integer
-                        host:
-                          description: The value of the host header in the HTTP health
-                            check request. If left empty (default value), the name
-                            "contour-envoy-healthcheck" will be used.
-                          type: string
-                        intervalSeconds:
-                          description: The interval (seconds) between health checks
-                          format: int64
-                          type: integer
-                        path:
-                          description: HTTP endpoint used to perform health checks
-                            on upstream service
-                          type: string
-                        timeoutSeconds:
-                          description: The time to wait (seconds) for a health check
-                            response
-                          format: int64
-                          type: integer
-                        unhealthyThresholdCount:
-                          description: The number of unhealthy health checks required
-                            before a host is marked unhealthy
-                          format: int64
-                          minimum: 0
-                          type: integer
-                      required:
-                      - path
-                      type: object
-                    loadBalancerPolicy:
-                      description: The load balancing policy for this route.
-                      properties:
-                        requestHashPolicies:
-                          description: RequestHashPolicies contains a list of hash
-                            policies to apply when the `RequestHash` load balancing
-                            strategy is chosen. If an element of the supplied list
-                            of hash policies is invalid, it will be ignored. If the
-                            list of hash policies is empty after validation, the load
-                            balancing strategy will fall back the the default `RoundRobin`.
-                          items:
-                            description: RequestHashPolicy contains configuration
-                              for an individual hash policy on a request attribute.
-                            properties:
-                              hashSourceIP:
-                                description: HashSourceIP should be set to true when
-                                  request source IP hash based load balancing is desired.
-                                  It must be the only hash option field set, otherwise
-                                  this request hash policy object will be ignored.
-                                type: boolean
-                              headerHashOptions:
-                                description: HeaderHashOptions should be set when
-                                  request header hash based load balancing is desired.
-                                  It must be the only hash option field set, otherwise
-                                  this request hash policy object will be ignored.
-                                properties:
-                                  headerName:
-                                    description: HeaderName is the name of the HTTP
-                                      request header that will be used to calculate
-                                      the hash key. If the header specified is not
-                                      present on a request, no hash will be produced.
-                                    minLength: 1
-                                    type: string
-                                type: object
-                              terminal:
-                                description: Terminal is a flag that allows for short-circuiting
-                                  computing of a hash for a given request. If set
-                                  to true, and the request attribute specified in
-                                  the attribute hash options is present, no further
-                                  hash policies will be used to calculate a hash for
-                                  the request.
-                                type: boolean
-                            type: object
-                          type: array
-                        strategy:
-                          description: Strategy specifies the policy used to balance
-                            requests across the pool of backend pods. Valid policy
-                            names are `Random`, `RoundRobin`, `WeightedLeastRequest`,
-                            `Cookie`, and `RequestHash`. If an unknown strategy name
-                            is specified or no policy is supplied, the default `RoundRobin`
-                            policy is used.
-                          type: string
-                      type: object
-                    pathRewritePolicy:
-                      description: The policy for rewriting the path of the request
-                        URL after the request has been routed to a Service.
-                      properties:
-                        replacePrefix:
-                          description: ReplacePrefix describes how the path prefix
-                            should be replaced.
-                          items:
-                            description: ReplacePrefix describes a path prefix replacement.
-                            properties:
-                              prefix:
-                                description: "Prefix specifies the URL path prefix
+                      loadBalancerPolicy:
+                        description: The load balancing policy for this route.
+                        properties:
+                          requestHashPolicies:
+                            description: RequestHashPolicies contains a list of hash
+                              policies to apply when the `RequestHash` load balancing
+                              strategy is chosen. If an element of the supplied list
+                              of hash policies is invalid, it will be ignored. If the
+                              list of hash policies is empty after validation, the load
+                              balancing strategy will fall back the the default `RoundRobin`.
+                            items:
+                              description: RequestHashPolicy contains configuration
+                                for an individual hash policy on a request attribute.
+                              properties:
+                                hashSourceIP:
+                                  description: HashSourceIP should be set to true when
+                                    request source IP hash based load balancing is desired.
+                                    It must be the only hash option field set, otherwise
+                                    this request hash policy object will be ignored.
+                                  type: boolean
+                                headerHashOptions:
+                                  description: HeaderHashOptions should be set when
+                                    request header hash based load balancing is desired.
+                                    It must be the only hash option field set, otherwise
+                                    this request hash policy object will be ignored.
+                                  properties:
+                                    headerName:
+                                      description: HeaderName is the name of the HTTP
+                                        request header that will be used to calculate
+                                        the hash key. If the header specified is not
+                                        present on a request, no hash will be produced.
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                                terminal:
+                                  description: Terminal is a flag that allows for short-circuiting
+                                    computing of a hash for a given request. If set
+                                    to true, and the request attribute specified in
+                                    the attribute hash options is present, no further
+                                    hash policies will be used to calculate a hash for
+                                    the request.
+                                  type: boolean
+                              type: object
+                            type: array
+                          strategy:
+                            description: Strategy specifies the policy used to balance
+                              requests across the pool of backend pods. Valid policy
+                              names are `Random`, `RoundRobin`, `WeightedLeastRequest`,
+                              `Cookie`, and `RequestHash`. If an unknown strategy name
+                              is specified or no policy is supplied, the default `RoundRobin`
+                              policy is used.
+                            type: string
+                        type: object
+                      pathRewritePolicy:
+                        description: The policy for rewriting the path of the request
+                          URL after the request has been routed to a Service.
+                        properties:
+                          replacePrefix:
+                            description: ReplacePrefix describes how the path prefix
+                              should be replaced.
+                            items:
+                              description: ReplacePrefix describes a path prefix replacement.
+                              properties:
+                                prefix:
+                                  description: "Prefix specifies the URL path prefix
                                   to be replaced. \n If Prefix is specified, it must
                                   exactly match the MatchCondition prefix that is
                                   rendered by the chain of including HTTPProxies and
@@ -391,371 +390,743 @@ spec:
                                   leaving others unmodified. \n If Prefix is not specified,
                                   all routing prefixes rendered by the include chain
                                   will be replaced."
-                                minLength: 1
-                                type: string
-                              replacement:
-                                description: Replacement is the string that the routing
-                                  path prefix will be replaced with. This must not
-                                  be empty.
-                                minLength: 1
+                                  minLength: 1
+                                  type: string
+                                replacement:
+                                  description: Replacement is the string that the routing
+                                    path prefix will be replaced with. This must not
+                                    be empty.
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - replacement
+                              type: object
+                            type: array
+                        type: object
+                      permitInsecure:
+                        description: Allow this path to respond to insecure requests
+                          over HTTP which are normally not permitted when a `virtualhost.tls`
+                          block is present.
+                        type: boolean
+                      rateLimitPolicy:
+                        description: The policy for rate limiting on the route.
+                        properties:
+                          global:
+                            description: Global defines global rate limiting parameters,
+                              i.e. parameters defining descriptors that are sent to
+                              an external rate limit service (RLS) for a rate limit
+                              decision on each request.
+                            properties:
+                              descriptors:
+                                description: Descriptors defines the list of descriptors
+                                  that will be generated and sent to the rate limit
+                                  service. Each descriptor contains 1+ key-value pair
+                                  entries.
+                                items:
+                                  description: RateLimitDescriptor defines a list of
+                                    key-value pair generators.
+                                  properties:
+                                    entries:
+                                      description: Entries is the list of key-value
+                                        pair generators.
+                                      items:
+                                        description: RateLimitDescriptorEntry is a key-value
+                                          pair generator. Exactly one field on this
+                                          struct must be non-nil.
+                                        properties:
+                                          genericKey:
+                                            description: GenericKey defines a descriptor
+                                              entry with a static key and value.
+                                            properties:
+                                              key:
+                                                description: Key defines the key of
+                                                  the descriptor entry. If not set,
+                                                  the key is set to "generic_key".
+                                                type: string
+                                              value:
+                                                description: Value defines the value
+                                                  of the descriptor entry.
+                                                minLength: 1
+                                                type: string
+                                            type: object
+                                          remoteAddress:
+                                            description: RemoteAddress defines a descriptor
+                                              entry with a key of "remote_address" and
+                                              a value equal to the client's IP address
+                                              (from x-forwarded-for).
+                                            type: object
+                                          requestHeader:
+                                            description: RequestHeader defines a descriptor
+                                              entry that's populated only if a given
+                                              header is present on the request. The
+                                              descriptor key is static, and the descriptor
+                                              value is equal to the value of the header.
+                                            properties:
+                                              descriptorKey:
+                                                description: DescriptorKey defines the
+                                                  key to use on the descriptor entry.
+                                                minLength: 1
+                                                type: string
+                                              headerName:
+                                                description: HeaderName defines the
+                                                  name of the header to look for on
+                                                  the request.
+                                                minLength: 1
+                                                type: string
+                                            type: object
+                                          requestHeaderValueMatch:
+                                            description: RequestHeaderValueMatch defines
+                                              a descriptor entry that's populated if
+                                              the request's headers match a set of 1+
+                                              match criteria. The descriptor key is
+                                              "header_match", and the descriptor value
+                                              is static.
+                                            properties:
+                                              expectMatch:
+                                                default: true
+                                                description: ExpectMatch defines whether
+                                                  the request must positively match
+                                                  the match criteria in order to generate
+                                                  a descriptor entry (i.e. true), or
+                                                  not match the match criteria in order
+                                                  to generate a descriptor entry (i.e.
+                                                  false). The default is true.
+                                                type: boolean
+                                              headers:
+                                                description: Headers is a list of 1+
+                                                  match criteria to apply against the
+                                                  request to determine whether to populate
+                                                  the descriptor entry or not.
+                                                items:
+                                                  description: HeaderMatchCondition
+                                                    specifies how to conditionally match
+                                                    against HTTP headers. The Name field
+                                                    is required, but only one of the
+                                                    remaining fields should be be provided.
+                                                  properties:
+                                                    contains:
+                                                      description: Contains specifies
+                                                        a substring that must be present
+                                                        in the header value.
+                                                      type: string
+                                                    exact:
+                                                      description: Exact specifies a
+                                                        string that the header value
+                                                        must be equal to.
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of the header to match against.
+                                                        Name is required. Header names
+                                                        are case insensitive.
+                                                      type: string
+                                                    notcontains:
+                                                      description: NotContains specifies
+                                                        a substring that must not be
+                                                        present in the header value.
+                                                      type: string
+                                                    notexact:
+                                                      description: NoExact specifies
+                                                        a string that the header value
+                                                        must not be equal to. The condition
+                                                        is true if the header has any
+                                                        other value.
+                                                      type: string
+                                                    notpresent:
+                                                      description: NotPresent specifies
+                                                        that condition is true when
+                                                        the named header is not present.
+                                                        Note that setting NotPresent
+                                                        to false does not make the condition
+                                                        true if the named header is
+                                                        present.
+                                                      type: boolean
+                                                    present:
+                                                      description: Present specifies
+                                                        that condition is true when
+                                                        the named header is present,
+                                                        regardless of its value. Note
+                                                        that setting Present to false
+                                                        does not make the condition
+                                                        true if the named header is
+                                                        absent.
+                                                      type: boolean
+                                                  required:
+                                                    - name
+                                                  type: object
+                                                minItems: 1
+                                                type: array
+                                              value:
+                                                description: Value defines the value
+                                                  of the descriptor entry.
+                                                minLength: 1
+                                                type: string
+                                            type: object
+                                        type: object
+                                      minItems: 1
+                                      type: array
+                                  type: object
+                                minItems: 1
+                                type: array
+                            type: object
+                          local:
+                            description: Local defines local rate limiting parameters,
+                              i.e. parameters for rate limiting that occurs within each
+                              Envoy pod as requests are handled.
+                            properties:
+                              burst:
+                                description: Burst defines the number of requests above
+                                  the requests per unit that should be allowed within
+                                  a short period of time.
+                                format: int32
+                                type: integer
+                              requests:
+                                description: Requests defines how many requests per
+                                  unit of time should be allowed before rate limiting
+                                  occurs.
+                                format: int32
+                                minimum: 1
+                                type: integer
+                              responseHeadersToAdd:
+                                description: ResponseHeadersToAdd is an optional list
+                                  of response headers to set when a request is rate-limited.
+                                items:
+                                  description: HeaderValue represents a header name/value
+                                    pair
+                                  properties:
+                                    name:
+                                      description: Name represents a key of a header
+                                      minLength: 1
+                                      type: string
+                                    value:
+                                      description: Value represents the value of a header
+                                        specified by a key
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                    - name
+                                    - value
+                                  type: object
+                                type: array
+                              responseStatusCode:
+                                description: ResponseStatusCode is the HTTP status code
+                                  to use for responses to rate-limited requests. Codes
+                                  must be in the 400-599 range (inclusive). If not specified,
+                                  the Envoy default of 429 (Too Many Requests) is used.
+                                format: int32
+                                maximum: 599
+                                minimum: 400
+                                type: integer
+                              unit:
+                                description: Unit defines the period of time within
+                                  which requests over the limit will be rate limited.
+                                  Valid values are "second", "minute" and "hour".
+                                enum:
+                                  - second
+                                  - minute
+                                  - hour
                                 type: string
                             required:
-                            - replacement
+                              - requests
+                              - unit
                             type: object
-                          type: array
-                      type: object
-                    permitInsecure:
-                      description: Allow this path to respond to insecure requests
-                        over HTTP which are normally not permitted when a `virtualhost.tls`
-                        block is present.
-                      type: boolean
-                    rateLimitPolicy:
-                      description: The policy for rate limiting on the route.
-                      properties:
-                        global:
-                          description: Global defines global rate limiting parameters,
-                            i.e. parameters defining descriptors that are sent to
-                            an external rate limit service (RLS) for a rate limit
-                            decision on each request.
-                          properties:
-                            descriptors:
-                              description: Descriptors defines the list of descriptors
-                                that will be generated and sent to the rate limit
-                                service. Each descriptor contains 1+ key-value pair
-                                entries.
-                              items:
-                                description: RateLimitDescriptor defines a list of
-                                  key-value pair generators.
-                                properties:
-                                  entries:
-                                    description: Entries is the list of key-value
-                                      pair generators.
-                                    items:
-                                      description: RateLimitDescriptorEntry is a key-value
-                                        pair generator. Exactly one field on this
-                                        struct must be non-nil.
-                                      properties:
-                                        genericKey:
-                                          description: GenericKey defines a descriptor
-                                            entry with a static key and value.
-                                          properties:
-                                            key:
-                                              description: Key defines the key of
-                                                the descriptor entry. If not set,
-                                                the key is set to "generic_key".
-                                              type: string
-                                            value:
-                                              description: Value defines the value
-                                                of the descriptor entry.
-                                              minLength: 1
-                                              type: string
-                                          type: object
-                                        remoteAddress:
-                                          description: RemoteAddress defines a descriptor
-                                            entry with a key of "remote_address" and
-                                            a value equal to the client's IP address
-                                            (from x-forwarded-for).
-                                          type: object
-                                        requestHeader:
-                                          description: RequestHeader defines a descriptor
-                                            entry that's populated only if a given
-                                            header is present on the request. The
-                                            descriptor key is static, and the descriptor
-                                            value is equal to the value of the header.
-                                          properties:
-                                            descriptorKey:
-                                              description: DescriptorKey defines the
-                                                key to use on the descriptor entry.
-                                              minLength: 1
-                                              type: string
-                                            headerName:
-                                              description: HeaderName defines the
-                                                name of the header to look for on
-                                                the request.
-                                              minLength: 1
-                                              type: string
-                                          type: object
-                                        requestHeaderValueMatch:
-                                          description: RequestHeaderValueMatch defines
-                                            a descriptor entry that's populated if
-                                            the request's headers match a set of 1+
-                                            match criteria. The descriptor key is
-                                            "header_match", and the descriptor value
-                                            is static.
-                                          properties:
-                                            expectMatch:
-                                              default: true
-                                              description: ExpectMatch defines whether
-                                                the request must positively match
-                                                the match criteria in order to generate
-                                                a descriptor entry (i.e. true), or
-                                                not match the match criteria in order
-                                                to generate a descriptor entry (i.e.
-                                                false). The default is true.
-                                              type: boolean
-                                            headers:
-                                              description: Headers is a list of 1+
-                                                match criteria to apply against the
-                                                request to determine whether to populate
-                                                the descriptor entry or not.
-                                              items:
-                                                description: HeaderMatchCondition
-                                                  specifies how to conditionally match
-                                                  against HTTP headers. The Name field
-                                                  is required, but only one of the
-                                                  remaining fields should be be provided.
-                                                properties:
-                                                  contains:
-                                                    description: Contains specifies
-                                                      a substring that must be present
-                                                      in the header value.
-                                                    type: string
-                                                  exact:
-                                                    description: Exact specifies a
-                                                      string that the header value
-                                                      must be equal to.
-                                                    type: string
-                                                  name:
-                                                    description: Name is the name
-                                                      of the header to match against.
-                                                      Name is required. Header names
-                                                      are case insensitive.
-                                                    type: string
-                                                  notcontains:
-                                                    description: NotContains specifies
-                                                      a substring that must not be
-                                                      present in the header value.
-                                                    type: string
-                                                  notexact:
-                                                    description: NoExact specifies
-                                                      a string that the header value
-                                                      must not be equal to. The condition
-                                                      is true if the header has any
-                                                      other value.
-                                                    type: string
-                                                  notpresent:
-                                                    description: NotPresent specifies
-                                                      that condition is true when
-                                                      the named header is not present.
-                                                      Note that setting NotPresent
-                                                      to false does not make the condition
-                                                      true if the named header is
-                                                      present.
-                                                    type: boolean
-                                                  present:
-                                                    description: Present specifies
-                                                      that condition is true when
-                                                      the named header is present,
-                                                      regardless of its value. Note
-                                                      that setting Present to false
-                                                      does not make the condition
-                                                      true if the named header is
-                                                      absent.
-                                                    type: boolean
-                                                required:
-                                                - name
-                                                type: object
-                                              minItems: 1
-                                              type: array
-                                            value:
-                                              description: Value defines the value
-                                                of the descriptor entry.
-                                              minLength: 1
-                                              type: string
-                                          type: object
-                                      type: object
-                                    minItems: 1
-                                    type: array
-                                type: object
-                              minItems: 1
-                              type: array
-                          type: object
-                        local:
-                          description: Local defines local rate limiting parameters,
-                            i.e. parameters for rate limiting that occurs within each
-                            Envoy pod as requests are handled.
-                          properties:
-                            burst:
-                              description: Burst defines the number of requests above
-                                the requests per unit that should be allowed within
-                                a short period of time.
-                              format: int32
-                              type: integer
-                            requests:
-                              description: Requests defines how many requests per
-                                unit of time should be allowed before rate limiting
-                                occurs.
-                              format: int32
-                              minimum: 1
-                              type: integer
-                            responseHeadersToAdd:
-                              description: ResponseHeadersToAdd is an optional list
-                                of response headers to set when a request is rate-limited.
-                              items:
-                                description: HeaderValue represents a header name/value
-                                  pair
-                                properties:
-                                  name:
-                                    description: Name represents a key of a header
-                                    minLength: 1
-                                    type: string
-                                  value:
-                                    description: Value represents the value of a header
-                                      specified by a key
-                                    minLength: 1
-                                    type: string
-                                required:
+                        type: object
+                      requestHeadersPolicy:
+                        description: The policy for managing request headers during
+                          proxying.
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove.
+                            items:
+                              type: string
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
                                 - name
                                 - value
-                                type: object
-                              type: array
-                            responseStatusCode:
-                              description: ResponseStatusCode is the HTTP status code
-                                to use for responses to rate-limited requests. Codes
-                                must be in the 400-599 range (inclusive). If not specified,
-                                the Envoy default of 429 (Too Many Requests) is used.
-                              format: int32
-                              maximum: 599
-                              minimum: 400
-                              type: integer
-                            unit:
-                              description: Unit defines the period of time within
-                                which requests over the limit will be rate limited.
-                                Valid values are "second", "minute" and "hour".
-                              enum:
-                              - second
-                              - minute
-                              - hour
+                              type: object
+                            type: array
+                        type: object
+                      requestRedirectPolicy:
+                        description: RequestRedirectPolicy defines an HTTP redirection.
+                        properties:
+                          hostname:
+                            description: Hostname is the precise hostname to be used
+                              in the value of the `Location` header in the response.
+                              When empty, the hostname of the request is used. No wildcards
+                              are allowed.
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          path:
+                            description: "Path allows for redirection to a different
+                            path from the original on the request. The path must start
+                            with a leading slash. \n Note: Only one of Path or Prefix
+                            can be defined."
+                            pattern: ^\/.*$
+                            type: string
+                          port:
+                            description: Port is the port to be used in the value of
+                              the `Location` header in the response. When empty, port
+                              (if specified) of the request is used.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          prefix:
+                            description: "Prefix defines the value to swap the matched
+                            prefix or path with. The prefix must start with a leading
+                            slash. \n Note: Only one of Path or Prefix can be defined."
+                            pattern: ^\/.*$
+                            type: string
+                          scheme:
+                            description: Scheme is the scheme to be used in the value
+                              of the `Location` header in the response. When empty,
+                              the scheme of the request is used.
+                            enum:
+                              - http
+                              - https
+                            type: string
+                          statusCode:
+                            default: 302
+                            description: StatusCode is the HTTP status code to be used
+                              in response.
+                            enum:
+                              - 301
+                              - 302
+                            type: integer
+                        type: object
+                      responseHeadersPolicy:
+                        description: The policy for managing response headers during
+                          proxying. Rewriting the 'Host' header is not supported.
+                        properties:
+                          remove:
+                            description: Remove specifies a list of HTTP header names
+                              to remove.
+                            items:
                               type: string
-                          required:
-                          - requests
-                          - unit
-                          type: object
-                      type: object
-                    requestHeadersPolicy:
-                      description: The policy for managing request headers during
-                        proxying.
-                      properties:
-                        remove:
-                          description: Remove specifies a list of HTTP header names
-                            to remove.
-                          items:
+                            type: array
+                          set:
+                            description: Set specifies a list of HTTP header values
+                              that will be set in the HTTP header. If the header does
+                              not exist it will be added, otherwise it will be overwritten
+                              with the new value.
+                            items:
+                              description: HeaderValue represents a header name/value
+                                pair
+                              properties:
+                                name:
+                                  description: Name represents a key of a header
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: Value represents the value of a header
+                                    specified by a key
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                        type: object
+                      retryPolicy:
+                        description: The retry policy for this route.
+                        properties:
+                          count:
+                            default: 1
+                            description: NumRetries is maximum allowed number of retries.
+                              If set to -1, then retries are disabled. If set to 0 or
+                              not supplied, the value is set to the Envoy default of
+                              1.
+                            format: int64
+                            minimum: -1
+                            type: integer
+                          perTryTimeout:
+                            description: PerTryTimeout specifies the timeout per retry
+                              attempt. Ignored if NumRetries is not supplied.
+                            pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                             type: string
-                          type: array
-                        set:
-                          description: Set specifies a list of HTTP header values
-                            that will be set in the HTTP header. If the header does
-                            not exist it will be added, otherwise it will be overwritten
-                            with the new value.
-                          items:
-                            description: HeaderValue represents a header name/value
-                              pair
-                            properties:
-                              name:
-                                description: Name represents a key of a header
-                                minLength: 1
-                                type: string
-                              value:
-                                description: Value represents the value of a header
-                                  specified by a key
-                                minLength: 1
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                      type: object
-                    responseHeadersPolicy:
-                      description: The policy for managing response headers during
-                        proxying. Rewriting the 'Host' header is not supported.
-                      properties:
-                        remove:
-                          description: Remove specifies a list of HTTP header names
-                            to remove.
-                          items:
-                            type: string
-                          type: array
-                        set:
-                          description: Set specifies a list of HTTP header values
-                            that will be set in the HTTP header. If the header does
-                            not exist it will be added, otherwise it will be overwritten
-                            with the new value.
-                          items:
-                            description: HeaderValue represents a header name/value
-                              pair
-                            properties:
-                              name:
-                                description: Name represents a key of a header
-                                minLength: 1
-                                type: string
-                              value:
-                                description: Value represents the value of a header
-                                  specified by a key
-                                minLength: 1
-                                type: string
-                            required:
-                            - name
-                            - value
-                            type: object
-                          type: array
-                      type: object
-                    retryPolicy:
-                      description: The retry policy for this route.
-                      properties:
-                        count:
-                          default: 1
-                          description: NumRetries is maximum allowed number of retries.
-                            If set to -1, then retries are disabled. If set to 0 or
-                            not supplied, the value is set to the Envoy default of
-                            1.
-                          format: int64
-                          minimum: -1
-                          type: integer
-                        perTryTimeout:
-                          description: PerTryTimeout specifies the timeout per retry
-                            attempt. Ignored if NumRetries is not supplied.
-                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
-                          type: string
-                        retriableStatusCodes:
-                          description: "RetriableStatusCodes specifies the HTTP status
+                          retriableStatusCodes:
+                            description: "RetriableStatusCodes specifies the HTTP status
                             codes that should be retried. \n This field is only respected
                             when you include `retriable-status-codes` in the `RetryOn`
                             field."
-                          items:
-                            format: int32
-                            type: integer
-                          type: array
-                        retryOn:
-                          description: "RetryOn specifies the conditions on which
+                            items:
+                              format: int32
+                              type: integer
+                            type: array
+                          retryOn:
+                            description: "RetryOn specifies the conditions on which
                             to retry a request. \n Supported [HTTP conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on):
                             \n - `5xx` - `gateway-error` - `reset` - `connect-failure`
                             - `retriable-4xx` - `refused-stream` - `retriable-status-codes`
                             - `retriable-headers` \n Supported [gRPC conditions](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on):
                             \n - `cancelled` - `deadline-exceeded` - `internal` -
                             `resource-exhausted` - `unavailable`"
-                          items:
-                            description: RetryOn is a string type alias with validation
-                              to ensure that the value is valid.
-                            enum:
-                            - 5xx
-                            - gateway-error
-                            - reset
-                            - connect-failure
-                            - retriable-4xx
-                            - refused-stream
-                            - retriable-status-codes
-                            - retriable-headers
-                            - cancelled
-                            - deadline-exceeded
-                            - internal
-                            - resource-exhausted
-                            - unavailable
+                            items:
+                              description: RetryOn is a string type alias with validation
+                                to ensure that the value is valid.
+                              enum:
+                                - 5xx
+                                - gateway-error
+                                - reset
+                                - connect-failure
+                                - retriable-4xx
+                                - refused-stream
+                                - retriable-status-codes
+                                - retriable-headers
+                                - cancelled
+                                - deadline-exceeded
+                                - internal
+                                - resource-exhausted
+                                - unavailable
+                              type: string
+                            type: array
+                        type: object
+                      services:
+                        description: Services are the services to proxy traffic.
+                        items:
+                          description: Service defines an Kubernetes Service to proxy
+                            traffic.
+                          properties:
+                            cookieRewritePolicies:
+                              description: The policies for rewriting Set-Cookie header
+                                attributes.
+                              items:
+                                properties:
+                                  domainRewrite:
+                                    description: DomainRewrite enables rewriting the
+                                      Set-Cookie Domain element. If not set, Domain
+                                      will not be rewritten.
+                                    properties:
+                                      value:
+                                        description: Value is the value to rewrite the
+                                          Domain attribute to. For now this is required.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        type: string
+                                    required:
+                                      - value
+                                    type: object
+                                  name:
+                                    description: Name is the name of the cookie for
+                                      which attributes will be rewritten.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                    type: string
+                                  pathRewrite:
+                                    description: PathRewrite enables rewriting the Set-Cookie
+                                      Path element. If not set, Path will not be rewritten.
+                                    properties:
+                                      value:
+                                        description: Value is the value to rewrite the
+                                          Path attribute to. For now this is required.
+                                        maxLength: 4096
+                                        minLength: 1
+                                        pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
+                                        type: string
+                                    required:
+                                      - value
+                                    type: object
+                                  sameSite:
+                                    description: SameSite enables rewriting the Set-Cookie
+                                      SameSite element. If not set, SameSite attribute
+                                      will not be rewritten.
+                                    enum:
+                                      - Strict
+                                      - Lax
+                                      - None
+                                    type: string
+                                  secure:
+                                    description: Secure enables rewriting the Set-Cookie
+                                      Secure element. If not set, Secure attribute will
+                                      not be rewritten.
+                                    type: boolean
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                            mirror:
+                              description: If Mirror is true the Service will receive
+                                a read only mirror of the traffic for this route.
+                              type: boolean
+                            name:
+                              description: Name is the name of Kubernetes service to
+                                proxy traffic. Names defined here will be used to look
+                                up corresponding endpoints which contain the ips to
+                                route.
+                              type: string
+                            port:
+                              description: Port (defined as Integer) to proxy traffic
+                                to since a service can have multiple defined.
+                              exclusiveMaximum: true
+                              maximum: 65536
+                              minimum: 1
+                              type: integer
+                            protocol:
+                              description: Protocol may be used to specify (or override)
+                                the protocol used to reach this Service. Values may
+                                be tls, h2, h2c. If omitted, protocol-selection falls
+                                back on Service annotations.
+                              enum:
+                                - h2
+                                - h2c
+                                - tls
+                              type: string
+                            requestHeadersPolicy:
+                              description: The policy for managing request headers during
+                                proxying. Rewriting the 'Host' header is not supported.
+                              properties:
+                                remove:
+                                  description: Remove specifies a list of HTTP header
+                                    names to remove.
+                                  items:
+                                    type: string
+                                  type: array
+                                set:
+                                  description: Set specifies a list of HTTP header values
+                                    that will be set in the HTTP header. If the header
+                                    does not exist it will be added, otherwise it will
+                                    be overwritten with the new value.
+                                  items:
+                                    description: HeaderValue represents a header name/value
+                                      pair
+                                    properties:
+                                      name:
+                                        description: Name represents a key of a header
+                                        minLength: 1
+                                        type: string
+                                      value:
+                                        description: Value represents the value of a
+                                          header specified by a key
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                              type: object
+                            responseHeadersPolicy:
+                              description: The policy for managing response headers
+                                during proxying. Rewriting the 'Host' header is not
+                                supported.
+                              properties:
+                                remove:
+                                  description: Remove specifies a list of HTTP header
+                                    names to remove.
+                                  items:
+                                    type: string
+                                  type: array
+                                set:
+                                  description: Set specifies a list of HTTP header values
+                                    that will be set in the HTTP header. If the header
+                                    does not exist it will be added, otherwise it will
+                                    be overwritten with the new value.
+                                  items:
+                                    description: HeaderValue represents a header name/value
+                                      pair
+                                    properties:
+                                      name:
+                                        description: Name represents a key of a header
+                                        minLength: 1
+                                        type: string
+                                      value:
+                                        description: Value represents the value of a
+                                          header specified by a key
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                              type: object
+                            validation:
+                              description: UpstreamValidation defines how to verify
+                                the backend service's certificate
+                              properties:
+                                caSecret:
+                                  description: Name or namespaced name of the Kubernetes
+                                    secret used to validate the certificate presented
+                                    by the backend
+                                  type: string
+                                subjectName:
+                                  description: Key which is expected to be present in
+                                    the 'subjectAltName' of the presented certificate
+                                  type: string
+                              required:
+                                - caSecret
+                                - subjectName
+                              type: object
+                            weight:
+                              description: Weight defines percentage of traffic to balance
+                                traffic
+                              format: int64
+                              minimum: 0
+                              type: integer
+                          required:
+                            - name
+                            - port
+                          type: object
+                        type: array
+                      timeoutPolicy:
+                        description: The timeout policy for this route.
+                        properties:
+                          idle:
+                            description: Timeout for how long the proxy should wait
+                              while there is no activity during single request/response
+                              (for HTTP/1.1) or stream (for HTTP/2). Timeout will not
+                              trigger while HTTP/1.1 connection is idle between two
+                              consecutive requests. If not specified, there is no per-route
+                              idle timeout, though a connection manager-wide stream_idle_timeout
+                              default of 5m still applies.
+                            pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                             type: string
+                          response:
+                            description: Timeout for receiving a response from the server
+                              after processing a request from client. If not supplied,
+                              Envoy's default value of 15s applies.
+                            pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                            type: string
+                        type: object
+                    type: object
+                  type: array
+                tcpproxy:
+                  description: TCPProxy holds TCP proxy information.
+                  properties:
+                    healthCheckPolicy:
+                      description: The health check policy for this tcp proxy
+                      properties:
+                        healthyThresholdCount:
+                          description: The number of healthy health checks required
+                            before a host is marked healthy
+                          format: int32
+                          type: integer
+                        intervalSeconds:
+                          description: The interval (seconds) between health checks
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: The time to wait (seconds) for a health check
+                            response
+                          format: int64
+                          type: integer
+                        unhealthyThresholdCount:
+                          description: The number of unhealthy health checks required
+                            before a host is marked unhealthy
+                          format: int32
+                          type: integer
+                      type: object
+                    include:
+                      description: Include specifies that this tcpproxy should be delegated
+                        to another HTTPProxy.
+                      properties:
+                        name:
+                          description: Name of the child HTTPProxy
+                          type: string
+                        namespace:
+                          description: Namespace of the HTTPProxy to include. Defaults
+                            to the current namespace if not supplied.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    includes:
+                      description: "IncludesDeprecated allow for specific routing configuration
+                      to be appended to another HTTPProxy in another namespace. \n
+                      Exists due to a mistake when developing HTTPProxy and the field
+                      was marked plural when it should have been singular. This field
+                      should stay to not break backwards compatibility to v1 users."
+                      properties:
+                        name:
+                          description: Name of the child HTTPProxy
+                          type: string
+                        namespace:
+                          description: Namespace of the HTTPProxy to include. Defaults
+                            to the current namespace if not supplied.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    loadBalancerPolicy:
+                      description: The load balancing policy for the backend services.
+                        Note that the `Cookie` and `RequestHash` load balancing strategies
+                        cannot be used here.
+                      properties:
+                        requestHashPolicies:
+                          description: RequestHashPolicies contains a list of hash policies
+                            to apply when the `RequestHash` load balancing strategy
+                            is chosen. If an element of the supplied list of hash policies
+                            is invalid, it will be ignored. If the list of hash policies
+                            is empty after validation, the load balancing strategy will
+                            fall back the the default `RoundRobin`.
+                          items:
+                            description: RequestHashPolicy contains configuration for
+                              an individual hash policy on a request attribute.
+                            properties:
+                              hashSourceIP:
+                                description: HashSourceIP should be set to true when
+                                  request source IP hash based load balancing is desired.
+                                  It must be the only hash option field set, otherwise
+                                  this request hash policy object will be ignored.
+                                type: boolean
+                              headerHashOptions:
+                                description: HeaderHashOptions should be set when request
+                                  header hash based load balancing is desired. It must
+                                  be the only hash option field set, otherwise this
+                                  request hash policy object will be ignored.
+                                properties:
+                                  headerName:
+                                    description: HeaderName is the name of the HTTP
+                                      request header that will be used to calculate
+                                      the hash key. If the header specified is not present
+                                      on a request, no hash will be produced.
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              terminal:
+                                description: Terminal is a flag that allows for short-circuiting
+                                  computing of a hash for a given request. If set to
+                                  true, and the request attribute specified in the attribute
+                                  hash options is present, no further hash policies
+                                  will be used to calculate a hash for the request.
+                                type: boolean
+                            type: object
                           type: array
+                        strategy:
+                          description: Strategy specifies the policy used to balance
+                            requests across the pool of backend pods. Valid policy names
+                            are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Cookie`,
+                            and `RequestHash`. If an unknown strategy name is specified
+                            or no policy is supplied, the default `RoundRobin` policy
+                            is used.
+                          type: string
                       type: object
                     services:
-                      description: Services are the services to proxy traffic.
+                      description: Services are the services to proxy traffic
                       items:
                         description: Service defines an Kubernetes Service to proxy
                           traffic.
@@ -766,9 +1137,8 @@ spec:
                             items:
                               properties:
                                 domainRewrite:
-                                  description: DomainRewrite enables rewriting the
-                                    Set-Cookie Domain element. If not set, Domain
-                                    will not be rewritten.
+                                  description: DomainRewrite enables rewriting the Set-Cookie
+                                    Domain element. If not set, Domain will not be rewritten.
                                   properties:
                                     value:
                                       description: Value is the value to rewrite the
@@ -778,11 +1148,11 @@ spec:
                                       pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                                       type: string
                                   required:
-                                  - value
+                                    - value
                                   type: object
                                 name:
-                                  description: Name is the name of the cookie for
-                                    which attributes will be rewritten.
+                                  description: Name is the name of the cookie for which
+                                    attributes will be rewritten.
                                   maxLength: 4096
                                   minLength: 1
                                   pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
@@ -799,16 +1169,16 @@ spec:
                                       pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
                                       type: string
                                   required:
-                                  - value
+                                    - value
                                   type: object
                                 sameSite:
                                   description: SameSite enables rewriting the Set-Cookie
                                     SameSite element. If not set, SameSite attribute
                                     will not be rewritten.
                                   enum:
-                                  - Strict
-                                  - Lax
-                                  - None
+                                    - Strict
+                                    - Lax
+                                    - None
                                   type: string
                                 secure:
                                   description: Secure enables rewriting the Set-Cookie
@@ -816,7 +1186,7 @@ spec:
                                     not be rewritten.
                                   type: boolean
                               required:
-                              - name
+                                - name
                               type: object
                             type: array
                           mirror:
@@ -824,10 +1194,9 @@ spec:
                               a read only mirror of the traffic for this route.
                             type: boolean
                           name:
-                            description: Name is the name of Kubernetes service to
-                              proxy traffic. Names defined here will be used to look
-                              up corresponding endpoints which contain the ips to
-                              route.
+                            description: Name is the name of Kubernetes service to proxy
+                              traffic. Names defined here will be used to look up corresponding
+                              endpoints which contain the ips to route.
                             type: string
                           port:
                             description: Port (defined as Integer) to proxy traffic
@@ -838,13 +1207,13 @@ spec:
                             type: integer
                           protocol:
                             description: Protocol may be used to specify (or override)
-                              the protocol used to reach this Service. Values may
-                              be tls, h2, h2c. If omitted, protocol-selection falls
-                              back on Service annotations.
+                              the protocol used to reach this Service. Values may be
+                              tls, h2, h2c. If omitted, protocol-selection falls back
+                              on Service annotations.
                             enum:
-                            - h2
-                            - h2c
-                            - tls
+                              - h2
+                              - h2c
+                              - tls
                             type: string
                           requestHeadersPolicy:
                             description: The policy for managing request headers during
@@ -870,20 +1239,19 @@ spec:
                                       minLength: 1
                                       type: string
                                     value:
-                                      description: Value represents the value of a
-                                        header specified by a key
+                                      description: Value represents the value of a header
+                                        specified by a key
                                       minLength: 1
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                             type: object
                           responseHeadersPolicy:
-                            description: The policy for managing response headers
-                              during proxying. Rewriting the 'Host' header is not
-                              supported.
+                            description: The policy for managing response headers during
+                              proxying. Rewriting the 'Host' header is not supported.
                             properties:
                               remove:
                                 description: Remove specifies a list of HTTP header
@@ -905,19 +1273,19 @@ spec:
                                       minLength: 1
                                       type: string
                                     value:
-                                      description: Value represents the value of a
-                                        header specified by a key
+                                      description: Value represents the value of a header
+                                        specified by a key
                                       minLength: 1
                                       type: string
                                   required:
-                                  - name
-                                  - value
+                                    - name
+                                    - value
                                   type: object
                                 type: array
                             type: object
                           validation:
-                            description: UpstreamValidation defines how to verify
-                              the backend service's certificate
+                            description: UpstreamValidation defines how to verify the
+                              backend service's certificate
                             properties:
                               caSecret:
                                 description: Name or namespaced name of the Kubernetes
@@ -929,8 +1297,8 @@ spec:
                                   the 'subjectAltName' of the presented certificate
                                 type: string
                             required:
-                            - caSecret
-                            - subjectName
+                              - caSecret
+                              - subjectName
                             type: object
                           weight:
                             description: Weight defines percentage of traffic to balance
@@ -939,688 +1307,386 @@ spec:
                             minimum: 0
                             type: integer
                         required:
-                        - name
-                        - port
+                          - name
+                          - port
                         type: object
-                      minItems: 1
                       type: array
-                    timeoutPolicy:
-                      description: The timeout policy for this route.
-                      properties:
-                        idle:
-                          description: Timeout for how long the proxy should wait
-                            while there is no activity during single request/response
-                            (for HTTP/1.1) or stream (for HTTP/2). Timeout will not
-                            trigger while HTTP/1.1 connection is idle between two
-                            consecutive requests. If not specified, there is no per-route
-                            idle timeout, though a connection manager-wide stream_idle_timeout
-                            default of 5m still applies.
-                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
-                          type: string
-                        response:
-                          description: Timeout for receiving a response from the server
-                            after processing a request from client. If not supplied,
-                            Envoy's default value of 15s applies.
-                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
-                          type: string
-                      type: object
-                  required:
-                  - services
                   type: object
-                type: array
-              tcpproxy:
-                description: TCPProxy holds TCP proxy information.
-                properties:
-                  healthCheckPolicy:
-                    description: The health check policy for this tcp proxy
-                    properties:
-                      healthyThresholdCount:
-                        description: The number of healthy health checks required
-                          before a host is marked healthy
-                        format: int32
-                        type: integer
-                      intervalSeconds:
-                        description: The interval (seconds) between health checks
-                        format: int64
-                        type: integer
-                      timeoutSeconds:
-                        description: The time to wait (seconds) for a health check
-                          response
-                        format: int64
-                        type: integer
-                      unhealthyThresholdCount:
-                        description: The number of unhealthy health checks required
-                          before a host is marked unhealthy
-                        format: int32
-                        type: integer
-                    type: object
-                  include:
-                    description: Include specifies that this tcpproxy should be delegated
-                      to another HTTPProxy.
-                    properties:
-                      name:
-                        description: Name of the child HTTPProxy
-                        type: string
-                      namespace:
-                        description: Namespace of the HTTPProxy to include. Defaults
-                          to the current namespace if not supplied.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  includes:
-                    description: "IncludesDeprecated allow for specific routing configuration
-                      to be appended to another HTTPProxy in another namespace. \n
-                      Exists due to a mistake when developing HTTPProxy and the field
-                      was marked plural when it should have been singular. This field
-                      should stay to not break backwards compatibility to v1 users."
-                    properties:
-                      name:
-                        description: Name of the child HTTPProxy
-                        type: string
-                      namespace:
-                        description: Namespace of the HTTPProxy to include. Defaults
-                          to the current namespace if not supplied.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  loadBalancerPolicy:
-                    description: The load balancing policy for the backend services.
-                      Note that the `Cookie` and `RequestHash` load balancing strategies
-                      cannot be used here.
-                    properties:
-                      requestHashPolicies:
-                        description: RequestHashPolicies contains a list of hash policies
-                          to apply when the `RequestHash` load balancing strategy
-                          is chosen. If an element of the supplied list of hash policies
-                          is invalid, it will be ignored. If the list of hash policies
-                          is empty after validation, the load balancing strategy will
-                          fall back the the default `RoundRobin`.
-                        items:
-                          description: RequestHashPolicy contains configuration for
-                            an individual hash policy on a request attribute.
-                          properties:
-                            hashSourceIP:
-                              description: HashSourceIP should be set to true when
-                                request source IP hash based load balancing is desired.
-                                It must be the only hash option field set, otherwise
-                                this request hash policy object will be ignored.
-                              type: boolean
-                            headerHashOptions:
-                              description: HeaderHashOptions should be set when request
-                                header hash based load balancing is desired. It must
-                                be the only hash option field set, otherwise this
-                                request hash policy object will be ignored.
-                              properties:
-                                headerName:
-                                  description: HeaderName is the name of the HTTP
-                                    request header that will be used to calculate
-                                    the hash key. If the header specified is not present
-                                    on a request, no hash will be produced.
-                                  minLength: 1
-                                  type: string
-                              type: object
-                            terminal:
-                              description: Terminal is a flag that allows for short-circuiting
-                                computing of a hash for a given request. If set to
-                                true, and the request attribute specified in the attribute
-                                hash options is present, no further hash policies
-                                will be used to calculate a hash for the request.
-                              type: boolean
-                          type: object
-                        type: array
-                      strategy:
-                        description: Strategy specifies the policy used to balance
-                          requests across the pool of backend pods. Valid policy names
-                          are `Random`, `RoundRobin`, `WeightedLeastRequest`, `Cookie`,
-                          and `RequestHash`. If an unknown strategy name is specified
-                          or no policy is supplied, the default `RoundRobin` policy
-                          is used.
-                        type: string
-                    type: object
-                  services:
-                    description: Services are the services to proxy traffic
-                    items:
-                      description: Service defines an Kubernetes Service to proxy
-                        traffic.
+                virtualhost:
+                  description: Virtualhost appears at most once. If it is present, the
+                    object is considered to be a "root" HTTPProxy.
+                  properties:
+                    authorization:
+                      description: This field configures an extension service to perform
+                        authorization for this virtual host. Authorization can only
+                        be configured on virtual hosts that have TLS enabled. If the
+                        TLS configuration requires client certificate validation, the
+                        client certificate is always included in the authentication
+                        check request.
                       properties:
-                        cookieRewritePolicies:
-                          description: The policies for rewriting Set-Cookie header
-                            attributes.
-                          items:
-                            properties:
-                              domainRewrite:
-                                description: DomainRewrite enables rewriting the Set-Cookie
-                                  Domain element. If not set, Domain will not be rewritten.
-                                properties:
-                                  value:
-                                    description: Value is the value to rewrite the
-                                      Domain attribute to. For now this is required.
-                                    maxLength: 4096
-                                    minLength: 1
-                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                                    type: string
-                                required:
-                                - value
-                                type: object
-                              name:
-                                description: Name is the name of the cookie for which
-                                  attributes will be rewritten.
-                                maxLength: 4096
-                                minLength: 1
-                                pattern: ^[^()<>@,;:\\"\/[\]?={} \t\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
-                                type: string
-                              pathRewrite:
-                                description: PathRewrite enables rewriting the Set-Cookie
-                                  Path element. If not set, Path will not be rewritten.
-                                properties:
-                                  value:
-                                    description: Value is the value to rewrite the
-                                      Path attribute to. For now this is required.
-                                    maxLength: 4096
-                                    minLength: 1
-                                    pattern: ^[^;\x7f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f]+$
-                                    type: string
-                                required:
-                                - value
-                                type: object
-                              sameSite:
-                                description: SameSite enables rewriting the Set-Cookie
-                                  SameSite element. If not set, SameSite attribute
-                                  will not be rewritten.
-                                enum:
-                                - Strict
-                                - Lax
-                                - None
-                                type: string
-                              secure:
-                                description: Secure enables rewriting the Set-Cookie
-                                  Secure element. If not set, Secure attribute will
-                                  not be rewritten.
-                                type: boolean
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        mirror:
-                          description: If Mirror is true the Service will receive
-                            a read only mirror of the traffic for this route.
-                          type: boolean
-                        name:
-                          description: Name is the name of Kubernetes service to proxy
-                            traffic. Names defined here will be used to look up corresponding
-                            endpoints which contain the ips to route.
-                          type: string
-                        port:
-                          description: Port (defined as Integer) to proxy traffic
-                            to since a service can have multiple defined.
-                          exclusiveMaximum: true
-                          maximum: 65536
-                          minimum: 1
-                          type: integer
-                        protocol:
-                          description: Protocol may be used to specify (or override)
-                            the protocol used to reach this Service. Values may be
-                            tls, h2, h2c. If omitted, protocol-selection falls back
-                            on Service annotations.
-                          enum:
-                          - h2
-                          - h2c
-                          - tls
-                          type: string
-                        requestHeadersPolicy:
-                          description: The policy for managing request headers during
-                            proxying. Rewriting the 'Host' header is not supported.
+                        authPolicy:
+                          description: AuthPolicy sets a default authorization policy
+                            for client requests. This policy will be used unless overridden
+                            by individual routes.
                           properties:
-                            remove:
-                              description: Remove specifies a list of HTTP header
-                                names to remove.
-                              items:
+                            context:
+                              additionalProperties:
                                 type: string
-                              type: array
-                            set:
-                              description: Set specifies a list of HTTP header values
-                                that will be set in the HTTP header. If the header
-                                does not exist it will be added, otherwise it will
-                                be overwritten with the new value.
-                              items:
-                                description: HeaderValue represents a header name/value
-                                  pair
-                                properties:
-                                  name:
-                                    description: Name represents a key of a header
-                                    minLength: 1
-                                    type: string
-                                  value:
-                                    description: Value represents the value of a header
-                                      specified by a key
-                                    minLength: 1
-                                    type: string
-                                required:
-                                - name
-                                - value
-                                type: object
-                              type: array
+                              description: Context is a set of key/value pairs that
+                                are sent to the authentication server in the check request.
+                                If a context is provided at an enclosing scope, the
+                                entries are merged such that the inner scope overrides
+                                matching keys from the outer scope.
+                              type: object
+                            disabled:
+                              description: When true, this field disables client request
+                                authentication for the scope of the policy.
+                              type: boolean
                           type: object
-                        responseHeadersPolicy:
-                          description: The policy for managing response headers during
-                            proxying. Rewriting the 'Host' header is not supported.
+                        extensionRef:
+                          description: ExtensionServiceRef specifies the extension resource
+                            that will authorize client requests.
                           properties:
-                            remove:
-                              description: Remove specifies a list of HTTP header
-                                names to remove.
-                              items:
-                                type: string
-                              type: array
-                            set:
-                              description: Set specifies a list of HTTP header values
-                                that will be set in the HTTP header. If the header
-                                does not exist it will be added, otherwise it will
-                                be overwritten with the new value.
-                              items:
-                                description: HeaderValue represents a header name/value
-                                  pair
-                                properties:
-                                  name:
-                                    description: Name represents a key of a header
-                                    minLength: 1
-                                    type: string
-                                  value:
-                                    description: Value represents the value of a header
-                                      specified by a key
-                                    minLength: 1
-                                    type: string
-                                required:
-                                - name
-                                - value
-                                type: object
-                              type: array
-                          type: object
-                        validation:
-                          description: UpstreamValidation defines how to verify the
-                            backend service's certificate
-                          properties:
-                            caSecret:
-                              description: Name or namespaced name of the Kubernetes
-                                secret used to validate the certificate presented
-                                by the backend
+                            apiVersion:
+                              description: API version of the referent. If this field
+                                is not specified, the default "projectcontour.io/v1alpha1"
+                                will be used
+                              minLength: 1
                               type: string
-                            subjectName:
-                              description: Key which is expected to be present in
-                                the 'subjectAltName' of the presented certificate
+                            name:
+                              description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                              minLength: 1
                               type: string
-                          required:
-                          - caSecret
-                          - subjectName
-                          type: object
-                        weight:
-                          description: Weight defines percentage of traffic to balance
-                            traffic
-                          format: int64
-                          minimum: 0
-                          type: integer
-                      required:
-                      - name
-                      - port
-                      type: object
-                    type: array
-                type: object
-              virtualhost:
-                description: Virtualhost appears at most once. If it is present, the
-                  object is considered to be a "root" HTTPProxy.
-                properties:
-                  authorization:
-                    description: This field configures an extension service to perform
-                      authorization for this virtual host. Authorization can only
-                      be configured on virtual hosts that have TLS enabled. If the
-                      TLS configuration requires client certificate validation, the
-                      client certificate is always included in the authentication
-                      check request.
-                    properties:
-                      authPolicy:
-                        description: AuthPolicy sets a default authorization policy
-                          for client requests. This policy will be used unless overridden
-                          by individual routes.
-                        properties:
-                          context:
-                            additionalProperties:
-                              type: string
-                            description: Context is a set of key/value pairs that
-                              are sent to the authentication server in the check request.
-                              If a context is provided at an enclosing scope, the
-                              entries are merged such that the inner scope overrides
-                              matching keys from the outer scope.
-                            type: object
-                          disabled:
-                            description: When true, this field disables client request
-                              authentication for the scope of the policy.
-                            type: boolean
-                        type: object
-                      extensionRef:
-                        description: ExtensionServiceRef specifies the extension resource
-                          that will authorize client requests.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent. If this field
-                              is not specified, the default "projectcontour.io/v1alpha1"
-                              will be used
-                            minLength: 1
-                            type: string
-                          name:
-                            description: "Name of the referent. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
-                            minLength: 1
-                            type: string
-                          namespace:
-                            description: "Namespace of the referent. If this field
+                            namespace:
+                              description: "Namespace of the referent. If this field
                               is not specifies, the namespace of the resource that
                               targets the referent will be used. \n More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
-                            minLength: 1
+                              minLength: 1
+                              type: string
+                          type: object
+                        failOpen:
+                          description: If FailOpen is true, the client request is forwarded
+                            to the upstream service even if the authorization server
+                            fails to respond. This field should not be set in most cases.
+                            It is intended for use only while migrating applications
+                            from internal authorization to Contour external authorization.
+                          type: boolean
+                        responseTimeout:
+                          description: ResponseTimeout configures maximum time to wait
+                            for a check response from the authorization server. Timeout
+                            durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                            Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                            "h". The string "infinity" is also a valid input and specifies
+                            no timeout.
+                          pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                          type: string
+                        withRequestBody:
+                          description: WithRequestBody specifies configuration for sending
+                            the client request's body to authorization server.
+                          properties:
+                            allowPartialMessage:
+                              description: If AllowPartialMessage is true, then Envoy
+                                will buffer the body until MaxRequestBytes are reached.
+                              type: boolean
+                            maxRequestBytes:
+                              default: 1024
+                              description: MaxRequestBytes sets the maximum size of
+                                message body ExtAuthz filter will hold in-memory.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            packAsBytes:
+                              description: If PackAsBytes is true, the body sent to
+                                Authorization Server is in raw bytes.
+                              type: boolean
+                          type: object
+                      required:
+                        - extensionRef
+                      type: object
+                    corsPolicy:
+                      description: Specifies the cross-origin policy to apply to the
+                        VirtualHost.
+                      properties:
+                        allowCredentials:
+                          description: Specifies whether the resource allows credentials.
+                          type: boolean
+                        allowHeaders:
+                          description: AllowHeaders specifies the content for the *access-control-allow-headers*
+                            header.
+                          items:
+                            description: CORSHeaderValue specifies the value of the
+                              string headers returned by a cross-domain request.
+                            pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                             type: string
-                        type: object
-                      failOpen:
-                        description: If FailOpen is true, the client request is forwarded
-                          to the upstream service even if the authorization server
-                          fails to respond. This field should not be set in most cases.
-                          It is intended for use only while migrating applications
-                          from internal authorization to Contour external authorization.
-                        type: boolean
-                      responseTimeout:
-                        description: ResponseTimeout configures maximum time to wait
-                          for a check response from the authorization server. Timeout
-                          durations are expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
-                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
-                          "h". The string "infinity" is also a valid input and specifies
-                          no timeout.
-                        pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
-                        type: string
-                    required:
-                    - extensionRef
-                    type: object
-                  corsPolicy:
-                    description: Specifies the cross-origin policy to apply to the
-                      VirtualHost.
-                    properties:
-                      allowCredentials:
-                        description: Specifies whether the resource allows credentials.
-                        type: boolean
-                      allowHeaders:
-                        description: AllowHeaders specifies the content for the *access-control-allow-headers*
-                          header.
-                        items:
-                          description: CORSHeaderValue specifies the value of the
-                            string headers returned by a cross-domain request.
-                          pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
-                          type: string
-                        type: array
-                      allowMethods:
-                        description: AllowMethods specifies the content for the *access-control-allow-methods*
-                          header.
-                        items:
-                          description: CORSHeaderValue specifies the value of the
-                            string headers returned by a cross-domain request.
-                          pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
-                          type: string
-                        type: array
-                      allowOrigin:
-                        description: AllowOrigin specifies the origins that will be
-                          allowed to do CORS requests. "*" means allow any origin.
-                        items:
-                          type: string
-                        type: array
-                      exposeHeaders:
-                        description: ExposeHeaders Specifies the content for the *access-control-expose-headers*
-                          header.
-                        items:
-                          description: CORSHeaderValue specifies the value of the
-                            string headers returned by a cross-domain request.
-                          pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
-                          type: string
-                        type: array
-                      maxAge:
-                        description: MaxAge indicates for how long the results of
-                          a preflight request can be cached. MaxAge durations are
-                          expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
-                          Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
-                          "h". Only positive values are allowed while 0 disables the
-                          cache requiring a preflight OPTIONS check for all cross-origin
-                          requests.
-                        type: string
-                    required:
-                    - allowMethods
-                    - allowOrigin
-                    type: object
-                  fqdn:
-                    description: The fully qualified domain name of the root of the
-                      ingress tree all leaves of the DAG rooted at this object relate
-                      to the fqdn.
-                    pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    type: string
-                  rateLimitPolicy:
-                    description: The policy for rate limiting on the virtual host.
-                    properties:
-                      global:
-                        description: Global defines global rate limiting parameters,
-                          i.e. parameters defining descriptors that are sent to an
-                          external rate limit service (RLS) for a rate limit decision
-                          on each request.
-                        properties:
-                          descriptors:
-                            description: Descriptors defines the list of descriptors
-                              that will be generated and sent to the rate limit service.
-                              Each descriptor contains 1+ key-value pair entries.
-                            items:
-                              description: RateLimitDescriptor defines a list of key-value
-                                pair generators.
-                              properties:
-                                entries:
-                                  description: Entries is the list of key-value pair
-                                    generators.
-                                  items:
-                                    description: RateLimitDescriptorEntry is a key-value
-                                      pair generator. Exactly one field on this struct
-                                      must be non-nil.
-                                    properties:
-                                      genericKey:
-                                        description: GenericKey defines a descriptor
-                                          entry with a static key and value.
-                                        properties:
-                                          key:
-                                            description: Key defines the key of the
-                                              descriptor entry. If not set, the key
-                                              is set to "generic_key".
-                                            type: string
-                                          value:
-                                            description: Value defines the value of
-                                              the descriptor entry.
-                                            minLength: 1
-                                            type: string
-                                        type: object
-                                      remoteAddress:
-                                        description: RemoteAddress defines a descriptor
-                                          entry with a key of "remote_address" and
-                                          a value equal to the client's IP address
-                                          (from x-forwarded-for).
-                                        type: object
-                                      requestHeader:
-                                        description: RequestHeader defines a descriptor
-                                          entry that's populated only if a given header
-                                          is present on the request. The descriptor
-                                          key is static, and the descriptor value
-                                          is equal to the value of the header.
-                                        properties:
-                                          descriptorKey:
-                                            description: DescriptorKey defines the
-                                              key to use on the descriptor entry.
-                                            minLength: 1
-                                            type: string
-                                          headerName:
-                                            description: HeaderName defines the name
-                                              of the header to look for on the request.
-                                            minLength: 1
-                                            type: string
-                                        type: object
-                                      requestHeaderValueMatch:
-                                        description: RequestHeaderValueMatch defines
-                                          a descriptor entry that's populated if the
-                                          request's headers match a set of 1+ match
-                                          criteria. The descriptor key is "header_match",
-                                          and the descriptor value is static.
-                                        properties:
-                                          expectMatch:
-                                            default: true
-                                            description: ExpectMatch defines whether
-                                              the request must positively match the
-                                              match criteria in order to generate
-                                              a descriptor entry (i.e. true), or not
-                                              match the match criteria in order to
-                                              generate a descriptor entry (i.e. false).
-                                              The default is true.
-                                            type: boolean
-                                          headers:
-                                            description: Headers is a list of 1+ match
-                                              criteria to apply against the request
-                                              to determine whether to populate the
-                                              descriptor entry or not.
-                                            items:
-                                              description: HeaderMatchCondition specifies
-                                                how to conditionally match against
-                                                HTTP headers. The Name field is required,
-                                                but only one of the remaining fields
-                                                should be be provided.
-                                              properties:
-                                                contains:
-                                                  description: Contains specifies
-                                                    a substring that must be present
-                                                    in the header value.
-                                                  type: string
-                                                exact:
-                                                  description: Exact specifies a string
-                                                    that the header value must be
-                                                    equal to.
-                                                  type: string
-                                                name:
-                                                  description: Name is the name of
-                                                    the header to match against. Name
-                                                    is required. Header names are
-                                                    case insensitive.
-                                                  type: string
-                                                notcontains:
-                                                  description: NotContains specifies
-                                                    a substring that must not be present
-                                                    in the header value.
-                                                  type: string
-                                                notexact:
-                                                  description: NoExact specifies a
-                                                    string that the header value must
-                                                    not be equal to. The condition
-                                                    is true if the header has any
-                                                    other value.
-                                                  type: string
-                                                notpresent:
-                                                  description: NotPresent specifies
-                                                    that condition is true when the
-                                                    named header is not present. Note
-                                                    that setting NotPresent to false
-                                                    does not make the condition true
-                                                    if the named header is present.
-                                                  type: boolean
-                                                present:
-                                                  description: Present specifies that
-                                                    condition is true when the named
-                                                    header is present, regardless
-                                                    of its value. Note that setting
-                                                    Present to false does not make
-                                                    the condition true if the named
-                                                    header is absent.
-                                                  type: boolean
-                                              required:
-                                              - name
-                                              type: object
-                                            minItems: 1
-                                            type: array
-                                          value:
-                                            description: Value defines the value of
-                                              the descriptor entry.
-                                            minLength: 1
-                                            type: string
-                                        type: object
-                                    type: object
-                                  minItems: 1
-                                  type: array
-                              type: object
-                            minItems: 1
-                            type: array
-                        type: object
-                      local:
-                        description: Local defines local rate limiting parameters,
-                          i.e. parameters for rate limiting that occurs within each
-                          Envoy pod as requests are handled.
-                        properties:
-                          burst:
-                            description: Burst defines the number of requests above
-                              the requests per unit that should be allowed within
-                              a short period of time.
-                            format: int32
-                            type: integer
-                          requests:
-                            description: Requests defines how many requests per unit
-                              of time should be allowed before rate limiting occurs.
-                            format: int32
-                            minimum: 1
-                            type: integer
-                          responseHeadersToAdd:
-                            description: ResponseHeadersToAdd is an optional list
-                              of response headers to set when a request is rate-limited.
-                            items:
-                              description: HeaderValue represents a header name/value
-                                pair
-                              properties:
-                                name:
-                                  description: Name represents a key of a header
-                                  minLength: 1
-                                  type: string
-                                value:
-                                  description: Value represents the value of a header
-                                    specified by a key
-                                  minLength: 1
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          responseStatusCode:
-                            description: ResponseStatusCode is the HTTP status code
-                              to use for responses to rate-limited requests. Codes
-                              must be in the 400-599 range (inclusive). If not specified,
-                              the Envoy default of 429 (Too Many Requests) is used.
-                            format: int32
-                            maximum: 599
-                            minimum: 400
-                            type: integer
-                          unit:
-                            description: Unit defines the period of time within which
-                              requests over the limit will be rate limited. Valid
-                              values are "second", "minute" and "hour".
-                            enum:
-                            - second
-                            - minute
-                            - hour
+                          type: array
+                        allowMethods:
+                          description: AllowMethods specifies the content for the *access-control-allow-methods*
+                            header.
+                          items:
+                            description: CORSHeaderValue specifies the value of the
+                              string headers returned by a cross-domain request.
+                            pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
                             type: string
-                        required:
-                        - requests
-                        - unit
-                        type: object
-                    type: object
-                  tls:
-                    description: If present the fields describes TLS properties of
-                      the virtual host. The SNI names that will be matched on are
-                      described in fqdn, the tls.secretName secret must contain a
-                      certificate that itself contains a name that matches the FQDN.
-                    properties:
-                      clientValidation:
-                        description: "ClientValidation defines how to verify the client
+                          type: array
+                        allowOrigin:
+                          description: AllowOrigin specifies the origins that will be
+                            allowed to do CORS requests. "*" means allow any origin.
+                          items:
+                            type: string
+                          type: array
+                        exposeHeaders:
+                          description: ExposeHeaders Specifies the content for the *access-control-expose-headers*
+                            header.
+                          items:
+                            description: CORSHeaderValue specifies the value of the
+                              string headers returned by a cross-domain request.
+                            pattern: ^[a-zA-Z0-9!#$%&'*+.^_`|~-]+$
+                            type: string
+                          type: array
+                        maxAge:
+                          description: MaxAge indicates for how long the results of
+                            a preflight request can be cached. MaxAge durations are
+                            expressed in the Go [Duration format](https://godoc.org/time#ParseDuration).
+                            Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+                            "h". Only positive values are allowed while 0 disables the
+                            cache requiring a preflight OPTIONS check for all cross-origin
+                            requests.
+                          type: string
+                      required:
+                        - allowMethods
+                        - allowOrigin
+                      type: object
+                    fqdn:
+                      description: The fully qualified domain name of the root of the
+                        ingress tree all leaves of the DAG rooted at this object relate
+                        to the fqdn.
+                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    rateLimitPolicy:
+                      description: The policy for rate limiting on the virtual host.
+                      properties:
+                        global:
+                          description: Global defines global rate limiting parameters,
+                            i.e. parameters defining descriptors that are sent to an
+                            external rate limit service (RLS) for a rate limit decision
+                            on each request.
+                          properties:
+                            descriptors:
+                              description: Descriptors defines the list of descriptors
+                                that will be generated and sent to the rate limit service.
+                                Each descriptor contains 1+ key-value pair entries.
+                              items:
+                                description: RateLimitDescriptor defines a list of key-value
+                                  pair generators.
+                                properties:
+                                  entries:
+                                    description: Entries is the list of key-value pair
+                                      generators.
+                                    items:
+                                      description: RateLimitDescriptorEntry is a key-value
+                                        pair generator. Exactly one field on this struct
+                                        must be non-nil.
+                                      properties:
+                                        genericKey:
+                                          description: GenericKey defines a descriptor
+                                            entry with a static key and value.
+                                          properties:
+                                            key:
+                                              description: Key defines the key of the
+                                                descriptor entry. If not set, the key
+                                                is set to "generic_key".
+                                              type: string
+                                            value:
+                                              description: Value defines the value of
+                                                the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                        remoteAddress:
+                                          description: RemoteAddress defines a descriptor
+                                            entry with a key of "remote_address" and
+                                            a value equal to the client's IP address
+                                            (from x-forwarded-for).
+                                          type: object
+                                        requestHeader:
+                                          description: RequestHeader defines a descriptor
+                                            entry that's populated only if a given header
+                                            is present on the request. The descriptor
+                                            key is static, and the descriptor value
+                                            is equal to the value of the header.
+                                          properties:
+                                            descriptorKey:
+                                              description: DescriptorKey defines the
+                                                key to use on the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                            headerName:
+                                              description: HeaderName defines the name
+                                                of the header to look for on the request.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                        requestHeaderValueMatch:
+                                          description: RequestHeaderValueMatch defines
+                                            a descriptor entry that's populated if the
+                                            request's headers match a set of 1+ match
+                                            criteria. The descriptor key is "header_match",
+                                            and the descriptor value is static.
+                                          properties:
+                                            expectMatch:
+                                              default: true
+                                              description: ExpectMatch defines whether
+                                                the request must positively match the
+                                                match criteria in order to generate
+                                                a descriptor entry (i.e. true), or not
+                                                match the match criteria in order to
+                                                generate a descriptor entry (i.e. false).
+                                                The default is true.
+                                              type: boolean
+                                            headers:
+                                              description: Headers is a list of 1+ match
+                                                criteria to apply against the request
+                                                to determine whether to populate the
+                                                descriptor entry or not.
+                                              items:
+                                                description: HeaderMatchCondition specifies
+                                                  how to conditionally match against
+                                                  HTTP headers. The Name field is required,
+                                                  but only one of the remaining fields
+                                                  should be be provided.
+                                                properties:
+                                                  contains:
+                                                    description: Contains specifies
+                                                      a substring that must be present
+                                                      in the header value.
+                                                    type: string
+                                                  exact:
+                                                    description: Exact specifies a string
+                                                      that the header value must be
+                                                      equal to.
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name of
+                                                      the header to match against. Name
+                                                      is required. Header names are
+                                                      case insensitive.
+                                                    type: string
+                                                  notcontains:
+                                                    description: NotContains specifies
+                                                      a substring that must not be present
+                                                      in the header value.
+                                                    type: string
+                                                  notexact:
+                                                    description: NoExact specifies a
+                                                      string that the header value must
+                                                      not be equal to. The condition
+                                                      is true if the header has any
+                                                      other value.
+                                                    type: string
+                                                  notpresent:
+                                                    description: NotPresent specifies
+                                                      that condition is true when the
+                                                      named header is not present. Note
+                                                      that setting NotPresent to false
+                                                      does not make the condition true
+                                                      if the named header is present.
+                                                    type: boolean
+                                                  present:
+                                                    description: Present specifies that
+                                                      condition is true when the named
+                                                      header is present, regardless
+                                                      of its value. Note that setting
+                                                      Present to false does not make
+                                                      the condition true if the named
+                                                      header is absent.
+                                                    type: boolean
+                                                required:
+                                                  - name
+                                                type: object
+                                              minItems: 1
+                                              type: array
+                                            value:
+                                              description: Value defines the value of
+                                                the descriptor entry.
+                                              minLength: 1
+                                              type: string
+                                          type: object
+                                      type: object
+                                    minItems: 1
+                                    type: array
+                                type: object
+                              minItems: 1
+                              type: array
+                          type: object
+                        local:
+                          description: Local defines local rate limiting parameters,
+                            i.e. parameters for rate limiting that occurs within each
+                            Envoy pod as requests are handled.
+                          properties:
+                            burst:
+                              description: Burst defines the number of requests above
+                                the requests per unit that should be allowed within
+                                a short period of time.
+                              format: int32
+                              type: integer
+                            requests:
+                              description: Requests defines how many requests per unit
+                                of time should be allowed before rate limiting occurs.
+                              format: int32
+                              minimum: 1
+                              type: integer
+                            responseHeadersToAdd:
+                              description: ResponseHeadersToAdd is an optional list
+                                of response headers to set when a request is rate-limited.
+                              items:
+                                description: HeaderValue represents a header name/value
+                                  pair
+                                properties:
+                                  name:
+                                    description: Name represents a key of a header
+                                    minLength: 1
+                                    type: string
+                                  value:
+                                    description: Value represents the value of a header
+                                      specified by a key
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - name
+                                  - value
+                                type: object
+                              type: array
+                            responseStatusCode:
+                              description: ResponseStatusCode is the HTTP status code
+                                to use for responses to rate-limited requests. Codes
+                                must be in the 400-599 range (inclusive). If not specified,
+                                the Envoy default of 429 (Too Many Requests) is used.
+                              format: int32
+                              maximum: 599
+                              minimum: 400
+                              type: integer
+                            unit:
+                              description: Unit defines the period of time within which
+                                requests over the limit will be rate limited. Valid
+                                values are "second", "minute" and "hour".
+                              enum:
+                                - second
+                                - minute
+                                - hour
+                              type: string
+                          required:
+                            - requests
+                            - unit
+                          type: object
+                      type: object
+                    tls:
+                      description: If present the fields describes TLS properties of
+                        the virtual host. The SNI names that will be matched on are
+                        described in fqdn, the tls.secretName secret must contain a
+                        certificate that itself contains a name that matches the FQDN.
+                      properties:
+                        clientValidation:
+                          description: "ClientValidation defines how to verify the client
                           certificate when an external client establishes a TLS connection
                           to Envoy. \n This setting: \n 1. Enables TLS client certificate
                           validation. 2. Specifies how the client certificate will
@@ -1629,65 +1695,65 @@ spec:
                           should be only used in conjunction with an external authorization
                           server that performs client validation as Contour will ensure
                           client certificates are passed along."
-                        properties:
-                          caSecret:
-                            description: Name of a Kubernetes secret that contains
-                              a CA certificate bundle. The client certificate must
-                              validate against the certificates in the bundle. If
-                              specified and SkipClientCertValidation is true, client
-                              certificates will be required on requests.
-                            minLength: 1
-                            type: string
-                          skipClientCertValidation:
-                            description: SkipClientCertValidation disables downstream
-                              client certificate validation. Defaults to false. This
-                              field is intended to be used in conjunction with external
-                              authorization in order to enable the external authorization
-                              server to validate client certificates. When this field
-                              is set to true, client certificates are requested but
-                              not verified by Envoy. If CACertificate is specified,
-                              client certificates are required on requests, but not
-                              verified. If external authorization is in use, they
-                              are presented to the external authorization server.
-                            type: boolean
-                        type: object
-                      enableFallbackCertificate:
-                        description: EnableFallbackCertificate defines if the vhost
-                          should allow a default certificate to be applied which handles
-                          all requests which don't match the SNI defined in this vhost.
-                        type: boolean
-                      minimumProtocolVersion:
-                        description: MinimumProtocolVersion is the minimum TLS version
-                          this vhost should negotiate. Valid options are `1.2` (default)
-                          and `1.3`. Any other value defaults to TLS 1.2.
-                        type: string
-                      passthrough:
-                        description: Passthrough defines whether the encrypted TLS
-                          handshake will be passed through to the backing cluster.
-                          Either Passthrough or SecretName must be specified, but
-                          not both.
-                        type: boolean
-                      secretName:
-                        description: SecretName is the name of a TLS secret in the
-                          current namespace. Either SecretName or Passthrough must
-                          be specified, but not both. If specified, the named secret
-                          must contain a matching certificate for the virtual host's
-                          FQDN.
-                        type: string
-                    type: object
-                required:
-                - fqdn
-                type: object
-            type: object
-          status:
-            default:
-              currentStatus: NotReconciled
-              description: Waiting for controller
-            description: Status is a container for computed information about the
-              HTTPProxy.
-            properties:
-              conditions:
-                description: "Conditions contains information about the current status
+                          properties:
+                            caSecret:
+                              description: Name of a Kubernetes secret that contains
+                                a CA certificate bundle. The client certificate must
+                                validate against the certificates in the bundle. If
+                                specified and SkipClientCertValidation is true, client
+                                certificates will be required on requests.
+                              minLength: 1
+                              type: string
+                            skipClientCertValidation:
+                              description: SkipClientCertValidation disables downstream
+                                client certificate validation. Defaults to false. This
+                                field is intended to be used in conjunction with external
+                                authorization in order to enable the external authorization
+                                server to validate client certificates. When this field
+                                is set to true, client certificates are requested but
+                                not verified by Envoy. If CACertificate is specified,
+                                client certificates are required on requests, but not
+                                verified. If external authorization is in use, they
+                                are presented to the external authorization server.
+                              type: boolean
+                          type: object
+                        enableFallbackCertificate:
+                          description: EnableFallbackCertificate defines if the vhost
+                            should allow a default certificate to be applied which handles
+                            all requests which don't match the SNI defined in this vhost.
+                          type: boolean
+                        minimumProtocolVersion:
+                          description: MinimumProtocolVersion is the minimum TLS version
+                            this vhost should negotiate. Valid options are `1.2` (default)
+                            and `1.3`. Any other value defaults to TLS 1.2.
+                          type: string
+                        passthrough:
+                          description: Passthrough defines whether the encrypted TLS
+                            handshake will be passed through to the backing cluster.
+                            Either Passthrough or SecretName must be specified, but
+                            not both.
+                          type: boolean
+                        secretName:
+                          description: SecretName is the name of a TLS secret in the
+                            current namespace. Either SecretName or Passthrough must
+                            be specified, but not both. If specified, the named secret
+                            must contain a matching certificate for the virtual host's
+                            FQDN.
+                          type: string
+                      type: object
+                  required:
+                    - fqdn
+                  type: object
+              type: object
+            status:
+              default:
+                currentStatus: NotReconciled
+                description: Waiting for controller
+              description: Status is a container for computed information about the
+                HTTPProxy.
+              properties:
+                conditions:
+                  description: "Conditions contains information about the current status
                   of the HTTPProxy, in an upstream-friendly container. \n Contour
                   will update a single condition, `Valid`, that is in normal-true
                   polarity. That is, when `currentStatus` is `valid`, the `Valid`
@@ -1696,8 +1762,8 @@ spec:
                   some other controller wants to add a Condition. \n If you are another
                   controller owner and wish to add a condition, you *should* namespace
                   your condition with a label, like `controller.domain.com/ConditionName`."
-                items:
-                  description: "DetailedCondition is an extension of the normal Kubernetes
+                  items:
+                    description: "DetailedCondition is an extension of the normal Kubernetes
                     conditions, with two extra fields to hold sub-conditions, which
                     provide more detailed reasons for the state (True or False) of
                     the condition. \n `errors` holds information about sub-conditions
@@ -1726,14 +1792,14 @@ spec:
                     the detail of the reason (if there is one and only one entry in
                     total across both the `errors` and `warnings` slices), or `MultipleReasons`
                     if there is more than one entry."
-                  properties:
-                    errors:
-                      description: "Errors contains a slice of relevant error subconditions
+                    properties:
+                      errors:
+                        description: "Errors contains a slice of relevant error subconditions
                         for this object. \n Subconditions are expected to appear when
                         relevant (when there is a error), and disappear when not relevant.
                         An empty slice here indicates no errors."
-                      items:
-                        description: "SubCondition is a Condition-like type intended
+                        items:
+                          description: "SubCondition is a Condition-like type intended
                           for use as a subcondition inside a DetailedCondition. \n
                           It contains a subset of the Condition fields. \n It is intended
                           for warnings and errors, so `type` names should use abnormal-true
@@ -1741,103 +1807,103 @@ spec:
                           true\". \n The expected lifecycle for these errors is that
                           they should only be present when the error or warning is,
                           and should be removed when they are not relevant."
-                        properties:
-                          message:
-                            description: "Message is a human readable message indicating
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
                               details about the transition. \n This may be an empty
                               string."
-                            maxLength: 32768
-                            type: string
-                          reason:
-                            description: "Reason contains a programmatic identifier
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
                               indicating the reason for the condition's last transition.
                               Producers of specific condition types may define expected
                               values and meanings for this field, and whether the
                               values are considered a guaranteed API. \n The value
                               should be a CamelCase string. \n This field may not
                               be empty."
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
                               \n This must be in abnormal-true polarity, that is,
                               `ErrorFound` or `controller.io/ErrorFound`. \n The regex
                               it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                    warnings:
-                      description: "Warnings contains a slice of relevant warning
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition
+                          transitioned from one status to another. This should be when
+                          the underlying condition changed.  If that is not known, then
+                          using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating
+                          details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if .metadata.generation
+                          is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition. Producers
+                          of specific condition types may define expected values and
+                          meanings for this field, and whether the values are considered
+                          a guaranteed API. The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          --- Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                      warnings:
+                        description: "Warnings contains a slice of relevant warning
                         subconditions for this object. \n Subconditions are expected
                         to appear when relevant (when there is a warning), and disappear
                         when not relevant. An empty slice here indicates no warnings."
-                      items:
-                        description: "SubCondition is a Condition-like type intended
+                        items:
+                          description: "SubCondition is a Condition-like type intended
                           for use as a subcondition inside a DetailedCondition. \n
                           It contains a subset of the Condition fields. \n It is intended
                           for warnings and errors, so `type` names should use abnormal-true
@@ -1845,92 +1911,92 @@ spec:
                           true\". \n The expected lifecycle for these errors is that
                           they should only be present when the error or warning is,
                           and should be removed when they are not relevant."
-                        properties:
-                          message:
-                            description: "Message is a human readable message indicating
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
                               details about the transition. \n This may be an empty
                               string."
-                            maxLength: 32768
-                            type: string
-                          reason:
-                            description: "Reason contains a programmatic identifier
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
                               indicating the reason for the condition's last transition.
                               Producers of specific condition types may define expected
                               values and meanings for this field, and whether the
                               values are considered a guaranteed API. \n The value
                               should be a CamelCase string. \n This field may not
                               be empty."
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
                               \n This must be in abnormal-true polarity, that is,
                               `ErrorFound` or `controller.io/ErrorFound`. \n The regex
                               it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-              currentStatus:
-                type: string
-              description:
-                type: string
-              loadBalancer:
-                description: LoadBalancer contains the current status of the load
-                  balancer.
-                properties:
-                  ingress:
-                    description: Ingress is a list containing ingress points for the
-                      load-balancer. Traffic intended for the service should be sent
-                      to these ingress points.
-                    items:
-                      description: 'LoadBalancerIngress represents the status of a
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                currentStatus:
+                  type: string
+                description:
+                  type: string
+                loadBalancer:
+                  description: LoadBalancer contains the current status of the load
+                    balancer.
+                  properties:
+                    ingress:
+                      description: Ingress is a list containing ingress points for the
+                        load-balancer. Traffic intended for the service should be sent
+                        to these ingress points.
+                      items:
+                        description: 'LoadBalancerIngress represents the status of a
                         load-balancer ingress point: traffic intended for the service
                         should be sent to an ingress point.'
-                      properties:
-                        hostname:
-                          description: Hostname is set for load-balancer ingress points
-                            that are DNS based (typically AWS load-balancers)
-                          type: string
-                        ip:
-                          description: IP is set for load-balancer ingress points
-                            that are IP based (typically GCE or OpenStack load-balancers)
-                          type: string
-                        ports:
-                          description: Ports is a list of records of service ports
-                            If used, every port defined in the service should have
-                            an entry in it
-                          items:
-                            properties:
-                              error:
-                                description: 'Error is to record the problem with
+                        properties:
+                          hostname:
+                            description: Hostname is set for load-balancer ingress points
+                              that are DNS based (typically AWS load-balancers)
+                            type: string
+                          ip:
+                            description: IP is set for load-balancer ingress points
+                              that are IP based (typically GCE or OpenStack load-balancers)
+                            type: string
+                          ports:
+                            description: Ports is a list of records of service ports
+                              If used, every port defined in the service should have
+                              an entry in it
+                            items:
+                              properties:
+                                error:
+                                  description: 'Error is to record the problem with
                                   the service port The format of the error shall comply
                                   with the following rules: - built-in error values
                                   shall be specified in this file and those shall
@@ -1938,41 +2004,35 @@ spec:
                                   error values must have names that comply with the   format
                                   foo.example.com/CamelCase. --- The regex it matches
                                   is (dns1123SubdomainFmt/)?(qualifiedNameFmt)'
-                                maxLength: 316
-                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                                type: string
-                              port:
-                                description: Port is the port number of the service
-                                  port of which status is recorded here
-                                format: int32
-                                type: integer
-                              protocol:
-                                default: TCP
-                                description: 'Protocol is the protocol of the service
+                                  maxLength: 316
+                                  pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                  type: string
+                                port:
+                                  description: Port is the port number of the service
+                                    port of which status is recorded here
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  description: 'Protocol is the protocol of the service
                                   port of which status is recorded here The supported
                                   values are: "TCP", "UDP", "SCTP"'
-                                type: string
-                            required:
-                            - port
-                            - protocol
-                            type: object
-                          type: array
-                          x-kubernetes-list-type: atomic
-                      type: object
-                    type: array
-                type: object
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                                  type: string
+                              required:
+                                - port
+                                - protocol
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/bitnami/contour/resources/tlscertificatedeligations.yaml
+++ b/bitnami/contour/resources/tlscertificatedeligations.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
   name: tlscertificatedelegations.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -13,62 +12,62 @@ spec:
     listKind: TLSCertificateDelegationList
     plural: tlscertificatedelegations
     shortNames:
-    - tlscerts
+      - tlscerts
     singular: tlscertificatedelegation
   scope: Namespaced
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: TLSCertificateDelegation is an TLS Certificate Delegation CRD
-          specification. See design/tls-certificate-delegation.md for details.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: TLSCertificateDelegation is an TLS Certificate Delegation CRD
+            specification. See design/tls-certificate-delegation.md for details.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: TLSCertificateDelegationSpec defines the spec of the CRD
-            properties:
-              delegations:
-                items:
-                  description: CertificateDelegation maps the authority to reference
-                    a secret in the current namespace to a set of namespaces.
-                  properties:
-                    secretName:
-                      description: required, the name of a secret in the current namespace.
-                      type: string
-                    targetNamespaces:
-                      description: required, the namespaces the authority to reference
-                        the the secret will be delegated to. If TargetNamespaces is
-                        nil or empty, the CertificateDelegation' is ignored. If the
-                        TargetNamespace list contains the character, "*" the secret
-                        will be delegated to all namespaces.
-                      items:
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: TLSCertificateDelegationSpec defines the spec of the CRD
+              properties:
+                delegations:
+                  items:
+                    description: CertificateDelegation maps the authority to reference
+                      a secret in the current namespace to a set of namespaces.
+                    properties:
+                      secretName:
+                        description: required, the name of a secret in the current namespace.
                         type: string
-                      type: array
-                  required:
-                  - secretName
-                  - targetNamespaces
-                  type: object
-                type: array
-            required:
-            - delegations
-            type: object
-          status:
-            description: TLSCertificateDelegationStatus allows for the status of the
-              delegation to be presented to the user.
-            properties:
-              conditions:
-                description: "Conditions contains information about the current status
+                      targetNamespaces:
+                        description: required, the namespaces the authority to reference
+                          the the secret will be delegated to. If TargetNamespaces is
+                          nil or empty, the CertificateDelegation' is ignored. If the
+                          TargetNamespace list contains the character, "*" the secret
+                          will be delegated to all namespaces.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - secretName
+                      - targetNamespaces
+                    type: object
+                  type: array
+              required:
+                - delegations
+              type: object
+            status:
+              description: TLSCertificateDelegationStatus allows for the status of the
+                delegation to be presented to the user.
+              properties:
+                conditions:
+                  description: "Conditions contains information about the current status
                   of the HTTPProxy, in an upstream-friendly container. \n Contour
                   will update a single condition, `Valid`, that is in normal-true
                   polarity. That is, when `currentStatus` is `valid`, the `Valid`
@@ -77,8 +76,8 @@ spec:
                   some other controller wants to add a Condition. \n If you are another
                   controller owner and wish to add a condition, you *should* namespace
                   your condition with a label, like `controller.domain.com\\ConditionName`."
-                items:
-                  description: "DetailedCondition is an extension of the normal Kubernetes
+                  items:
+                    description: "DetailedCondition is an extension of the normal Kubernetes
                     conditions, with two extra fields to hold sub-conditions, which
                     provide more detailed reasons for the state (True or False) of
                     the condition. \n `errors` holds information about sub-conditions
@@ -107,14 +106,14 @@ spec:
                     the detail of the reason (if there is one and only one entry in
                     total across both the `errors` and `warnings` slices), or `MultipleReasons`
                     if there is more than one entry."
-                  properties:
-                    errors:
-                      description: "Errors contains a slice of relevant error subconditions
+                    properties:
+                      errors:
+                        description: "Errors contains a slice of relevant error subconditions
                         for this object. \n Subconditions are expected to appear when
                         relevant (when there is a error), and disappear when not relevant.
                         An empty slice here indicates no errors."
-                      items:
-                        description: "SubCondition is a Condition-like type intended
+                        items:
+                          description: "SubCondition is a Condition-like type intended
                           for use as a subcondition inside a DetailedCondition. \n
                           It contains a subset of the Condition fields. \n It is intended
                           for warnings and errors, so `type` names should use abnormal-true
@@ -122,103 +121,103 @@ spec:
                           true\". \n The expected lifecycle for these errors is that
                           they should only be present when the error or warning is,
                           and should be removed when they are not relevant."
-                        properties:
-                          message:
-                            description: "Message is a human readable message indicating
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
                               details about the transition. \n This may be an empty
                               string."
-                            maxLength: 32768
-                            type: string
-                          reason:
-                            description: "Reason contains a programmatic identifier
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
                               indicating the reason for the condition's last transition.
                               Producers of specific condition types may define expected
                               values and meanings for this field, and whether the
                               values are considered a guaranteed API. \n The value
                               should be a CamelCase string. \n This field may not
                               be empty."
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
                               \n This must be in abnormal-true polarity, that is,
                               `ErrorFound` or `controller.io/ErrorFound`. \n The regex
                               it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                    warnings:
-                      description: "Warnings contains a slice of relevant warning
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition
+                          transitioned from one status to another. This should be when
+                          the underlying condition changed.  If that is not known, then
+                          using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating
+                          details about the transition. This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation
+                          that the condition was set based upon. For instance, if .metadata.generation
+                          is currently 12, but the .status.conditions[x].observedGeneration
+                          is 9, the condition is out of date with respect to the current
+                          state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating
+                          the reason for the condition's last transition. Producers
+                          of specific condition types may define expected values and
+                          meanings for this field, and whether the values are considered
+                          a guaranteed API. The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          --- Many .condition.type values are consistent across resources
+                          like Available, but because arbitrary conditions can be useful
+                          (see .node.status.conditions), the ability to deconflict is
+                          important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                      warnings:
+                        description: "Warnings contains a slice of relevant warning
                         subconditions for this object. \n Subconditions are expected
                         to appear when relevant (when there is a warning), and disappear
                         when not relevant. An empty slice here indicates no warnings."
-                      items:
-                        description: "SubCondition is a Condition-like type intended
+                        items:
+                          description: "SubCondition is a Condition-like type intended
                           for use as a subcondition inside a DetailedCondition. \n
                           It contains a subset of the Condition fields. \n It is intended
                           for warnings and errors, so `type` names should use abnormal-true
@@ -226,71 +225,65 @@ spec:
                           true\". \n The expected lifecycle for these errors is that
                           they should only be present when the error or warning is,
                           and should be removed when they are not relevant."
-                        properties:
-                          message:
-                            description: "Message is a human readable message indicating
+                          properties:
+                            message:
+                              description: "Message is a human readable message indicating
                               details about the transition. \n This may be an empty
                               string."
-                            maxLength: 32768
-                            type: string
-                          reason:
-                            description: "Reason contains a programmatic identifier
+                              maxLength: 32768
+                              type: string
+                            reason:
+                              description: "Reason contains a programmatic identifier
                               indicating the reason for the condition's last transition.
                               Producers of specific condition types may define expected
                               values and meanings for this field, and whether the
                               values are considered a guaranteed API. \n The value
                               should be a CamelCase string. \n This field may not
                               be empty."
-                            maxLength: 1024
-                            minLength: 1
-                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                            type: string
-                          status:
-                            description: Status of the condition, one of True, False,
-                              Unknown.
-                            enum:
-                            - "True"
-                            - "False"
-                            - Unknown
-                            type: string
-                          type:
-                            description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: Status of the condition, one of True, False,
+                                Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
                               \n This must be in abnormal-true polarity, that is,
                               `ErrorFound` or `controller.io/ErrorFound`. \n The regex
                               it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                            maxLength: 316
-                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                            type: string
-                        required:
-                        - message
-                        - reason
-                        - status
-                        - type
-                        type: object
-                      type: array
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-                x-kubernetes-list-map-keys:
-                - type
-                x-kubernetes-list-type: map
-            type: object
-        required:
-        - metadata
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        type: array
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - metadata
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -92,7 +92,7 @@ contour:
   image:
     registry: docker.io
     repository: bitnami/contour
-    tag: 1.20.1-debian-10-r2
+    tag: 1.20.1-debian-10-r13
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -421,7 +421,7 @@ envoy:
   image:
     registry: docker.io
     repository: bitnami/envoy
-    tag: 1.21.1-debian-10-r3
+    tag: 1.21.1-debian-10-r13
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -799,7 +799,7 @@ defaultBackend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.21.6-debian-10-r29
+    tag: 1.21.6-debian-10-r39
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 7.6.17
+version: 7.7.0

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -419,6 +419,22 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `["infinity"]` |
 
 
+### Security Parameters
+
+| Name                       | Description                                                                        | Value          |
+|----------------------------|------------------------------------------------------------------------------------| -------------- |
+| `security.allow_embedding` | Allow embedding grafana dashboards in other frames on other websites (e.g. iFrame) | `false`        |
+
+
+### Auth Anonymous Parameters
+
+| Name                      | Description                                                                                                 | Value   |
+|---------------------------|-------------------------------------------------------------------------------------------------------------|---------|
+| `auth_anonymous.enabled`  | Enable anonymous authentication for presenting the dashboards.                                              | `false` |
+| `auth_anonymous.org_name` | Organization name that should be used for unauthenticated users. You find the organization in preferences.  | ""      |
+| `auth_anonymous.org_role` | Role for unauthenticated users. Valid values are `Editor`, `Admin` and `Viewer`.                            | ""      |
+
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -125,6 +125,18 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.extraEnvVarsSecret "context" $) }}
             {{- end }}
           env:
+            {{- if .Values.auth_anonymous.enabled }}
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_NAME
+              value: {{ .Values.auth_anonymous.org_name }}
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: {{ .Values.auth_anonymous.org_role }}
+            {{- end }}
+            {{- if .Values.security.allow_embedding }}
+            - name: GF_SECURITY_ALLOW_EMBEDDING
+              value: "true"
+            {{- end }}
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -1028,3 +1028,27 @@ diagnosticMode:
   ##
   args:
     - infinity
+
+## @section Security Parameters
+
+## Allow embedding
+##
+security:
+  ## @param security.allow_embedding Allow embedding grafana dashboards in other frames on other websites (e.g. iFrame)
+  ##
+  allow_embedding: false
+
+## @section Auth Anonymous Parameters
+
+## Enable anonymous authentication
+##
+auth_anonymous:
+  ## @param Enable anonymous authentication for presenting the dashboards.
+  ##
+  enabled: false
+  ## @param Organization name that should be used for unauthenticated users. You find the organization in preferences.
+  ##
+  org_name: ""
+  ## @param Role for unauthenticated users. Valid values are `Editor`, `Admin` and `Viewer`.
+  ##
+  org_role: ""

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 7.3.0
+version: 7.3.1

--- a/bitnami/redis-cluster/templates/scripts-configmap.yaml
+++ b/bitnami/redis-cluster/templates/scripts-configmap.yaml
@@ -38,7 +38,7 @@ data:
 {{- end }}
         ping
     )
-    if [ $? == 124 ]; then
+    if [[ "$?" -eq "124" ]]; then
       echo "Timed out"
       exit 1
     fi
@@ -63,7 +63,7 @@ data:
   {{- end }}
           CLUSTER INFO | grep cluster_state | tr -d '[:space:]'
       )
-      if [ $? == 124 ]; then
+      if [[ "$?" -eq "124" ]]; then
         echo "Timed out"
         exit 1
       fi
@@ -100,7 +100,7 @@ data:
 {{- end }}
         ping
     )
-    if [ $? == 124 ]; then
+    if [[ "$?" -eq "124" ]]; then
       echo "Timed out"
       exit 1
     fi

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.5.0
+version: 16.5.1

--- a/bitnami/redis/templates/health-configmap.yaml
+++ b/bitnami/redis/templates/health-configmap.yaml
@@ -33,7 +33,7 @@ data:
 {{- end }}
         ping
     )
-    if [ $? == 124 ]; then
+    if [[ "$?" -eq "124" ]]; then
       echo "Timed out"
       exit 1
     fi
@@ -63,7 +63,7 @@ data:
 {{- end }}
         ping
     )
-    if [ $? == 124 ]; then
+    if [[ "$?" -eq "124" ]]; then
       echo "Timed out"
       exit 1
     fi
@@ -97,7 +97,7 @@ data:
 {{- end }}
         ping
     )
-    if [ $? == 124 ]; then
+    if [[ "$?" -eq "124" ]]; then
       echo "Timed out"
       exit 1
     fi
@@ -141,7 +141,7 @@ data:
 {{- end }}
         ping
     )
-    if [ $? == 124 ]; then
+    if [[ "$?" -eq "124" ]]; then
       echo "Timed out"
       exit 1
     fi
@@ -169,7 +169,7 @@ data:
 {{- end }}
         ping
     )
-    if [ $? == 124 ]; then
+    if [[ "$?" -eq "124" ]]; then
       echo "Timed out"
       exit 1
     fi


### PR DESCRIPTION
**Description of the change**

You can allow embedding for grafana dashboards in other websites with anonymous authentication

**Benefits**

You can allow embedding for grafana dashboards in other websites with anonymous authentication

**Possible drawbacks**

Nothing

**Applicable issues**

  - fixes no issue only my own one.

**Additional information**


**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)