### PR TITLE
bitnami/spring-cloud-dataflow: deployer.podSecurityContext can be switched off without warnings

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 5.2.1
+version: 5.2.2

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -291,6 +291,7 @@ helm uninstall my-release
 | `deployer.volumeMounts`                       | Streaming applications extra volume mounts                                                  | `{}`   |
 | `deployer.volumes`                            | Streaming applications extra volumes                                                        | `{}`   |
 | `deployer.environmentVariables`               | Streaming applications environment variables                                                | `[]`   |
+| `deployer.podSecurityContext.enabled`         | Enabled pods' Security Context of the deployed pods batch or stream pods                    | `true` |
 | `deployer.podSecurityContext.runAsUser`       | Set Dataflow Streams container's Security Context runAsUser                                 | `1001` |
 | `deployer.imagePullSecrets`                   | Streaming applications imagePullSecrets                                                     | `[]`   |
 | `deployer.secretRefs`                         | Streaming applications secretRefs                                                           | `[]`   |

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -67,8 +67,8 @@ data:
                     {{- if .Values.deployer.volumes }}
                     volumes: {{- toYaml .Values.deployer.volumes | nindent 22 }}
                     {{- end }}
-                    {{- if .Values.deployer.podSecurityContext }}
-                    podSecurityContext: {{- toYaml .Values.deployer.podSecurityContext | nindent 22 }}
+                    {{- if .Values.deployer.podSecurityContext.enabled }}
+                    podSecurityContext: {{- omit .Values.deployer.podSecurityContext "enabled" | toYaml | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.imagePullSecrets }}
                     imagePullSecrets: {{- toYaml .Values.deployer.imagePullSecrets | nindent 22 }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -93,8 +93,8 @@ data:
                     {{- if .Values.deployer.volumes }}
                     volumes: {{- toYaml .Values.deployer.volumes | nindent 22 }}
                     {{- end }}
-                    {{- if .Values.deployer.podSecurityContext }}
-                    podSecurityContext: {{- toYaml .Values.deployer.podSecurityContext | nindent 22 }}
+                    {{- if .Values.deployer.podSecurityContext.enabled }}
+                    podSecurityContext: {{- omit .Values.deployer.podSecurityContext "enabled" | toYaml | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.imagePullSecrets }}
                     imagePullSecrets: {{- toYaml .Values.deployer.imagePullSecrets | nindent 22 }}

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -982,9 +982,10 @@ deployer:
   environmentVariables: []
   ## Streams containers' Security Context. This security context will be use in every deployed stream.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+  ## @param deployer.podSecurityContext.enabled Enabled pods' Security Context of the deployed pods batch or stream pods
   ## @param deployer.podSecurityContext.runAsUser Set Dataflow Streams container's Security Context runAsUser
-  ##
   podSecurityContext:
+    enabled: true
     runAsUser: 1001
   ## @param deployer.imagePullSecrets Streaming applications imagePullSecrets
   ##


### PR DESCRIPTION
Signed-off-by: Ernst Plüss <ernst@pluess.li>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Switching off the podSecurityContext requires setting the value to an empty array. This is not how features are switched of normally in bitnami and also triggers a warning during helm install/update.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Instead of the ernous

    deployer:
        podSecurityContext: []

user can use

        deployer:
            podSecurityContext:
                enabled: false


<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
None. It's even backwards compatible if the old buggy format is used.

<!-- Describe any known limitations with your change -->

**Applicable issues**
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #9207 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)