### PR TITLE
[bitnami/testlink] Deprecate TestLink chart

### DIFF
--- a/bitnami/testlink/Chart.lock
+++ b/bitnami/testlink/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 10.4.1
+  version: 10.4.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.12.0
-digest: sha256:90f1c3a5544dd77476d014ba6aa7aec2ca50fdf39d4b8c40ac063c36c743dc08
-generated: "2022-03-16T15:41:25.309792596Z"
+digest: sha256:bb4d47d9373b856398c9ab9a1434d54a4c62770ab7aa11967294d569a44606b3
+generated: "2022-03-23T15:07:18.436903957Z"

--- a/bitnami/testlink/Chart.yaml
+++ b/bitnami/testlink/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 1.x.x
 # The TestLink chart is deprecated and no longer maintained.
 deprecated: true
-description: DEPRECATED TestLink is test management software that facilitates software quality assurance. It suppors test cases, test suites, test plans, test projects and user management, and stats reporting.
+description: TestLink is test management software that facilitates software quality assurance. It suppors test cases, test suites, test plans, test projects and user management, and stats reporting.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/testlink
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/bitnami/testlink/Chart.yaml
+++ b/bitnami/testlink/Chart.yaml
@@ -12,7 +12,9 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: TestLink is test management software that facilitates software quality assurance. It suppors test cases, test suites, test plans, test projects and user management, and stats reporting.
+# The TestLink chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED TestLink is test management software that facilitates software quality assurance. It suppors test cases, test suites, test plans, test projects and user management, and stats reporting.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/testlink
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png
@@ -21,11 +23,9 @@ keywords:
   - testing
   - http
   - php
-maintainers:
-  - email: containers@bitnami.com
-    name: Bitnami
+maintainers: []
 name: testlink
 sources:
   - https://github.com/bitnami/bitnami-docker-testlink
   - https://www.testlink.org/
-version: 10.0.14
+version: 10.0.15

--- a/bitnami/testlink/README.md
+++ b/bitnami/testlink/README.md
@@ -8,10 +8,6 @@ TestLink is test management software that facilitates software quality assurance
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
                            
-## This Helm chart is deprecated
-
-The upstream project has been discontinued and no new features.
-
 ## TL;DR
 
 ```console

--- a/bitnami/testlink/README.md
+++ b/bitnami/testlink/README.md
@@ -8,6 +8,10 @@ TestLink is test management software that facilitates software quality assurance
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
                            
+## This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 ## TL;DR
 
 ```console

--- a/bitnami/testlink/templates/NOTES.txt
+++ b/bitnami/testlink/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}

--- a/bitnami/testlink/values.yaml
+++ b/bitnami/testlink/values.yaml
@@ -51,7 +51,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/testlink
-  tag: 1.9.20-debian-10-r671
+  tag: 1.9.20-debian-10-r676
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -707,7 +707,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r368
+    tag: 10-debian-10-r374
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -755,7 +755,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.11.0-debian-10-r88
+    tag: 0.11.0-debian-10-r93
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -825,7 +825,7 @@ certificates:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r368
+    tag: 10-debian-10-r374
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

TestLink helm chart will be deprecated since the upstream project is no longer maintained and has no new features.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)