### PR TITLE
[bitnami/kubewatch] Mark Kubewatch chart as deprecated

### DIFF
--- a/bitnami/kubewatch/Chart.lock
+++ b/bitnami/kubewatch/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.11.3
-digest: sha256:d5f850d857edd58b32c0e10652f6ec3ce5018def5542f2bcef38fd7fa0079d6b
-generated: "2022-03-16T09:34:38.204729054Z"
+  version: 1.12.0
+digest: sha256:7e484480451778c273e7a165dbfaa5594ec1c9a63a114ce9d458626cadd28893
+generated: "2022-03-23T13:12:25.426775553Z"

--- a/bitnami/kubewatch/Chart.yaml
+++ b/bitnami/kubewatch/Chart.yaml
@@ -8,7 +8,9 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: Kubewatch is a Kubernetes watcher that currently publishes notification to Slack. Run it in your k8s cluster, and you will get event notifications in a slack channel.
+# The Kubewatch chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED Kubewatch is a Kubernetes watcher that currently publishes notification to Slack. Run it in your k8s cluster, and you will get event notifications in a slack channel.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/kubewatch
 icon: https://bitnami.com/assets/stacks/kubewatch/img/kubewatch-stack-220x234.png
@@ -19,13 +21,9 @@ keywords:
   - mattermost
   - flock
   - msteams
-maintainers:
-  - email: casey@monax.io
-    name: compleatang
-  - email: containers@bitnami.com
-    name: Bitnami
+maintainers: []
 name: kubewatch
 sources:
   - https://github.com/bitnami/bitnami-docker-kubewatch
   - https://github.com/bitnami-labs/kubewatch
-version: 3.3.2
+version: 3.3.3

--- a/bitnami/kubewatch/Chart.yaml
+++ b/bitnami/kubewatch/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 1.x.x
 # The Kubewatch chart is deprecated and no longer maintained.
 deprecated: true
-description: DEPRECATED Kubewatch is a Kubernetes watcher that currently publishes notification to Slack. Run it in your k8s cluster, and you will get event notifications in a slack channel.
+description: Kubewatch is a Kubernetes watcher that currently publishes notification to Slack. Run it in your k8s cluster, and you will get event notifications in a slack channel.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/kubewatch
 icon: https://bitnami.com/assets/stacks/kubewatch/img/kubewatch-stack-220x234.png

--- a/bitnami/kubewatch/README.md
+++ b/bitnami/kubewatch/README.md
@@ -6,8 +6,10 @@ Kubewatch is a Kubernetes watcher that currently publishes notification to Slack
 
 [Overview of Kubewatch](https://github.com/bitnami-labs/kubewatch)
 
+## This Helm chart is deprecated
 
-                           
+The upstream project has been discontinued and no new features.
+
 ## TL;DR
 
 ```console

--- a/bitnami/kubewatch/README.md
+++ b/bitnami/kubewatch/README.md
@@ -6,10 +6,8 @@ Kubewatch is a Kubernetes watcher that currently publishes notification to Slack
 
 [Overview of Kubewatch](https://github.com/bitnami-labs/kubewatch)
 
-## This Helm chart is deprecated
 
-The upstream project has been discontinued and no new features.
-
+                           
 ## TL;DR
 
 ```console

--- a/bitnami/kubewatch/templates/NOTES.txt
+++ b/bitnami/kubewatch/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}

--- a/bitnami/kubewatch/values.yaml
+++ b/bitnami/kubewatch/values.yaml
@@ -62,7 +62,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/kubewatch
-  tag: 0.1.0-debian-10-r563
+  tag: 0.1.0-debian-10-r571
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

Kubewatch Helm chart will be deprecated since the upstream project has been [discontinued](https://github.com/bitnami-labs/kubewatch#warning-kubewatch-is-no-longer-actively-maintained-by-vmware) and no new features. 

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])