### PR TITLE
[bitnami/elasticsearch] fix: :bug: Adapt metrics configuration when TLS is enabled

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.9.15
+version: 17.9.16

--- a/bitnami/elasticsearch/templates/metrics-deploy.yaml
+++ b/bitnami/elasticsearch/templates/metrics-deploy.yaml
@@ -41,18 +41,32 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else }}
           args:
+            {{- $protocol := (ternary "https" "http" .Values.security.tls.restEncryption) }}
             {{- if gt (int .Values.coordinating.replicas) 0 }}
             # Prefer coordinating only nodes to do the initial metrics query
-            - --es.uri=http://{{- if .Values.security.enabled }}elastic:{{ .Values.security.elasticPassword }}@{{- end }}{{ template "elasticsearch.coordinating.fullname" . }}:{{ .Values.coordinating.service.port }}
+            - --es.uri={{$protocol}}://{{ template "elasticsearch.coordinating.fullname" . }}:{{ .Values.coordinating.service.port }}
             {{- else }}
             # Using master nodes as there are no coordinating only nodes
-            - --es.uri=http://{{- if .Values.security.enabled }}elastic:{{ .Values.security.elasticPassword }}@{{- end }}{{ include "elasticsearch.master.fullname" . }}:9200
+            - --es.uri={{$protocol}}://{{ include "elasticsearch.master.fullname" . }}:9200
             {{- end }}
             - --es.all
+            {{- if .Values.security.enabled }}
+            - --es.ssl-skip-verify
+            {{- end }}
             {{- if .Values.metrics.extraArgs }}
             {{- toYaml .Values.metrics.extraArgs | nindent 12 }}
             {{- end }}
           {{- end }}
+          env:
+            {{- if .Values.security.enabled }}
+            - name: ES_USERNAME
+              value: "elastic"
+            - name: ES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                    name: {{ include "elasticsearch.secretName" . }}
+                    key: elasticsearch-password
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 9114


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

The metrics endpoint was not taking into account when TLS was enabled, being unable to handle metrics in this case. This PR fixes the issue and also hides the password, which was in plain text in the rendered YAML.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/charts/issues/9470

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)