### PR TITLE
[bitnami/solr] init-certs.sh prefers user provided keystore/truststore

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/bitnami-docker-solr
   - https://lucene.apache.org/solr/
-version: 3.0.11
+version: 3.0.12

--- a/bitnami/solr/templates/scripts-configmap.yaml
+++ b/bitnami/solr/templates/scripts-configmap.yaml
@@ -15,6 +15,8 @@ data:
   init-certs.sh: |-
     #!/bin/bash
 
+    . /opt/bitnami/scripts/liblog.sh
+
     if [[ -f "/certs/keystore.p12" ]] && [[ -f "/certs/truststore.p12" ]]; then
         # the user provided keystore.p12 and truststore.p12 files (prefered)
         cp "/certs/keystore.p12" "/opt/bitnami/solr/certs/keystore.p12"
@@ -32,7 +34,7 @@ data:
         rm "/tmp/keystore.p12"
         keytool -import -file "/certs/ca.crt" -keystore "/opt/bitnami/solr/certs/truststore.p12" -storepass "${SOLR_SSL_TRUST_STORE_PASSWORD}" -noprompt
     else
-        echo "no certificate files provided ... nothing to do ..."
+        info "No certificate files provided ... nothing to do ..."
     fi
   setup.sh: |-
     #!/bin/bash

--- a/bitnami/solr/templates/scripts-configmap.yaml
+++ b/bitnami/solr/templates/scripts-configmap.yaml
@@ -15,7 +15,12 @@ data:
   init-certs.sh: |-
     #!/bin/bash
 
-    if [[ -f "/certs/ca.crt" ]] && [[ -f "/certs/tls.key" ]] && [[ -f "/certs/tls.crt" ]]; then
+    if [[ -f "/certs/keystore.p12" ]] && [[ -f "/certs/truststore.p12" ]]; then
+        # the user provided keystore.p12 and truststore.p12 files (prefered)
+        cp "/certs/keystore.p12" "/opt/bitnami/solr/certs/keystore.p12"
+        cp "/certs/truststore.p12" "/opt/bitnami/solr/certs/truststore.p12"
+    elif [[ -f "/certs/ca.crt" ]] && [[ -f "/certs/tls.key" ]] && [[ -f "/certs/tls.crt" ]]; then
+        # the user provided ca.crt & tls.key & tls.crt so we "calculate" keystore.p12 and truststore.p12
         openssl pkcs12 -export -in "/certs/tls.crt" \
             -inkey "/certs/tls.key" -out "/tmp/keystore.p12" \
             -passin pass:"/certs/tls.key" -passout pass:"${SOLR_SSL_KEY_STORE_PASSWORD}"
@@ -27,8 +32,7 @@ data:
         rm "/tmp/keystore.p12"
         keytool -import -file "/certs/ca.crt" -keystore "/opt/bitnami/solr/certs/truststore.p12" -storepass "${SOLR_SSL_TRUST_STORE_PASSWORD}" -noprompt
     else
-        cp "/certs/keystore.p12" "/opt/bitnami/solr/certs/keystore.p12"
-        cp "/certs/truststore.p12" "/opt/bitnami/solr/certs/truststore.p12"
+        echo "no certificate files provided ... nothing to do ..."
     fi
   setup.sh: |-
     #!/bin/bash


### PR DESCRIPTION
**Description of the change**

The `init-certs.sh` script perferes the keystore/truststore provided by the user.

**Benefits**

The [cert-manager](https://cert-manager.io/) can generate `keystore.p12` and `truststore.p12` for the user. These are generated to the same secret (together with `ca.crt`, `tls.crt` and `tls.key`). This helm-chart should prefere these files over generating some files on it's own.

**Applicable issues**

  - related to #9506

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).(https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
