### PR TITLE
[bitnami/kubeapps] Fix kubeapps existing secret

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/kubeapps/kubeapps
-version: 8.0.0
+version: 8.0.1

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -7,7 +7,7 @@ Kubeapps is a web-based UI for launching and managing applications on Kubernetes
 [Overview of Kubeapps](https://kubeapps.com)
 
 
-                           
+
 ## TL;DR
 
 ```bash
@@ -958,12 +958,15 @@ The following values have been renamed:
 - `assetsvc.service.port` renamed as `assetsvc.service.ports.http`.
 - `assetsvc.containerPort` renamed as `assetsvc.containerPorts.http`.
 - `authProxy.containerPort` renamed as `authProxy.containerPorts.proxy`.
+- `authProxy.additionalFlags` renamed as `authProxy.extraFlags`,
 - Pinniped Proxy service no longer uses `pinnipedProxy.containerPort`. Use `pinnipedProxy.service.ports.pinnipedProxy` to change the service port.
 - `pinnipedProxy.containerPort` renamed as `pinnipedProxy.containerPorts.pinnipedProxy`.
 - `postgresql.replication.enabled` has been removed. Use `postgresql.architecture` instead.
 - `postgresql.postgresqlDatabase` renamed as `postgresql.auth.database`.
 - `postgresql.postgresqlPassword` renamed as `postgresql.auth.password`.
+- `postgresql.existingSecret` renamed as `postgresql.auth.existingSecret`.
 - `redis.redisPassword` renamed as `redis.auth.password`.
+- `redis.existingSecret` renamed as `redis.auth.existingSecret`.
 
 ### Nginx Ipv6 error
 

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -20,7 +20,7 @@ helm install kubeapps --namespace kubeapps bitnami/kubeapps
 
 ## Introduction
 
-[![CircleCI](https://circleci.com/gh/kubeapps/kubeapps/tree/master.svg?style=svg)](https://circleci.com/gh/kubeapps/kubeapps/tree/master)
+[![CircleCI](https://circleci.com/gh/kubeapps/kubeapps/tree/main.svg?style=svg)](https://circleci.com/gh/kubeapps/kubeapps/tree/main)
 
 This chart bootstraps a [Kubeapps](https://kubeapps.com) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
@@ -58,7 +58,7 @@ The command deploys Kubeapps on the Kubernetes cluster in the `kubeapps` namespa
 
 > **Caveat**: Only one Kubeapps installation is supported per namespace
 
-Once you have installed Kubeapps follow the [Getting Started Guide](https://github.com/kubeapps/kubeapps/blob/master/docs/user/getting-started.md) for additional information on how to access and use Kubeapps.
+Once you have installed Kubeapps follow the [Getting Started Guide](https://github.com/kubeapps/kubeapps/blob/main/docs/user/getting-started.md) for additional information on how to access and use Kubeapps.
 
 ## Parameters
 
@@ -967,6 +967,8 @@ The following values have been renamed:
 - `postgresql.existingSecret` renamed as `postgresql.auth.existingSecret`.
 - `redis.redisPassword` renamed as `redis.auth.password`.
 - `redis.existingSecret` renamed as `redis.auth.existingSecret`.
+
+Note also that if you have an existing Postgresql secret that is used for Kubeapps, you will need to update the key from `postgresql-password` to `postgres-password`.
 
 ### Nginx Ipv6 error
 

--- a/bitnami/kubeapps/templates/_helpers.tpl
+++ b/bitnami/kubeapps/templates/_helpers.tpl
@@ -295,8 +295,8 @@ Returns the name of the globalRepos namespace
 Return the Postgresql secret name
 */}}
 {{- define "kubeapps.postgresql.secretName" -}}
-  {{- if .Values.postgresql.existingSecret }}
-      {{- printf "%s" .Values.postgresql.existingSecret -}}
+  {{- if .Values.postgresql.auth.existingSecret }}
+      {{- printf "%s" .Values.postgresql.auth.existingSecret -}}
   {{- else -}}
       {{- printf "%s" (include "kubeapps.postgresql.fullname" .) -}}
   {{- end -}}
@@ -306,8 +306,8 @@ Return the Postgresql secret name
 Return the Redis secret name
 */}}
 {{- define "kubeapps.redis.secretName" -}}
-  {{- if .Values.redis.existingSecret }}
-      {{- printf "%s" .Values.redis.existingSecret -}}
+  {{- if .Values.redis.auth.existingSecret }}
+      {{- printf "%s" .Values.redis.auth.existingSecret -}}
   {{- else -}}
       {{- printf "%s" (include "kubeapps.redis.fullname" .) -}}
   {{- end -}}


### PR DESCRIPTION

**Description of the change**

I noticed when testing the latest chart change in my dev environment that it was broken, with pods connecting to postgres erroring with:

```
  Warning  Failed     2s (x6 over 53s)  kubelet            Error: secret "kubeapps-postgresql" not found
```

Turns out it there were two renames which we missed:
1. `existingSecret` -> `auth.existingSecret`. This required a change to the `_helpers.tpl` to fix the chart. 
2. `additionalFlags` -> `extraFlags` for the auth proxy. This wasn't a chart change (other than docs), but did break my dev env (and will do so for anyone using OIDC for authentication with Kubeapps), so worth including in the upgrade notes.

I also added a note about the changed `postgres-password` key, since anyone upgrading will need to update the key on the secret.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

Save other people losing the hours I lost figuring out the above :)

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)