### PR TITLE
[bitnami/kibana] Updated the auth URL for Elasticsearch

### DIFF
--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -25,4 +25,4 @@ name: kibana
 sources:
   - https://github.com/bitnami/bitnami-docker-kibana
   - https://www.elastic.co/products/kibana
-version: 9.3.8
+version: 9.3.9

--- a/bitnami/kibana/templates/NOTES.txt
+++ b/bitnami/kibana/templates/NOTES.txt
@@ -43,7 +43,6 @@ Replacing "YOUR_ES_HOST" and "YOUR_ES_PORT" placeholders by the proper values of
 
 WARNING: Kibana is externally accessible from the cluster but the dashboard does not contain authentication mechanisms. Make sure you follow the authentication guidelines in your Elastic stack.
 +info https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
-
 {{- end }}
 
 {{- if .Values.metrics.enabled }}

--- a/bitnami/kibana/templates/NOTES.txt
+++ b/bitnami/kibana/templates/NOTES.txt
@@ -42,7 +42,8 @@ Replacing "YOUR_ES_HOST" and "YOUR_ES_PORT" placeholders by the proper values of
 {{- if or .Values.ingress.enabled (contains "NodePort" .Values.service.type) (contains "LoadBalancer" .Values.service.type) }}
 
 WARNING: Kibana is externally accessible from the cluster but the dashboard does not contain authentication mechanisms. Make sure you follow the authentication guidelines in your Elastic stack.
-+info https://www.elastic.co/guide/en/elastic-stack-overview/current/setting-up-authentication.html
++info https://www.elastic.co/guide/en/elasticsearch/reference/current/setting-up-authentication.html
+
 {{- end }}
 
 {{- if .Values.metrics.enabled }}


### PR DESCRIPTION
Signed-off-by: alukic <alukic@vmware.com>

**Description of the change**

Updated the URL in the user guide since I noticed it was pointing to an old resource. 

**Benefits**

Improved user experience. 

**Possible drawbacks**

I don't see any.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Bumped the chart version in Chart.yaml 
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)