### PR TITLE
bitnami/keycloak: sets default to true for automountServiceAccountToken (#9372)

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 7.1.1
+version: 7.1.2

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -672,7 +672,7 @@ serviceAccount:
   name: ""
   ## @param serviceAccount.automountServiceAccountToken Auto-mount the service account token in the pod
   ##
-  automountServiceAccountToken: false
+  automountServiceAccountToken: true
   ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
   ##
   annotations: {}


### PR DESCRIPTION
**Description of the change**
Sets the recommended default for `automountServiceAccountToken` as recommended by the Kuberenets documentation.

**Benefits**
no issues with bootstrapping a keycloak cluster

**Possible drawbacks**
none

**Applicable issues**
  - fixes #9372

**Additional information**
**Checklist**
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])(https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)