### PR TITLE
[bitnami/harbor] Fix context for include inside range extraHosts

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-harbor-registry
   - https://github.com/bitnami/bitnami-docker-harbor-registryctl
   - https://goharbor.io/
-version: 12.1.0
+version: 12.1.1

--- a/bitnami/harbor/templates/ingress/core-ingress.yaml
+++ b/bitnami/harbor/templates/ingress/core-ingress.yaml
@@ -100,7 +100,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.core" .) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.core" $) "servicePort" (ternary "https" "http" .Values.internalTLS.enabled) "context" $) | nindent 14 }}
     {{- end }}
   {{- if or (and .Values.ingress.core.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.core.annotations )) .Values.ingress.core.selfSigned)) .Values.ingress.core.extraTls }}
   tls:

--- a/bitnami/harbor/templates/ingress/notary-ingress.yaml
+++ b/bitnami/harbor/templates/ingress/notary-ingress.yaml
@@ -48,7 +48,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.notary-server" .) "servicePort" "notary-server" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "harbor.notary-server" $) "servicePort" "notary-server" "context" $) | nindent 14 }}
     {{- end }}
   {{- if or (and .Values.ingress.notary.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.notary.annotations )) .Values.ingress.notary.selfSigned)) .Values.ingress.notary.extraTls }}
   tls:


### PR DESCRIPTION
Prevent `nil pointer evaluating interface {}.*`

**Related issues**

https://github.com/bitnami/charts/pull/5499
https://github.com/bitnami/charts/issues/5927

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)