### PR TITLE
[bitnami/kafka] Add the possibility to provision kafka topics in parallel

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 16.0.0
+version: 16.1.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -414,6 +414,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `provisioning.numPartitions`                         | Default number of partitions for topics when unspecified                                                                      | `1`                   |
 | `provisioning.replicationFactor`                     | Default replication factor for topics when unspecified                                                                        | `1`                   |
 | `provisioning.topics`                                | Kafka provisioning topics                                                                                                     | `[]`                  |
+| `provisioning.parallel`                              | Number of parallel provisioning                                                                                               | `1`                   |
 | `provisioning.command`                               | Override provisioning container command                                                                                       | `[]`                  |
 | `provisioning.args`                                  | Override provisioning container arguments                                                                                     | `[]`                  |
 | `provisioning.podAnnotations`                        | Extra annotations for Kafka provisioning pods                                                                                 | `{}`                  |

--- a/bitnami/kafka/templates/kafka-provisioning.yaml
+++ b/bitnami/kafka/templates/kafka-provisioning.yaml
@@ -110,21 +110,37 @@ spec:
                 {{- end }}
                 {{- end }}
               fi
+
               {{- $bootstrapServer := printf "%s:%d" (include "common.names.fullname" .) (.Values.service.ports.client | int64) }}
+
+              kafka_provisioning_commands=(
               {{- range $topic := .Values.provisioning.topics }}
-              echo "Ensure topic '{{ $topic.name }}' exists"
-              /opt/bitnami/kafka/bin/kafka-topics.sh \
-                --create \
-                --if-not-exists \
-                --bootstrap-server {{ $bootstrapServer }} \
-                --replication-factor {{ $topic.replicationFactor | default $.Values.provisioning.replicationFactor }} \
-                --partitions {{ $topic.partitions | default $.Values.provisioning.numPartitions }} \
-                {{- range $name, $value := $topic.config }}
-                --config {{ $name }}={{ $value }} \
-                {{- end }}
-                --command-config $CLIENT_CONF \
-                --topic {{ $topic.name }}
+                "/opt/bitnami/kafka/bin/kafka-topics.sh \
+                    --create \
+                    --if-not-exists \
+                    --bootstrap-server {{ $bootstrapServer }} \
+                    --replication-factor {{ $topic.replicationFactor | default $.Values.provisioning.replicationFactor }} \
+                    --partitions {{ $topic.partitions | default $.Values.provisioning.numPartitions }} \
+                    {{- range $name, $value := $topic.config }}
+                    --config {{ $name }}={{ $value }} \
+                    {{- end }}
+                    --command-config ${CLIENT_CONF} \
+                    --topic {{ $topic.name }}"
               {{- end }}
+              )
+
+              echo "Starting provisioning"
+
+              for ((index=0; index < ${#kafka_provisioning_commands[@]}; index+={{ .Values.provisioning.parallel }}))
+              do
+                for j in $(seq ${index} $((${index}+{{ .Values.provisioning.parallel }}-1)))
+                do
+                    ${kafka_provisioning_commands[j]} & # Async command
+                done
+
+                wait  # Wait the end of the jobs
+              done
+
               echo "Provisioning succeeded"
           {{- end }}
           env:

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1441,6 +1441,9 @@ provisioning:
   ##     flush.messages: 1
   ##
   topics: []
+  ## @param provisioning.parallel Number of parallel provisioning topic
+  ##
+  parallel: 1
   ## @param provisioning.command Override provisioning container command
   ##
   command: []


### PR DESCRIPTION
**Description of the change**

Add the possibility to provision the kafka topics in parallel.

**Benefits**

Reduce the provisioning time.

**Possible drawbacks**

None.

**Applicable issues**

Resolve #9479

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)