### PR TITLE
[bitnami/geode] Fix context for include inside range extraHosts

### DIFF
--- a/bitnami/geode/Chart.yaml
+++ b/bitnami/geode/Chart.yaml
@@ -22,4 +22,4 @@ name: geode
 sources:
   - https://github.com/bitnami/bitnami-docker-geode
   - https://github.com/apache/geode
-version: 0.4.10
+version: 0.4.11

--- a/bitnami/geode/templates/ingress.yaml
+++ b/bitnami/geode/templates/ingress.yaml
@@ -38,7 +38,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-locator" (include "common.names.fullname" .)) "servicePort" "http" "context" $)  | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-locator" (include "common.names.fullname" $)) "servicePort" "http" "context" $)  | nindent 14 }}
     {{- end }}
   {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
   tls:


### PR DESCRIPTION
Prevent `nil pointer evaluating interface {}.*`

**Related issues**

https://github.com/bitnami/charts/pull/5499
https://github.com/bitnami/charts/issues/5927

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)