### PR TITLE
[bitnami/aspnet-core] Fix context for include inside range extraHosts

### DIFF
--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -22,4 +22,4 @@ name: aspnet-core
 sources:
   - https://github.com/bitnami/bitnami-docker-aspnet-core
   - https://dotnet.microsoft.com/apps/aspnet
-version: 3.1.10
+version: 3.1.11

--- a/bitnami/aspnet-core/templates/health-ingress.yaml
+++ b/bitnami/aspnet-core/templates/health-ingress.yaml
@@ -43,10 +43,10 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.healthIngress.extraPaths  "context" $) | nindent 10 }}
           {{- end }}
           - path: {{ .Values.healthIngress.path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ .Values.healthIngress.pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "aspnet-core.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "aspnet-core.fullname" $) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
   {{- if or .Values.healthIngress.tls .Values.healthIngress.extraTls .Values.healthIngress.hosts }}
   tls:


### PR DESCRIPTION
Prevent `nil pointer evaluating interface {}.*`

**Related issues**

https://github.com/bitnami/charts/pull/5499
https://github.com/bitnami/charts/issues/5927

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)