### PR TITLE
[bitnami/nginx] Disable replicas when autoscaling enabled

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 9.9.4
+version: 9.9.5

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -10,7 +10,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   {{- if .Values.updateStrategy }}
   strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
When autoscaling is enabled, key `.spec.replicas` in `deployment.yaml` manifest is still generated, which causing problem when using GitOps like ArgoCD.

**Description of the change**

When `.Values.autoscaling.enabled=true` field `.spec.replicas` in `deployment.yaml` is not generated.

**Benefits**

When autoscaling is disabled (by default), replicas field is generated. When autoscaling is enabled, replicas field is not generated.

**Possible drawbacks**

**Applicable issues**

**Additional information**

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)