### PR TITLE
[bitnami/kong] Chart standardized

### DIFF
--- a/bitnami/kong/Chart.lock
+++ b/bitnami/kong/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.4
+  version: 11.1.6
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.11.3
 - name: cassandra
   repository: https://charts.bitnami.com/bitnami
   version: 9.1.8
-digest: sha256:18641429d851b580e6c6598fd1b50f39330b0ef08d8af063457e22082b38c2af
-generated: "2022-03-09T11:27:59.574608+01:00"
+digest: sha256:f7148bdf098a9685a5b57b8b81b92efa9235d9bfefa5b9fe08301fa4bcba79e3
+generated: "2022-03-11T12:10:22.396029162Z"

--- a/bitnami/kong/Chart.lock
+++ b/bitnami/kong/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.3
+  version: 11.1.4
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.11.3
 - name: cassandra
   repository: https://charts.bitnami.com/bitnami
   version: 9.1.8
-digest: sha256:c3015c160b6aa8096402b02ef926054010c7abf3100b32a6a1fb57eb0e162a59
-generated: "2022-03-04T15:39:01.294999811Z"
+digest: sha256:18641429d851b580e6c6598fd1b50f39330b0ef08d8af063457e22082b38c2af
+generated: "2022-03-09T11:27:59.574608+01:00"

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 2.7.1
+appVersion: 2.8.0
 dependencies:
   - condition: postgresql.enabled
     name: postgresql

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -34,4 +34,4 @@ name: kong
 sources:
   - https://github.com/bitnami/bitnami-docker-kong
   - https://konghq.com/
-version: 6.0.2
+version: 6.1.0

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -126,7 +126,7 @@ To uninstall/delete the `my-release` deployment:
 | `autoscaling.minReplicas`               | Minimum number of replicas to scale back                                                                                           | `2`                   |
 | `autoscaling.maxReplicas`               | Maximum number of replicas to scale out                                                                                            | `5`                   |
 | `autoscaling.metrics`                   | Metrics to use when deciding to scale the deployment (evaluated as a template)                                                     | `[]`                  |
-| `pdb.enabled`                           | Deploy a PodDisruptionBudget object for Kong deployment                                                                            | `false`               |
+| `pdb.create`                            | Deploy a PodDisruptionBudget object for Kong deployment                                                                            | `false`               |
 | `pdb.minAvailable`                      | Minimum available Kong replicas (expressed in percentage)                                                                          | `""`                  |
 | `pdb.maxUnavailable`                    | Maximum unavailable Kong replicas (expressed in percentage)                                                                        | `50%`                 |
 
@@ -215,7 +215,6 @@ To uninstall/delete the `my-release` deployment:
 | Name                                                            | Description                                                                                                                                   | Value                             |
 | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
 | `ingressController.enabled`                                     | Enable/disable the Kong Ingress Controller                                                                                                    | `true`                            |
-| `ingressController.customResourceDeletePolicy`                  | Add custom CRD resource delete policy (for Helm 2 support)                                                                                    | `{}`                              |
 | `ingressController.image.registry`                              | Kong Ingress Controller image registry                                                                                                        | `docker.io`                       |
 | `ingressController.image.repository`                            | Kong Ingress Controller image name                                                                                                            | `bitnami/kong-ingress-controller` |
 | `ingressController.image.tag`                                   | Kong Ingress Controller image tag                                                                                                             | `2.2.1-debian-10-r9`              |
@@ -276,6 +275,8 @@ To uninstall/delete the `my-release` deployment:
 | `migration.resources.requests` | The requested resources for the container                                                                                  | `{}`  |
 | `migration.hostAliases`        | Add deployment host aliases                                                                                                | `[]`  |
 | `migration.annotations`        | Add annotations to the job                                                                                                 | `{}`  |
+| `migration.podLabels`          | Additional pod labels                                                                                                      | `{}`  |
+| `migration.podAnnotations`     | Additional pod annotations                                                                                                 | `{}`  |
 
 
 ### PostgreSQL Parameters
@@ -311,6 +312,7 @@ To uninstall/delete the `my-release` deployment:
 | `cassandra.dbUser.password`                    | Password for `cassandra.dbUser.user`. Randomly generated if empty        | `""`    |
 | `cassandra.dbUser.existingSecret`              | Name of existing secret to use for Cassandra credentials                 | `""`    |
 | `cassandra.usePasswordFile`                    | Mount credentials as a files instead of using an environment variable    | `false` |
+| `cassandra.replicaCount`                       | Number of Cassandra replicas                                             | `1`     |
 | `cassandra.external.hosts`                     | List of Cassandra hosts                                                  | `[]`    |
 | `cassandra.external.port`                      | Cassandra port number                                                    | `9042`  |
 | `cassandra.external.user`                      | Username of the external cassandra installation                          | `""`    |
@@ -321,25 +323,26 @@ To uninstall/delete the `my-release` deployment:
 
 ### Metrics Parameters
 
-| Name                                       | Description                                                                           | Value       |
-| ------------------------------------------ | ------------------------------------------------------------------------------------- | ----------- |
-| `metrics.enabled`                          | Enable the export of Prometheus metrics                                               | `false`     |
-| `metrics.containerPorts.http`              | Prometheus metrics HTTP container port                                                | `9119`      |
-| `metrics.service.annotations`              | Annotations for Prometheus metrics service                                            | `{}`        |
-| `metrics.service.type`                     | Type of the Prometheus metrics service                                                | `ClusterIP` |
-| `metrics.service.ports.http`               | Prometheus metrics service HTTP port                                                  | `9119`      |
-| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator          | `false`     |
-| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                              | `""`        |
-| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                           | `30s`       |
-| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                   | `""`        |
-| `metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`        |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                   | `{}`        |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                    | `[]`        |
-| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                             | `[]`        |
-| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels              | `false`     |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.     | `""`        |
-| `metrics.serviceMonitor.serviceAccount`    | Service account used by Prometheus Operator                                           | `""`        |
-| `metrics.serviceMonitor.rbac.create`       | Create the necessary RBAC resources so Prometheus Operator can reach Kong's namespace | `true`      |
+| Name                                       | Description                                                                           | Value   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------- | ------- |
+| `metrics.enabled`                          | Enable the export of Prometheus metrics                                               | `false` |
+| `metrics.containerPorts.http`              | Prometheus metrics HTTP container port                                                | `9119`  |
+| `metrics.service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                      | `None`  |
+| `metrics.service.clusterIP`                | Cluster internal IP of the service                                                    | `""`    |
+| `metrics.service.annotations`              | Annotations for Prometheus metrics service                                            | `{}`    |
+| `metrics.service.ports.http`               | Prometheus metrics service HTTP port                                                  | `9119`  |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator          | `false` |
+| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                              | `""`    |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                           | `30s`   |
+| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                   | `""`    |
+| `metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`    |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                   | `{}`    |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                    | `[]`    |
+| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                             | `[]`    |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels              | `false` |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.     | `""`    |
+| `metrics.serviceMonitor.serviceAccount`    | Service account used by Prometheus Operator                                           | `""`    |
+| `metrics.serviceMonitor.rbac.create`       | Create the necessary RBAC resources so Prometheus Operator can reach Kong's namespace | `true`  |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -63,123 +63,203 @@ To uninstall/delete the `my-release` deployment:
 
 ### Common parameters
 
-| Name                     | Description                                                                                              | Value           |
-| ------------------------ | -------------------------------------------------------------------------------------------------------- | --------------- |
-| `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                                     | `""`            |
-| `nameOverride`           | String to partially override kong.fullname template with a string (will prepend the release name)        | `""`            |
-| `fullnameOverride`       | String to fully override kong.fullname template with a string                                            | `""`            |
-| `commonAnnotations`      | Common annotations to add to all Kong resources (sub-charts are not considered). Evaluated as a template | `{}`            |
-| `commonLabels`           | Common labels to add to all Kong resources (sub-charts are not considered). Evaluated as a template      | `{}`            |
-| `clusterDomain`          | Kubernetes cluster domain                                                                                | `cluster.local` |
-| `extraDeploy`            | Array of extra objects to deploy with the release (evaluated as a template).                             | `[]`            |
-| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                  | `false`         |
-| `diagnosticMode.command` | Command to override all containers in the deployment                                                     | `["sleep"]`     |
-| `diagnosticMode.args`    | Args to override all containers in the deployment                                                        | `["infinity"]`  |
+| Name                     | Description                                                                                               | Value           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                                      | `""`            |
+| `nameOverride`           | String to partially override common.names.fullname template with a string (will prepend the release name) | `""`            |
+| `fullnameOverride`       | String to fully override common.names.fullname template with a string                                     | `""`            |
+| `commonAnnotations`      | Common annotations to add to all Kong resources (sub-charts are not considered). Evaluated as a template  | `{}`            |
+| `commonLabels`           | Common labels to add to all Kong resources (sub-charts are not considered). Evaluated as a template       | `{}`            |
+| `clusterDomain`          | Kubernetes cluster domain                                                                                 | `cluster.local` |
+| `extraDeploy`            | Array of extra objects to deploy with the release (evaluated as a template).                              | `[]`            |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                   | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the daemonset/deployment                                            | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the daemonset/deployment                                               | `["infinity"]`  |
 
 
-### Deployment parameters
+### Kong common parameters
 
-| Name                                    | Description                                                                                                                                                                      | Value                 |
-| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `image.registry`                        | kong image registry                                                                                                                                                              | `docker.io`           |
-| `image.repository`                      | kong image repository                                                                                                                                                            | `bitnami/kong`        |
-| `image.tag`                             | kong image tag (immutable tags are recommended)                                                                                                                                  | `2.7.1-debian-10-r15` |
-| `image.pullPolicy`                      | kong image pull policy                                                                                                                                                           | `IfNotPresent`        |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                                                                                 | `[]`                  |
-| `image.debug`                           | Enable image debug mode                                                                                                                                                          | `false`               |
-| `database`                              | Select which database backend Kong will use. Can be 'postgresql' or 'cassandra'                                                                                                  | `postgresql`          |
-| `replicaCount`                          | Number of replicas of the kong Pod                                                                                                                                               | `2`                   |
-| `hostAliases`                           | Add deployment host aliases                                                                                                                                                      | `[]`                  |
-| `updateStrategy.type`                   | Set up update strategy for kong installation. Set to Recreate if you use persistent volume that cannot be mounted by more than one pods to makesure the pods is destroyed first. | `RollingUpdate`       |
-| `schedulerName`                         | Alternative scheduler                                                                                                                                                            | `""`                  |
-| `useDaemonset`                          | Use a daemonset instead of a deployment. `replicaCount` will not take effect.                                                                                                    | `false`               |
-| `extraVolumes`                          | Array of extra volumes to be added to the Kong deployment deployment (evaluated as template). Requires setting `extraVolumeMounts`                                               | `[]`                  |
-| `initContainers`                        | Add additional init containers to the pod (evaluated as a template)                                                                                                              | `[]`                  |
-| `sidecars`                              | Attach additional containers to the pod (evaluated as a template)                                                                                                                | `[]`                  |
-| `containerSecurityContext.runAsUser`    | Set Kong container's Security Context runAsUser                                                                                                                                  | `1001`                |
-| `containerSecurityContext.runAsNonRoot` | Set Kong container's Security Context runAsNonRoot                                                                                                                               | `true`                |
-| `podSecurityContext`                    | Pod security context                                                                                                                                                             | `{}`                  |
-| `nodeSelector`                          | Node labels for pod assignment                                                                                                                                                   | `{}`                  |
-| `tolerations`                           | Tolerations for pod assignment                                                                                                                                                   | `[]`                  |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                                              | `""`                  |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                                         | `soft`                |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                                        | `""`                  |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                                                                                            | `""`                  |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                                                                                        | `[]`                  |
-| `affinity`                              | Affinity for pod assignment                                                                                                                                                      | `{}`                  |
-| `podAnnotations`                        | Pod annotations                                                                                                                                                                  | `{}`                  |
-| `podLabels`                             | Pod labels                                                                                                                                                                       | `{}`                  |
-| `autoscaling.enabled`                   | Deploy a HorizontalPodAutoscaler object for the Kong deployment                                                                                                                  | `false`               |
-| `autoscaling.apiVersion`                | API Version of the HPA object (for compatibility with Openshift)                                                                                                                 | `autoscaling/v2beta1` |
-| `autoscaling.minReplicas`               | Minimum number of replicas to scale back                                                                                                                                         | `2`                   |
-| `autoscaling.maxReplicas`               | Maximum number of replicas to scale out                                                                                                                                          | `5`                   |
-| `autoscaling.metrics`                   | Metrics to use when deciding to scale the deployment (evaluated as a template)                                                                                                   | `[]`                  |
-| `pdb.enabled`                           | Deploy a pdb object for the Kong pod                                                                                                                                             | `false`               |
-| `pdb.maxUnavailable`                    | Maximum unavailable Kong replicas (expressed in percentage)                                                                                                                      | `50%`                 |
+| Name                | Description                                                                     | Value                 |
+| ------------------- | ------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`    | kong image registry                                                             | `docker.io`           |
+| `image.repository`  | kong image repository                                                           | `bitnami/kong`        |
+| `image.tag`         | kong image tag (immutable tags are recommended)                                 | `2.7.1-debian-10-r27` |
+| `image.pullPolicy`  | kong image pull policy                                                          | `IfNotPresent`        |
+| `image.pullSecrets` | Specify docker-registry secret names as an array                                | `[]`                  |
+| `image.debug`       | Enable image debug mode                                                         | `false`               |
+| `database`          | Select which database backend Kong will use. Can be 'postgresql' or 'cassandra' | `postgresql`          |
 
 
-### Traffic Exposure Parameters
+### Kong deployment / daemonset parameters
 
-| Name                            | Description                                                                                                                      | Value                    |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `service.type`                  | Kubernetes Service type                                                                                                          | `ClusterIP`              |
-| `service.clusterIP`             | Cluster internal IP of the service                                                                                               | `""`                     |
-| `service.externalTrafficPolicy` | external traffic policy managing client source IP preservation                                                                   | `""`                     |
-| `service.proxyHttpPort`         | kong proxy HTTP service port port                                                                                                | `80`                     |
-| `service.proxyHttpsPort`        | kong proxy HTTPS service port port                                                                                               | `443`                    |
-| `service.exposeAdmin`           | Add the Kong Admin ports to the service                                                                                          | `false`                  |
-| `service.adminHttpPort`         | kong admin HTTPS service port (only if service.exposeAdmin=true)                                                                 | `8001`                   |
-| `service.adminHttpsPort`        | kong admin HTTPS service port (only if service.exposeAdmin=true)                                                                 | `8444`                   |
-| `service.disableHttpPort`       | Disable Kong proxy HTTP and Kong admin HTTP ports                                                                                | `false`                  |
-| `service.proxyHttpNodePort`     | Port to bind to for NodePort service type (proxy HTTP)                                                                           | `""`                     |
-| `service.proxyHttpsNodePort`    | Port to bind to for NodePort service type (proxy HTTPS)                                                                          | `""`                     |
-| `service.adminHttpNodePort`     | Port to bind to for NodePort service type (admin HTTP)                                                                           | `""`                     |
-| `service.adminHttpsNodePort`    | Port to bind to for NodePort service type (admin HTTPS)                                                                          | `""`                     |
-| `service.loadBalancerIP`        | loadBalancerIP if kong service type is `LoadBalancer`                                                                            | `""`                     |
-| `service.annotations`           | Annotations for kong service                                                                                                     | `{}`                     |
-| `service.extraPorts`            | Extra ports to expose (normally used with the `sidecar` value)                                                                   | `[]`                     |
-| `ingress.enabled`               | Enable ingress controller resource                                                                                               | `false`                  |
-| `ingress.pathType`              | Ingress path type                                                                                                                | `ImplementationSpecific` |
-| `ingress.apiVersion`            | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
-| `ingress.hostname`              | Default host for the ingress resource                                                                                            | `kong.local`             |
-| `ingress.path`                  | Ingress path                                                                                                                     | `/`                      |
-| `ingress.annotations`           | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
-| `ingress.tls`                   | Create TLS Secret                                                                                                                | `false`                  |
-| `ingress.extraHosts`            | The list of additional hostnames to be covered with this ingress record.                                                         | `[]`                     |
-| `ingress.extraPaths`            | Additional arbitrary path/backend objects                                                                                        | `[]`                     |
-| `ingress.extraTls`              | The tls configuration for additional hostnames to be covered with this ingress record.                                           | `[]`                     |
-| `ingress.secrets`               | If you're providing your own certificates, please use this to add the certificates as secrets                                    | `[]`                     |
+| Name                                    | Description                                                                                                                        | Value                 |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `useDaemonset`                          | Use a daemonset instead of a deployment. `replicaCount` will not take effect.                                                      | `false`               |
+| `replicaCount`                          | Number of Kong replicas                                                                                                            | `2`                   |
+| `containerSecurityContext.enabled`      | Enabled Kong containers' Security Context                                                                                          | `true`                |
+| `containerSecurityContext.runAsUser`    | Set Kong container's Security Context runAsUser                                                                                    | `1001`                |
+| `containerSecurityContext.runAsNonRoot` | Set Kong container's Security Context runAsNonRoot                                                                                 | `true`                |
+| `podSecurityContext.enabled`            | Enabled Kong pods' Security Context                                                                                                | `false`               |
+| `podSecurityContext.fsGroup`            | Set Kong pod's Security Context fsGroup                                                                                            | `1001`                |
+| `updateStrategy.type`                   | Kong update strategy                                                                                                               | `RollingUpdate`       |
+| `updateStrategy.rollingUpdate`          | Kong deployment rolling update configuration parameters                                                                            | `{}`                  |
+| `hostAliases`                           | Add deployment host aliases                                                                                                        | `[]`                  |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template           | `{}`                  |
+| `priorityClassName`                     | Priority Class Name                                                                                                                | `""`                  |
+| `schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                          | `""`                  |
+| `terminationGracePeriodSeconds`         | Seconds Kong pod needs to terminate gracefully                                                                                     | `""`                  |
+| `podAnnotations`                        | Additional pod annotations                                                                                                         | `{}`                  |
+| `podLabels`                             | Additional pod labels                                                                                                              | `{}`                  |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                | `""`                  |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                           | `soft`                |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                          | `""`                  |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                                              | `""`                  |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                                          | `[]`                  |
+| `affinity`                              | Affinity for pod assignment                                                                                                        | `{}`                  |
+| `nodeSelector`                          | Node labels for pod assignment                                                                                                     | `{}`                  |
+| `tolerations`                           | Tolerations for pod assignment                                                                                                     | `[]`                  |
+| `extraVolumes`                          | Array of extra volumes to be added to the Kong deployment deployment (evaluated as template). Requires setting `extraVolumeMounts` | `[]`                  |
+| `initContainers`                        | Add additional init containers to the Kong pods                                                                                    | `[]`                  |
+| `sidecars`                              | Add additional sidecar containers to the Kong pods                                                                                 | `[]`                  |
+| `autoscaling.enabled`                   | Deploy a HorizontalPodAutoscaler object for the Kong deployment                                                                    | `false`               |
+| `autoscaling.apiVersion`                | API Version of the HPA object (for compatibility with Openshift)                                                                   | `autoscaling/v2beta1` |
+| `autoscaling.minReplicas`               | Minimum number of replicas to scale back                                                                                           | `2`                   |
+| `autoscaling.maxReplicas`               | Maximum number of replicas to scale out                                                                                            | `5`                   |
+| `autoscaling.metrics`                   | Metrics to use when deciding to scale the deployment (evaluated as a template)                                                     | `[]`                  |
+| `pdb.enabled`                           | Deploy a PodDisruptionBudget object for Kong deployment                                                                            | `false`               |
+| `pdb.minAvailable`                      | Minimum available Kong replicas (expressed in percentage)                                                                          | `""`                  |
+| `pdb.maxUnavailable`                    | Maximum unavailable Kong replicas (expressed in percentage)                                                                        | `50%`                 |
 
 
 ### Kong Container Parameters
 
-| Name                                      | Description                                                                                                                | Value  |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------ |
-| `kong.command`                            | Override default container command (useful when using custom images)                                                       | `[]`   |
-| `kong.args`                               | Override default container args (useful when using custom images)                                                          | `[]`   |
-| `kong.initScriptsCM`                      | Configmap with init scripts to execute                                                                                     | `""`   |
-| `kong.initScriptsSecret`                  | Configmap with init scripts to execute                                                                                     | `""`   |
-| `kong.extraEnvVars`                       | Array containing extra env vars to configure Kong                                                                          | `[]`   |
-| `kong.extraEnvVarsCM`                     | ConfigMap containing extra env vars to configure Kong                                                                      | `""`   |
-| `kong.extraEnvVarsSecret`                 | Secret containing extra env vars to configure Kong (in case of sensitive data)                                             | `""`   |
-| `kong.extraVolumeMounts`                  | Array of extra volume mounts to be added to the Kong Container (evaluated as template). Normally used with `extraVolumes`. | `[]`   |
-| `kong.customLivenessProbe`                | Override default liveness probe (kong container)                                                                           | `{}`   |
-| `kong.customReadinessProbe`               | Override default readiness probe (kong container)                                                                          | `{}`   |
-| `kong.livenessProbe.enabled`              | Enable livenessProbe                                                                                                       | `true` |
-| `kong.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                    | `120`  |
-| `kong.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                           | `10`   |
-| `kong.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                          | `5`    |
-| `kong.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                        | `6`    |
-| `kong.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                        | `1`    |
-| `kong.readinessProbe.enabled`             | Enable readinessProbe                                                                                                      | `true` |
-| `kong.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                   | `30`   |
-| `kong.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                          | `10`   |
-| `kong.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                         | `5`    |
-| `kong.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                       | `6`    |
-| `kong.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                       | `1`    |
-| `kong.lifecycleHooks`                     | Lifecycle hooks (kong container)                                                                                           | `{}`   |
-| `kong.resources.limits`                   | The resources limits for the container                                                                                     | `{}`   |
-| `kong.resources.requests`                 | The requested resources for the container                                                                                  | `{}`   |
+| Name                                      | Description                                                                                                                | Value   |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `kong.command`                            | Override default container command (useful when using custom images)                                                       | `[]`    |
+| `kong.args`                               | Override default container args (useful when using custom images)                                                          | `[]`    |
+| `kong.initScriptsCM`                      | Configmap with init scripts to execute                                                                                     | `""`    |
+| `kong.initScriptsSecret`                  | Configmap with init scripts to execute                                                                                     | `""`    |
+| `kong.extraEnvVars`                       | Array containing extra env vars to configure Kong                                                                          | `[]`    |
+| `kong.extraEnvVarsCM`                     | ConfigMap containing extra env vars to configure Kong                                                                      | `""`    |
+| `kong.extraEnvVarsSecret`                 | Secret containing extra env vars to configure Kong (in case of sensitive data)                                             | `""`    |
+| `kong.extraVolumeMounts`                  | Array of extra volume mounts to be added to the Kong Container (evaluated as template). Normally used with `extraVolumes`. | `[]`    |
+| `kong.containerPorts.proxyHttp`           | Kong proxy HTTP container port                                                                                             | `8000`  |
+| `kong.containerPorts.proxyHttps`          | Kong proxy HTTPS container port                                                                                            | `8443`  |
+| `kong.containerPorts.adminHttp`           | Kong admin HTTP container port                                                                                             | `8001`  |
+| `kong.containerPorts.adminHttps`          | Kong admin HTTPS container port                                                                                            | `8444`  |
+| `kong.resources.limits`                   | The resources limits for the Kong container                                                                                | `{}`    |
+| `kong.resources.requests`                 | The requested resources for the Kong container                                                                             | `{}`    |
+| `kong.livenessProbe.enabled`              | Enable livenessProbe on Kong containers                                                                                    | `true`  |
+| `kong.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                    | `120`   |
+| `kong.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                           | `10`    |
+| `kong.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                          | `5`     |
+| `kong.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                        | `6`     |
+| `kong.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                        | `1`     |
+| `kong.readinessProbe.enabled`             | Enable readinessProbe on Kong containers                                                                                   | `true`  |
+| `kong.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                   | `30`    |
+| `kong.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                          | `10`    |
+| `kong.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                         | `5`     |
+| `kong.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                       | `6`     |
+| `kong.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                       | `1`     |
+| `kong.startupProbe.enabled`               | Enable startupProbe on Kong containers                                                                                     | `false` |
+| `kong.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                                     | `10`    |
+| `kong.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                                            | `15`    |
+| `kong.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                                           | `3`     |
+| `kong.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                                         | `20`    |
+| `kong.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                                         | `1`     |
+| `kong.customLivenessProbe`                | Override default liveness probe (kong container)                                                                           | `{}`    |
+| `kong.customReadinessProbe`               | Override default readiness probe (kong container)                                                                          | `{}`    |
+| `kong.customStartupProbe`                 | Override default startup probe (kong container)                                                                            | `{}`    |
+| `kong.lifecycleHooks`                     | Lifecycle hooks (kong container)                                                                                           | `{}`    |
+
+
+### Traffic Exposure Parameters
+
+| Name                               | Description                                                                                                                      | Value                    |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.type`                     | Kubernetes Service type                                                                                                          | `ClusterIP`              |
+| `service.exposeAdmin`              | Add the Kong Admin ports to the service                                                                                          | `false`                  |
+| `service.disableHttpPort`          | Disable Kong proxy HTTP and Kong admin HTTP ports                                                                                | `false`                  |
+| `service.ports.proxyHttp`          | Kong proxy service HTTP port                                                                                                     | `80`                     |
+| `service.ports.proxyHttps`         | Kong proxy service HTTPS port                                                                                                    | `443`                    |
+| `service.ports.adminHttp`          | Kong admin service HTTP port (only if service.exposeAdmin=true)                                                                  | `8001`                   |
+| `service.ports.adminHttps`         | Kong admin service HTTPS port (only if service.exposeAdmin=true)                                                                 | `8444`                   |
+| `service.nodePorts.proxyHttp`      | NodePort for the Kong proxy HTTP endpoint                                                                                        | `""`                     |
+| `service.nodePorts.proxyHttps`     | NodePort for the Kong proxy HTTPS endpoint                                                                                       | `""`                     |
+| `service.nodePorts.adminHttp`      | NodePort for the Kong admin HTTP endpoint                                                                                        | `""`                     |
+| `service.nodePorts.adminHttps`     | NodePort for the Kong admin HTTPS endpoint                                                                                       | `""`                     |
+| `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                                                 | `None`                   |
+| `service.clusterIP`                | Cluster internal IP of the service                                                                                               | `""`                     |
+| `service.externalTrafficPolicy`    | external traffic policy managing client source IP preservation                                                                   | `""`                     |
+| `service.loadBalancerIP`           | loadBalancerIP if kong service type is `LoadBalancer`                                                                            | `""`                     |
+| `service.loadBalancerSourceRanges` | Kong service Load Balancer sources                                                                                               | `[]`                     |
+| `service.annotations`              | Annotations for Kong service                                                                                                     | `{}`                     |
+| `service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)                                                                   | `[]`                     |
+| `ingress.enabled`                  | Enable ingress controller resource                                                                                               | `false`                  |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
+| `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
+| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
+| `ingress.hostname`                 | Default host for the ingress resource                                                                                            | `kong.local`             |
+| `ingress.path`                     | Ingress path                                                                                                                     | `/`                      |
+| `ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
+| `ingress.tls`                      | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |
+| `ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
+| `ingress.extraHosts`               | The list of additional hostnames to be covered with this ingress record.                                                         | `[]`                     |
+| `ingress.extraPaths`               | Additional arbitrary path/backend objects                                                                                        | `[]`                     |
+| `ingress.extraTls`                 | The tls configuration for additional hostnames to be covered with this ingress record.                                           | `[]`                     |
+| `ingress.secrets`                  | If you're providing your own certificates, please use this to add the certificates as secrets                                    | `[]`                     |
+
+
+### Kong Ingress Controller Container Parameters
+
+| Name                                                            | Description                                                                                                                                   | Value                             |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `ingressController.enabled`                                     | Enable/disable the Kong Ingress Controller                                                                                                    | `true`                            |
+| `ingressController.customResourceDeletePolicy`                  | Add custom CRD resource delete policy (for Helm 2 support)                                                                                    | `{}`                              |
+| `ingressController.image.registry`                              | Kong Ingress Controller image registry                                                                                                        | `docker.io`                       |
+| `ingressController.image.repository`                            | Kong Ingress Controller image name                                                                                                            | `bitnami/kong-ingress-controller` |
+| `ingressController.image.tag`                                   | Kong Ingress Controller image tag                                                                                                             | `2.2.1-debian-10-r9`              |
+| `ingressController.image.pullPolicy`                            | Kong Ingress Controller image pull policy                                                                                                     | `IfNotPresent`                    |
+| `ingressController.image.pullSecrets`                           | Specify docker-registry secret names as an array                                                                                              | `[]`                              |
+| `ingressController.proxyReadyTimeout`                           | Maximum time (in seconds) to wait for the Kong container to be ready                                                                          | `300`                             |
+| `ingressController.ingressClass`                                | Name of the class to register Kong Ingress Controller (useful when having other Ingress Controllers in the cluster)                           | `kong`                            |
+| `ingressController.command`                                     | Override default container command (useful when using custom images)                                                                          | `[]`                              |
+| `ingressController.args`                                        | Override default container args (useful when using custom images)                                                                             | `[]`                              |
+| `ingressController.extraEnvVars`                                | Array containing extra env vars to configure Kong                                                                                             | `[]`                              |
+| `ingressController.extraEnvVarsCM`                              | ConfigMap containing extra env vars to configure Kong Ingress Controller                                                                      | `""`                              |
+| `ingressController.extraEnvVarsSecret`                          | Secret containing extra env vars to configure Kong Ingress Controller (in case of sensitive data)                                             | `""`                              |
+| `ingressController.extraVolumeMounts`                           | Array of extra volume mounts to be added to the Kong Ingress Controller container (evaluated as template). Normally used with `extraVolumes`. | `[]`                              |
+| `ingressController.containerPorts.health`                       | Kong Ingress Controller health container port                                                                                                 | `10254`                           |
+| `ingressController.resources.limits`                            | The resources limits for the Kong Ingress Controller container                                                                                | `{}`                              |
+| `ingressController.resources.requests`                          | The requested resources for the Kong Ingress Controller container                                                                             | `{}`                              |
+| `ingressController.livenessProbe.enabled`                       | Enable livenessProbe on Kong Ingress Controller containers                                                                                    | `true`                            |
+| `ingressController.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                                                       | `120`                             |
+| `ingressController.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                                                              | `10`                              |
+| `ingressController.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                                                             | `5`                               |
+| `ingressController.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                                                           | `6`                               |
+| `ingressController.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                                                           | `1`                               |
+| `ingressController.readinessProbe.enabled`                      | Enable readinessProbe on Kong Ingress Controller containers                                                                                   | `true`                            |
+| `ingressController.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                                                                      | `30`                              |
+| `ingressController.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                                                             | `10`                              |
+| `ingressController.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                                                            | `5`                               |
+| `ingressController.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                                                          | `6`                               |
+| `ingressController.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                                                          | `1`                               |
+| `ingressController.startupProbe.enabled`                        | Enable startupProbe on Kong Ingress Controller containers                                                                                     | `false`                           |
+| `ingressController.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                                                        | `10`                              |
+| `ingressController.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                                                               | `15`                              |
+| `ingressController.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                                                              | `3`                               |
+| `ingressController.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                                                            | `20`                              |
+| `ingressController.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                                                            | `1`                               |
+| `ingressController.customLivenessProbe`                         | Override default liveness probe (Kong Ingress Controller container)                                                                           | `{}`                              |
+| `ingressController.customReadinessProbe`                        | Override default readiness probe (Kong Ingress Controller container)                                                                          | `{}`                              |
+| `ingressController.customStartupProbe`                          | Override default startup probe (Kong Ingress Controller container)                                                                            | `{}`                              |
+| `ingressController.lifecycleHooks`                              | Lifecycle hooks (Kong Ingress Controller container)                                                                                           | `{}`                              |
+| `ingressController.serviceAccount.create`                       | Enable the creation of a ServiceAccount for Keycloak pods                                                                                     | `true`                            |
+| `ingressController.serviceAccount.name`                         | Name of the created ServiceAccount (name generated using common.names.fullname template otherwise)                                            | `""`                              |
+| `ingressController.serviceAccount.automountServiceAccountToken` | Auto-mount the service account token in the pod                                                                                               | `true`                            |
+| `ingressController.serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                                                                          | `{}`                              |
+| `ingressController.rbac.create`                                 | Create the necessary RBAC resources for the Ingress Controller to work                                                                        | `true`                            |
+| `ingressController.rbac.rules`                                  | Custom RBAC rules                                                                                                                             | `[]`                              |
 
 
 ### Kong Migration job Parameters
@@ -188,105 +268,78 @@ To uninstall/delete the `my-release` deployment:
 | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------- | ----- |
 | `migration.command`            | Override default container command (useful when using custom images)                                                       | `[]`  |
 | `migration.args`               | Override default container args (useful when using custom images)                                                          | `[]`  |
-| `migration.hostAliases`        | Add deployment host aliases                                                                                                | `[]`  |
-| `migration.annotations`        | Add annotations to the job                                                                                                 | `{}`  |
 | `migration.extraEnvVars`       | Array containing extra env vars to configure the Kong migration job                                                        | `[]`  |
 | `migration.extraEnvVarsCM`     | ConfigMap containing extra env vars to configure the Kong migration job                                                    | `""`  |
 | `migration.extraEnvVarsSecret` | Secret containing extra env vars to configure the Kong migration job (in case of sensitive data)                           | `""`  |
 | `migration.extraVolumeMounts`  | Array of extra volume mounts to be added to the Kong Container (evaluated as template). Normally used with `extraVolumes`. | `[]`  |
 | `migration.resources.limits`   | The resources limits for the container                                                                                     | `{}`  |
 | `migration.resources.requests` | The requested resources for the container                                                                                  | `{}`  |
-
-
-### Kong Ingress Controller Container Parameters
-
-| Name                                                   | Description                                                                                                                                   | Value                             |
-| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `ingressController.enabled`                            | Enable/disable the Kong Ingress Controller                                                                                                    | `true`                            |
-| `ingressController.customResourceDeletePolicy`         | Add custom CRD resource delete policy (for Helm 2 support)                                                                                    | `{}`                              |
-| `ingressController.image.registry`                     | Kong Ingress Controller image registry                                                                                                        | `docker.io`                       |
-| `ingressController.image.repository`                   | Kong Ingress Controller image name                                                                                                            | `bitnami/kong-ingress-controller` |
-| `ingressController.image.tag`                          | Kong Ingress Controller image tag                                                                                                             | `2.2.0-debian-10-r7`              |
-| `ingressController.image.pullPolicy`                   | kong ingress controller image pull policy                                                                                                     | `IfNotPresent`                    |
-| `ingressController.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                                                              | `[]`                              |
-| `ingressController.proxyReadyTimeout`                  | Maximum time (in seconds) to wait for the Kong container to be ready                                                                          | `300`                             |
-| `ingressController.rbac.create`                        | Create the necessary Service Accounts, Roles and Rolebindings for the Ingress Controller to work                                              | `true`                            |
-| `ingressController.rbac.existingServiceAccount`        | Use an existing service account for all the RBAC operations                                                                                   | `""`                              |
-| `ingressController.ingressClass`                       | Name of the class to register Kong Ingress Controller (useful when having other Ingress Controllers in the cluster)                           | `kong`                            |
-| `ingressController.command`                            | Override default container command (useful when using custom images)                                                                          | `[]`                              |
-| `ingressController.args`                               | Override default container args (useful when using custom images)                                                                             | `[]`                              |
-| `ingressController.extraEnvVars`                       | Array containing extra env vars to configure Kong                                                                                             | `[]`                              |
-| `ingressController.extraEnvVarsCM`                     | ConfigMap containing extra env vars to configure Kong Ingress Controller                                                                      | `""`                              |
-| `ingressController.extraEnvVarsSecret`                 | Secret containing extra env vars to configure Kong Ingress Controller (in case of sensitive data)                                             | `""`                              |
-| `ingressController.extraVolumeMounts`                  | Array of extra volume mounts to be added to the Kong Ingress Controller container (evaluated as template). Normally used with `extraVolumes`. | `[]`                              |
-| `ingressController.customLivenessProbe`                | Override default liveness probe (kong ingress controller container)                                                                           | `{}`                              |
-| `ingressController.customReadinessProbe`               | Override default readiness probe (kong ingress controller container)                                                                          | `{}`                              |
-| `ingressController.livenessProbe.enabled`              | Enable livenessProbe                                                                                                                          | `true`                            |
-| `ingressController.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                                       | `120`                             |
-| `ingressController.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                                              | `10`                              |
-| `ingressController.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                                             | `5`                               |
-| `ingressController.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                                           | `6`                               |
-| `ingressController.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                                           | `1`                               |
-| `ingressController.readinessProbe.enabled`             | Enable readinessProbe                                                                                                                         | `true`                            |
-| `ingressController.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                                      | `30`                              |
-| `ingressController.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                                             | `10`                              |
-| `ingressController.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                                            | `5`                               |
-| `ingressController.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                                          | `6`                               |
-| `ingressController.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                                          | `1`                               |
-| `ingressController.resources.limits`                   | The resources limits for the container                                                                                                        | `{}`                              |
-| `ingressController.resources.requests`                 | The requested resources for the container                                                                                                     | `{}`                              |
+| `migration.hostAliases`        | Add deployment host aliases                                                                                                | `[]`  |
+| `migration.annotations`        | Add annotations to the job                                                                                                 | `{}`  |
 
 
 ### PostgreSQL Parameters
 
-| Name                               | Description                                                                    | Value                 |
-| ---------------------------------- | ------------------------------------------------------------------------------ | --------------------- |
-| `postgresql.enabled`               | Deploy the PostgreSQL sub-chart                                                | `true`                |
-| `postgresql.image.registry`        | PostgreSQL image registry                                                      | `docker.io`           |
-| `postgresql.image.repository`      | PostgreSQL image repository                                                    | `bitnami/postgresql`  |
-| `postgresql.image.tag`             | PostgreSQL image tag (immutable tags are recommended)                          | `13.6.0-debian-10-r8` |
-| `postgresql.image.pullPolicy`      | PostgreSQL image pull policy                                                   | `IfNotPresent`        |
-| `postgresql.image.pullSecrets`     | Specify image pull secrets                                                     | `[]`                  |
-| `postgresql.external.host`         | Host of an external PostgreSQL installation                                    | `""`                  |
-| `postgresql.external.user`         | Username of the external PostgreSQL installation                               | `""`                  |
-| `postgresql.external.password`     | Password of the external PostgreSQL installation                               | `""`                  |
-| `postgresql.auth.username`         | Postgresql username                                                            | `kong`                |
-| `postgresql.auth.password`         | Postgresql password                                                            | `""`                  |
-| `postgresql.auth.database`         | Postgresql database                                                            | `kong`                |
-| `postgresql.auth.postgresPassword` | Postgresql password for the postgres user                                      | `""`                  |
-| `postgresql.auth.existingSecret`   | Name of an existing secret containing the PostgreSQL password ('password' key) | `""`                  |
-| `postgresql.auth.usePasswordFiles` | Mount credentials as a files instead of using an environment variable          | `false`               |
+| Name                                            | Description                                                             | Value                   |
+| ----------------------------------------------- | ----------------------------------------------------------------------- | ----------------------- |
+| `postgresql.enabled`                            | Switch to enable or disable the PostgreSQL helm chart                   | `true`                  |
+| `postgresql.auth.postgresPassword`              | Password for the "postgres" admin user                                  | `""`                    |
+| `postgresql.auth.username`                      | Name for a custom user to create                                        | `kong`                  |
+| `postgresql.auth.password`                      | Password for the custom user to create                                  | `""`                    |
+| `postgresql.auth.database`                      | Name for a custom database to create                                    | `kong`                  |
+| `postgresql.auth.existingSecret`                | Name of existing secret to use for PostgreSQL credentials               | `""`                    |
+| `postgresql.auth.usePasswordFiles`              | Mount credentials as a files instead of using an environment variable   | `false`                 |
+| `postgresql.architecture`                       | PostgreSQL architecture (`standalone` or `replication`)                 | `standalone`            |
+| `postgresql.image.registry`                     | PostgreSQL image registry                                               | `docker.io`             |
+| `postgresql.image.repository`                   | PostgreSQL image repository                                             | `bitnami/postgresql`    |
+| `postgresql.image.tag`                          | PostgreSQL image tag (immutable tags are recommended)                   | `11.15.0-debian-10-r20` |
+| `postgresql.external.host`                      | Database host                                                           | `""`                    |
+| `postgresql.external.port`                      | Database port number                                                    | `5432`                  |
+| `postgresql.external.user`                      | Non-root username for Kong                                              | `kong`                  |
+| `postgresql.external.password`                  | Password for the non-root username for Kong                             | `""`                    |
+| `postgresql.external.database`                  | Kong database name                                                      | `kong`                  |
+| `postgresql.external.existingSecret`            | Name of an existing secret resource containing the database credentials | `""`                    |
+| `postgresql.external.existingSecretPasswordKey` | Name of an existing secret key containing the database credentials      | `""`                    |
 
 
 ### Cassandra Parameters
 
-| Name                          | Description                                                                                                                   | Value   |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `cassandra.enabled`           | Deploy the Cassandra sub-chart                                                                                                | `false` |
-| `cassandra.dbUser.user`       | Username to be created by the cassandra bundled chart                                                                         | `kong`  |
-| `cassandra.usePasswordFile`   | Mount the Cassandra secret as a file                                                                                          | `false` |
-| `cassandra.external.hosts`    | Hosts of an external cassandra installation                                                                                   | `[]`    |
-| `cassandra.external.port`     | Port of an external cassandra installation                                                                                    | `9042`  |
-| `cassandra.external.user`     | Username of the external cassandra installation                                                                               | `""`    |
-| `cassandra.external.password` | Password of the external cassandra installation                                                                               | `""`    |
-| `cassandra.existingSecret`    | Use an existing secret file with the Cassandra password (can be used with the bundled chart or with an existing installation) | `""`    |
+| Name                                           | Description                                                              | Value   |
+| ---------------------------------------------- | ------------------------------------------------------------------------ | ------- |
+| `cassandra.enabled`                            | Switch to enable or disable the Cassandra helm chart                     | `false` |
+| `cassandra.dbUser.user`                        | Cassandra admin user                                                     | `kong`  |
+| `cassandra.dbUser.password`                    | Password for `cassandra.dbUser.user`. Randomly generated if empty        | `""`    |
+| `cassandra.dbUser.existingSecret`              | Name of existing secret to use for Cassandra credentials                 | `""`    |
+| `cassandra.usePasswordFile`                    | Mount credentials as a files instead of using an environment variable    | `false` |
+| `cassandra.external.hosts`                     | List of Cassandra hosts                                                  | `[]`    |
+| `cassandra.external.port`                      | Cassandra port number                                                    | `9042`  |
+| `cassandra.external.user`                      | Username of the external cassandra installation                          | `""`    |
+| `cassandra.external.password`                  | Password of the external cassandra installation                          | `""`    |
+| `cassandra.external.existingSecret`            | Name of an existing secret resource containing the Cassandra credentials | `""`    |
+| `cassandra.external.existingSecretPasswordKey` | Name of an existing secret key containing the Cassandra credentials      | `""`    |
 
 
 ### Metrics Parameters
 
-| Name                                    | Description                                                                                            | Value       |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------- |
-| `metrics.enabled`                       | Enable the export of Prometheus metrics                                                                | `false`     |
-| `metrics.service.annotations`           | Annotations for Prometheus metrics service                                                             | `{}`        |
-| `metrics.service.type`                  | Type of the Prometheus metrics service                                                                 | `ClusterIP` |
-| `metrics.service.port`                  | Port of the Prometheus metrics service                                                                 | `9119`      |
-| `metrics.serviceMonitor.enabled`        | If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`     |
-| `metrics.serviceMonitor.namespace`      | Namespace in which Prometheus is running                                                               | `""`        |
-| `metrics.serviceMonitor.serviceAccount` | Service account used by Prometheus                                                                     | `""`        |
-| `metrics.serviceMonitor.interval`       | Interval at which metrics should be scraped.                                                           | `""`        |
-| `metrics.serviceMonitor.scrapeTimeout`  | Timeout after which the scrape is ended                                                                | `""`        |
-| `metrics.serviceMonitor.selector`       | Prometheus instance selector labels                                                                    | `{}`        |
-| `metrics.serviceMonitor.rbac.enabled`   | Whether to enable RBAC                                                                                 | `true`      |
+| Name                                       | Description                                                                           | Value       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------- | ----------- |
+| `metrics.enabled`                          | Enable the export of Prometheus metrics                                               | `false`     |
+| `metrics.containerPorts.http`              | Prometheus metrics HTTP container port                                                | `9119`      |
+| `metrics.service.annotations`              | Annotations for Prometheus metrics service                                            | `{}`        |
+| `metrics.service.type`                     | Type of the Prometheus metrics service                                                | `ClusterIP` |
+| `metrics.service.ports.http`               | Prometheus metrics service HTTP port                                                  | `9119`      |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator          | `false`     |
+| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                              | `""`        |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                           | `30s`       |
+| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                   | `""`        |
+| `metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`        |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                   | `{}`        |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                    | `[]`        |
+| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                             | `[]`        |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels              | `false`     |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.     | `""`        |
+| `metrics.serviceMonitor.serviceAccount`    | Service account used by Prometheus Operator                                           | `""`        |
+| `metrics.serviceMonitor.rbac.create`       | Create the necessary RBAC resources so Prometheus Operator can reach Kong's namespace | `true`      |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/kong/ci/values-ingress.yaml
+++ b/bitnami/kong/ci/values-ingress.yaml
@@ -1,2 +1,4 @@
 ingress:
   enabled: true
+  tls: true
+  selfSigned: true

--- a/bitnami/kong/ci/values-metrics-hpa-pdb.yaml
+++ b/bitnami/kong/ci/values-metrics-hpa-pdb.yaml
@@ -2,6 +2,5 @@ metrics:
   enabled: true
 autoscaling:
   enabled: true
-
 pdb:
   enabled: true

--- a/bitnami/kong/templates/NOTES.txt
+++ b/bitnami/kong/templates/NOTES.txt
@@ -5,6 +5,7 @@ APP VERSION: {{ .Chart.AppVersion }}
 ** Please be patient while the chart is being deployed **
 
 {{- if .Values.diagnosticMode.enabled }}
+
 The chart has been deployed in diagnostic mode. All probes have been disabled and the command has been overwritten with:
 
   command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 4 }}
@@ -23,30 +24,30 @@ In order to replicate the container startup scripts execute this command:
     /opt/bitnami/scripts/kong/entrypoint.sh /opt/bitnami/scripts/kong/run.sh
 
 {{- else }}
-
+{{- $proxyPort := coalesce .Values.service.ports.proxyHttp .Values.service.proxyHttpPort | toString }}
+{{- $adminPort := coalesce .Values.service.ports.adminHttp .Values.service.adminHttpPort | toString }}
 {{- if .Values.ingress.enabled }}
-    Kong URL(s):
-{{- if .Values.ingress.hostname }}
-    - http://{{ .Values.ingress.hostname }}
-{{- end }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-    - http://{{ $host.name }}{{ . }}
-  {{- end }}
-{{- end }}
+
+Get the Kong proxy URL and associate its hostname to your cluster external IP:
+
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   echo "Kong proxy URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}"
+   echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
+
 {{- else if contains "NodePort" .Values.service.type }}
 
-    Get the Kubernetes node IP by using the following command
+Get the Kubernetes node IP by using the following command:
+
     export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
 
-    Access the Kong proxy by using the following commands
+Access the Kong proxy by using the following commands:
 
     export PROXY_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
     echo http://$NODE_IP:$PROXY_NODE_PORT
 
     {{- if .Values.service.exposeAdmin }}
 
-    Access the Kong admin by using the following commands
+Access the Kong admin by using the following commands:
 
     export ADMIN_NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[2].nodePort}" services {{ include "common.names.fullname" . }})
     echo http://$NODE_IP:$ADMIN_NODE_PORT
@@ -54,26 +55,36 @@ In order to replicate the container startup scripts execute this command:
     {{- end }}
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "common.names.fullname" . }}'
+
+Access the Kong proxy by using the following commands:
+
     export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    echo http://$SERVICE_IP:{{ .Values.service.proxyHttpPort }}
+    echo http://$SERVICE_IP:{{ $proxyPort }}
+
+    {{- if .Values.service.exposeAdmin }}
+
+Access the Kong admin by using the following commands:
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo http://$SERVICE_IP:{{ $adminPort }}
+
+    {{- end }}
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-    Access the Kong proxy by using the following commands
+Access the Kong proxy by using the following commands:
 
     echo "Browse to http://127.0.0.1:8000"
-    kubectl port-forward svc/{{ include "common.names.fullname" . }} 8080:{{ .Values.service.proxyHttpPort }} &
+    kubectl port-forward svc/{{ include "common.names.fullname" . }} 8080:{{ $proxyPort }} &
 
-    Access the Kong admin by using the following commands
+    {{- if .Values.service.exposeAdmin }}
+
+Access the Kong admin by using the following commands:
 
     echo "Browse to http://127.0.0.1:8001"
-    {{- if .Values.service.exposeAdmin }}
-    kubectl port-forward svc/{{ include "common.names.fullname" . }} 8001:{{ .Values.service.adminHttpPort }} &
-    {{- else }}
-    export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name:{{ include "common.names.name" . }},app.kubernetes.io/instance:{{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+    kubectl port-forward svc/{{ include "common.names.fullname" . }} 8080:{{ $adminPort }} &
 
-    kubectl port-forward pod/$POD_NAME 8001:8001 &
     {{- end }}
 {{- end }}
 
@@ -105,10 +116,9 @@ If you want to upgrade the installation you will need to re-set the database cre
 {{- end }}
 
 {{- if .Values.service.exposeAdmin }}
-
 WARNING: You made the Kong admin {{ if contains "ClusterIP" .Values.service.type }}accessible from other pods in the cluster{{ else }}externally accessible{{- end }}. We do not recommend this configuration in production. For accessing the admin, using pod port-forwarding or using the Kong Ingress Controller is preferred.
 {{- end }}
 
-{{ include "kong.validateValues" . }}
+{{- include "kong.validateValues" . }}
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}
 {{- end }}

--- a/bitnami/kong/templates/_helpers.tpl
+++ b/bitnami/kong/templates/_helpers.tpl
@@ -239,12 +239,13 @@ Validate values for kong.
 Function to validate the RBAC
 */}}
 {{- define "kong.validateValues.rbac" -}}
-{{- if and .Values.ingressController.enabled (not .Values.ingressController.rbac.existingServiceAccount) (not .Values.ingressController.rbac.create) -}}
+{{- if and .Values.ingressController.enabled (not .Values.ingressController.serviceAccount.create) (not .Values.ingressController.serviceAccount.name) (not .Values.ingressController.rbac.create) -}}
 INVALID RBAC: You enabled the Kong Ingress Controller sidecar without creating RBAC objects and not
-specifying an existing Service Account. Specify an existing Service Account in ingressController.rbac.existingServiceAccount
+specifying an existing Service Account. Specify an existing Service Account in ingressController.serviceAccount.name
 or allow the chart to create the proper RBAC objects with ingressController.rbac.create
 {{- end -}}
 {{- end -}}
+
 {{/*
 Function to validate the external database
 */}}

--- a/bitnami/kong/templates/_helpers.tpl
+++ b/bitnami/kong/templates/_helpers.tpl
@@ -17,9 +17,20 @@ Return the proper kong migration image name
 */}}
 {{- define "kong.migration.image" -}}
 {{- if .Values.migration.image -}}
-{{ include "common.images.image" (dict "imageRoot" .Values.migration.image "global" .Values.global) }}
+    {{- include "common.images.image" (dict "imageRoot" .Values.migration.image "global" .Values.global) -}}
 {{- else -}}
-{{- template "kong.image" . -}}
+    {{- template "kong.image" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "kong.imagePullSecrets" -}}
+{{- if .Values.migration.image -}}
+    {{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.ingressController.image .Values.migration.image) "global" .Values.global) -}}
+{{- else -}}
+    {{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.ingressController.image) "global" .Values.global) -}}
 {{- end -}}
 {{- end -}}
 
@@ -28,7 +39,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "kong.postgresql.fullname" -}}
-{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) -}}
 {{- end -}}
 
 {{/*
@@ -36,18 +47,14 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "kong.cassandra.fullname" -}}
-{{- printf "%s-%s" .Release.Name "cassandra" | trunc 63 | trimSuffix "-" -}}
+{{- include "common.names.dependency.fullname" (dict "chartName" "cassandra" "chartValues" .Values.cassandra "context" $) -}}
 {{- end -}}
 
 {{/*
 Get Cassandra port
 */}}
 {{- define "kong.cassandra.port" -}}
-{{- if .Values.cassandra.enabled -}}
-{{- .Values.cassandra.service.port -}}
-{{- else -}}
-{{- .Values.cassandra.external.port -}}
-{{- end -}}
+{{- ternary "9042" .Values.cassandra.external.port .Values.cassandra.enabled | quote -}}
 {{- end -}}
 
 {{/*
@@ -79,21 +86,32 @@ Get Cassandra contact points
 Get PostgreSQL host
 */}}
 {{- define "kong.postgresql.host" -}}
-{{- if .Values.postgresql.enabled -}}
-  {{- template "kong.postgresql.fullname" . -}}
-{{- else -}}
-  {{ .Values.postgresql.external.host }}
+{{- ternary (include "kong.postgresql.fullname" .) .Values.postgresql.external.host .Values.postgresql.enabled | quote -}}
 {{- end -}}
+
+{{/*
+Get PostgreSQL port
+*/}}
+{{- define "kong.postgresql.port" -}}
+{{- ternary "5432" .Values.postgresql.external.port .Values.postgresql.enabled | quote -}}
 {{- end -}}
 
 {{/*
 Get PostgreSQL user
 */}}
 {{- define "kong.postgresql.user" -}}
-{{- if .Values.postgresql.enabled -}}
-  {{- .Values.postgresql.auth.username -}}
+{{- if .Values.postgresql.enabled }}
+    {{- if .Values.global.postgresql }}
+        {{- if .Values.global.postgresql.auth }}
+            {{- coalesce .Values.global.postgresql.auth.username .Values.postgresql.auth.username | quote -}}
+        {{- else -}}
+            {{- .Values.postgresql.auth.username | quote -}}
+        {{- end -}}
+    {{- else -}}
+        {{- .Values.postgresql.auth.username | quote -}}
+    {{- end -}}
 {{- else -}}
-  {{ .Values.postgresql.external.user }}
+    {{- .Values.postgresql.external.user | quote -}}
 {{- end -}}
 {{- end -}}
 
@@ -102,9 +120,9 @@ Get Cassandra user
 */}}
 {{- define "kong.cassandra.user" -}}
 {{- if .Values.cassandra.enabled -}}
-  {{- .Values.cassandra.dbUser.user -}}
+    {{- .Values.cassandra.dbUser.user | quote -}}
 {{- else -}}
-  {{ .Values.cassandra.external.user }}
+    {{- .Values.cassandra.external.user | quote -}}
 {{- end -}}
 {{- end -}}
 
@@ -112,12 +130,29 @@ Get Cassandra user
 Get Cassandra secret
 */}}
 {{- define "kong.cassandra.secretName" -}}
-{{- if .Values.cassandra.existingSecret -}}
-  {{- .Values.cassandra.existingSecret -}}
-{{- else if .Values.cassandra.enabled }}
-  {{- template "kong.cassandra.fullname" . -}}
+{{- if .Values.cassandra.enabled -}}
+    {{- default (include "kong.cassandra.fullname" .) (tpl .Values.cassandra.dbUser.existingSecret $) -}}
 {{- else -}}
-  {{- printf "%s-external-secret" ( include "common.names.fullname" . ) -}}
+    {{- printf "%s-external-secret" ( include "common.names.fullname" . ) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Add environment variables to configure database values
+*/}}
+{{- define "kong.cassandra.databaseSecretKey" -}}
+{{- if .Values.cassandra.enabled -}}
+    {{- print "cassandra-password" -}}
+{{- else -}}
+    {{- if .Values.cassandra.external.existingSecret -}}
+        {{- if .Values.cassandra.external.existingSecretPasswordKey -}}
+            {{- printf "%s" .Values.cassandra.external.existingSecretPasswordKey -}}
+        {{- else -}}
+            {{- print "cassandra-password" -}}
+        {{- end -}}
+    {{- else -}}
+        {{- print "cassandra-password" -}}
+    {{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -125,27 +160,49 @@ Get Cassandra secret
 Get PostgreSQL secret
 */}}
 {{- define "kong.postgresql.secretName" -}}
-{{- if .Values.postgresql.auth.existingSecret -}}
-  {{- .Values.postgresql.auth.existingSecret -}}
-{{- else if .Values.postgresql.enabled }}
-  {{- template "kong.postgresql.fullname" . -}}
+{{- if .Values.postgresql.enabled }}
+    {{- if .Values.global.postgresql }}
+        {{- if .Values.global.postgresql.auth }}
+            {{- if .Values.global.postgresql.auth.existingSecret }}
+                {{- tpl .Values.global.postgresql.auth.existingSecret $ -}}
+            {{- else -}}
+               {{- default (include "kong.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
+            {{- end -}}
+        {{- else -}}
+            {{- default (include "kong.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
+        {{- end -}}
+    {{- else -}}
+        {{- default (include "kong.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
+    {{- end -}}
 {{- else -}}
-  {{- printf "%s-external-secret" ( include "common.names.fullname" . ) -}}
+    {{- default (printf "%s-external-secret" (include "common.names.fullname" .)) (tpl .Values.postgresql.external.existingSecret $) -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Return the proper Docker Image Registry Secret Names
+Add environment variables to configure database values
 */}}
-{{- define "kong.imagePullSecrets" -}}
-{{ include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.ingressController.image) "global" .Values.global) }}
+{{- define "kong.postgresql.databaseSecretKey" -}}
+{{- if .Values.postgresql.enabled -}}
+    {{- print "password" -}}
+{{- else -}}
+    {{- if .Values.postgresql.external.existingSecret -}}
+        {{- if .Values.postgresql.external.existingSecretPasswordKey -}}
+            {{- printf "%s" .Values.postgresql.external.existingSecretPasswordKey -}}
+        {{- else -}}
+            {{- print "password" -}}
+        {{- end -}}
+    {{- else -}}
+        {{- print "password" -}}
+    {{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*
 Return true if a secret for a external database should be created
 */}}
 {{- define "kong.createExternalDBSecret" -}}
-{{- if and (not .Values.postgresql.enabled) (not .Values.cassandra.enabled) (not .Values.cassandra.existingSecret) (not .Values.postgresql.auth.existingSecret) -}}
+{{- if or (and (eq .Values.database "postgresql") (not .Values.postgresql.enabled) (not .Values.postgresql.external.existingSecret)) (and (eq .Values.database "cassandra") (not .Values.cassandra.enabled) (not .Values.cassandra.external.existingSecret)) -}}
   {{- true -}}
 {{- end -}}
 {{- end -}}
@@ -153,11 +210,11 @@ Return true if a secret for a external database should be created
 {{/*
 Get proper service account
 */}}
-{{- define "kong.serviceAccount" -}}
-{{- if .Values.ingressController.rbac.existingServiceAccount -}}
-{{ .Values.ingressController.rbac.existingServiceAccount }}
+{{- define "kong.ingressController.serviceAccountName" -}}
+{{- if .Values.ingressController.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.ingressController.serviceAccount.name }}
 {{- else -}}
-{{- include "common.names.fullname" . -}}
+    {{ default "default" .Values.ingressController.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -169,6 +226,7 @@ Validate values for kong.
 {{- $messages := append $messages (include "kong.validateValues.database" .) -}}
 {{- $messages := append $messages (include "kong.validateValues.rbac" .) -}}
 {{- $messages := append $messages (include "kong.validateValues.ingressController" .) -}}
+{{- $messages := append $messages (include "kong.validateValues.daemonset" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -213,16 +271,23 @@ PostgreSQL instance. Only one of postgresql.enabled (deploy sub-chart) and postg
 {{- if and (eq .Values.database "cassandra") .Values.cassandra.enabled .Values.cassandra.external.hosts -}}
 CONFLICT: You specified to deploy the Cassandra sub-chart and also specified external
 Cassandra hosts. Only one of cassandra.enabled (deploy sub-chart) and cassandra.external.hosts can be set
-{{- end }}
+{{- end -}}
 {{- end -}}
 
 {{/*
 Function to validate the ingress controller
 */}}
 {{- define "kong.validateValues.ingressController" -}}
-
 {{- if (and (eq .Values.database "cassandra") .Values.ingressController.enabled) -}}
 INGRESS AND CASANDRA: Cassandra-backed deployments of Kong managed by Kong Ingress Controller are no longer supported. You must migrate to a Postgres-backed deployment or disable Kong Ingress Controller.
-{{- end }}
+{{- end -}}
+{{- end -}}
 
+{{/*
+Function to validate incompatibilities with deploying Kong as a daemonset
+*/}}
+{{- define "kong.validateValues.daemonset" -}}
+{{- if and .Values.useDaemonset (or .Values.pdb.enabled .Values.autoscaling.enabled) -}}
+INVALID SETUP: Deploying a HorizontalPodAutoscaler or a PodDisruptionBudget is not compatible with deploying Kong as a daemonset.
+{{- end -}}
 {{- end -}}

--- a/bitnami/kong/templates/dep-ds.yaml
+++ b/bitnami/kong/templates/dep-ds.yaml
@@ -48,18 +48,12 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
     spec:
+      {{- include "kong.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.ingressController.enabled }}
-      serviceAccountName: {{ include "kong.serviceAccount" . }}
-      {{- end }}
-      {{- if .Values.podSecurityContext }}
-      securityContext: {{- include "common.tplvalues.render" (dict "value" .Values.podSecurityContext "context" $) | nindent 8 }}
-      {{- end }}
-      {{- include "kong.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.schedulerName }}
-      schedulerName: {{ .Values.schedulerName | quote }}
+      serviceAccountName: {{ include "kong.ingressController.serviceAccountName" . }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
@@ -75,6 +69,21 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}
@@ -82,8 +91,8 @@ spec:
         - name: kong
           image: {{ template "kong.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.containerSecurityContext }}
-          securityContext: {{- include "common.tplvalues.render" (dict "value" .Values.containerSecurityContext "context" $) | nindent 12 }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
@@ -102,43 +111,43 @@ spec:
             - name: KONG_ADMIN_LISTEN_ADDRESS
               value: "0.0.0.0"
             {{- end }}
-            {{- if (eq .Values.database "postgresql") }}
             - name: KONG_DATABASE
-              value: "postgres"
+              value: {{ ternary "postgres" "cassandra" (eq .Values.database "postgresql") | quote }}
+            {{- if (eq .Values.database "postgresql") }}
             {{- if .Values.postgresql.auth.usePasswordFiles }}
             - name: KONG_POSTGRESQL_PASSWORD_FILE
-              value: "/bitnami/kong/secrets/password"
+              value: {{ printf "/bitnami/kong/secrets/%s" (include "kong.postgresql.databaseSecretKey" .) }}
             {{- else }}
             - name: KONG_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kong.postgresql.secretName" . }}
-                  key: password
+                  key: {{ include "kong.postgresql.databaseSecretKey" . }}
             {{- end }}
             - name: KONG_PG_HOST
               value: {{ include "kong.postgresql.host" . }}
+            - name: KONG_PG_PORT
+              value: {{ include "kong.postgresql.port" . }}
             - name: KONG_PG_USER
               value: {{ include "kong.postgresql.user" . }}
             {{- end }}
             {{- if (eq .Values.database "cassandra") }}
-            - name: KONG_DATABASE
-              value: "cassandra"
             {{- if .Values.cassandra.usePasswordFile }}
             - name: KONG_CASSANDRA_PASSWORD_FILE
-              value: "/bitnami/kong/secrets/cassandra-password"
+              value: {{ printf "/bitnami/kong/secrets/%s" (include "kong.cassandra.databaseSecretKey" .) }}
             {{- else }}
             - name: KONG_CASSANDRA_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kong.cassandra.secretName" . }}
-                  key: cassandra-password
+                  key: {{ include "kong.cassandra.databaseSecretKey" . }}
             {{- end }}
             - name: KONG_CASSANDRA_CONTACT_POINTS
               value: {{ include "kong.cassandra.contactPoints" . }}
             - name: KONG_CASSANDRA_PORT
-              value: {{ include "kong.cassandra.port" . | quote }}
+              value: {{ include "kong.cassandra.port" . }}
             - name: KONG_CASSANDRA_USER
-              value: {{ include "kong.cassandra.user" . | quote }}
+              value: {{ include "kong.cassandra.user" . }}
             {{- end }}
             {{- if .Values.metrics.enabled }}
             - name: KONG_NGINX_HTTP_INCLUDE
@@ -160,50 +169,47 @@ spec:
           {{- end }}
           ports:
             - name: http-proxy
-              containerPort: 8000
+              containerPort: {{ .Values.kong.containerPorts.proxyHttp }}
               protocol: TCP
             - name: https-proxy
-              containerPort: 8443
+              containerPort: {{ .Values.kong.containerPorts.proxyHttps }}
               protocol: TCP
             - name: http-admin
-              containerPort: 8001
+              containerPort: {{ .Values.kong.containerPorts.adminHttp }}
               protocol: TCP
             - name: https-admin
-              containerPort: 8444
+              containerPort: {{ .Values.kong.containerPorts.adminHttps }}
               protocol: TCP
             {{- if .Values.metrics.enabled }}
             - name: http-metrics
-              containerPort: {{ .Values.metrics.service.port }}
+              containerPort: {{ .Values.metrics.containerPorts.http }}
               protocol: TCP
             {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.kong.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kong.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http-proxy
+          {{- else if .Values.kong.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kong.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.kong.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kong.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - /health/kong-container-health.sh
-            initialDelaySeconds: {{ .Values.kong.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.kong.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.kong.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.kong.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.kong.livenessProbe.successThreshold }}
           {{- else if .Values.kong.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kong.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.kong.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kong.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - /bin/bash
                 - -ec
                 - /health/kong-container-health.sh
-            initialDelaySeconds: {{ .Values.kong.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.kong.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.kong.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.kong.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.kong.readinessProbe.successThreshold }}
           {{- else if .Values.kong.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kong.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -215,7 +221,7 @@ spec:
                   - /bin/sh
                   - -c
                   - kong quit
-          {{ else }}
+          {{- else }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.kong.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
@@ -246,8 +252,8 @@ spec:
         - name: kong-ingress-controller
           image: {{ template "kong.ingress-controller.image" . }}
           imagePullPolicy: {{ .Values.ingressController.image.pullPolicy }}
-          {{- if .Values.containerSecurityContext }}
-          securityContext: {{- include "common.tplvalues.render" (dict "value" .Values.containerSecurityContext "context" $) | nindent 12 }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
@@ -266,7 +272,7 @@ spec:
           {{- end }}
           env:
             - name: CONTROLLER_KONG_ADMIN_URL
-              value: http://127.0.0.1:8001
+              value: http://127.0.0.1:{{ .Values.kong.containerPorts.adminHttp }}
             - name: CONTROLLER_PUBLISH_SERVICE
               value: {{ printf "%s/%s" .Release.Namespace (include "common.names.fullname" .) | quote }}
             - name: CONTROLLER_INGRESS_CLASS
@@ -297,37 +303,37 @@ spec:
           {{- end }}
           ports:
             - name: http-health
-              containerPort: 10254
+              containerPort: {{ .Values.ingressController.containerPorts.health }}
               protocol: TCP
           {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.ingressController.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingressController.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http-health
+          {{- else if .Values.ingressController.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingressController.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- if .Values.ingressController.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingressController.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: "/healthz"
               port: http-health
               scheme: HTTP
-            initialDelaySeconds: {{ .Values.ingressController.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.ingressController.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.ingressController.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.ingressController.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.ingressController.livenessProbe.successThreshold }}
           {{- else if .Values.ingressController.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingressController.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.ingressController.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingressController.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: "/healthz"
               port: http-health
               scheme: HTTP
-            initialDelaySeconds: {{ .Values.ingressController.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.ingressController.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.ingressController.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.ingressController.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.ingressController.readinessProbe.successThreshold }}
           {{- else if .Values.ingressController.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingressController.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.ingressController.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.ingressController.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.ingressController.resources }}
           resources: {{- toYaml .Values.ingressController.resources | nindent 12 }}

--- a/bitnami/kong/templates/external-database-secret.yaml
+++ b/bitnami/kong/templates/external-database-secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.names.fullname" . }}-external-secret
+  name: {{ printf "%s-external-secret" (include "common.names.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
@@ -14,10 +14,10 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if .Values.cassandra.external.password }}
+  {{- if eq .Values.database "cassandra" }}
   cassandra-password: {{ .Values.cassandra.external.password | b64enc | quote }}
   {{- end }}
-  {{- if .Values.postgresql.external.password }}
+  {{- if eq .Values.database "postgresql" }}
   password: {{ .Values.postgresql.external.password | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/bitnami/kong/templates/hpa.yaml
+++ b/bitnami/kong/templates/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if and .Values.autoscaling.enabled (not .Values.useDaemonset) }}
 apiVersion: {{ .Values.autoscaling.apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
@@ -19,6 +19,5 @@ spec:
     name: {{ include "common.names.fullname" . }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
-  metrics:
-    {{- include "common.tplvalues.render" (dict "value" .Values.autoscaling.metrics "context" $) | nindent 4 }}
+  metrics: {{- include "common.tplvalues.render" (dict "value" .Values.autoscaling.metrics "context" $) | nindent 4 }}
 {{- end }}

--- a/bitnami/kong/templates/ingress-controller-rbac.yaml
+++ b/bitnami/kong/templates/ingress-controller-rbac.yaml
@@ -43,6 +43,9 @@ rules:
       - endpoints
     verbs:
       - get
+  {{- if .Values.ingressController.rbac.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.ingressController.rbac.rules "context" $ ) | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
@@ -63,12 +66,13 @@ roleRef:
   name: {{ template "common.names.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "kong.serviceAccount" . }}
+    name: {{ include "kong.ingressController.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
+  name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
     {{- if .Values.commonLabels }}
@@ -77,7 +81,6 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  name: {{ template "common.names.fullname" . }}
 rules:
   - apiGroups:
       - ""
@@ -147,6 +150,9 @@ rules:
       - get
       - list
       - watch
+  {{- if .Values.ingressController.rbac.rules }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.ingressController.rbac.rules "context" $ ) | nindent 2 }}
+  {{- end }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
@@ -166,22 +172,7 @@ roleRef:
   name: {{ template "common.names.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "kong.serviceAccount" . }}
+    name: {{ include "kong.ingressController.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 ---
-{{- if not .Values.ingressController.rbac.existingServiceAccount }}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: server
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
-{{- end }}
 {{- end }}

--- a/bitnami/kong/templates/ingress-controller-serviceaccount.yaml
+++ b/bitnami/kong/templates/ingress-controller-serviceaccount.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.ingressController.enabled .Values.ingressController.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kong.ingressController.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: server
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.ingressController.serviceAccount.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.ingressController.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingressController.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.ingressController.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/bitnami/kong/templates/ingress.yaml
+++ b/bitnami/kong/templates/ingress.yaml
@@ -11,9 +11,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
-    {{- if .Values.ingress.certManager }}
-    kubernetes.io/tls-acme: "true"
-    {{- end }}
     {{- if .Values.ingress.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
@@ -21,6 +18,9 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
+  {{- if and .Values.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
     - host: {{ .Values.ingress.hostname }}
@@ -45,11 +45,11 @@ spec:
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" $backendPort "context" $) | nindent 14 }}
     {{- end }}
-  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
+  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
   tls:
-    {{- if .Values.ingress.tls }}
+    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
     - hosts:
-        - {{ .Values.ingress.hostname }}
+        - {{ .Values.ingress.hostname | quote }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}

--- a/bitnami/kong/templates/kong-prometheus-role.yaml
+++ b/bitnami/kong/templates/kong-prometheus-role.yaml
@@ -2,10 +2,10 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
-  name: {{ template "common.names.fullname" . }}-prometheus
+  name: {{ printf "%s-prometheus" (include "common.names.fullname" .) }}
   namespace: {{ .Release.Namespace }}
 rules:
-- apiGroups: [""]
-  resources: ["endpoints", "services", "pods"]
-  verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["endpoints", "services", "pods"]
+    verbs: ["get", "list", "watch"]
 {{- end }}

--- a/bitnami/kong/templates/kong-prometheus-rolebinding.yaml
+++ b/bitnami/kong/templates/kong-prometheus-rolebinding.yaml
@@ -2,18 +2,14 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
-  name: {{ template "common.names.fullname" . }}-prometheus
+  name: printf "%s-prometheus" (include "common.names.fullname" .)
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "common.names.fullname" . }}-prometheus
+  name: printf "%s-prometheus" (include "common.names.fullname" .)
 subjects:
-  {{- if .Values.metrics.serviceMonitor.namespace }}
-  - namespace: {{ .Values.metrics.serviceMonitor.namespace }}
-  {{- else }}
-  - namespace: {{ .Release.Namespace }}
-  {{- end }}
-  kind: ServiceAccount
-  name: {{ required "A valid .Values.metrics.serviceMonitor.serviceAccount entry required!" .Values.metrics.serviceMonitor.serviceAccount }}
+  - namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace }}
+    kind: ServiceAccount
+    name: {{ required "A valid .Values.metrics.serviceMonitor.serviceAccount entry required!" .Values.metrics.serviceMonitor.serviceAccount }}
 {{- end }}

--- a/bitnami/kong/templates/kong-script-configmap.yaml
+++ b/bitnami/kong/templates/kong-script-configmap.yaml
@@ -32,7 +32,7 @@ data:
     #!/bin/bash
 
     echo "Waiting for the Kong container to be ready"
-    if wait-for-port --timeout={{ .Values.ingressController.proxyReadyTimeout }} --host=127.0.0.1 --state=inuse 8000; then
+    if wait-for-port --timeout={{ .Values.ingressController.proxyReadyTimeout }} --host=127.0.0.1 --state=inuse {{ .Values.kong.containerPorts.proxyHttp }}; then
       echo "Kong container ready"
     else
       echo "Kong not ready after {{ .Values.ingressController.proxyReadyTimeout }} seconds"

--- a/bitnami/kong/templates/metrics-exporter-configmap.yaml
+++ b/bitnami/kong/templates/metrics-exporter-configmap.yaml
@@ -17,7 +17,7 @@ data:
     # Prometheus metrics
     server {
         server_name kong_prometheus_exporter;
-        listen 0.0.0.0:{{ .Values.metrics.service.port }};
+        listen 0.0.0.0:{{ coalesce .Values.metrics.service.ports.http .Values.metrics.service.port }};
         access_log off;
         location /metrics {
             default_type text/plain;

--- a/bitnami/kong/templates/metrics-script-configmap.yaml
+++ b/bitnami/kong/templates/metrics-script-configmap.yaml
@@ -20,11 +20,11 @@ data:
 
     info "Enabling prometheus plugin"
 
-    if curl --silent http://localhost:8001/ | grep -Eo '"prometheus":false' > /dev/null; then
-      if ! curl --silent http://localhost:8001/plugins -d name=prometheus; then
+    if curl --silent http://localhost:{{ .Values.kong.containerPorts.adminHttp }}/ | grep -Eo '"prometheus":false' > /dev/null; then
+      if ! curl --silent http://localhost:{{ .Values.kong.containerPorts.adminHttp }}/plugins -d name=prometheus; then
          info "Issue enabling prometheus plugin, this could be due to a race condition with another kong node. Checking status"
       fi
-      if curl http://localhost:8001/ | grep -Eo '"prometheus":true' > /dev/null; then
+      if curl http://localhost:{{ .Values.kong.containerPorts.adminHttp }}/ | grep -Eo '"prometheus":true' > /dev/null; then
          info "Prometheus metrics plugin enabled"
       else
          error "Error enabling Prometheus plugin"

--- a/bitnami/kong/templates/metrics-service.yaml
+++ b/bitnami/kong/templates/metrics-service.yaml
@@ -19,6 +19,10 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
+  sessionAffinity: {{ .Values.metrics.service.sessionAffinity }}
+  {{- if .Values.metrics.service.clusterIP }}
+  clusterIP: {{ .Values.metrics.service.clusterIP }}
+  {{- end }}
   ports:
     - port: {{ coalesce .Values.metrics.service.ports.http .Values.metrics.service.port }}
       targetPort: http-metrics

--- a/bitnami/kong/templates/metrics-service.yaml
+++ b/bitnami/kong/templates/metrics-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.metrics.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,19 +19,11 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  type: {{ .Values.metrics.service.type }}
-  {{- if and (eq .Values.metrics.service.type "LoadBalancer") (not (empty .Values.metrics.service.loadBalancerIP)) }}
-  loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}
-  {{- end }}
   ports:
-    - port: {{ .Values.metrics.service.port }}
+    - port: {{ coalesce .Values.metrics.service.ports.http .Values.metrics.service.port }}
       targetPort: http-metrics
       protocol: TCP
       name: http-metrics
-      {{- if and (or (eq .Values.metrics.service.type "NodePort") (eq .Values.metrics.service.type "LoadBalancer")) (not (empty .Values.metrics.service.nodePort)) }}
-      nodePort: {{ .Values.metrics.service.nodePort }}
-      {{- else if eq .Values.metrics.service.type "ClusterIP" }}
-      nodePort: null
-      {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: server
+{{- end }}

--- a/bitnami/kong/templates/migrate-job.yaml
+++ b/bitnami/kong/templates/migrate-job.yaml
@@ -17,9 +17,11 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: migration
-      annotations:
+        {{- if .Values.migration.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.migration.podLabels "context" $) | nindent 8 }}
+        {{- end }}
       {{- if .Values.migration.podAnnotations }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.migration.podAnnotations "context" $) | nindent 8 }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.migration.podAnnotations "context" $) | nindent 8 }}
       {{- end }}
     spec:
       {{- include "kong.imagePullSecrets" . | nindent 6 }}

--- a/bitnami/kong/templates/migrate-job.yaml
+++ b/bitnami/kong/templates/migrate-job.yaml
@@ -24,8 +24,8 @@ spec:
     spec:
       {{- include "kong.imagePullSecrets" . | nindent 6 }}
       restartPolicy: OnFailure
-      {{- if .Values.podSecurityContext }}
-      securityContext: {{- include "common.tplvalues.render" (dict "value" .Values.podSecurityContext "context" $) | nindent 8 }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.migration.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.migration.hostAliases "context" $) | nindent 8 }}
@@ -40,8 +40,8 @@ spec:
           {{- if .Values.migration.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.migration.args "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.containerSecurityContext }}
-          securityContext: {{- include "common.tplvalues.render" (dict "value" .Values.containerSecurityContext "context" $) | nindent 12 }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
           env:
             - name: KONG_MIGRATE
@@ -50,36 +50,36 @@ spec:
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: KONG_EXIT_AFTER_MIGRATE
               value: "yes"
-            {{- if (eq .Values.database "postgresql") }}
             - name: KONG_DATABASE
-              value: "postgres"
+              value: {{ ternary "postgres" "cassandra" (eq .Values.database "postgresql") | quote }}
+            {{- if (eq .Values.database "postgresql") }}
             {{- if .Values.postgresql.auth.usePasswordFiles }}
             - name: KONG_POSTGRESQL_PASSWORD_FILE
-              value: "/bitnami/kong/secrets/password"
+              value: {{ printf "/bitnami/kong/secrets/%s" (include "kong.postgresql.databaseSecretKey" .) }}
             {{- else }}
             - name: KONG_PG_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kong.postgresql.secretName" . }}
-                  key: password
+                  key: {{ include "kong.postgresql.databaseSecretKey" . }}
             {{- end }}
             - name: KONG_PG_HOST
               value: {{ include "kong.postgresql.host" . }}
+            - name: KONG_PG_PORT
+              value: {{ include "kong.postgresql.port" . }}
             - name: KONG_PG_USER
               value: {{ include "kong.postgresql.user" . }}
             {{- end }}
             {{- if (eq .Values.database "cassandra") }}
-            - name: KONG_DATABASE
-              value: "cassandra"
             {{- if .Values.cassandra.usePasswordFile }}
             - name: KONG_CASSANDRA_PASSWORD_FILE
-              value: "/bitnami/kong/secrets/cassandra-password"
+              value: {{ printf "/bitnami/kong/secrets/%s" (include "kong.cassandra.databaseSecretKey" .) }}
             {{- else }}
             - name: KONG_CASSANDRA_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "kong.cassandra.secretName" . }}
-                  key: cassandra-password
+                  key: {{ include "kong.cassandra.databaseSecretKey" . }}
             {{- end }}
             - name: KONG_CASSANDRA_CONTACT_POINTS
               value: {{ include "kong.cassandra.contactPoints" . }}

--- a/bitnami/kong/templates/pdb.yaml
+++ b/bitnami/kong/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pdb.enabled }}
+{{- if and .Values.pdb.enabled (not .Values.useDaemonset) }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
@@ -20,6 +20,6 @@ spec:
   maxUnavailable: {{ .Values.pdb.maxUnavailable }}
   {{- end  }}
   selector:
-    matchLabels:
-      {{- include "common.labels.matchLabels" . | nindent 6 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
 {{- end }}

--- a/bitnami/kong/templates/pdb.yaml
+++ b/bitnami/kong/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.pdb.enabled (not .Values.useDaemonset) }}
+{{- if and (coalesce .Values.pdb.create .Values.pdb.enabled) (not .Values.useDaemonset) }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/bitnami/kong/templates/service.yaml
+++ b/bitnami/kong/templates/service.yaml
@@ -19,54 +19,60 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.externalTrafficPolicy)) }}
-  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
-  {{- end }}
-  {{- if not (empty .Values.service.clusterIP) }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
-  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
+  {{- if (or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  {{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{- end }}
+  {{- if not (empty .Values.service.loadBalancerIP) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   {{- end }}
   ports:
     {{- if not .Values.service.disableHttpPort }}
-    - port: {{ .Values.service.proxyHttpPort }}
+    - port: {{ coalesce .Values.service.ports.proxyHttp .Values.service.proxyHttpPort }}
       targetPort: http-proxy
       protocol: TCP
       name: http-proxy
-      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.proxyHttpNodePort)) }}
-      nodePort: {{ .Values.service.proxyHttpNodePort }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty (coalesce .Values.service.nodePorts.proxyHttp .Values.service.proxyHttpNodePort))) }}
+      nodePort: {{ coalesce .Values.service.nodePorts.proxyHttp .Values.service.proxyHttpNodePort }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
     {{- end }}
-    - port: {{ .Values.service.proxyHttpsPort }}
+    - port: {{ coalesce .Values.service.ports.proxyHttps .Values.service.proxyHttpsPort }}
       targetPort: https-proxy
       protocol: TCP
       name: https-proxy
-      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.proxyHttpsNodePort)) }}
-      nodePort: {{ .Values.service.proxyHttpsNodePort }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty (coalesce .Values.service.nodePorts.proxyHttps .Values.service.proxyHttpsNodePort))) }}
+      nodePort: {{ coalesce .Values.service.nodePorts.proxyHttps .Values.service.proxyHttpsNodePort }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
     {{- if .Values.service.exposeAdmin }}
     {{- if not .Values.service.disableHttpPort }}
-    - port: {{ .Values.service.adminHttpPort }}
+    - port: {{ coalesce .Values.service.ports.adminHttp .Values.service.adminHttpPort }}
       targetPort: http-admin
       protocol: TCP
       name: http-admin
-      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.adminHttpNodePort)) }}
-      nodePort: {{ .Values.service.adminHttpNodePort }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty (coalesce .Values.service.nodePorts.adminHttp .Values.service.adminHttpNodePort))) }}
+      nodePort: {{ coalesce .Values.service.nodePorts.adminHttp .Values.service.adminHttpNodePort }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
     {{- end }}
-    - port: {{ .Values.service.adminHttpsPort }}
+    - port: {{ coalesce .Values.service.ports.adminHttps .Values.service.adminHttpsPort }}
       targetPort: https-admin
       protocol: TCP
       name: https-admin
-      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.adminHttpsNodePort)) }}
-      nodePort: {{ .Values.service.adminHttpsNodePort }}
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty (coalesce .Values.service.nodePorts.adminHttps .Values.service.adminHttpsNodePort))) }}
+      nodePort: {{ coalesce .Values.service.nodePorts.adminHttps .Values.service.adminHttpsNodePort }}
       {{- else if eq .Values.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}

--- a/bitnami/kong/templates/servicemonitor.yaml
+++ b/bitnami/kong/templates/servicemonitor.yaml
@@ -3,13 +3,12 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
-  {{- if .Values.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace }}
-  {{- else }}
-  namespace: {{ .Release.Namespace }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
+    {{- end }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -17,11 +16,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  selector:
-    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
-      {{- if .Values.metrics.serviceMonitor.selector }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
-      {{- end }}
+  {{- if .Values.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}
+  {{- end }}
   endpoints:
     - port: http-metrics
       path: "/metrics"
@@ -31,7 +28,22 @@ spec:
       {{- if .Values.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.metrics.serviceMonitor.relabelings }}
+      relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 6 }}
+      {{- end }}
+      {{- if .Values.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ .Values.metrics.serviceMonitor.honorLabels }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+      {{- if .Values.metrics.serviceMonitor.selector }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
+      {{- end }}
+      app.kubernetes.io/component: server
 {{- end }}

--- a/bitnami/kong/templates/tls-secrets.yaml
+++ b/bitnami/kong/templates/tls-secrets.yaml
@@ -19,7 +19,8 @@ data:
   tls.key: {{ .key | b64enc }}
 ---
 {{- end }}
-{{- else if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- end }}
+{{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
 {{- $ca := genCA "kong-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
 apiVersion: v1

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -242,12 +242,12 @@ autoscaling:
         targetAverageUtilization: 80
 ## Kong Pod Disruption Budget
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-## @param pdb.enabled Deploy a PodDisruptionBudget object for Kong deployment
+## @param pdb.create Deploy a PodDisruptionBudget object for Kong deployment
 ## @param pdb.minAvailable Minimum available Kong replicas (expressed in percentage)
 ## @param pdb.maxUnavailable Maximum unavailable Kong replicas (expressed in percentage)
 ##
 pdb:
-  enabled: false
+  create: false
   minAvailable: ""
   maxUnavailable: "50%"
 
@@ -526,9 +526,6 @@ ingressController:
   ## @param ingressController.enabled Enable/disable the Kong Ingress Controller
   ##
   enabled: true
-  ## @param ingressController.customResourceDeletePolicy Add custom CRD resource delete policy (for Helm 2 support)
-  ##
-  customResourceDeletePolicy: {}
   ## @param ingressController.image.registry Kong Ingress Controller image registry
   ## @param ingressController.image.repository Kong Ingress Controller image name
   ## @param ingressController.image.tag Kong Ingress Controller image tag
@@ -722,8 +719,16 @@ migration:
   ## @param migration.annotations [object] Add annotations to the job
   ##
   annotations:
-    helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook: post-install, pre-upgrade
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  ## @param migration.podLabels Additional pod labels
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param migration.podAnnotations Additional pod annotations
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
 
 ## @section PostgreSQL Parameters
 ##
@@ -788,6 +793,7 @@ postgresql:
 ## @param cassandra.dbUser.password Password for `cassandra.dbUser.user`. Randomly generated if empty
 ## @param cassandra.dbUser.existingSecret Name of existing secret to use for Cassandra credentials
 ## @param cassandra.usePasswordFile Mount credentials as a files instead of using an environment variable
+## @param cassandra.replicaCount Number of Cassandra replicas
 ##
 cassandra:
   enabled: false
@@ -796,6 +802,7 @@ cassandra:
     password: ""
     existingSecret: ""
   usePasswordFile: false
+  replicaCount: 1
   ## External Cassandra configuration
   ## All of these values are only used when cassandra.enabled is set to false
   ## @param cassandra.external.hosts List of Cassandra hosts
@@ -827,16 +834,26 @@ metrics:
   containerPorts:
     http: 9119
   ## Kong metrics service configuration
-  ## @param metrics.service.annotations [object] Annotations for Prometheus metrics service
-  ## @param metrics.service.type Type of the Prometheus metrics service
-  ## @param metrics.service.ports.http Prometheus metrics service HTTP port
   ##
   service:
-    type: ClusterIP
+    ## @param metrics.service.sessionAffinity Control where client requests go, to the same pod or round-robin
+    ## Values: ClientIP or None
+    ## ref: https://kubernetes.io/docs/user-guide/services/
+    ##
+    sessionAffinity: None
+    ## @param metrics.service.clusterIP Cluster internal IP of the service
+    ## This is the internal IP address of the service and is usually assigned randomly.
+    ## ref: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
+    ##
+    clusterIP: ""
+    ## @param metrics.service.annotations [object] Annotations for Prometheus metrics service
+    ##
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ coalesce .Values.metrics.service.ports.http .Values.metrics.service.port }}"
       prometheus.io/path: "/metrics"
+    ## @param metrics.service.ports.http Prometheus metrics service HTTP port
+    ##
     ports:
       http: 9119
   ## Kong ServiceMonitor configuration

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -23,10 +23,10 @@ global:
 ## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
 ##
 kubeVersion: ""
-## @param nameOverride String to partially override kong.fullname template with a string (will prepend the release name)
+## @param nameOverride String to partially override common.names.fullname template with a string (will prepend the release name)
 ##
 nameOverride: ""
-## @param fullnameOverride String to fully override kong.fullname template with a string
+## @param fullnameOverride String to fully override common.names.fullname template with a string
 ##
 fullnameOverride: ""
 ## @param commonAnnotations Common annotations to add to all Kong resources (sub-charts are not considered). Evaluated as a template
@@ -41,24 +41,22 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release (evaluated as a template).
 ##
 extraDeploy: []
-
-## Enable diagnostic mode in the deployment
+## Enable diagnostic mode in the daemonset/deployment
 ##
 diagnosticMode:
   ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
   ##
   enabled: false
-  ## @param diagnosticMode.command Command to override all containers in the deployment
+  ## @param diagnosticMode.command Command to override all containers in the daemonset/deployment
   ##
   command:
     - sleep
-  ## @param diagnosticMode.args Args to override all containers in the deployment
+  ## @param diagnosticMode.args Args to override all containers in the daemonset/deployment
   ##
   args:
     - infinity
 
-## @section Deployment parameters
-##
+## @section Kong common parameters
 
 ## Bitnami kong image version
 ## ref: https://hub.docker.com/r/bitnami/kong/tags/
@@ -81,7 +79,7 @@ image:
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  ## Example:
+  ## E.g:
   ## pullSecrets:
   ##   - myRegistryKeySecretName
   ##
@@ -92,16 +90,38 @@ image:
 ## @param database Select which database backend Kong will use. Can be 'postgresql' or 'cassandra'
 ##
 database: postgresql
-## @param replicaCount Number of replicas of the kong Pod
+
+## @section Kong deployment / daemonset parameters
+
+## @param useDaemonset Use a daemonset instead of a deployment. `replicaCount` will not take effect.
+##
+useDaemonset: false
+## @param replicaCount Number of Kong replicas
 ##
 replicaCount: 2
-## @param hostAliases Add deployment host aliases
-## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+## Kong containers' Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## @param containerSecurityContext.enabled Enabled Kong containers' Security Context
+## @param containerSecurityContext.runAsUser Set Kong container's Security Context runAsUser
+## @param containerSecurityContext.runAsNonRoot Set Kong container's Security Context runAsNonRoot
 ##
-hostAliases: []
-## @param updateStrategy.type Set up update strategy for kong installation. Set to Recreate if you use persistent volume that cannot be mounted by more than one pods to makesure the pods is destroyed first.
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+  runAsNonRoot: true
+## Kong pods' Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param podSecurityContext.enabled Enabled Kong pods' Security Context
+## @param podSecurityContext.fsGroup Set Kong pod's Security Context fsGroup
+##
+podSecurityContext:
+  enabled: false
+  fsGroup: 1001
+## @param updateStrategy.type Kong update strategy
+## @param updateStrategy.rollingUpdate Kong deployment rolling update configuration parameters
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
-## Example:
+## Note: Set to Recreate if you use persistent volume that cannot be mounted by more than one pods to make sure the pods is destroyed first.
+## E.g:
 ## updateStrategy:
 ##  type: RollingUpdate
 ##  rollingUpdate:
@@ -110,55 +130,35 @@ hostAliases: []
 ##
 updateStrategy:
   type: RollingUpdate
-## @param schedulerName Alternative scheduler
+  rollingUpdate: {}
+## @param hostAliases Add deployment host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+##
+topologySpreadConstraints: {}
+## @param priorityClassName Priority Class Name
+## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
+##
+priorityClassName: ""
+## @param schedulerName Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
 schedulerName: ""
-## @param useDaemonset Use a daemonset instead of a deployment. `replicaCount` will not take effect.
+## @param terminationGracePeriodSeconds Seconds Kong pod needs to terminate gracefully
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
 ##
-useDaemonset: false
-## @param extraVolumes Array of extra volumes to be added to the Kong deployment deployment (evaluated as template). Requires setting `extraVolumeMounts`
+terminationGracePeriodSeconds: ""
+## @param podAnnotations Additional pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
-extraVolumes: []
-## @param initContainers Add additional init containers to the pod (evaluated as a template)
-## e.g.
-## - name: your-image-name
-##   image: your-image
-##   imagePullPolicy: Always
-##   ports:
-##     - name: portname
-##        containerPort: 1234
+podAnnotations: {}
+## @param podLabels Additional pod labels
+## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
-initContainers: []
-## @param sidecars Attach additional containers to the pod (evaluated as a template)
-## e.g.
-## - name: your-image-name
-##   image: your-image
-##   imagePullPolicy: Always
-##   ports:
-##     - name: portname
-##        containerPort: 1234
-##
-sidecars: []
-## SecurityContext configuration
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-## @param containerSecurityContext.runAsUser Set Kong container's Security Context runAsUser
-## @param containerSecurityContext.runAsNonRoot Set Kong container's Security Context runAsNonRoot
-##
-containerSecurityContext:
-  runAsUser: 1001
-  runAsNonRoot: true
-## @param podSecurityContext Pod security context
-##
-podSecurityContext: {}
-## @param nodeSelector Node labels for pod assignment
-## Ref: https://kubernetes.io/docs/user-guide/node-selection/
-##
-nodeSelector: {}
-## @param tolerations Tolerations for pod assignment
-## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-##
-tolerations: []
+podLabels: {}
 ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
 ##
@@ -188,17 +188,40 @@ nodeAffinityPreset:
   values: []
 ## @param affinity Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
-## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
+## Note: `podAffinityPreset`, `podAntiAffinityPreset`, and `nodeAffinityPreset` will be ignored when it's set
 ##
 affinity: {}
-## @param podAnnotations Pod annotations
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+## @param nodeSelector Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
-podAnnotations: {}
-## @param podLabels Pod labels
-## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+nodeSelector: {}
+## @param tolerations Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
-podLabels: {}
+tolerations: []
+## @param extraVolumes Array of extra volumes to be added to the Kong deployment deployment (evaluated as template). Requires setting `extraVolumeMounts`
+##
+extraVolumes: []
+## @param initContainers Add additional init containers to the Kong pods
+## e.g.
+## - name: your-image-name
+##   image: your-image
+##   imagePullPolicy: Always
+##   ports:
+##     - name: portname
+##        containerPort: 1234
+##
+initContainers: []
+## @param sidecars Add additional sidecar containers to the Kong pods
+## e.g.
+## - name: your-image-name
+##   image: your-image
+##   imagePullPolicy: Always
+##   ports:
+##     - name: portname
+##        containerPort: 1234
+##
+sidecars: []
 ## Add an horizontal pod autoscaler
 ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
 ## @param autoscaling.enabled Deploy a HorizontalPodAutoscaler object for the Kong deployment
@@ -219,12 +242,123 @@ autoscaling:
         targetAverageUtilization: 80
 ## Kong Pod Disruption Budget
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-## @param pdb.enabled Deploy a pdb object for the Kong pod
+## @param pdb.enabled Deploy a PodDisruptionBudget object for Kong deployment
+## @param pdb.minAvailable Minimum available Kong replicas (expressed in percentage)
 ## @param pdb.maxUnavailable Maximum unavailable Kong replicas (expressed in percentage)
 ##
 pdb:
   enabled: false
+  minAvailable: ""
   maxUnavailable: "50%"
+
+## @section Kong Container Parameters
+
+kong:
+  ## @param kong.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param kong.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param kong.initScriptsCM Configmap with init scripts to execute
+  ## ConfigMap containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time (evaluated as a template)
+  ##
+  initScriptsCM: ""
+  ## @param kong.initScriptsSecret Configmap with init scripts to execute
+  ## Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time (that contain sensitive data). Evaluated as a template.
+  ##
+  initScriptsSecret: ""
+  ## @param kong.extraEnvVars Array containing extra env vars to configure Kong
+  ## For example:
+  ## extraEnvVars:
+  ##  - name: GF_DEFAULT_INSTANCE_NAME
+  ##    value: my-instance
+  ##
+  extraEnvVars: []
+  ## @param kong.extraEnvVarsCM ConfigMap containing extra env vars to configure Kong
+  ##
+  extraEnvVarsCM: ""
+  ## @param kong.extraEnvVarsSecret Secret containing extra env vars to configure Kong (in case of sensitive data)
+  ##
+  extraEnvVarsSecret: ""
+  ## @param kong.extraVolumeMounts Array of extra volume mounts to be added to the Kong Container (evaluated as template). Normally used with `extraVolumes`.
+  ##
+  extraVolumeMounts: []
+  ## @param kong.containerPorts.proxyHttp Kong proxy HTTP container port
+  ## @param kong.containerPorts.proxyHttps Kong proxy HTTPS container port
+  ## @param kong.containerPorts.adminHttp Kong admin HTTP container port
+  ## @param kong.containerPorts.adminHttps Kong admin HTTPS container port
+  ##
+  containerPorts:
+    proxyHttp: 8000
+    proxyHttps: 8443
+    adminHttp: 8001
+    adminHttps: 8444
+  ## Container resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param kong.resources.limits The resources limits for the Kong container
+  ## @param kong.resources.requests The requested resources for the Kong container
+  ##
+  resources:
+    limits: {}
+    requests: {}
+  ## Configure extra options for Kong containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param kong.livenessProbe.enabled Enable livenessProbe on Kong containers
+  ## @param kong.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  ## @param kong.livenessProbe.periodSeconds Period seconds for livenessProbe
+  ## @param kong.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  ## @param kong.livenessProbe.failureThreshold Failure threshold for livenessProbe
+  ## @param kong.livenessProbe.successThreshold Success threshold for livenessProbe
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 120
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param kong.readinessProbe.enabled Enable readinessProbe on Kong containers
+  ## @param kong.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param kong.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param kong.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param kong.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param kong.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  ## @param kong.startupProbe.enabled Enable startupProbe on Kong containers
+  ## @param kong.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param kong.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param kong.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param kong.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param kong.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 20
+    successThreshold: 1
+  ## @param kong.customLivenessProbe Override default liveness probe (kong container)
+  ##
+  customLivenessProbe: {}
+  ## @param kong.customReadinessProbe Override default readiness probe (kong container)
+  ##
+  customReadinessProbe: {}
+  ## @param kong.customStartupProbe Override default startup probe (kong container)
+  ##
+  customStartupProbe: {}
+  ## @param kong.lifecycleHooks Lifecycle hooks (kong container)
+  ## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  ##
+  lifecycleHooks: {}
 
 ## @section Traffic Exposure Parameters
 ##
@@ -235,6 +369,38 @@ service:
   ## @param service.type Kubernetes Service type
   ##
   type: ClusterIP
+  ## @param service.exposeAdmin Add the Kong Admin ports to the service
+  ##
+  exposeAdmin: false
+  ## @param service.disableHttpPort Disable Kong proxy HTTP and Kong admin HTTP ports
+  ##
+  disableHttpPort: false
+  ## @param service.ports.proxyHttp Kong proxy service HTTP port
+  ## @param service.ports.proxyHttps Kong proxy service HTTPS port
+  ## @param service.ports.adminHttp Kong admin service HTTP port (only if service.exposeAdmin=true)
+  ## @param service.ports.adminHttps Kong admin service HTTPS port (only if service.exposeAdmin=true)
+  ##
+  ports:
+    proxyHttp: 80
+    proxyHttps: 443
+    adminHttp: 8001
+    adminHttps: 8444
+  ## @param service.nodePorts.proxyHttp NodePort for the Kong proxy HTTP endpoint
+  ## @param service.nodePorts.proxyHttps NodePort for the Kong proxy HTTPS endpoint
+  ## @param service.nodePorts.adminHttp NodePort for the Kong admin HTTP endpoint
+  ## @param service.nodePorts.adminHttps NodePort for the Kong admin HTTPS endpoint
+  ## NOTE: choose port between <30000-32767>
+  ##
+  nodePorts:
+    proxyHttp: ""
+    proxyHttps: ""
+    adminHttp: ""
+    adminHttps: ""
+  ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
+  ## Values: ClientIP or None
+  ## ref: https://kubernetes.io/docs/user-guide/services/
+  ##
+  sessionAffinity: None
   ## @param service.clusterIP Cluster internal IP of the service
   ## This is the internal IP address of the service and is usually assigned randomly.
   ## ref: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
@@ -246,40 +412,18 @@ service:
   ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
   ##
   externalTrafficPolicy: ""
-  ## @param service.proxyHttpPort kong proxy HTTP service port port
-  ##
-  proxyHttpPort: 80
-  ## @param service.proxyHttpsPort kong proxy HTTPS service port port
-  ##
-  proxyHttpsPort: 443
-  ## @param service.exposeAdmin Add the Kong Admin ports to the service
-  ##
-  exposeAdmin: false
-  ## @param service.adminHttpPort kong admin HTTPS service port (only if service.exposeAdmin=true)
-  ##
-  adminHttpPort: 8001
-  ## @param service.adminHttpsPort kong admin HTTPS service port (only if service.exposeAdmin=true)
-  ##
-  adminHttpsPort: 8444
-  ## @param service.disableHttpPort Disable Kong proxy HTTP and Kong admin HTTP ports
-  ##
-  disableHttpPort: false
-  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
-  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
-  ## @param service.proxyHttpNodePort Port to bind to for NodePort service type (proxy HTTP)
-  ## @param service.proxyHttpsNodePort Port to bind to for NodePort service type (proxy HTTPS)
-  ## @param service.adminHttpNodePort Port to bind to for NodePort service type (admin HTTP)
-  ## @param service.adminHttpsNodePort Port to bind to for NodePort service type (admin HTTPS)
-  ##
-  proxyHttpNodePort: ""
-  proxyHttpsNodePort: ""
-  adminHttpNodePort: ""
-  adminHttpsNodePort: ""
   ## @param service.loadBalancerIP loadBalancerIP if kong service type is `LoadBalancer`
   ## ref: https://kubernetes.io/docs/user-guide/services/#type-loadbalancer
   ##
   loadBalancerIP: ""
-  ## @param service.annotations Annotations for kong service
+  ## @param service.loadBalancerSourceRanges Kong service Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## @param service.annotations Annotations for Kong service
   ## set the LoadBalancer service type to internal only.
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
@@ -287,6 +431,7 @@ service:
   ## @param service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
   ##
   extraPorts: []
+
 ## Configure the ingress resource that allows you to access the
 ## Kong installation. Set up the URL
 ## ref: https://kubernetes.io/docs/user-guide/ingress/
@@ -295,10 +440,11 @@ ingress:
   ## @param ingress.enabled Enable ingress controller resource
   ##
   enabled: false
-  ## DEPRECATED: Use ingress.annotations instead of ingress.certManager
-  ## certManager: false
+  ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster.
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
   ##
-
+  ingressClassName: ""
   ## @param ingress.pathType Ingress path type
   ##
   pathType: ImplementationSpecific
@@ -309,26 +455,29 @@ ingress:
   ##
   hostname: kong.local
   ## @param ingress.path Ingress path
-  ## with ALB ingress controllers.
+  ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
   ##
   path: /
-  ## @param ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ## @param ingress.annotations [object] Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
   ## Use this parameter to set the required annotations for cert-manager, see
   ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
-  ##
   ## e.g:
   ## annotations:
   ##   kubernetes.io/ingress.class: nginx
   ##   cert-manager.io/cluster-issuer: cluster-issuer-name
   ##
   annotations: {}
-  ## @param ingress.tls Create TLS Secret
-  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
-  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
+  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting the corresponding annotations
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
   ##
   tls: false
+  ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+  ##
+  selfSigned: false
   ## @param ingress.extraHosts The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
   ## extraHosts:
@@ -371,171 +520,7 @@ ingress:
   ##
   secrets: []
 
-## @section Kong Container Parameters
-##
-
-kong:
-  ## @param kong.command Override default container command (useful when using custom images)
-  ##
-  command: []
-  ## @param kong.args Override default container args (useful when using custom images)
-  ##
-  args: []
-  ## @param kong.initScriptsCM Configmap with init scripts to execute
-  ## ConfigMap containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time (evaluated as a template)
-  ##
-  initScriptsCM: ""
-  ## @param kong.initScriptsSecret Configmap with init scripts to execute
-  ## Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time (that contain sensitive data). Evaluated as a template.
-  ##
-  initScriptsSecret: ""
-  ## @param kong.extraEnvVars Array containing extra env vars to configure Kong
-  ## For example:
-  ## extraEnvVars:
-  ##  - name: GF_DEFAULT_INSTANCE_NAME
-  ##    value: my-instance
-  ##
-  extraEnvVars: []
-  ## @param kong.extraEnvVarsCM ConfigMap containing extra env vars to configure Kong
-  ##
-  extraEnvVarsCM: ""
-  ## @param kong.extraEnvVarsSecret Secret containing extra env vars to configure Kong (in case of sensitive data)
-  ##
-  extraEnvVarsSecret: ""
-  ## @param kong.extraVolumeMounts Array of extra volume mounts to be added to the Kong Container (evaluated as template). Normally used with `extraVolumes`.
-  ##
-  extraVolumeMounts: []
-  ## @param kong.customLivenessProbe Override default liveness probe (kong container)
-  ##
-  customLivenessProbe: {}
-  ## @param kong.customReadinessProbe Override default readiness probe (kong container)
-  ##
-  customReadinessProbe: {}
-  ## Configure extra options for liveness probe
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param kong.livenessProbe.enabled Enable livenessProbe
-  ## @param kong.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
-  ## @param kong.livenessProbe.periodSeconds Period seconds for livenessProbe
-  ## @param kong.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
-  ## @param kong.livenessProbe.failureThreshold Failure threshold for livenessProbe
-  ## @param kong.livenessProbe.successThreshold Success threshold for livenessProbe
-  ##
-  livenessProbe:
-    enabled: true
-    initialDelaySeconds: 120
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
-    successThreshold: 1
-  ## Configure extra options for readiness probe
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param kong.readinessProbe.enabled Enable readinessProbe
-  ## @param kong.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
-  ## @param kong.readinessProbe.periodSeconds Period seconds for readinessProbe
-  ## @param kong.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
-  ## @param kong.readinessProbe.failureThreshold Failure threshold for readinessProbe
-  ## @param kong.readinessProbe.successThreshold Success threshold for readinessProbe
-  ##
-  readinessProbe:
-    enabled: true
-    initialDelaySeconds: 30
-    periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
-    successThreshold: 1
-  ## @param kong.lifecycleHooks Lifecycle hooks (kong container)
-  ## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
-  ##
-  lifecycleHooks: {}
-  ## Container resource requests and limits
-  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param kong.resources.limits The resources limits for the container
-  ## @param kong.resources.requests The requested resources for the container
-  ##
-  resources:
-    ## Example:
-    ## limits:
-    ##    cpu: 500m
-    ##    memory: 1Gi
-    ##
-    limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 100m
-    ##    memory: 128Mi
-    ##
-    requests: {}
-
-## @section Kong Migration job Parameters
-##
-
-migration:
-  ## In case you want to use a custom image for Kong migration, set this value
-  ## image:
-  ##   registry:
-  ##   repository:
-  ##   tag:
-  ##
-  ## @param migration.command Override default container command (useful when using custom images)
-  ##
-  command: []
-  ## @param migration.args Override default container args (useful when using custom images)
-  ##
-  args: []
-  ## @param migration.hostAliases Add deployment host aliases
-  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
-  ##
-  hostAliases: []
-  ## @param migration.annotations [object] Add annotations to the job
-  ##
-  annotations:
-    helm.sh/hook: post-install, post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-  ## @param migration.extraEnvVars Array containing extra env vars to configure the Kong migration job
-  ## For example:
-  ## extraEnvVars:
-  ##  - name: GF_DEFAULT_INSTANCE_NAME
-  ##    value: my-instance
-  ##
-  extraEnvVars: []
-  ## @param migration.extraEnvVarsCM ConfigMap containing extra env vars to configure the Kong migration job
-  ##
-  extraEnvVarsCM: ""
-  ## @param migration.extraEnvVarsSecret Secret containing extra env vars to configure the Kong migration job (in case of sensitive data)
-  ##
-  extraEnvVarsSecret: ""
-  ## @param migration.extraVolumeMounts Array of extra volume mounts to be added to the Kong Container (evaluated as template). Normally used with `extraVolumes`.
-  ##
-  extraVolumeMounts: []
-  ## Container resource requests and limits
-  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param migration.resources.limits The resources limits for the container
-  ## @param migration.resources.requests The requested resources for the container
-  ##
-  resources:
-    ## Example:
-    ## limits:
-    ##    cpu: 500m
-    ##    memory: 1Gi
-    ##
-    limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 250m
-    ##    memory: 256Mi
-    ##
-    requests: {}
-
 ## @section Kong Ingress Controller Container Parameters
-##
 
 ingressController:
   ## @param ingressController.enabled Enable/disable the Kong Ingress Controller
@@ -547,7 +532,7 @@ ingressController:
   ## @param ingressController.image.registry Kong Ingress Controller image registry
   ## @param ingressController.image.repository Kong Ingress Controller image name
   ## @param ingressController.image.tag Kong Ingress Controller image tag
-  ## @param ingressController.image.pullPolicy kong ingress controller image pull policy
+  ## @param ingressController.image.pullPolicy Kong Ingress Controller image pull policy
   ## @param ingressController.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
@@ -562,7 +547,7 @@ ingressController:
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## Example:
+    ## E.g:
     ## pullSecrets:
     ##   - myRegistryKeySecretName
     ##
@@ -570,12 +555,6 @@ ingressController:
   ## @param ingressController.proxyReadyTimeout Maximum time (in seconds) to wait for the Kong container to be ready
   ##
   proxyReadyTimeout: 300
-  ## @param ingressController.rbac.create Create the necessary Service Accounts, Roles and Rolebindings for the Ingress Controller to work
-  ## @param ingressController.rbac.existingServiceAccount Use an existing service account for all the RBAC operations
-  ##
-  rbac:
-    create: true
-    existingServiceAccount: ""
   ## @param ingressController.ingressClass Name of the class to register Kong Ingress Controller (useful when having other Ingress Controllers in the cluster)
   ##
   ingressClass: kong
@@ -601,15 +580,21 @@ ingressController:
   ## @param ingressController.extraVolumeMounts Array of extra volume mounts to be added to the Kong Ingress Controller container (evaluated as template). Normally used with `extraVolumes`.
   ##
   extraVolumeMounts: []
-  ## @param ingressController.customLivenessProbe Override default liveness probe (kong ingress controller container)
+  ## @param ingressController.containerPorts.health Kong Ingress Controller health container port
   ##
-  customLivenessProbe: {}
-  ## @param ingressController.customReadinessProbe Override default readiness probe (kong ingress controller container)
+  containerPorts:
+    health: 10254
+  ## Container resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## @param ingressController.resources.limits The resources limits for the Kong Ingress Controller container
+  ## @param ingressController.resources.requests The requested resources for the Kong Ingress Controller container
   ##
-  customReadinessProbe: {}
-  ## Configure extra options for liveness probe
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param ingressController.livenessProbe.enabled Enable livenessProbe
+  resources:
+    limits: {}
+    requests: {}
+  ## Configure extra options for Kong Ingress Controller containers' liveness, readiness and startup probes
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  ## @param ingressController.livenessProbe.enabled Enable livenessProbe on Kong Ingress Controller containers
   ## @param ingressController.livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
   ## @param ingressController.livenessProbe.periodSeconds Period seconds for livenessProbe
   ## @param ingressController.livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
@@ -623,9 +608,7 @@ ingressController:
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
-  ## Configure extra options for readiness probe
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
-  ## @param ingressController.readinessProbe.enabled Enable readinessProbe
+  ## @param ingressController.readinessProbe.enabled Enable readinessProbe on Kong Ingress Controller containers
   ## @param ingressController.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
   ## @param ingressController.readinessProbe.periodSeconds Period seconds for readinessProbe
   ## @param ingressController.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
@@ -639,131 +622,196 @@ ingressController:
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
+  ## @param ingressController.startupProbe.enabled Enable startupProbe on Kong Ingress Controller containers
+  ## @param ingressController.startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+  ## @param ingressController.startupProbe.periodSeconds Period seconds for startupProbe
+  ## @param ingressController.startupProbe.timeoutSeconds Timeout seconds for startupProbe
+  ## @param ingressController.startupProbe.failureThreshold Failure threshold for startupProbe
+  ## @param ingressController.startupProbe.successThreshold Success threshold for startupProbe
+  ##
+  startupProbe:
+    enabled: false
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    timeoutSeconds: 3
+    failureThreshold: 20
+    successThreshold: 1
+  ## @param ingressController.customLivenessProbe Override default liveness probe (Kong Ingress Controller container)
+  ##
+  customLivenessProbe: {}
+  ## @param ingressController.customReadinessProbe Override default readiness probe (Kong Ingress Controller container)
+  ##
+  customReadinessProbe: {}
+  ## @param ingressController.customStartupProbe Override default startup probe (Kong Ingress Controller container)
+  ##
+  customStartupProbe: {}
+  ## @param ingressController.lifecycleHooks Lifecycle hooks (Kong Ingress Controller container)
+  ## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  ##
+  lifecycleHooks: {}
+  ## @param ingressController.serviceAccount.create Enable the creation of a ServiceAccount for Keycloak pods
+  ## @param ingressController.serviceAccount.name Name of the created ServiceAccount (name generated using common.names.fullname template otherwise)
+  ## @param ingressController.serviceAccount.automountServiceAccountToken Auto-mount the service account token in the pod
+  ## @param ingressController.serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  serviceAccount:
+    create: true
+    name: ""
+    automountServiceAccountToken: true
+    annotations: {}
+  ## @param ingressController.rbac.create Create the necessary RBAC resources for the Ingress Controller to work
+  ## @param ingressController.rbac.rules Custom RBAC rules
+  ##
+  rbac:
+    create: true
+    ## Example:
+    ## rules:
+    ##   - apiGroups:
+    ##       - ""
+    ##     resources:
+    ##       - pods
+    ##     verbs:
+    ##       - get
+    ##       - list
+    ##
+    rules: []
+
+## @section Kong Migration job Parameters
+
+migration:
+  ## In case you want to use a custom image for Kong migration, set this value
+  ## image:
+  ##   registry:
+  ##   repository:
+  ##   tag:
+  ##
+  ## @param migration.command Override default container command (useful when using custom images)
+  ##
+  command: []
+  ## @param migration.args Override default container args (useful when using custom images)
+  ##
+  args: []
+  ## @param migration.extraEnvVars Array containing extra env vars to configure the Kong migration job
+  ## For example:
+  ## extraEnvVars:
+  ##  - name: GF_DEFAULT_INSTANCE_NAME
+  ##    value: my-instance
+  ##
+  extraEnvVars: []
+  ## @param migration.extraEnvVarsCM ConfigMap containing extra env vars to configure the Kong migration job
+  ##
+  extraEnvVarsCM: ""
+  ## @param migration.extraEnvVarsSecret Secret containing extra env vars to configure the Kong migration job (in case of sensitive data)
+  ##
+  extraEnvVarsSecret: ""
+  ## @param migration.extraVolumeMounts Array of extra volume mounts to be added to the Kong Container (evaluated as template). Normally used with `extraVolumes`.
+  ##
+  extraVolumeMounts: []
   ## Container resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-  ## We usually recommend not to specify default resources and to leave this as a conscious
-  ## choice for the user. This also increases chances charts run on environments with little
-  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
-  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  ## @param ingressController.resources.limits The resources limits for the container
-  ## @param ingressController.resources.requests The requested resources for the container
+  ## @param migration.resources.limits The resources limits for the container
+  ## @param migration.resources.requests The requested resources for the container
   ##
   resources:
-    ## Example:
-    ## limits:
-    ##    cpu: 500m
-    ##    memory: 1Gi
-    ##
     limits: {}
-    ## Examples:
-    ## requests:
-    ##    cpu: 250m
-    ##    memory: 256Mi
-    ##
     requests: {}
+  ## @param migration.hostAliases Add deployment host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param migration.annotations [object] Add annotations to the job
+  ##
+  annotations:
+    helm.sh/hook: post-install, post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
 ## @section PostgreSQL Parameters
 ##
 
-## PostgreSQL properties
+## PostgreSQL chart configuration
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
+## @param postgresql.enabled Switch to enable or disable the PostgreSQL helm chart
+## @param postgresql.auth.postgresPassword Password for the "postgres" admin user
+## @param postgresql.auth.username Name for a custom user to create
+## @param postgresql.auth.password Password for the custom user to create
+## @param postgresql.auth.database Name for a custom database to create
+## @param postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials
+## @param postgresql.auth.usePasswordFiles Mount credentials as a files instead of using an environment variable
+## @param postgresql.architecture PostgreSQL architecture (`standalone` or `replication`)
 ##
 postgresql:
-  ## @param postgresql.enabled Deploy the PostgreSQL sub-chart
-  ##
   enabled: true
-  ## Properties for using an existing PostgreSQL installation
+  ## Override PostgreSQL default image as 14.x is not supported
+  ## ref: https://github.com/bitnami/bitnami-docker-postgresql
   ## @param postgresql.image.registry PostgreSQL image registry
   ## @param postgresql.image.repository PostgreSQL image repository
   ## @param postgresql.image.tag PostgreSQL image tag (immutable tags are recommended)
-  ## @param postgresql.image.pullPolicy PostgreSQL image pull policy
-  ## @param postgresql.image.pullSecrets Specify image pull secrets
   ##
   image:
     registry: docker.io
     repository: bitnami/postgresql
-    tag: 11.15.0-debian-10-r14
-    ## Specify a imagePullPolicy
-    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
-    ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-    ##
-    pullPolicy: IfNotPresent
-    ## Optionally specify an array of imagePullSecrets.
-    ## Secrets must be manually created in the namespace.
-    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-    ## Example:
-    ## pullSecrets:
-    ##   - myRegistryKeySecretName
-    ##
-    pullSecrets: []
-  external:
-    ## @param postgresql.external.host Host of an external PostgreSQL installation
-    ##
-    host: ""
-    ## @param postgresql.external.user Username of the external PostgreSQL installation
-    ##
-    user: ""
-    ## @param postgresql.external.password Password of the external PostgreSQL installation
-    ##
-    password: ""
+    tag: 11.15.0-debian-10-r20
   auth:
-    ## @param postgresql.auth.username Postgresql username
-    ##
     username: kong
-    ## @param postgresql.auth.password Postgresql password
-    ##
     password: ""
-    ## @param postgresql.auth.database Postgresql database
-    ##
     database: kong
-    ## @param postgresql.auth.postgresPassword Postgresql password for the postgres user
-    ##
     postgresPassword: ""
-    ## This secret is used in case of postgresql.enabled=true and we would like to specify password for newly created postgresql instance
-    ## @param postgresql.auth.existingSecret Name of an existing secret containing the PostgreSQL password ('password' key)
-    ##
     existingSecret: ""
-    ## @param postgresql.auth.usePasswordFiles Mount credentials as a files instead of using an environment variable
-    ##
     usePasswordFiles: false
+  architecture: standalone
+  ## External PostgreSQL configuration
+  ## All of these values are only used when postgresql.enabled is set to false
+  ## @param postgresql.external.host Database host
+  ## @param postgresql.external.port Database port number
+  ## @param postgresql.external.user Non-root username for Kong
+  ## @param postgresql.external.password Password for the non-root username for Kong
+  ## @param postgresql.external.database Kong database name
+  ## @param postgresql.external.existingSecret Name of an existing secret resource containing the database credentials
+  ## @param postgresql.external.existingSecretPasswordKey Name of an existing secret key containing the database credentials
+  ##
+  external:
+    host: ""
+    port: 5432
+    user: kong
+    password: ""
+    database: kong
+    existingSecret: ""
+    existingSecretPasswordKey: ""
 
 ## @section Cassandra Parameters
 ##
 
-## Cassandra properties
+## Cassandra chart configuration
+## ref: https://github.com/bitnami/charts/blob/master/bitnami/cassandra/values.yaml
+## @param cassandra.enabled Switch to enable or disable the Cassandra helm chart
+## @param cassandra.dbUser.user Cassandra admin user
+## @param cassandra.dbUser.password Password for `cassandra.dbUser.user`. Randomly generated if empty
+## @param cassandra.dbUser.existingSecret Name of existing secret to use for Cassandra credentials
+## @param cassandra.usePasswordFile Mount credentials as a files instead of using an environment variable
 ##
 cassandra:
-  ## @param cassandra.enabled Deploy the Cassandra sub-chart
-  ##
   enabled: false
-  ## @param cassandra.dbUser.user Username to be created by the cassandra bundled chart
-  ##
   dbUser:
     user: kong
-  ## @param cassandra.usePasswordFile Mount the Cassandra secret as a file
-  ##
+    password: ""
+    existingSecret: ""
   usePasswordFile: false
-  ## Properties for using an existing Cassandra installation
+  ## External Cassandra configuration
+  ## All of these values are only used when cassandra.enabled is set to false
+  ## @param cassandra.external.hosts List of Cassandra hosts
+  ## @param cassandra.external.port Cassandra port number
+  ## @param cassandra.external.user Username of the external cassandra installation
+  ## @param cassandra.external.password Password of the external cassandra installation
+  ## @param cassandra.external.existingSecret Name of an existing secret resource containing the Cassandra credentials
+  ## @param cassandra.external.existingSecretPasswordKey Name of an existing secret key containing the Cassandra credentials
   ##
   external:
-    ## @param cassandra.external.hosts Hosts of an external cassandra installation
-    ## e.g:
-    ## hosts:
-    ##   - host1
-    ##   - host2
-    ##
     hosts: []
-    ## @param cassandra.external.port Port of an external cassandra installation
-    ##
     port: 9042
-    ## @param cassandra.external.user Username of the external cassandra installation
-    ##
     user: ""
-    ## @param cassandra.external.password Password of the external cassandra installation
-    ##
     password: ""
-  ## @param cassandra.existingSecret Use an existing secret file with the Cassandra password (can be used with the bundled chart or with an existing installation)
-  ##
-  existingSecret: ""
+    existingSecret: ""
+    existingSecretPasswordKey: ""
 
 ## @section Metrics Parameters
 ##
@@ -774,55 +822,63 @@ metrics:
   ## @param metrics.enabled Enable the export of Prometheus metrics
   ##
   enabled: false
+  ## @param metrics.containerPorts.http Prometheus metrics HTTP container port
+  ##
+  containerPorts:
+    http: 9119
   ## Kong metrics service configuration
   ## @param metrics.service.annotations [object] Annotations for Prometheus metrics service
   ## @param metrics.service.type Type of the Prometheus metrics service
-  ## @param metrics.service.port Port of the Prometheus metrics service
+  ## @param metrics.service.ports.http Prometheus metrics service HTTP port
   ##
   service:
+    type: ClusterIP
     annotations:
       prometheus.io/scrape: "true"
-      prometheus.io/port: "{{ .Values.metrics.service.port }}"
+      prometheus.io/port: "{{ coalesce .Values.metrics.service.ports.http .Values.metrics.service.port }}"
       prometheus.io/path: "/metrics"
-    type: ClusterIP
-    port: 9119
+    ports:
+      http: 9119
   ## Kong ServiceMonitor configuration
   ##
   serviceMonitor:
-    ## @param metrics.serviceMonitor.enabled If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)
+    ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
     ##
     enabled: false
-    ## @param metrics.serviceMonitor.namespace Namespace in which Prometheus is running
-    ## e.g:
-    ## namespace: monitoring
+    ## @param metrics.serviceMonitor.namespace Namespace which Prometheus is running in
     ##
     namespace: ""
-    ## @param metrics.serviceMonitor.serviceAccount Service account used by Prometheus
-    ## e.g:
-    ## serviceAccount: prometheus
+    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped
     ##
-    serviceAccount: ""
-    ## @param metrics.serviceMonitor.interval Interval at which metrics should be scraped.
-    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    interval: 30s
+    ## @param metrics.serviceMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
     ## e.g:
-    ## interval: 10s
-    ##
-    interval: ""
-    ## @param metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
-    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
-    ## e.g:
-    ## scrapeTimeout: 10s
+    ##   scrapeTimeout: 30s
     ##
     scrapeTimeout: ""
+    ## @param metrics.serviceMonitor.labels Additional labels that can be used so ServiceMonitor will be discovered by Prometheus
+    ##
+    labels: {}
     ## @param metrics.serviceMonitor.selector Prometheus instance selector labels
     ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
-    ## e.g:
-    ## selector:
-    ##   prometheus: my-prometheus
     ##
     selector: {}
-    ## @param metrics.serviceMonitor.rbac.enabled Whether to enable RBAC
-    ## If RBAC is enabled on the cluster, additional resources will be required so Prometheus can reach kong's namespace
+    ## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
+    ##
+    relabelings: []
+    ## @param metrics.serviceMonitor.metricRelabelings MetricRelabelConfigs to apply to samples before ingestion
+    ##
+    metricRelabelings: []
+    ## @param metrics.serviceMonitor.honorLabels honorLabels chooses the metric's labels on collisions with target labels
+    ##
+    honorLabels: false
+    ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
+    ##
+    jobLabel: ""
+    ## @param metrics.serviceMonitor.serviceAccount Service account used by Prometheus Operator
+    ##
+    serviceAccount: ""
+    ## @param metrics.serviceMonitor.rbac.create Create the necessary RBAC resources so Prometheus Operator can reach Kong's namespace
     ##
     rbac:
-      enabled: true
+      create: true

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -70,7 +70,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/kong
-  tag: 2.7.1-debian-10-r27
+  tag: 2.8.0-debian-10-r0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -535,7 +535,7 @@ ingressController:
   image:
     registry: docker.io
     repository: bitnami/kong-ingress-controller
-    tag: 2.2.1-debian-10-r9
+    tag: 2.2.1-debian-10-r22
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -755,7 +755,7 @@ postgresql:
   image:
     registry: docker.io
     repository: bitnami/postgresql
-    tag: 11.15.0-debian-10-r20
+    tag: 11.15.0-debian-10-r28
   auth:
     username: kong
     password: ""


### PR DESCRIPTION
Signed-off-by: juan131 <juanariza@vmware.com>

**Description of the change**

This PR standardizes the `bitnami/kong` chart to be in line with the rest of the catalog.

**Benefits**

Standardization.

**Possible drawbacks**

None. No major bump is required since breaking changes were added support for deprecated values using `coalesce`.

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using (readme-generator-for-helm)[https://github.com/bitnami-labs/readme-generator-for-helm]
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])