### PR TITLE
[bitnami/spring-cloud-dataflow] Add missing entryPointStyle so that entrypoint may be configured for tasks

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 6.0.5
+version: 6.0.6

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -76,6 +76,9 @@ data:
                     {{- if .Values.deployer.secretRefs }}
                     secretRefs: {{- toYaml .Values.deployer.secretRefs | nindent 22 }}
                     {{- end }}
+                    {{- if .Values.deployer.entryPointStyle }}
+                    entryPointStyle: {{ .Values.deployer.entryPointStyle }}
+                    {{- end }}
           {{- end }}
           {{- if .Values.server.configuration.containerRegistries }}
           container:


### PR DESCRIPTION
**Description of the change**

Added `entryPointStyle` to the server config so tasks will use the configured `entryPointStyle`

**Benefits**

`entryPointStyle` can be changed from the default for tasks if required. 

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

This will allow the user to configure a global entry point as documented https://docs.spring.io/spring-cloud-dataflow/docs/current/reference/htmlsingle/#_entry_point_style

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)