### PR TITLE
[bitnami/harbor] Escape a pipe that broke the markdown table

### DIFF
--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -105,7 +105,7 @@ Additionally, if `persistence.resourcePolicy` is set to `keep`, you should manua
 
 | Name                               | Description                                                                                                                      | Value                    |
 | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `exposureType`                     | The way to expose Harbor. Allowed values are [ ingress | proxy ]                                                                 | `proxy`                  |
+| `exposureType`                     | The way to expose Harbor. Allowed values are [ ingress \| proxy ]                                                                | `proxy`                  |
 | `service.type`                     | NGINX proxy service type                                                                                                         | `LoadBalancer`           |
 | `service.ports.http`               | NGINX proxy service HTTP port                                                                                                    | `80`                     |
 | `service.ports.https`              | NGINX proxy service HTTPS port                                                                                                   | `443`                    |


### PR DESCRIPTION

**Description of the change**

Escape a pipe that broke the markdown table.

**Benefits**

Markdown renders correctly.

**Possible drawbacks**

None.

**Applicable issues**

None, I think.

**Additional information**

I'd recommend using `markdownlint` to identify issues with your README files. :)

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)