### PR TITLE
[bitnami/rabbitmq-cluster-operator] Set readOnlyRootFileSystem by default

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.lock
+++ b/bitnami/rabbitmq-cluster-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.3
-digest: sha256:d5f850d857edd58b32c0e10652f6ec3ce5018def5542f2bcef38fd7fa0079d6b
-generated: "2022-03-09T13:03:11.26187938Z"
+  version: 1.12.0
+digest: sha256:7e484480451778c273e7a165dbfaa5594ec1c9a63a114ce9d458626cadd28893
+generated: "2022-03-18T14:09:29.606467378Z"

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 2.3.4
+version: 2.4.0

--- a/bitnami/rabbitmq-cluster-operator/README.md
+++ b/bitnami/rabbitmq-cluster-operator/README.md
@@ -134,7 +134,7 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 ### Global parameters
 
 | Name                      | Description                                     | Value |
-|:--------------------------|:------------------------------------------------|:------|
+| ------------------------- | ----------------------------------------------- | ----- |
 | `global.imageRegistry`    | Global Docker image registry                    | `""`  |
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
@@ -143,7 +143,7 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 ### Common parameters
 
 | Name                | Description                                        | Value           |
-|:--------------------|:---------------------------------------------------|:----------------|
+| ------------------- | -------------------------------------------------- | --------------- |
 | `kubeVersion`       | Override Kubernetes version                        | `""`            |
 | `nameOverride`      | String to partially override common.names.fullname | `""`            |
 | `fullnameOverride`  | String to fully override common.names.fullname     | `""`            |
@@ -155,220 +155,222 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 
 ### RabbitMQ Cluster Operator Parameters
 
-| Name                                                          | Description                                                                                                 | Value                                    |
-|:--------------------------------------------------------------|:------------------------------------------------------------------------------------------------------------|:-----------------------------------------|
-| `rabbitmqImage.registry`                                      | RabbitMQ Image registry                                                                                     | `docker.io`                              |
-| `rabbitmqImage.repository`                                    | RabbitMQ Image repository                                                                                   | `bitnami/rabbitmq`                       |
-| `rabbitmqImage.tag`                                           | RabbitMQ Image tag (immutable tags are recommended)                                                         | `3.8.27-debian-10-r6`                    |
-| `rabbitmqImage.pullSecrets`                                   | RabbitMQ Image pull secrets                                                                                 | `[]`                                     |
-| `credentialUpdaterImage.registry`                             | RabbitMQ Default User Credential Updater Image registry                                                     | `docker.io`                              |
-| `credentialUpdaterImage.repository`                           | RabbitMQ Default User Credential Updater Image repository                                                   | `bitnami/rmq-default-credential-updater` |
-| `credentialUpdaterImage.tag`                                  | RabbitMQ Default User Credential Updater Image tag (immutable tags are recommended)                         | `1.0.1-scratch-r0`                       |
-| `credentialUpdaterImage.pullSecrets`                          | RabbitMQ Default User Credential Updater Image pull secrets                                                 | `[]`                                     |
-| `clusterOperator.image.registry`                              | RabbitMQ Cluster Operator image registry                                                                | `docker.io`                              |
-| `clusterOperator.image.repository`                            | RabbitMQ Cluster Operator image repository                                                              | `bitnami/rabbitmq-cluster-operator`      |
-| `clusterOperator.image.tag`                                   | RabbitMQ Cluster Operator image tag (immutable tags are recommended)                                    | `1.11.0-scratch-r0`                      |
-| `clusterOperator.image.pullPolicy`                            | RabbitMQ Cluster Operator image pull policy                                                             | `IfNotPresent`                           |
-| `clusterOperator.image.pullSecrets`                           | RabbitMQ Cluster Operator image pull secrets                                                            | `[]`                                     |
-| `clusterOperator.replicaCount`                                | Number of RabbitMQ Cluster Operator replicas to deploy                                                  | `1`                                      |
-| `clusterOperator.schedulerName`                               | Alternative scheduler                                                                                       | `""`                                     |
-| `clusterOperator.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                              | `[]`                                     |
-| `clusterOperator.livenessProbe.enabled`                       | Enable livenessProbe on RabbitMQ Cluster Operator nodes                                                 | `true`                                   |
-| `clusterOperator.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                     | `5`                                      |
-| `clusterOperator.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                            | `30`                                     |
-| `clusterOperator.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                           | `5`                                      |
-| `clusterOperator.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                         | `5`                                      |
-| `clusterOperator.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                         | `1`                                      |
-| `clusterOperator.readinessProbe.enabled`                      | Enable readinessProbe on RabbitMQ Cluster Operator nodes                                                | `true`                                   |
-| `clusterOperator.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                                    | `5`                                      |
-| `clusterOperator.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                           | `30`                                     |
-| `clusterOperator.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                          | `5`                                      |
-| `clusterOperator.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                        | `5`                                      |
-| `clusterOperator.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                        | `1`                                      |
-| `clusterOperator.startupProbe.enabled`                        | Enable startupProbe on RabbitMQ Cluster Operator nodes                                                  | `false`                                  |
-| `clusterOperator.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                      | `5`                                      |
-| `clusterOperator.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                             | `30`                                     |
-| `clusterOperator.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                            | `5`                                      |
-| `clusterOperator.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                          | `5`                                      |
-| `clusterOperator.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                          | `1`                                      |
-| `clusterOperator.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                         | `{}`                                     |
-| `clusterOperator.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                        | `{}`                                     |
-| `clusterOperator.customStartupProbe`                          | Custom startupProbe that overrides the default one                                                          | `{}`                                     |
-| `clusterOperator.resources.limits`                            | The resources limits for the RabbitMQ Cluster Operator containers                                       | `{}`                                     |
-| `clusterOperator.resources.requests`                          | The requested resources for the RabbitMQ Cluster Operator containers                                    | `{}`                                     |
-| `clusterOperator.podSecurityContext.enabled`                  | Enabled RabbitMQ Cluster Operator pods' Security Context                                                | `true`                                   |
-| `clusterOperator.podSecurityContext.fsGroup`                  | Set RabbitMQ Cluster Operator pod's Security Context fsGroup                                            | `1001`                                   |
-| `clusterOperator.containerSecurityContext.enabled`            | Enabled RabbitMQ Cluster Operator containers' Security Context                                          | `true`                                   |
-| `clusterOperator.containerSecurityContext.runAsUser`          | Set RabbitMQ Cluster Operator containers' Security Context runAsUser                                    | `1001`                                   |
-| `clusterOperator.containerSecurityContext.runAsNonRoot`       | Force running the container as non root                                                                     | `true`                                   |
-| `clusterOperator.command`                                     | Override default container command (useful when using custom images)                                        | `[]`                                     |
-| `clusterOperator.args`                                        | Override default container args (useful when using custom images)                                           | `[]`                                     |
-| `clusterOperator.hostAliases`                                 | RabbitMQ Cluster Operator pods host aliases                                                             | `[]`                                     |
-| `clusterOperator.podLabels`                                   | Extra labels for RabbitMQ Cluster Operator pods                                                         | `{}`                                     |
-| `clusterOperator.podAnnotations`                              | Annotations for RabbitMQ Cluster Operator pods                                                          | `{}`                                     |
-| `clusterOperator.podAffinityPreset`                           | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                         | `""`                                     |
-| `clusterOperator.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                    | `soft`                                   |
-| `clusterOperator.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                   | `""`                                     |
-| `clusterOperator.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `affinity` is set                                                       | `""`                                     |
-| `clusterOperator.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `affinity` is set                                                    | `[]`                                     |
-| `clusterOperator.affinity`                                    | Affinity for RabbitMQ Cluster Operator pods assignment                                                  | `{}`                                     |
-| `clusterOperator.nodeSelector`                                | Node labels for RabbitMQ Cluster Operator pods assignment                                               | `{}`                                     |
-| `clusterOperator.tolerations`                                 | Tolerations for RabbitMQ Cluster Operator pods assignment                                               | `[]`                                     |
-| `clusterOperator.updateStrategy.type`                         | RabbitMQ Cluster Operator statefulset strategy type                                                     | `RollingUpdate`                          |
-| `clusterOperator.priorityClassName`                           | RabbitMQ Cluster Operator pods' priorityClassName                                                       | `""`                                     |
-| `clusterOperator.lifecycleHooks`                              | for the RabbitMQ Cluster Operator container(s) to automate configuration before or after startup        | `{}`                                     |
-| `clusterOperator.containerPorts.metrics`                      | RabbitMQ Cluster Operator container port (used for metrics)                                             | `9782`                                   |
-| `clusterOperator.extraEnvVars`                                | Array with extra environment variables to add to RabbitMQ Cluster Operator nodes                        | `[]`                                     |
-| `clusterOperator.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for RabbitMQ Cluster Operator nodes                | `""`                                     |
-| `clusterOperator.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for RabbitMQ Cluster Operator nodes                   | `""`                                     |
-| `clusterOperator.extraVolumes`                                | Optionally specify extra list of additional volumes for the RabbitMQ Cluster Operator pod(s)            | `[]`                                     |
-| `clusterOperator.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the RabbitMQ Cluster Operator container(s) | `[]`                                     |
-| `clusterOperator.sidecars`                                    | Add additional sidecar containers to the RabbitMQ Cluster Operator pod(s)                               | `[]`                                     |
-| `clusterOperator.initContainers`                              | Add additional init containers to the RabbitMQ Cluster Operator pod(s)                                  | `[]`                                     |
-| `clusterOperator.rbac.create`                                 | Specifies whether RBAC resources should be created                                                          | `true`                                   |
-| `clusterOperator.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                        | `true`                                   |
-| `clusterOperator.serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                      | `""`                                     |
-| `clusterOperator.serviceAccount.annotations`                  | Add annotations                                                                                             | `{}`                                     |
-| `clusterOperator.serviceAccount.automountServiceAccountToken` | Automount API credentials for a service account.                                                            | `true`                                   |
+| Name                                                              | Description                                                                                             | Value                                    |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `rabbitmqImage.registry`                                          | RabbitMQ Image registry                                                                                 | `docker.io`                              |
+| `rabbitmqImage.repository`                                        | RabbitMQ Image repository                                                                               | `bitnami/rabbitmq`                       |
+| `rabbitmqImage.tag`                                               | RabbitMQ Image tag (immutable tags are recommended)                                                     | `3.8.27-debian-10-r49`                   |
+| `rabbitmqImage.pullSecrets`                                       | RabbitMQ Image pull secrets                                                                             | `[]`                                     |
+| `credentialUpdaterImage.registry`                                 | RabbitMQ Default User Credential Updater Image registry                                                 | `docker.io`                              |
+| `credentialUpdaterImage.repository`                               | RabbitMQ Default User Credential Updater Image repository                                               | `bitnami/rmq-default-credential-updater` |
+| `credentialUpdaterImage.tag`                                      | RabbitMQ Default User Credential Updater Image tag (immutable tags are recommended)                     | `1.0.2-scratch-r0`                       |
+| `credentialUpdaterImage.pullSecrets`                              | RabbitMQ Default User Credential Updater Image pull secrets                                             | `[]`                                     |
+| `clusterOperator.image.registry`                                  | RabbitMQ Cluster Operator image registry                                                                | `docker.io`                              |
+| `clusterOperator.image.repository`                                | RabbitMQ Cluster Operator image repository                                                              | `bitnami/rabbitmq-cluster-operator`      |
+| `clusterOperator.image.tag`                                       | RabbitMQ Cluster Operator image tag (immutable tags are recommended)                                    | `1.12.1-scratch-r0`                      |
+| `clusterOperator.image.pullPolicy`                                | RabbitMQ Cluster Operator image pull policy                                                             | `IfNotPresent`                           |
+| `clusterOperator.image.pullSecrets`                               | RabbitMQ Cluster Operator image pull secrets                                                            | `[]`                                     |
+| `clusterOperator.replicaCount`                                    | Number of RabbitMQ Cluster Operator replicas to deploy                                                  | `1`                                      |
+| `clusterOperator.schedulerName`                                   | Alternative scheduler                                                                                   | `""`                                     |
+| `clusterOperator.topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment                                                          | `[]`                                     |
+| `clusterOperator.livenessProbe.enabled`                           | Enable livenessProbe on RabbitMQ Cluster Operator nodes                                                 | `true`                                   |
+| `clusterOperator.livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                 | `5`                                      |
+| `clusterOperator.livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                        | `30`                                     |
+| `clusterOperator.livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                                       | `5`                                      |
+| `clusterOperator.livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                                     | `5`                                      |
+| `clusterOperator.livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                                     | `1`                                      |
+| `clusterOperator.readinessProbe.enabled`                          | Enable readinessProbe on RabbitMQ Cluster Operator nodes                                                | `true`                                   |
+| `clusterOperator.readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                                | `5`                                      |
+| `clusterOperator.readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                                       | `30`                                     |
+| `clusterOperator.readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                                      | `5`                                      |
+| `clusterOperator.readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                                    | `5`                                      |
+| `clusterOperator.readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                                    | `1`                                      |
+| `clusterOperator.startupProbe.enabled`                            | Enable startupProbe on RabbitMQ Cluster Operator nodes                                                  | `false`                                  |
+| `clusterOperator.startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                                  | `5`                                      |
+| `clusterOperator.startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                                         | `30`                                     |
+| `clusterOperator.startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                                        | `5`                                      |
+| `clusterOperator.startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                                      | `5`                                      |
+| `clusterOperator.startupProbe.successThreshold`                   | Success threshold for startupProbe                                                                      | `1`                                      |
+| `clusterOperator.customLivenessProbe`                             | Custom livenessProbe that overrides the default one                                                     | `{}`                                     |
+| `clusterOperator.customReadinessProbe`                            | Custom readinessProbe that overrides the default one                                                    | `{}`                                     |
+| `clusterOperator.customStartupProbe`                              | Custom startupProbe that overrides the default one                                                      | `{}`                                     |
+| `clusterOperator.resources.limits`                                | The resources limits for the RabbitMQ Cluster Operator containers                                       | `{}`                                     |
+| `clusterOperator.resources.requests`                              | The requested resources for the RabbitMQ Cluster Operator containers                                    | `{}`                                     |
+| `clusterOperator.podSecurityContext.enabled`                      | Enabled RabbitMQ Cluster Operator pods' Security Context                                                | `true`                                   |
+| `clusterOperator.podSecurityContext.fsGroup`                      | Set RabbitMQ Cluster Operator pod's Security Context fsGroup                                            | `1001`                                   |
+| `clusterOperator.containerSecurityContext.enabled`                | Enabled RabbitMQ Cluster Operator containers' Security Context                                          | `true`                                   |
+| `clusterOperator.containerSecurityContext.runAsUser`              | Set RabbitMQ Cluster Operator containers' Security Context runAsUser                                    | `1001`                                   |
+| `clusterOperator.containerSecurityContext.runAsNonRoot`           | Force running the container as non root                                                                 | `true`                                   |
+| `clusterOperator.containerSecurityContext.readOnlyRootFilesystem` | mount / (root) as a readonly filesystem on cluster operator containers                                  | `true`                                   |
+| `clusterOperator.command`                                         | Override default container command (useful when using custom images)                                    | `[]`                                     |
+| `clusterOperator.args`                                            | Override default container args (useful when using custom images)                                       | `[]`                                     |
+| `clusterOperator.hostAliases`                                     | RabbitMQ Cluster Operator pods host aliases                                                             | `[]`                                     |
+| `clusterOperator.podLabels`                                       | Extra labels for RabbitMQ Cluster Operator pods                                                         | `{}`                                     |
+| `clusterOperator.podAnnotations`                                  | Annotations for RabbitMQ Cluster Operator pods                                                          | `{}`                                     |
+| `clusterOperator.podAffinityPreset`                               | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`                                     |
+| `clusterOperator.podAntiAffinityPreset`                           | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `soft`                                   |
+| `clusterOperator.nodeAffinityPreset.type`                         | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`                                     |
+| `clusterOperator.nodeAffinityPreset.key`                          | Node label key to match. Ignored if `affinity` is set                                                   | `""`                                     |
+| `clusterOperator.nodeAffinityPreset.values`                       | Node label values to match. Ignored if `affinity` is set                                                | `[]`                                     |
+| `clusterOperator.affinity`                                        | Affinity for RabbitMQ Cluster Operator pods assignment                                                  | `{}`                                     |
+| `clusterOperator.nodeSelector`                                    | Node labels for RabbitMQ Cluster Operator pods assignment                                               | `{}`                                     |
+| `clusterOperator.tolerations`                                     | Tolerations for RabbitMQ Cluster Operator pods assignment                                               | `[]`                                     |
+| `clusterOperator.updateStrategy.type`                             | RabbitMQ Cluster Operator statefulset strategy type                                                     | `RollingUpdate`                          |
+| `clusterOperator.priorityClassName`                               | RabbitMQ Cluster Operator pods' priorityClassName                                                       | `""`                                     |
+| `clusterOperator.lifecycleHooks`                                  | for the RabbitMQ Cluster Operator container(s) to automate configuration before or after startup        | `{}`                                     |
+| `clusterOperator.containerPorts.metrics`                          | RabbitMQ Cluster Operator container port (used for metrics)                                             | `9782`                                   |
+| `clusterOperator.extraEnvVars`                                    | Array with extra environment variables to add to RabbitMQ Cluster Operator nodes                        | `[]`                                     |
+| `clusterOperator.extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars for RabbitMQ Cluster Operator nodes                | `""`                                     |
+| `clusterOperator.extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars for RabbitMQ Cluster Operator nodes                   | `""`                                     |
+| `clusterOperator.extraVolumes`                                    | Optionally specify extra list of additional volumes for the RabbitMQ Cluster Operator pod(s)            | `[]`                                     |
+| `clusterOperator.extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the RabbitMQ Cluster Operator container(s) | `[]`                                     |
+| `clusterOperator.sidecars`                                        | Add additional sidecar containers to the RabbitMQ Cluster Operator pod(s)                               | `[]`                                     |
+| `clusterOperator.initContainers`                                  | Add additional init containers to the RabbitMQ Cluster Operator pod(s)                                  | `[]`                                     |
+| `clusterOperator.rbac.create`                                     | Specifies whether RBAC resources should be created                                                      | `true`                                   |
+| `clusterOperator.serviceAccount.create`                           | Specifies whether a ServiceAccount should be created                                                    | `true`                                   |
+| `clusterOperator.serviceAccount.name`                             | The name of the ServiceAccount to use.                                                                  | `""`                                     |
+| `clusterOperator.serviceAccount.annotations`                      | Add annotations                                                                                         | `{}`                                     |
+| `clusterOperator.serviceAccount.automountServiceAccountToken`     | Automount API credentials for a service account.                                                        | `true`                                   |
 
 
 ### RabbitMQ Cluster Operator Metrics parameters
 
-| Name                                                       | Description                                                                     | Value                    |
-|:-----------------------------------------------------------|:--------------------------------------------------------------------------------|:-------------------------|
-| `clusterOperator.metrics.enabled`                          | Create a service for accessing the metrics endpoint                             | `false`                  |
+| Name                                                       | Description                                                                 | Value                    |
+| ---------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------ |
+| `clusterOperator.metrics.enabled`                          | Create a service for accessing the metrics endpoint                         | `false`                  |
 | `clusterOperator.metrics.service.type`                     | RabbitMQ Cluster Operator metrics service type                              | `ClusterIP`              |
 | `clusterOperator.metrics.service.ports.http`               | RabbitMQ Cluster Operator metrics service HTTP port                         | `80`                     |
-| `clusterOperator.metrics.service.nodePorts.http`           | Node port for HTTP                                                              | `""`                     |
+| `clusterOperator.metrics.service.nodePorts.http`           | Node port for HTTP                                                          | `""`                     |
 | `clusterOperator.metrics.service.clusterIP`                | RabbitMQ Cluster Operator metrics service Cluster IP                        | `""`                     |
-| `clusterOperator.metrics.service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)                  | `[]`                     |
+| `clusterOperator.metrics.service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)              | `[]`                     |
 | `clusterOperator.metrics.service.loadBalancerIP`           | RabbitMQ Cluster Operator metrics service Load Balancer IP                  | `""`                     |
 | `clusterOperator.metrics.service.loadBalancerSourceRanges` | RabbitMQ Cluster Operator metrics service Load Balancer sources             | `[]`                     |
 | `clusterOperator.metrics.service.externalTrafficPolicy`    | RabbitMQ Cluster Operator metrics service external traffic policy           | `Cluster`                |
 | `clusterOperator.metrics.service.annotations`              | Additional custom annotations for RabbitMQ Cluster Operator metrics service | `{}`                     |
-| `clusterOperator.metrics.serviceMonitor.enabled`           | Specify if a servicemonitor will be deployed for prometheus-operator            | `false`                  |
-| `clusterOperator.metrics.serviceMonitor.jobLabel`          | Specify the jobLabel to use for the prometheus-operator                         | `app.kubernetes.io/name` |
-| `clusterOperator.metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                            | `false`                  |
-| `clusterOperator.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                             | `{}`                     |
-| `clusterOperator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                         | `""`                     |
-| `clusterOperator.metrics.serviceMonitor.interval`          | Scrape interval. If not set, the Prometheus default scrape interval is used     | `""`                     |
-| `clusterOperator.metrics.serviceMonitor.additionalLabels`  | Used to pass Labels that are required by the installed Prometheus Operator      | `{}`                     |
-| `clusterOperator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                        | `[]`                     |
-| `clusterOperator.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                      | `[]`                     |
+| `clusterOperator.metrics.serviceMonitor.enabled`           | Specify if a servicemonitor will be deployed for prometheus-operator        | `false`                  |
+| `clusterOperator.metrics.serviceMonitor.jobLabel`          | Specify the jobLabel to use for the prometheus-operator                     | `app.kubernetes.io/name` |
+| `clusterOperator.metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                        | `false`                  |
+| `clusterOperator.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                         | `{}`                     |
+| `clusterOperator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                     | `""`                     |
+| `clusterOperator.metrics.serviceMonitor.interval`          | Scrape interval. If not set, the Prometheus default scrape interval is used | `""`                     |
+| `clusterOperator.metrics.serviceMonitor.additionalLabels`  | Used to pass Labels that are required by the installed Prometheus Operator  | `{}`                     |
+| `clusterOperator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                    | `[]`                     |
+| `clusterOperator.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                  | `[]`                     |
 
 
 ### RabbitMQ Messaging Topology Operator Parameters
 
-| Name                                                              | Description                                                                                                        | Value                                     |
-|:------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------|:------------------------------------------|
-| `msgTopologyOperator.image.registry`                              | RabbitMQ Messaging Topology Operator image registry                                                                | `docker.io`                               |
-| `msgTopologyOperator.image.repository`                            | RabbitMQ Messaging Topology Operator image repository                                                              | `bitnami/rmq-messaging-topology-operator` |
-| `msgTopologyOperator.image.tag`                                   | RabbitMQ Messaging Topology Operator image tag (immutable tags are recommended)                                    | `1.2.1-scratch-r0`                        |
-| `msgTopologyOperator.image.pullPolicy`                            | RabbitMQ Messaging Topology Operator image pull policy                                                             | `IfNotPresent`                            |
-| `msgTopologyOperator.image.pullSecrets`                           | RabbitMQ Messaging Topology Operator image pull secrets                                                            | `[]`                                      |
-| `msgTopologyOperator.replicaCount`                                | Number of RabbitMQ Messaging Topology Operator replicas to deploy                                                  | `1`                                       |
-| `msgTopologyOperator.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                                     | `[]`                                      |
-| `msgTopologyOperator.schedulerName`                               | Alternative scheduler                                                                                              | `""`                                      |
-| `msgTopologyOperator.livenessProbe.enabled`                       | Enable livenessProbe on RabbitMQ Messaging Topology Operator nodes                                                 | `true`                                    |
-| `msgTopologyOperator.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                            | `5`                                       |
-| `msgTopologyOperator.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                                   | `30`                                      |
-| `msgTopologyOperator.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                                  | `5`                                       |
-| `msgTopologyOperator.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                                | `5`                                       |
-| `msgTopologyOperator.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                                | `1`                                       |
-| `msgTopologyOperator.readinessProbe.enabled`                      | Enable readinessProbe on RabbitMQ Messaging Topology Operator nodes                                                | `true`                                    |
-| `msgTopologyOperator.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                                           | `5`                                       |
-| `msgTopologyOperator.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                                  | `30`                                      |
-| `msgTopologyOperator.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                                 | `5`                                       |
-| `msgTopologyOperator.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                               | `5`                                       |
-| `msgTopologyOperator.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                               | `1`                                       |
-| `msgTopologyOperator.startupProbe.enabled`                        | Enable startupProbe on RabbitMQ Messaging Topology Operator nodes                                                  | `false`                                   |
-| `msgTopologyOperator.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                             | `5`                                       |
-| `msgTopologyOperator.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                                    | `30`                                      |
-| `msgTopologyOperator.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                                   | `5`                                       |
-| `msgTopologyOperator.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                                 | `5`                                       |
-| `msgTopologyOperator.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                                 | `1`                                       |
-| `msgTopologyOperator.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                                | `{}`                                      |
-| `msgTopologyOperator.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                               | `{}`                                      |
-| `msgTopologyOperator.customStartupProbe`                          | Custom startupProbe that overrides the default one                                                                 | `{}`                                      |
-| `msgTopologyOperator.existingWebhookCertSecret`                   | name of a secret containing the certificates (use it to avoid certManager creating one)                            | `""`                                      |
-| `msgTopologyOperator.existingWebhookCertCABundle`                 | PEM-encoded CA Bundle of the existing secret provided in existingWebhookCertSecret (only if useCertManager=false)  | `""`                                      |
-| `msgTopologyOperator.resources.limits`                            | The resources limits for the RabbitMQ Messaging Topology Operator containers                                       | `{}`                                      |
-| `msgTopologyOperator.resources.requests`                          | The requested resources for the RabbitMQ Messaging Topology Operator containers                                    | `{}`                                      |
-| `msgTopologyOperator.podSecurityContext.enabled`                  | Enabled RabbitMQ Messaging Topology Operator pods' Security Context                                                | `true`                                    |
-| `msgTopologyOperator.podSecurityContext.fsGroup`                  | Set RabbitMQ Messaging Topology Operator pod's Security Context fsGroup                                            | `1001`                                    |
-| `msgTopologyOperator.containerSecurityContext.enabled`            | Enabled RabbitMQ Messaging Topology Operator containers' Security Context                                          | `true`                                    |
-| `msgTopologyOperator.containerSecurityContext.runAsUser`          | Set RabbitMQ Messaging Topology Operator containers' Security Context runAsUser                                    | `1001`                                    |
-| `msgTopologyOperator.containerSecurityContext.runAsNonRoot`       | Force running the container as non root                                                                            | `true`                                    |
-| `msgTopologyOperator.fullnameOverride`                            | String to fully override rmqco.msgTopologyOperator.fullname template                                               | `""`                                      |
-| `msgTopologyOperator.command`                                     | Override default container command (useful when using custom images)                                               | `[]`                                      |
-| `msgTopologyOperator.args`                                        | Override default container args (useful when using custom images)                                                  | `[]`                                      |
-| `msgTopologyOperator.hostAliases`                                 | RabbitMQ Messaging Topology Operator pods host aliases                                                             | `[]`                                      |
-| `msgTopologyOperator.podLabels`                                   | Extra labels for RabbitMQ Messaging Topology Operator pods                                                         | `{}`                                      |
-| `msgTopologyOperator.podAnnotations`                              | Annotations for RabbitMQ Messaging Topology Operator pods                                                          | `{}`                                      |
-| `msgTopologyOperator.podAffinityPreset`                           | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                                      |
-| `msgTopologyOperator.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                           | `soft`                                    |
-| `msgTopologyOperator.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                          | `""`                                      |
-| `msgTopologyOperator.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `affinity` is set                                                              | `""`                                      |
-| `msgTopologyOperator.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `affinity` is set                                                           | `[]`                                      |
-| `msgTopologyOperator.affinity`                                    | Affinity for RabbitMQ Messaging Topology Operator pods assignment                                                  | `{}`                                      |
-| `msgTopologyOperator.nodeSelector`                                | Node labels for RabbitMQ Messaging Topology Operator pods assignment                                               | `{}`                                      |
-| `msgTopologyOperator.tolerations`                                 | Tolerations for RabbitMQ Messaging Topology Operator pods assignment                                               | `[]`                                      |
-| `msgTopologyOperator.updateStrategy.type`                         | RabbitMQ Messaging Topology Operator statefulset strategy type                                                     | `RollingUpdate`                           |
-| `msgTopologyOperator.priorityClassName`                           | RabbitMQ Messaging Topology Operator pods' priorityClassName                                                       | `""`                                      |
-| `msgTopologyOperator.lifecycleHooks`                              | for the RabbitMQ Messaging Topology Operator container(s) to automate configuration before or after startup        | `{}`                                      |
-| `msgTopologyOperator.containerPorts.metrics`                      | RabbitMQ Messaging Topology Operator container port (used for metrics)                                             | `8080`                                    |
-| `msgTopologyOperator.extraEnvVars`                                | Array with extra environment variables to add to RabbitMQ Messaging Topology Operator nodes                        | `[]`                                      |
-| `msgTopologyOperator.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for RabbitMQ Messaging Topology Operator nodes                | `""`                                      |
-| `msgTopologyOperator.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for RabbitMQ Messaging Topology Operator nodes                   | `""`                                      |
-| `msgTopologyOperator.extraVolumes`                                | Optionally specify extra list of additional volumes for the RabbitMQ Messaging Topology Operator pod(s)            | `[]`                                      |
-| `msgTopologyOperator.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the RabbitMQ Messaging Topology Operator container(s) | `[]`                                      |
-| `msgTopologyOperator.sidecars`                                    | Add additional sidecar containers to the RabbitMQ Messaging Topology Operator pod(s)                               | `[]`                                      |
-| `msgTopologyOperator.initContainers`                              | Add additional init containers to the RabbitMQ Messaging Topology Operator pod(s)                                  | `[]`                                      |
-| `msgTopologyOperator.service.type`                                | RabbitMQ Messaging Topology Operator webhook service type                                                          | `ClusterIP`                               |
-| `msgTopologyOperator.service.ports.webhook`                       | RabbitMQ Messaging Topology Operator webhook service HTTP port                                                     | `443`                                     |
-| `msgTopologyOperator.service.nodePorts.http`                      | Node port for HTTP                                                                                                 | `""`                                      |
-| `msgTopologyOperator.service.clusterIP`                           | RabbitMQ Messaging Topology Operator webhook service Cluster IP                                                    | `""`                                      |
-| `msgTopologyOperator.service.loadBalancerIP`                      | RabbitMQ Messaging Topology Operator webhook service Load Balancer IP                                              | `""`                                      |
-| `msgTopologyOperator.service.extraPorts`                          | Extra ports to expose (normally used with the `sidecar` value)                                                     | `[]`                                      |
-| `msgTopologyOperator.service.loadBalancerSourceRanges`            | RabbitMQ Messaging Topology Operator webhook service Load Balancer sources                                         | `[]`                                      |
-| `msgTopologyOperator.service.externalTrafficPolicy`               | RabbitMQ Messaging Topology Operator webhook service external traffic policy                                       | `Cluster`                                 |
-| `msgTopologyOperator.service.annotations`                         | Additional custom annotations for RabbitMQ Messaging Topology Operator webhook service                             | `{}`                                      |
-| `msgTopologyOperator.rbac.create`                                 | Specifies whether RBAC resources should be created                                                                 | `true`                                    |
-| `msgTopologyOperator.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                               | `true`                                    |
-| `msgTopologyOperator.serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                             | `""`                                      |
-| `msgTopologyOperator.serviceAccount.annotations`                  | Add annotations                                                                                                    | `{}`                                      |
-| `msgTopologyOperator.serviceAccount.automountServiceAccountToken` | Automount API credentials for a service account.                                                                   | `true`                                    |
+| Name                                                                  | Description                                                                                                        | Value                                     |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| `msgTopologyOperator.image.registry`                                  | RabbitMQ Messaging Topology Operator image registry                                                                | `docker.io`                               |
+| `msgTopologyOperator.image.repository`                                | RabbitMQ Messaging Topology Operator image repository                                                              | `bitnami/rmq-messaging-topology-operator` |
+| `msgTopologyOperator.image.tag`                                       | RabbitMQ Messaging Topology Operator image tag (immutable tags are recommended)                                    | `1.4.1-scratch-r0`                        |
+| `msgTopologyOperator.image.pullPolicy`                                | RabbitMQ Messaging Topology Operator image pull policy                                                             | `IfNotPresent`                            |
+| `msgTopologyOperator.image.pullSecrets`                               | RabbitMQ Messaging Topology Operator image pull secrets                                                            | `[]`                                      |
+| `msgTopologyOperator.replicaCount`                                    | Number of RabbitMQ Messaging Topology Operator replicas to deploy                                                  | `1`                                       |
+| `msgTopologyOperator.topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment                                                                     | `[]`                                      |
+| `msgTopologyOperator.schedulerName`                                   | Alternative scheduler                                                                                              | `""`                                      |
+| `msgTopologyOperator.livenessProbe.enabled`                           | Enable livenessProbe on RabbitMQ Messaging Topology Operator nodes                                                 | `true`                                    |
+| `msgTopologyOperator.livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                            | `5`                                       |
+| `msgTopologyOperator.livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                                   | `30`                                      |
+| `msgTopologyOperator.livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                                                  | `5`                                       |
+| `msgTopologyOperator.livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                                                | `5`                                       |
+| `msgTopologyOperator.livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                                                | `1`                                       |
+| `msgTopologyOperator.readinessProbe.enabled`                          | Enable readinessProbe on RabbitMQ Messaging Topology Operator nodes                                                | `true`                                    |
+| `msgTopologyOperator.readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                                           | `5`                                       |
+| `msgTopologyOperator.readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                                                  | `30`                                      |
+| `msgTopologyOperator.readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                                                 | `5`                                       |
+| `msgTopologyOperator.readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                                               | `5`                                       |
+| `msgTopologyOperator.readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                                               | `1`                                       |
+| `msgTopologyOperator.startupProbe.enabled`                            | Enable startupProbe on RabbitMQ Messaging Topology Operator nodes                                                  | `false`                                   |
+| `msgTopologyOperator.startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                                             | `5`                                       |
+| `msgTopologyOperator.startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                                                    | `30`                                      |
+| `msgTopologyOperator.startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                                                   | `5`                                       |
+| `msgTopologyOperator.startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                                                 | `5`                                       |
+| `msgTopologyOperator.startupProbe.successThreshold`                   | Success threshold for startupProbe                                                                                 | `1`                                       |
+| `msgTopologyOperator.customLivenessProbe`                             | Custom livenessProbe that overrides the default one                                                                | `{}`                                      |
+| `msgTopologyOperator.customReadinessProbe`                            | Custom readinessProbe that overrides the default one                                                               | `{}`                                      |
+| `msgTopologyOperator.customStartupProbe`                              | Custom startupProbe that overrides the default one                                                                 | `{}`                                      |
+| `msgTopologyOperator.existingWebhookCertSecret`                       | name of a secret containing the certificates (use it to avoid certManager creating one)                            | `""`                                      |
+| `msgTopologyOperator.existingWebhookCertCABundle`                     | PEM-encoded CA Bundle of the existing secret provided in existingWebhookCertSecret (only if useCertManager=false)  | `""`                                      |
+| `msgTopologyOperator.resources.limits`                                | The resources limits for the RabbitMQ Messaging Topology Operator containers                                       | `{}`                                      |
+| `msgTopologyOperator.resources.requests`                              | The requested resources for the RabbitMQ Messaging Topology Operator containers                                    | `{}`                                      |
+| `msgTopologyOperator.podSecurityContext.enabled`                      | Enabled RabbitMQ Messaging Topology Operator pods' Security Context                                                | `true`                                    |
+| `msgTopologyOperator.podSecurityContext.fsGroup`                      | Set RabbitMQ Messaging Topology Operator pod's Security Context fsGroup                                            | `1001`                                    |
+| `msgTopologyOperator.containerSecurityContext.enabled`                | Enabled RabbitMQ Messaging Topology Operator containers' Security Context                                          | `true`                                    |
+| `msgTopologyOperator.containerSecurityContext.runAsUser`              | Set RabbitMQ Messaging Topology Operator containers' Security Context runAsUser                                    | `1001`                                    |
+| `msgTopologyOperator.containerSecurityContext.runAsNonRoot`           | Force running the container as non root                                                                            | `true`                                    |
+| `msgTopologyOperator.containerSecurityContext.readOnlyRootFilesystem` | mount / (root) as a readonly filesystem on Messaging Topology Operator                                             | `true`                                    |
+| `msgTopologyOperator.fullnameOverride`                                | String to fully override rmqco.msgTopologyOperator.fullname template                                               | `""`                                      |
+| `msgTopologyOperator.command`                                         | Override default container command (useful when using custom images)                                               | `[]`                                      |
+| `msgTopologyOperator.args`                                            | Override default container args (useful when using custom images)                                                  | `[]`                                      |
+| `msgTopologyOperator.hostAliases`                                     | RabbitMQ Messaging Topology Operator pods host aliases                                                             | `[]`                                      |
+| `msgTopologyOperator.podLabels`                                       | Extra labels for RabbitMQ Messaging Topology Operator pods                                                         | `{}`                                      |
+| `msgTopologyOperator.podAnnotations`                                  | Annotations for RabbitMQ Messaging Topology Operator pods                                                          | `{}`                                      |
+| `msgTopologyOperator.podAffinityPreset`                               | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                                      |
+| `msgTopologyOperator.podAntiAffinityPreset`                           | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                           | `soft`                                    |
+| `msgTopologyOperator.nodeAffinityPreset.type`                         | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                          | `""`                                      |
+| `msgTopologyOperator.nodeAffinityPreset.key`                          | Node label key to match. Ignored if `affinity` is set                                                              | `""`                                      |
+| `msgTopologyOperator.nodeAffinityPreset.values`                       | Node label values to match. Ignored if `affinity` is set                                                           | `[]`                                      |
+| `msgTopologyOperator.affinity`                                        | Affinity for RabbitMQ Messaging Topology Operator pods assignment                                                  | `{}`                                      |
+| `msgTopologyOperator.nodeSelector`                                    | Node labels for RabbitMQ Messaging Topology Operator pods assignment                                               | `{}`                                      |
+| `msgTopologyOperator.tolerations`                                     | Tolerations for RabbitMQ Messaging Topology Operator pods assignment                                               | `[]`                                      |
+| `msgTopologyOperator.updateStrategy.type`                             | RabbitMQ Messaging Topology Operator statefulset strategy type                                                     | `RollingUpdate`                           |
+| `msgTopologyOperator.priorityClassName`                               | RabbitMQ Messaging Topology Operator pods' priorityClassName                                                       | `""`                                      |
+| `msgTopologyOperator.lifecycleHooks`                                  | for the RabbitMQ Messaging Topology Operator container(s) to automate configuration before or after startup        | `{}`                                      |
+| `msgTopologyOperator.containerPorts.metrics`                          | RabbitMQ Messaging Topology Operator container port (used for metrics)                                             | `8080`                                    |
+| `msgTopologyOperator.extraEnvVars`                                    | Array with extra environment variables to add to RabbitMQ Messaging Topology Operator nodes                        | `[]`                                      |
+| `msgTopologyOperator.extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars for RabbitMQ Messaging Topology Operator nodes                | `""`                                      |
+| `msgTopologyOperator.extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars for RabbitMQ Messaging Topology Operator nodes                   | `""`                                      |
+| `msgTopologyOperator.extraVolumes`                                    | Optionally specify extra list of additional volumes for the RabbitMQ Messaging Topology Operator pod(s)            | `[]`                                      |
+| `msgTopologyOperator.extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the RabbitMQ Messaging Topology Operator container(s) | `[]`                                      |
+| `msgTopologyOperator.sidecars`                                        | Add additional sidecar containers to the RabbitMQ Messaging Topology Operator pod(s)                               | `[]`                                      |
+| `msgTopologyOperator.initContainers`                                  | Add additional init containers to the RabbitMQ Messaging Topology Operator pod(s)                                  | `[]`                                      |
+| `msgTopologyOperator.service.type`                                    | RabbitMQ Messaging Topology Operator webhook service type                                                          | `ClusterIP`                               |
+| `msgTopologyOperator.service.ports.webhook`                           | RabbitMQ Messaging Topology Operator webhook service HTTP port                                                     | `443`                                     |
+| `msgTopologyOperator.service.nodePorts.http`                          | Node port for HTTP                                                                                                 | `""`                                      |
+| `msgTopologyOperator.service.clusterIP`                               | RabbitMQ Messaging Topology Operator webhook service Cluster IP                                                    | `""`                                      |
+| `msgTopologyOperator.service.loadBalancerIP`                          | RabbitMQ Messaging Topology Operator webhook service Load Balancer IP                                              | `""`                                      |
+| `msgTopologyOperator.service.extraPorts`                              | Extra ports to expose (normally used with the `sidecar` value)                                                     | `[]`                                      |
+| `msgTopologyOperator.service.loadBalancerSourceRanges`                | RabbitMQ Messaging Topology Operator webhook service Load Balancer sources                                         | `[]`                                      |
+| `msgTopologyOperator.service.externalTrafficPolicy`                   | RabbitMQ Messaging Topology Operator webhook service external traffic policy                                       | `Cluster`                                 |
+| `msgTopologyOperator.service.annotations`                             | Additional custom annotations for RabbitMQ Messaging Topology Operator webhook service                             | `{}`                                      |
+| `msgTopologyOperator.rbac.create`                                     | Specifies whether RBAC resources should be created                                                                 | `true`                                    |
+| `msgTopologyOperator.serviceAccount.create`                           | Specifies whether a ServiceAccount should be created                                                               | `true`                                    |
+| `msgTopologyOperator.serviceAccount.name`                             | The name of the ServiceAccount to use.                                                                             | `""`                                      |
+| `msgTopologyOperator.serviceAccount.annotations`                      | Add annotations                                                                                                    | `{}`                                      |
+| `msgTopologyOperator.serviceAccount.automountServiceAccountToken`     | Automount API credentials for a service account.                                                                   | `true`                                    |
 
 
 ### RabbitMQ Messaging Topology Operator parameters
 
-| Name                                                           | Description                                                                     | Value                    |
-|:---------------------------------------------------------------|:--------------------------------------------------------------------------------|:-------------------------|
-| `msgTopologyOperator.metrics.enabled`                          | Create a service for accessing the metrics endpoint                             | `false`                  |
+| Name                                                           | Description                                                                 | Value                    |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------ |
+| `msgTopologyOperator.metrics.enabled`                          | Create a service for accessing the metrics endpoint                         | `false`                  |
 | `msgTopologyOperator.metrics.service.type`                     | RabbitMQ Cluster Operator metrics service type                              | `ClusterIP`              |
 | `msgTopologyOperator.metrics.service.ports.http`               | RabbitMQ Cluster Operator metrics service HTTP port                         | `80`                     |
-| `msgTopologyOperator.metrics.service.nodePorts.http`           | Node port for HTTP                                                              | `""`                     |
+| `msgTopologyOperator.metrics.service.nodePorts.http`           | Node port for HTTP                                                          | `""`                     |
 | `msgTopologyOperator.metrics.service.clusterIP`                | RabbitMQ Cluster Operator metrics service Cluster IP                        | `""`                     |
-| `msgTopologyOperator.metrics.service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)                  | `[]`                     |
+| `msgTopologyOperator.metrics.service.extraPorts`               | Extra ports to expose (normally used with the `sidecar` value)              | `[]`                     |
 | `msgTopologyOperator.metrics.service.loadBalancerIP`           | RabbitMQ Cluster Operator metrics service Load Balancer IP                  | `""`                     |
 | `msgTopologyOperator.metrics.service.loadBalancerSourceRanges` | RabbitMQ Cluster Operator metrics service Load Balancer sources             | `[]`                     |
 | `msgTopologyOperator.metrics.service.externalTrafficPolicy`    | RabbitMQ Cluster Operator metrics service external traffic policy           | `Cluster`                |
 | `msgTopologyOperator.metrics.service.annotations`              | Additional custom annotations for RabbitMQ Cluster Operator metrics service | `{}`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.enabled`           | Specify if a servicemonitor will be deployed for prometheus-operator            | `false`                  |
-| `msgTopologyOperator.metrics.serviceMonitor.jobLabel`          | Specify the jobLabel to use for the prometheus-operator                         | `app.kubernetes.io/name` |
-| `msgTopologyOperator.metrics.serviceMonitor.additionalLabels`  | Used to pass Labels that are required by the installed Prometheus Operator      | `{}`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                             | `{}`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                            | `false`                  |
-| `msgTopologyOperator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                         | `""`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.interval`          | Scrape interval. If not set, the Prometheus default scrape interval is used     | `""`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                        | `[]`                     |
-| `msgTopologyOperator.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                      | `[]`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.enabled`           | Specify if a servicemonitor will be deployed for prometheus-operator        | `false`                  |
+| `msgTopologyOperator.metrics.serviceMonitor.jobLabel`          | Specify the jobLabel to use for the prometheus-operator                     | `app.kubernetes.io/name` |
+| `msgTopologyOperator.metrics.serviceMonitor.additionalLabels`  | Used to pass Labels that are required by the installed Prometheus Operator  | `{}`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                         | `{}`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                        | `false`                  |
+| `msgTopologyOperator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                     | `""`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.interval`          | Scrape interval. If not set, the Prometheus default scrape interval is used | `""`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                    | `[]`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                  | `[]`                     |
 
 
 ### cert-manager parameters
 
 | Name             | Description                                                       | Value   |
-|:-----------------|:------------------------------------------------------------------|:--------|
+| ---------------- | ----------------------------------------------------------------- | ------- |
 | `useCertManager` | Deploy cert-manager objects (Issuer and Certificate) for webhooks | `false` |
 
 

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -200,11 +200,13 @@ clusterOperator:
   ## @param clusterOperator.containerSecurityContext.enabled Enabled RabbitMQ Cluster Operator containers' Security Context
   ## @param clusterOperator.containerSecurityContext.runAsUser Set RabbitMQ Cluster Operator containers' Security Context runAsUser
   ## @param clusterOperator.containerSecurityContext.runAsNonRoot Force running the container as non root
+  ## @param clusterOperator.containerSecurityContext.readOnlyRootFilesystem mount / (root) as a readonly filesystem on cluster operator containers
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
     runAsNonRoot: true
+    readOnlyRootFilesystem: true
 
   ## @param clusterOperator.command Override default container command (useful when using custom images)
   ##
@@ -560,11 +562,13 @@ msgTopologyOperator:
   ## @param msgTopologyOperator.containerSecurityContext.enabled Enabled RabbitMQ Messaging Topology Operator containers' Security Context
   ## @param msgTopologyOperator.containerSecurityContext.runAsUser Set RabbitMQ Messaging Topology Operator containers' Security Context runAsUser
   ## @param msgTopologyOperator.containerSecurityContext.runAsNonRoot Force running the container as non root
+  ## @param msgTopologyOperator.containerSecurityContext.readOnlyRootFilesystem mount / (root) as a readonly filesystem on Messaging Topology Operator
   ##
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
     runAsNonRoot: true
+    readOnlyRootFilesystem: true
 
   ## @param msgTopologyOperator.fullnameOverride String to fully override rmqco.msgTopologyOperator.fullname template
   ##

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -55,7 +55,7 @@ extraDeploy: []
 rabbitmqImage:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.27-debian-10-r49
+  tag: 3.8.27-debian-10-r58
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-rabbitmqImage-private-registry/
@@ -97,7 +97,7 @@ clusterOperator:
   image:
     registry: docker.io
     repository: bitnami/rabbitmq-cluster-operator
-    tag: 1.12.1-scratch-r0
+    tag: 1.12.1-scratch-r1
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION

Signed-off-by: Miguel A. Cabrera Minagorri <mcabrera@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)