### PR TITLE
[bitnami/testlink] Add deprecation messages to the TestLink chart

### DIFF
--- a/bitnami/testlink/Chart.yaml
+++ b/bitnami/testlink/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 1.x.x
 # The TestLink chart is deprecated and no longer maintained.
 deprecated: true
-description: TestLink is test management software that facilitates software quality assurance. It suppors test cases, test suites, test plans, test projects and user management, and stats reporting.
+description: DEPRECATED TestLink is test management software that facilitates software quality assurance. It suppors test cases, test suites, test plans, test projects and user management, and stats reporting.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/testlink
 icon: https://bitnami.com/assets/stacks/testlink/img/testlink-stack-220x234.png

--- a/bitnami/testlink/Chart.yaml
+++ b/bitnami/testlink/Chart.yaml
@@ -28,4 +28,4 @@ name: testlink
 sources:
   - https://github.com/bitnami/bitnami-docker-testlink
   - https://www.testlink.org/
-version: 10.0.15
+version: 10.0.16

--- a/bitnami/testlink/README.md
+++ b/bitnami/testlink/README.md
@@ -8,6 +8,10 @@ TestLink is test management software that facilitates software quality assurance
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
                            
+## This Helm chart is deprecated
+
+The upstream project has been discontinued and no new features are expected.
+
 ## TL;DR
 
 ```console

--- a/bitnami/testlink/templates/NOTES.txt
+++ b/bitnami/testlink/templates/NOTES.txt
@@ -1,6 +1,6 @@
 This Helm chart is deprecated
 
-The upstream project has been discontinued and no new features.
+The upstream project has been discontinued and no new features are expected.
 
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}


### PR DESCRIPTION
**Description of the change**

TestLink helm chart will be deprecated since the upstream project is no longer maintained and no new features are expected.

Undo some automatic changes from https://github.com/bitnami/charts/pull/9535

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)