### PR TITLE
bitnami/thanos - Bugfix/typo servername thanos query

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 10.2.0
+version: 10.2.1

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -145,8 +145,8 @@ spec:
             - --grpc-client-tls-key=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "tls-key") }}
             - --grpc-client-tls-ca=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "ca-cert") }}
             {{- end }}
-            {{- if .Values.query.grpc.client.servername }}
-            - --grpc-client-server-name={{ .Values.query.grpc.client.servername }}
+            {{- if .Values.query.grpc.client.serverName }}
+            - --grpc-client-server-name={{ .Values.query.grpc.client.serverName }}
             {{- end }}
             {{- if .Values.query.extraFlags }}
             {{- .Values.query.extraFlags | toYaml | nindent 12 }}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -145,7 +145,7 @@ spec:
             - --grpc-client-tls-key=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "tls-key") }}
             - --grpc-client-tls-ca=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "ca-cert") }}
             {{- end }}
-            {{- if .Values.query.grpc.client.serverNam }}
+            {{- if .Values.query.grpc.client.serverName }}
             - --grpc-client-server-name={{ .Values.query.grpc.client.serverName }}
             {{- end }}
             {{- if .Values.query.extraFlags }}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -145,7 +145,7 @@ spec:
             - --grpc-client-tls-key=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "tls-key") }}
             - --grpc-client-tls-ca=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "ca-cert") }}
             {{- end }}
-            {{- if .Values.query.grpc.client.serverName }}
+            {{- if .Values.query.grpc.client.serverNam }}
             - --grpc-client-server-name={{ .Values.query.grpc.client.serverName }}
             {{- end }}
             {{- if .Values.query.extraFlags }}


### PR DESCRIPTION
**Description of the change**

To update thanos-query deployment to look for serverName instead of servername in the values.
https://github.com/bitnami/charts/issues/9332

**Benefits**

ServerName can be passed for query in Thanos when using mtls and you want to validate the server name using SNI.

**Possible drawbacks**
NA

**Applicable issues**
https://github.com/bitnami/charts/issues/9332

**Additional information**
None

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)