### PR TITLE
[bitnami/contour-operator] Adapt Helm chart to Contour 1.20

### DIFF
--- a/bitnami/contour-operator/Chart.yaml
+++ b/bitnami/contour-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: contour-operator
 sources:
   - https://github.com/projectcontour/contour-operator
   - https://github.com/bitnami/bitnami-docker-contour-operator
-version: 0.2.7
+version: 0.3.0

--- a/bitnami/contour-operator/crds/crd-contourconfiguration.yaml
+++ b/bitnami/contour-operator/crds/crd-contourconfiguration.yaml
@@ -83,6 +83,9 @@ spec:
                   defaultHTTPVersions:
                   - HTTP/1.1
                   - HTTP/2
+                  health:
+                    address: 0.0.0.0
+                    port: 8002
                   http:
                     accessLog: /dev/stdout
                     address: 0.0.0.0
@@ -94,6 +97,7 @@ spec:
                   listener:
                     connectionBalancer: ""
                     disableAllowChunkedLength: false
+                    disableMergeSlashes: false
                     tls:
                       cipherSuites:
                       - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
@@ -166,6 +170,24 @@ spec:
                       - HTTP/2
                       type: string
                     type: array
+                  health:
+                    default:
+                      address: 0.0.0.0
+                      port: 8002
+                    description: Health defines the endpoint Envoy uses to serve health
+                      checks.
+                    properties:
+                      address:
+                        description: Defines the health address interface.
+                        minLength: 1
+                        type: string
+                      port:
+                        description: Defines the health port.
+                        type: integer
+                    required:
+                    - address
+                    - port
+                    type: object
                   http:
                     default:
                       accessLog: /dev/stdout
@@ -231,6 +253,11 @@ spec:
                           revert back to Envoy''s default behavior in case of failures.
                           Please file an issue if failures are encountered. See: https://github.com/projectcontour/contour/issues/3221'
                         type: boolean
+                      disableMergeSlashes:
+                        description: DisableMergeSlashes disables Envoy's non-standard
+                          merge_slashes path transformation option which strips duplicate
+                          slashes from request URL paths.
+                        type: boolean
                       tls:
                         description: TLS holds various configurable Envoy TLS listener
                           values.
@@ -280,6 +307,7 @@ spec:
                     required:
                     - connectionBalancer
                     - disableAllowChunkedLength
+                    - disableMergeSlashes
                     - tls
                     - useProxyProtocol
                     type: object
@@ -298,6 +326,16 @@ spec:
                           when format is set to `envoy`. When empty, Envoy's default
                           format is used.
                         type: string
+                      accessLogLevel:
+                        default: info
+                        description: AccessLogLevel sets the verbosity level of the
+                          access log. Valid options are `info`, `error` and `disabled`.
+                          Default value is `info`, meaning all requests are logged.
+                        enum:
+                        - info
+                        - error
+                        - disabled
+                        type: string
                       jsonFields:
                         description: AccessLogFields sets the fields that JSON logging
                           will output when AccessLogFormat is json.
@@ -311,8 +349,8 @@ spec:
                     default:
                       address: 0.0.0.0
                       port: 8002
-                    description: Metrics defines the endpoints Envoy use to serve
-                      to metrics.
+                    description: Metrics defines the endpoint Envoy uses to serve
+                      metrics.
                     properties:
                       address:
                         description: Defines the metrics address interface.
@@ -322,6 +360,21 @@ spec:
                       port:
                         description: Defines the metrics port.
                         type: integer
+                      tls:
+                        description: TLS holds TLS file config details. Metrics and
+                          health endpoints cannot have same port number when metrics
+                          is served over HTTPS.
+                        properties:
+                          caFile:
+                            description: CA filename.
+                            type: string
+                          certFile:
+                            description: Client certificate filename.
+                            type: string
+                          keyFile:
+                            description: Client key filename.
+                            type: string
+                        type: object
                     required:
                     - address
                     - port
@@ -339,7 +392,7 @@ spec:
                       numTrustedHops:
                         description: "XffNumTrustedHops defines the number of additional
                           ingress proxy hops from the right side of the x-forwarded-for
-                          HTTP header to trust when determining the origin client's
+                          HTTP header to trust when determining the origin client’s
                           IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
                           for more information."
                         format: int32
@@ -366,6 +419,13 @@ spec:
                     description: Timeouts holds various configurable timeouts that
                       can be set in the config file.
                     properties:
+                      connectTimeout:
+                        description: "ConnectTimeout defines how long the proxy should
+                          wait when establishing connection to upstream service. If
+                          not set, a default value of 2 seconds will be used. \n See
+                          https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-connect-timeout
+                          for more information."
+                        type: string
                       connectionIdleTimeout:
                         description: "ConnectionIdleTimeout defines how long the proxy
                           should wait while there are no active requests (for HTTP/1.1)
@@ -447,15 +507,15 @@ spec:
                 default:
                   address: 0.0.0.0
                   port: 8000
-                description: Health contains parameters to configure endpoints which
-                  Contour exposes to respond to Kubernetes health checks.
+                description: Health defines the endpoints Contour uses to serve health
+                  checks.
                 properties:
                   address:
-                    description: Defines the Contour health address interface.
+                    description: Defines the health address interface.
                     minLength: 1
                     type: string
                   port:
-                    description: Defines the Contour health port.
+                    description: Defines the health port.
                     type: integer
                 required:
                 - address
@@ -495,55 +555,20 @@ spec:
               ingress:
                 description: Ingress contains parameters for ingress options.
                 properties:
-                  className:
-                    description: Ingress Class Name Contour should use.
-                    type: string
+                  classNames:
+                    description: Ingress Class Names Contour should use.
+                    items:
+                      type: string
+                    type: array
                   statusAddress:
                     description: Address to set in Ingress object status.
                     type: string
-                type: object
-              leaderElection:
-                default:
-                  configmap:
-                    name: leader-elect
-                    namespace: projectcontour
-                  disableLeaderElection: false
-                  leaseDuration: 15s
-                  renewDeadline: 10s
-                  retryPeriod: 2s
-                description: LeaderElection contains leader election parameters.
-                properties:
-                  configmap:
-                    description: NamespacedName defines the namespace/name of the
-                      Kubernetes resource referred from the config file. Used for
-                      Contour config YAML file parsing, otherwise we could use K8s
-                      types.NamespacedName.
-                    properties:
-                      name:
-                        type: string
-                      namespace:
-                        type: string
-                    required:
-                    - name
-                    - namespace
-                    type: object
-                  disableLeaderElection:
-                    type: boolean
-                  leaseDuration:
-                    type: string
-                  renewDeadline:
-                    type: string
-                  retryPeriod:
-                    type: string
-                required:
-                - disableLeaderElection
                 type: object
               metrics:
                 default:
                   address: 0.0.0.0
                   port: 8000
-                description: Metrics defines the endpoints Contour uses to serve to
-                  metrics.
+                description: Metrics defines the endpoint Contour uses to serve metrics.
                 properties:
                   address:
                     description: Defines the metrics address interface.
@@ -553,6 +578,21 @@ spec:
                   port:
                     description: Defines the metrics port.
                     type: integer
+                  tls:
+                    description: TLS holds TLS file config details. Metrics and health
+                      endpoints cannot have same port number when metrics is served
+                      over HTTPS.
+                    properties:
+                      caFile:
+                        description: CA filename.
+                        type: string
+                      certFile:
+                        description: Client certificate filename.
+                        type: string
+                      keyFile:
+                        description: Client key filename.
+                        type: string
+                    type: object
                 required:
                 - address
                 - port

--- a/bitnami/contour-operator/crds/crd-contourdeployment.yaml
+++ b/bitnami/contour-operator/crds/crd-contourdeployment.yaml
@@ -86,6 +86,9 @@ spec:
                       defaultHTTPVersions:
                       - HTTP/1.1
                       - HTTP/2
+                      health:
+                        address: 0.0.0.0
+                        port: 8002
                       http:
                         accessLog: /dev/stdout
                         address: 0.0.0.0
@@ -97,6 +100,7 @@ spec:
                       listener:
                         connectionBalancer: ""
                         disableAllowChunkedLength: false
+                        disableMergeSlashes: false
                         tls:
                           cipherSuites:
                           - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
@@ -169,6 +173,24 @@ spec:
                           - HTTP/2
                           type: string
                         type: array
+                      health:
+                        default:
+                          address: 0.0.0.0
+                          port: 8002
+                        description: Health defines the endpoint Envoy uses to serve
+                          health checks.
+                        properties:
+                          address:
+                            description: Defines the health address interface.
+                            minLength: 1
+                            type: string
+                          port:
+                            description: Defines the health port.
+                            type: integer
+                        required:
+                        - address
+                        - port
+                        type: object
                       http:
                         default:
                           accessLog: /dev/stdout
@@ -236,6 +258,11 @@ spec:
                               behavior in case of failures. Please file an issue if
                               failures are encountered. See: https://github.com/projectcontour/contour/issues/3221'
                             type: boolean
+                          disableMergeSlashes:
+                            description: DisableMergeSlashes disables Envoy's non-standard
+                              merge_slashes path transformation option which strips
+                              duplicate slashes from request URL paths.
+                            type: boolean
                           tls:
                             description: TLS holds various configurable Envoy TLS
                               listener values.
@@ -286,6 +313,7 @@ spec:
                         required:
                         - connectionBalancer
                         - disableAllowChunkedLength
+                        - disableMergeSlashes
                         - tls
                         - useProxyProtocol
                         type: object
@@ -304,6 +332,17 @@ spec:
                               format when format is set to `envoy`. When empty, Envoy's
                               default format is used.
                             type: string
+                          accessLogLevel:
+                            default: info
+                            description: AccessLogLevel sets the verbosity level of
+                              the access log. Valid options are `info`, `error` and
+                              `disabled`. Default value is `info`, meaning all requests
+                              are logged.
+                            enum:
+                            - info
+                            - error
+                            - disabled
+                            type: string
                           jsonFields:
                             description: AccessLogFields sets the fields that JSON
                               logging will output when AccessLogFormat is json.
@@ -317,8 +356,8 @@ spec:
                         default:
                           address: 0.0.0.0
                           port: 8002
-                        description: Metrics defines the endpoints Envoy use to serve
-                          to metrics.
+                        description: Metrics defines the endpoint Envoy uses to serve
+                          metrics.
                         properties:
                           address:
                             description: Defines the metrics address interface.
@@ -328,6 +367,21 @@ spec:
                           port:
                             description: Defines the metrics port.
                             type: integer
+                          tls:
+                            description: TLS holds TLS file config details. Metrics
+                              and health endpoints cannot have same port number when
+                              metrics is served over HTTPS.
+                            properties:
+                              caFile:
+                                description: CA filename.
+                                type: string
+                              certFile:
+                                description: Client certificate filename.
+                                type: string
+                              keyFile:
+                                description: Client key filename.
+                                type: string
+                            type: object
                         required:
                         - address
                         - port
@@ -346,7 +400,7 @@ spec:
                             description: "XffNumTrustedHops defines the number of
                               additional ingress proxy hops from the right side of
                               the x-forwarded-for HTTP header to trust when determining
-                              the origin client's IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
+                              the origin client’s IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
                               for more information."
                             format: int32
                             type: integer
@@ -372,6 +426,13 @@ spec:
                         description: Timeouts holds various configurable timeouts
                           that can be set in the config file.
                         properties:
+                          connectTimeout:
+                            description: "ConnectTimeout defines how long the proxy
+                              should wait when establishing connection to upstream
+                              service. If not set, a default value of 2 seconds will
+                              be used. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-connect-timeout
+                              for more information."
+                            type: string
                           connectionIdleTimeout:
                             description: "ConnectionIdleTimeout defines how long the
                               proxy should wait while there are no active requests
@@ -456,15 +517,15 @@ spec:
                     default:
                       address: 0.0.0.0
                       port: 8000
-                    description: Health contains parameters to configure endpoints
-                      which Contour exposes to respond to Kubernetes health checks.
+                    description: Health defines the endpoints Contour uses to serve
+                      health checks.
                     properties:
                       address:
-                        description: Defines the Contour health address interface.
+                        description: Defines the health address interface.
                         minLength: 1
                         type: string
                       port:
-                        description: Defines the Contour health port.
+                        description: Defines the health port.
                         type: integer
                     required:
                     - address
@@ -504,55 +565,21 @@ spec:
                   ingress:
                     description: Ingress contains parameters for ingress options.
                     properties:
-                      className:
-                        description: Ingress Class Name Contour should use.
-                        type: string
+                      classNames:
+                        description: Ingress Class Names Contour should use.
+                        items:
+                          type: string
+                        type: array
                       statusAddress:
                         description: Address to set in Ingress object status.
                         type: string
-                    type: object
-                  leaderElection:
-                    default:
-                      configmap:
-                        name: leader-elect
-                        namespace: projectcontour
-                      disableLeaderElection: false
-                      leaseDuration: 15s
-                      renewDeadline: 10s
-                      retryPeriod: 2s
-                    description: LeaderElection contains leader election parameters.
-                    properties:
-                      configmap:
-                        description: NamespacedName defines the namespace/name of
-                          the Kubernetes resource referred from the config file. Used
-                          for Contour config YAML file parsing, otherwise we could
-                          use K8s types.NamespacedName.
-                        properties:
-                          name:
-                            type: string
-                          namespace:
-                            type: string
-                        required:
-                        - name
-                        - namespace
-                        type: object
-                      disableLeaderElection:
-                        type: boolean
-                      leaseDuration:
-                        type: string
-                      renewDeadline:
-                        type: string
-                      retryPeriod:
-                        type: string
-                    required:
-                    - disableLeaderElection
                     type: object
                   metrics:
                     default:
                       address: 0.0.0.0
                       port: 8000
-                    description: Metrics defines the endpoints Contour uses to serve
-                      to metrics.
+                    description: Metrics defines the endpoint Contour uses to serve
+                      metrics.
                     properties:
                       address:
                         description: Defines the metrics address interface.
@@ -562,6 +589,21 @@ spec:
                       port:
                         description: Defines the metrics port.
                         type: integer
+                      tls:
+                        description: TLS holds TLS file config details. Metrics and
+                          health endpoints cannot have same port number when metrics
+                          is served over HTTPS.
+                        properties:
+                          caFile:
+                            description: CA filename.
+                            type: string
+                          certFile:
+                            description: Client certificate filename.
+                            type: string
+                          keyFile:
+                            description: Client key filename.
+                            type: string
+                        type: object
                     required:
                     - address
                     - port

--- a/bitnami/contour-operator/crds/crd-extensionservice.yaml
+++ b/bitnami/contour-operator/crds/crd-extensionservice.yaml
@@ -58,6 +58,12 @@ spec:
                       description: RequestHashPolicy contains configuration for an
                         individual hash policy on a request attribute.
                       properties:
+                        hashSourceIP:
+                          description: HashSourceIP should be set to true when request
+                            source IP hash based load balancing is desired. It must
+                            be the only hash option field set, otherwise this request
+                            hash policy object will be ignored.
+                          type: boolean
                         headerHashOptions:
                           description: HeaderHashOptions should be set when request
                             header hash based load balancing is desired. It must be

--- a/bitnami/contour-operator/crds/crd-httpproxy.yaml
+++ b/bitnami/contour-operator/crds/crd-httpproxy.yaml
@@ -332,6 +332,12 @@ spec:
                             description: RequestHashPolicy contains configuration
                               for an individual hash policy on a request attribute.
                             properties:
+                              hashSourceIP:
+                                description: HashSourceIP should be set to true when
+                                  request source IP hash based load balancing is desired.
+                                  It must be the only hash option field set, otherwise
+                                  this request hash policy object will be ignored.
+                                type: boolean
                               headerHashOptions:
                                 description: HeaderHashOptions should be set when
                                   request header hash based load balancing is desired.
@@ -661,6 +667,56 @@ spec:
                             type: object
                           type: array
                       type: object
+                    requestRedirectPolicy:
+                      description: RequestRedirectPolicy defines an HTTP redirection.
+                      properties:
+                        hostname:
+                          description: Hostname is the precise hostname to be used
+                            in the value of the `Location` header in the response.
+                            When empty, the hostname of the request is used. No wildcards
+                            are allowed.
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        path:
+                          description: "Path allows for redirection to a different
+                            path from the original on the request. The path must start
+                            with a leading slash. \n Note: Only one of Path or Prefix
+                            can be defined."
+                          pattern: ^\/.*$
+                          type: string
+                        port:
+                          description: Port is the port to be used in the value of
+                            the `Location` header in the response. When empty, port
+                            (if specified) of the request is used.
+                          format: int32
+                          maximum: 65535
+                          minimum: 1
+                          type: integer
+                        prefix:
+                          description: "Prefix defines the value to swap the matched
+                            prefix or path with. The prefix must start with a leading
+                            slash. \n Note: Only one of Path or Prefix can be defined."
+                          pattern: ^\/.*$
+                          type: string
+                        scheme:
+                          description: Scheme is the scheme to be used in the value
+                            of the `Location` header in the response. When empty,
+                            the scheme of the request is used.
+                          enum:
+                          - http
+                          - https
+                          type: string
+                        statusCode:
+                          default: 302
+                          description: StatusCode is the HTTP status code to be used
+                            in response.
+                          enum:
+                          - 301
+                          - 302
+                          type: integer
+                      type: object
                     responseHeadersPolicy:
                       description: The policy for managing response headers during
                         proxying. Rewriting the 'Host' header is not supported.
@@ -937,7 +993,6 @@ spec:
                         - name
                         - port
                         type: object
-                      minItems: 1
                       type: array
                     timeoutPolicy:
                       description: The timeout policy for this route.
@@ -959,8 +1014,6 @@ spec:
                           pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                           type: string
                       type: object
-                  required:
-                  - services
                   type: object
                 type: array
               tcpproxy:
@@ -1036,6 +1089,12 @@ spec:
                           description: RequestHashPolicy contains configuration for
                             an individual hash policy on a request attribute.
                           properties:
+                            hashSourceIP:
+                              description: HashSourceIP should be set to true when
+                                request source IP hash based load balancing is desired.
+                                It must be the only hash option field set, otherwise
+                                this request hash policy object will be ignored.
+                              type: boolean
                             headerHashOptions:
                               description: HeaderHashOptions should be set when request
                                 header hash based load balancing is desired. It must
@@ -1323,6 +1382,26 @@ spec:
                           no timeout.
                         pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                         type: string
+                      withRequestBody:
+                        description: WithRequestBody specifies configuration for sending
+                          the client request's body to authorization server.
+                        properties:
+                          allowPartialMessage:
+                            description: If AllowPartialMessage is true, then Envoy
+                              will buffer the body until MaxRequestBytes are reached.
+                            type: boolean
+                          maxRequestBytes:
+                            default: 1024
+                            description: MaxRequestBytes sets the maximum size of
+                              message body ExtAuthz filter will hold in-memory.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          packAsBytes:
+                            description: If PackAsBytes is true, the body sent to
+                              Authorization Server is in raw bytes.
+                            type: boolean
+                        type: object
                     required:
                     - extensionRef
                     type: object
@@ -1383,7 +1462,7 @@ spec:
                     description: The fully qualified domain name of the root of the
                       ingress tree all leaves of the DAG rooted at this object relate
                       to the fqdn.
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   rateLimitPolicy:
                     description: The policy for rate limiting on the virtual host.
@@ -1669,6 +1748,9 @@ spec:
                 type: object
             type: object
           status:
+            default:
+              currentStatus: NotReconciled
+              description: Waiting for controller
             description: Status is a container for computed information about the
               HTTPProxy.
             properties:

--- a/bitnami/contour-operator/crds/crd-tlscertificatedelegation.yaml
+++ b/bitnami/contour-operator/crds/crd-tlscertificatedelegation.yaml
@@ -20,7 +20,7 @@ spec:
   versions:
   - name: v1
     schema:
-      openAPIV3Schema:
+     openAPIV3Schema:
         description: TLSCertificateDelegation is an TLS Certificate Delegation CRD
           specification. See design/tls-certificate-delegation.md for details.
         properties:

--- a/bitnami/contour-operator/templates/clusterrole.yaml
+++ b/bitnami/contour-operator/templates/clusterrole.yaml
@@ -99,7 +99,6 @@ rules:
   - apiGroups:
       - networking.k8s.io
     resources:
-      - ingressclasses
       - ingresses
     verbs:
       - get


### PR DESCRIPTION
**Description of the change**

Adapt Helm chart for the new version. [Here](https://github.com/projectcontour/contour-operator/compare/v1.20.1...main) you can find the upstream changes