### PR TITLE
[bitnami/keycloak] Fix externalDB issue when using 'externalDatabatase.password'

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: Keycloak is a high performance Java-based identity and access management solution. It lets developers add an authentication layer to their applications with minimum effort. 
+description: Keycloak is a high performance Java-based identity and access management solution. It lets developers add an authentication layer to their applications with minimum effort.
 engine: gotpl
 home: https://www.keycloak.org
 icon: https://bitnami.com/assets/stacks/keycloak/img/keycloak-stack-220x234.png
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 7.1.1
+version: 7.1.2

--- a/bitnami/keycloak/templates/_helpers.tpl
+++ b/bitnami/keycloak/templates/_helpers.tpl
@@ -168,7 +168,7 @@ Return the Database encrypted password
         {{- default (include "keycloak.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
     {{- end -}}
 {{- else -}}
-    {{- default (tpl .Values.auth.existingSecret $) (tpl .Values.externalDatabase.existingSecret $) -}}
+    {{- default (include "common.secrets.name" (dict "existingSecret" .Values.auth.existingSecret "context" $)) (tpl .Values.externalDatabase.existingSecret $) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

**Description of the change**

Using the following `values.yaml`:
```yaml
postgresql:
  enabled: false
externalDatabase:
  host: "postgres"
  port: 5432
  user: keycloak
  database: keycloak
  password: "something-here"
  existingSecret: ""
  existingSecretPasswordKey: ""
```
Keycloak SecretRef will end up being empty:
```yaml
           - name: KEYCLOAK_DATABASE_PASSWORD
              valueFrom:
                secretKeyRef:
                  name:
                  key: password
```

This PR fixes the issue:
```yaml
           - name: KEYCLOAK_DATABASE_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: keycloak
                  key: password
```

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #9381

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)