### PR TITLE
[bitnami/airflow] Fix typo in container port

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 12.0.10
+version: 12.0.11

--- a/bitnami/airflow/templates/scheduler/service-headless.yaml
+++ b/bitnami/airflow/templates/scheduler/service-headless.yaml
@@ -15,7 +15,7 @@ spec:
   clusterIP: None
   ports:
     - name: task-logs
-      port: {{ .Values.worker.port }}
+      port: {{ .Values.worker.containerPorts.http }}
       targetPort: task-logs
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: scheduler


### PR DESCRIPTION
Fix a typo in the port parameter used in the `scheduler/service-headless.yaml`

- Fixes #9220