### PR TITLE
[bitnami/mongodb-sharded] Add externalIP in mongos service

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Database
 apiVersion: v2
-appVersion: 4.4.13
+appVersion: 4.4.14
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Database
 apiVersion: v2
-appVersion: 4.4.14
+appVersion: 4.4.13
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 4.0.11
+version: 4.0.12

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-service.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-service.yaml
@@ -18,6 +18,9 @@ spec:
   {{- end }}
   {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs: {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
   {{- end }}
   ports:
     - name: mongodb


### PR DESCRIPTION
**Description of the change**
Currently, [bitnami/mongodb-sharded] provide externalIPs field, however this field is not correctly supported. This MR add extenralIPs into service.


**Applicable issues**

#9522 

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)