### PR TITLE
[bitnami/fluentd] fix aggregator statefulset annotations

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: Fluentd collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on. 
+description: Fluentd collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/fluentd
 icon: https://bitnami.com/assets/stacks/fluentd/img/fluentd-stack-220x234.png
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/bitnami-docker-fluentd
   - https://www.fluentd.org/
-version: 5.0.9
+version: 5.0.10

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -14,8 +14,8 @@ metadata:
     {{- if .Values.aggregator.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.aggregator.annotations "context" $) | nindent 4 }}
     {{- end }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 spec:
   selector:


### PR DESCRIPTION
**Description of the change**

Fixes the aggregator statefulset rendering when adding annotations.

Given a values files wich contains the following content
```yaml
aggregator:
  annotations:
    configmap.reloader.stakater.com/reload: fluentd-forwarder
    secret.reloader.stakater.com/reload: fluentd-forwarder-certificate
```

I faced an error
```text
Error: YAML parse error on fluentd/templates/aggregator-statefulset.yaml: error converting YAML to JSON: yaml: line 15: did not find expected key
helm.go:88: [debug] error converting YAML to JSON: yaml: line 15: did not find expected key
YAML parse error on fluentd/templates/aggregator-statefulset.yaml
helm.sh/helm/v3/pkg/releaseutil.(*manifestFile).sort
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:146
helm.sh/helm/v3/pkg/releaseutil.SortManifests
        helm.sh/helm/v3/pkg/releaseutil/manifest_sorter.go:106
helm.sh/helm/v3/pkg/action.(*Configuration).renderResources
        helm.sh/helm/v3/pkg/action/action.go:165w
helm.sh/helm/v3/pkg/action.(*Install).RunWithContext
        helm.sh/helm/v3/pkg/action/install.go:259
main.runInstall
        helm.sh/helm/v3/cmd/helm/install.go:265
main.newTemplateCmd.func2
        helm.sh/helm/v3/cmd/helm/template.go:82
github.com/spf13/cobra.(*Command).execute
        github.com/spf13/cobra@v1.2.1/command.go:856                                                                           
github.com/spf13/cobra.(*Command).ExecuteC
        github.com/spf13/cobra@v1.2.1/command.go:974          
github.com/spf13/cobra.(*Command).Execute                                                                                      
        github.com/spf13/cobra@v1.2.1/command.go:902         
main.main                                                                                                                      
        helm.sh/helm/v3/cmd/helm/helm.go:87                                                                                    
runtime.main                                                                                                                                                                                                                                                  
        runtime/proc.go:225                                   
runtime.goexit                                                                                                                 
        runtime/asm_amd64.s:1371           
```

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

Signed-off-by: Smaine Kahlouch <smainklh@gmail.com>