### PR TITLE
[bitnami/elasticsearch] update the hosts depending of the cluster configuration.

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.9.15
+version: 17.9.16

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -56,14 +56,20 @@ Return the hostname of every ElasticSearch seed node
 {{- define "elasticsearch.hosts" -}}
 {{- $clusterDomain := .Values.clusterDomain }}
 {{- $releaseNamespace := .Release.Namespace }}
+{{- if gt (.Values.master.replicas | int) 0 }}
 {{- $masterFullname := include "elasticsearch.master.fullname" . }}
-{{- $coordinatingFullname := include "elasticsearch.coordinating.fullname" . }}
-{{- $dataFullname := include "elasticsearch.data.fullname" . }}
-{{- $ingestFullname := include "elasticsearch.ingest.fullname" . }}
 {{- $masterFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
+{{- end -}}
+{{- if gt (.Values.coordinating.replicas | int) 0 }}
+{{- $coordinatingFullname := include "elasticsearch.coordinating.fullname" . }}
 {{- $coordinatingFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
+{{- end -}}
+{{- if gt (.Values.data.replicas | int) 0 }}
+{{- $dataFullname := include "elasticsearch.data.fullname" . }}
 {{- $dataFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
-{{- if .Values.ingest.enabled }}
+{{- end -}}
+{{- if and (eq .Values.ingest.enabled true) (gt (.Values.ingest.replicas | int) 0) }}
+{{- $ingestFullname := include "elasticsearch.ingest.fullname" . }}
 {{- $ingestFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
**Description of the change**

The hosts provided through environment variables to the elasticsearch pods do not reflect the real ones. If the data node or the coordinating node is not configured in the chart, the hosts variable is not correctly updated.

**Benefits**

Prevent to expose unknown DNS.

**Possible drawbacks**

None

**Applicable issues**

Resolve #9527 

**Additional information**

None

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)