### PR TITLE
[bitnami/grafana] Added anonymous auth for embedding

### DIFF
--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana
   - https://grafana.com/
-version: 7.6.17
+version: 7.7.0

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -419,6 +419,22 @@ This solution allows to easily deploy multiple Grafana instances compared to the
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `["infinity"]` |
 
 
+### Security Parameters
+
+| Name                       | Description                                                                        | Value          |
+|----------------------------|------------------------------------------------------------------------------------| -------------- |
+| `security.allow_embedding` | Allow embedding grafana dashboards in other frames on other websites (e.g. iFrame) | `false`        |
+
+
+### Auth Anonymous Parameters
+
+| Name                      | Description                                                                                                 | Value   |
+|---------------------------|-------------------------------------------------------------------------------------------------------------|---------|
+| `auth_anonymous.enabled`  | Enable anonymous authentication for presenting the dashboards.                                              | `false` |
+| `auth_anonymous.org_name` | Organization name that should be used for unauthenticated users. You find the organization in preferences.  | ""      |
+| `auth_anonymous.org_role` | Role for unauthenticated users. Valid values are `Editor`, `Admin` and `Viewer`.                            | ""      |
+
+
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console

--- a/bitnami/grafana/templates/deployment.yaml
+++ b/bitnami/grafana/templates/deployment.yaml
@@ -125,6 +125,18 @@ spec:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.grafana.extraEnvVarsSecret "context" $) }}
             {{- end }}
           env:
+            {{- if .Values.auth_anonymous.enabled }}
+            - name: GF_AUTH_ANONYMOUS_ENABLED
+              value: "true"
+            - name: GF_AUTH_ANONYMOUS_ORG_NAME
+              value: {{ .Values.auth_anonymous.org_name }}
+            - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+              value: {{ .Values.auth_anonymous.org_role }}
+            {{- end }}
+            {{- if .Values.security.allow_embedding }}
+            - name: GF_SECURITY_ALLOW_EMBEDDING
+              value: "true"
+            {{- end }}
             - name: GF_SECURITY_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -1028,3 +1028,27 @@ diagnosticMode:
   ##
   args:
     - infinity
+
+## @section Security Parameters
+
+## Allow embedding
+##
+security:
+  ## @param security.allow_embedding Allow embedding grafana dashboards in other frames on other websites (e.g. iFrame)
+  ##
+  allow_embedding: false
+
+## @section Auth Anonymous Parameters
+
+## Enable anonymous authentication
+##
+auth_anonymous:
+  ## @param Enable anonymous authentication for presenting the dashboards.
+  ##
+  enabled: false
+  ## @param Organization name that should be used for unauthenticated users. You find the organization in preferences.
+  ##
+  org_name: ""
+  ## @param Role for unauthenticated users. Valid values are `Editor`, `Admin` and `Viewer`.
+  ##
+  org_role: ""

--- a/bitnami/grafana/values.yaml
+++ b/bitnami/grafana/values.yaml
@@ -1043,12 +1043,12 @@ security:
 ## Enable anonymous authentication
 ##
 auth_anonymous:
-  ## @param Enable anonymous authentication for presenting the dashboards.
+  ## @param auth_anonymous.enabled Enable anonymous authentication for presenting the dashboards.
   ##
   enabled: false
-  ## @param Organization name that should be used for unauthenticated users. You find the organization in preferences.
+  ## @param auth_anonymous.org_name Organization name that should be used for unauthenticated users. You find the organization in preferences.
   ##
   org_name: ""
-  ## @param Role for unauthenticated users. Valid values are `Editor`, `Admin` and `Viewer`.
+  ## @param auth_anonymous.org_role Role for unauthenticated users. Valid values are `Editor`, `Admin` and `Viewer`.
   ##
   org_role: ""


### PR DESCRIPTION
Signed-off-by: Christian Neufeld <c.neufeld@comanu.de>

**Description of the change**

I added the values for anonymous authentication and allow embedding.

**Benefits**

It is possible to allow embedding and enable anonymous authentication now.

**Possible drawbacks**

Nothing

**Applicable issues**

- just fix own issue

**Additional information**



**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)