### PR TITLE
[bitnami/thanos] - updated version and fixed typo servername to serverName in deployment.yml

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 10.2.1
+version: 10.2.2

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -145,8 +145,8 @@ spec:
             - --grpc-client-tls-key=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "tls-key") }}
             - --grpc-client-tls-ca=/certs/client/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.client.tls.existingSecret "key" "ca-cert") }}
             {{- end }}
-            {{- if .Values.query.grpc.client.servername }}
-            - --grpc-client-server-name={{ .Values.query.grpc.client.servername }}
+            {{- if .Values.query.grpc.client.serverName }}
+            - --grpc-client-server-name={{ .Values.query.grpc.client.serverName }}
             {{- end }}
             {{- if .Values.query.extraFlags }}
             {{- .Values.query.extraFlags | toYaml | nindent 12 }}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -53,7 +53,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/thanos
-  tag: 0.25.1-scratch-r2
+  tag: 0.25.1-scratch-r3
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -3663,7 +3663,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r369
+    tag: 10-debian-10-r371
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##


### PR DESCRIPTION
Description of the change

To update thanos-query deployment to look for serverName instead of servername in the values.
#9332

Benefits

ServerName can be passed for query in Thanos when using mtls and you want to validate the server name using SNI.

Possible drawbacks
NA

Applicable issues
#9332

Additional information
None

Checklist

[x] Chart version bumped in Chart.yaml according to semver.
[x] Variables are documented in the values.yaml and added to the README.md using readme-generator-for-helm
[x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
[x] All commits signed off and in agreement of Developer Certificate of Origin (DCO)