### PR TITLE
[bitnami/kube-prometheus] Support startup probe in prometheus

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -34,4 +34,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 6.7.1
+version: 6.8.0

--- a/bitnami/kube-prometheus/README.md
+++ b/bitnami/kube-prometheus/README.md
@@ -7,7 +7,7 @@ Prometheus Operator provides easy monitoring definitions for Kubernetes services
 [Overview of Prometheus Operator](https://github.com/coreos/prometheus-operator)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -243,6 +243,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `prometheus.readinessProbe.timeoutSeconds`                            | When the probe times out                                                                                                         | `3`                      |
 | `prometheus.readinessProbe.failureThreshold`                          | Minimum consecutive failures for the probe                                                                                       | `10`                     |
 | `prometheus.readinessProbe.successThreshold`                          | Minimum consecutive successes for the probe                                                                                      | `1`                      |
+| `prometheus.startupProbe.enabled`                                     | Turn on and off startup probe                                                                                                  | `true`                   |
+| `prometheus.startupProbe.path`                                        | Path of the HTTP service for checking the ready state                                                                            | `/-/ready`               |
+| `prometheus.startupProbe.initialDelaySeconds`                         | Delay before startup probe is initiated                                                                                        | `0`                      |
+| `prometheus.startupProbe.periodSeconds`                               | How often to perform the probe                                                                                                   | `15`                     |
+| `prometheus.startupProbe.timeoutSeconds`                              | When the probe times out                                                                                                         | `3`                      |
+| `prometheus.startupProbe.failureThreshold`                            | Minimum consecutive failures for the probe                                                                                       | `60`                     |
+| `prometheus.startupProbe.successThreshold`                            | Minimum consecutive successes for the probe                                                                                      | `1`                      |
 | `prometheus.enableAdminAPI`                                           | Enable Prometheus adminitrative API                                                                                              | `false`                  |
 | `prometheus.enableFeatures`                                           | Enable access to Prometheus disabled features.                                                                                   | `[]`                     |
 | `prometheus.alertingEndpoints`                                        | Alertmanagers to which alerts will be sent                                                                                       | `[]`                     |

--- a/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
@@ -316,6 +316,18 @@ spec:
         failureThreshold: {{ .Values.prometheus.readinessProbe.failureThreshold }}
         successThreshold: {{ .Values.prometheus.readinessProbe.successThreshold }}
       {{- end }}
+      {{- if .Values.prometheus.startupProbe.enabled }}
+      startupProbe:
+        httpGet:
+          path: {{ .Values.prometheus.startupProbe.path }}
+          port: web
+          scheme: HTTP
+        initialDelaySeconds: {{ .Values.prometheus.startupProbe.initialDelaySeconds }}
+        periodSeconds: {{ .Values.prometheus.startupProbe.periodSeconds }}
+        timeoutSeconds: {{ .Values.prometheus.startupProbe.timeoutSeconds }}
+        failureThreshold: {{ .Values.prometheus.startupProbe.failureThreshold }}
+        successThreshold: {{ .Values.prometheus.startupProbe.successThreshold }}
+      {{- end }}
     {{- end }}
     {{- if or .Values.operator.prometheusConfigReloader.containerSecurityContext.enabled .Values.operator.prometheusConfigReloader.livenessProbe.enabled .Values.operator.prometheusConfigReloader.readinessProbe.enabled }}
     ## This monkey patching is needed until the securityContexts are

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -662,6 +662,24 @@ prometheus:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 3
+  ## Configure extra options for startup probe
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  ## @param prometheus.startupProbe.enabled Turn on and off readiness probe
+  ## @param prometheus.startupProbe.path Path of the HTTP service for checking the ready state
+  ## @param prometheus.startupProbe.initialDelaySeconds Delay before readiness probe is initiated
+  ## @param prometheus.startupProbe.periodSeconds How often to perform the probe
+  ## @param prometheus.startupProbe.timeoutSeconds When the probe times out
+  ## @param prometheus.startupProbe.failureThreshold Minimum consecutive failures for the probe
+  ## @param prometheus.startupProbe.successThreshold Minimum consecutive successes for the probe
+  ##
+  startupProbe:
+    enabled: true
+    path: /-/ready
+    initialDelaySeconds: 0
+    failureThreshold: 60
+    periodSeconds: 15
+    successThreshold: 1
+    timeoutSeconds: 3
   ## @param prometheus.enableAdminAPI Enable Prometheus adminitrative API
   ## ref: https://prometheus.io/docs/prometheus/latest/querying/api/#tsdb-admin-apis
   ##


### PR DESCRIPTION
Signed-off-by: Marian Soltys <41568766+maso7@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add startup probe config

**Benefits**

- Option to change default values of the startup probe provided by operator.

**Possible drawbacks**

- None

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)