### PR TITLE
[bitnami/apache] Fix issue rendering metrics.*.additionalLabels

### DIFF
--- a/bitnami/apache/Chart.lock
+++ b/bitnami/apache/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.1
-digest: sha256:a000bcd4d4cdd813c67d633b5523b4a4cd478fb95f1cae665d9b0ba5c45b40e2
-generated: "2022-02-12T13:51:43.509063029Z"
+  version: 1.11.3
+digest: sha256:d5f850d857edd58b32c0e10652f6ec3ce5018def5542f2bcef38fd7fa0079d6b
+generated: "2022-03-09T18:06:38.055034199Z"

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -26,4 +26,4 @@ name: apache
 sources:
   - https://github.com/bitnami/bitnami-docker-apache
   - https://httpd.apache.org
-version: 9.0.6
+version: 9.0.7

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -7,7 +7,7 @@ Apache HTTP Server is an open-source HTTP server. The goal of this project is to
 [Overview of Apache](https://httpd.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -234,12 +234,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.serviceMonitor.namespace`         | Namespace for the PodMonitor Resource (defaults to the Release Namespace)                                                                 | `""`                      |
 | `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                                                              | `""`                      |
 | `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                                                   | `""`                      |
-| `metrics.serviceMonitor.additionalLabels`  | Additional labels that can be used so PodMonitor will be discovered by Prometheus                                                         | `{}`                      |
+| `metrics.serviceMonitor.labels`            | Labels that can be used so PodMonitor will be discovered by Prometheus                                                                    | `{}`                      |
 | `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                                                        | `[]`                      |
 | `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                                                                 | `[]`                      |
 | `metrics.prometheusRule.enabled`           | if `true`, creates a Prometheus Operator PrometheusRule (also requires `metrics.enabled` to be `true` and `metrics.prometheusRule.rules`) | `false`                   |
 | `metrics.prometheusRule.namespace`         | Namespace for the PrometheusRule Resource (defaults to the Release Namespace)                                                             | `""`                      |
-| `metrics.prometheusRule.additionalLabels`  | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                                     | `{}`                      |
+| `metrics.prometheusRule.labels`            | Labels that can be used so PrometheusRule will be discovered by Prometheus                                                                | `{}`                      |
 | `metrics.prometheusRule.rules`             | Prometheus Rule definitions                                                                                                               | `[]`                      |
 
 

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -7,7 +7,7 @@ Apache HTTP Server is an open-source HTTP server. The goal of this project is to
 [Overview of Apache](https://httpd.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-
+                           
 ## TL;DR
 
 ```bash

--- a/bitnami/apache/templates/prometheusrules.yaml
+++ b/bitnami/apache/templates/prometheusrules.yaml
@@ -13,7 +13,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.prometheusRule.additionalLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/apache/templates/prometheusrules.yaml
+++ b/bitnami/apache/templates/prometheusrules.yaml
@@ -13,8 +13,8 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-    {{- if .Values.metrics.prometheusRule.additionalLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheusRule.additionalLabels "context" $ ) | nindent 4 }}
+    {{- if .Values.metrics.prometheusRule.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.prometheusRule.labels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/apache/templates/servicemonitor.yaml
+++ b/bitnami/apache/templates/servicemonitor.yaml
@@ -8,8 +8,8 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $ ) | nindent 4 }}
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}

--- a/bitnami/apache/templates/servicemonitor.yaml
+++ b/bitnami/apache/templates/servicemonitor.yaml
@@ -8,7 +8,9 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.additionalLabels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -51,7 +51,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/apache
-  tag: 2.4.52-debian-10-r62
+  tag: 2.4.52-debian-10-r74
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -79,7 +79,7 @@ image:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.35.1-debian-10-r29
+  tag: 2.35.1-debian-10-r40
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -579,7 +579,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.11.0-debian-10-r68
+    tag: 0.11.0-debian-10-r79
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -649,9 +649,9 @@ metrics:
     ## scrapeTimeout: 10s
     ##
     scrapeTimeout: ""
-    ## @param metrics.serviceMonitor.additionalLabels Additional labels that can be used so PodMonitor will be discovered by Prometheus
+    ## @param metrics.serviceMonitor.laels Labels that can be used so PodMonitor will be discovered by Prometheus
     ##
-    additionalLabels: {}
+    labels: {}
     ## @param metrics.serviceMonitor.relabelings RelabelConfigs to apply to samples before scraping
     ##
     relabelings: []
@@ -667,9 +667,9 @@ metrics:
     ## @param metrics.prometheusRule.namespace Namespace for the PrometheusRule Resource (defaults to the Release Namespace)
     ##
     namespace: ""
-    ## @param metrics.prometheusRule.additionalLabels Additional labels that can be used so PrometheusRule will be discovered by Prometheus
+    ## @param metrics.prometheusRule.labels Labels that can be used so PrometheusRule will be discovered by Prometheus
     ##
-    additionalLabels: {}
+    labels: {}
     ## @param metrics.prometheusRule.rules Prometheus Rule definitions
     ##   - alert: LowInstance
     ##     expr: up{service="{{ template "common.names.fullname" . }}"} < 1


### PR DESCRIPTION
**Description of the change**
Currently the deployment with the proper values for metrics is failing, see
- prometheusRule
```console
$ helm template bitnami/apache --set metrics.enabled=true --set metrics.prometheusRule.enabled=true --debug -s templates/prometheusrules.yaml
---
# Source: apache/templates/prometheusrules.yaml

apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: RELEASE-NAME-apache
  namespace: default
  labels:
    app.kubernetes.io/name: apache
    helm.sh/chart: apache-9.0.6
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: metrics
    {}
spec:
  groups:
  - name: RELEASE-NAME-apache
    rules:
      []
Error: YAML parse error on apache/templates/prometheusrules.yaml: error converting YAML to JSON: yaml: line 11: did not find expected key
helm.go:88: [debug] error converting YAML to JSON: yaml: line 11: did not find expected key
```
fixed with this PR
```console
$ helm template . --set metrics.enabled=true --set metrics.prometheusRule.enabled=true --debug -s templates/prometheusrules.yaml
---
# Source: apache/templates/prometheusrules.yaml
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: RELEASE-NAME-apache
  namespace: default
  labels:
    app.kubernetes.io/name: apache
    helm.sh/chart: apache-9.0.6
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: metrics
spec:
  groups:
  - name: RELEASE-NAME-apache
    rules:
      []
```

- serviceMonitor
```console
$ helm template bitnami/apache --set metrics.enabled=true --set metrics.serviceMonitor.enabled=true --debug -s templates/servicemonitor.yaml
---
# Source: apache/templates/servicemonitor.yaml

apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: RELEASE-NAME-apache
  namespace: "default"
  labels:
    app.kubernetes.io/name: apache
    helm.sh/chart: apache-9.0.6
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    {}
spec:
  endpoints:
    - port: metrics
      path: /metrics
  namespaceSelector:
    matchNames:
      - default
  selector:
    matchLabels:
      app.kubernetes.io/name: apache
      app.kubernetes.io/instance: RELEASE-NAME
Error: YAML parse error on apache/templates/servicemonitor.yaml: error converting YAML to JSON: yaml: line 10: did not find expected key
helm.go:88: [debug] error converting YAML to JSON: yaml: line 10: did not find expected key
```
fixed with this PR
```console
$ helm template . --set metrics.enabled=true --set metrics.serviceMonitor.enabled=true --debug -s templates/servicemonitor.yaml
---
# Source: apache/templates/servicemonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: RELEASE-NAME-apache
  namespace: "default"
  labels:
    app.kubernetes.io/name: apache
    helm.sh/chart: apache-9.0.6
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
spec:
  endpoints:
    - port: metrics
      path: /metrics
  namespaceSelector:
    matchNames:
      - default
  selector:
    matchLabels:
      app.kubernetes.io/name: apache
      app.kubernetes.io/instance: RELEASE-NAME
```

Similar to https://github.com/bitnami/charts/pull/9245

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)