### PR TITLE
[bitnami/elasticsearch] Fix context for include inside range extraHosts

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.9.12
+version: 17.9.13

--- a/bitnami/elasticsearch/templates/ingress.yaml
+++ b/bitnami/elasticsearch/templates/ingress.yaml
@@ -39,7 +39,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "elasticsearch.master.fullname" $) "servicePort" (include "elasticsearch.httpPortName" .) "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "elasticsearch.master.fullname" $) "servicePort" (include "elasticsearch.httpPortName" $) "context" $) | nindent 14 }}
     {{- end }}
   {{- if or .Values.master.ingress.tls .Values.master.ingress.extraTls }}
   tls:


### PR DESCRIPTION
Prevent `nil pointer evaluating interface {}.*`

**Related issues**

https://github.com/bitnami/charts/pull/5499
https://github.com/bitnami/charts/issues/5927

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)