### PR TITLE
[bitnami/redis] fix topology spread constraints templating

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.5.4
+version: 16.5.5

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -7,7 +7,7 @@ Redis(TM) is an open source, advanced key-value store. It is often referred to a
 [Overview of Redis&trade;](http://redis.io)
 
 Disclaimer: Redis is a registered trademark of Redis Labs Ltd. Any rights therein are reserved to Redis Labs Ltd. Any use by Bitnami is for referential purposes only and does not indicate any sponsorship, endorsement, or affiliation between Redis Labs Ltd.
-                           
+
 ## TL;DR
 
 ```bash
@@ -176,7 +176,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.affinity`                           | Affinity for Redis&trade; master pods assignment                                                  | `{}`                     |
 | `master.nodeSelector`                       | Node labels for Redis&trade; master pods assignment                                               | `{}`                     |
 | `master.tolerations`                        | Tolerations for Redis&trade; master pods assignment                                               | `[]`                     |
-| `master.topologySpreadConstraints`          | Spread Constraints for Redis&trade; master pod assignment                                         | `{}`                     |
+| `master.topologySpreadConstraints`          | Spread Constraints for Redis&trade; master pod assignment                                         | `[]`                     |
 | `master.lifecycleHooks`                     | for the Redis&trade; master container(s) to automate configuration before or after startup        | `{}`                     |
 | `master.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis&trade; master pod(s)            | `[]`                     |
 | `master.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis&trade; master container(s) | `[]`                     |
@@ -267,7 +267,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replica.affinity`                           | Affinity for Redis&trade; replicas pods assignment                                                  | `{}`                     |
 | `replica.nodeSelector`                       | Node labels for Redis&trade; replicas pods assignment                                               | `{}`                     |
 | `replica.tolerations`                        | Tolerations for Redis&trade; replicas pods assignment                                               | `[]`                     |
-| `replica.topologySpreadConstraints`          | Spread Constraints for Redis&trade; replicas pod assignment                                         | `{}`                     |
+| `replica.topologySpreadConstraints`          | Spread Constraints for Redis&trade; replicas pod assignment                                         | `[]`                     |
 | `replica.lifecycleHooks`                     | for the Redis&trade; replica container(s) to automate configuration before or after startup         | `{}`                     |
 | `replica.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis&trade; replicas pod(s)            | `[]`                     |
 | `replica.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis&trade; replicas container(s) | `[]`                     |

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -346,7 +346,7 @@ master:
   ##     topologyKey: node
   ##     whenUnsatisfiable: DoNotSchedule
   ##
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
   ## @param master.lifecycleHooks for the Redis&trade; master container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
@@ -699,7 +699,7 @@ replica:
   ##     topologyKey: node
   ##     whenUnsatisfiable: DoNotSchedule
   ##
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
   ## @param replica.lifecycleHooks for the Redis&trade; replica container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}


### PR DESCRIPTION
**Description of the change**

Eliminate Helm warning if user defines topology spread
constraints for master: cannot overwrite table with non
table for redis.master.topologySpreadConstraints (map[])

Same is applicable to redis.replica.topologySpreadConstraints
(map[]) warning

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

**Benefits**

<!-- What benefits will be realized by the code change? -->

Warning will disappear

**Possible drawbacks**

N/A

**Applicable issues**

  - fixes #9493

**Additional information**

N/A

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)