### PR TITLE
[bitnami/nginx] Switch metric list order in nginx

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 9.9.3
+version: 9.9.4

--- a/bitnami/nginx/templates/hpa.yaml
+++ b/bitnami/nginx/templates/hpa.yaml
@@ -18,16 +18,16 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPU }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
-    {{- end }}
     {{- if .Values.autoscaling.targetMemory }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemory  }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
To circumvent issues https://github.com/kubernetes/kubernetes/issues/74099 causes with GitOps and using this chart. 

Same issue like [here](https://github.com/bitnami/charts/pull/7849).

**Description of the change**

Switched resource order in HPA.

**Benefits**

**Possible drawbacks**

Bypasses issue https://github.com/kubernetes/kubernetes/issues/74099 that can cause problems when using GitOps like ArgoCD. As the impact is minimal I believe this is the optimal solution for this problem.

**Applicable issues**

**Additional information**

**Checklist**

- [x] Chart version bumped in Chart.yaml according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])