### PR TITLE
[bitnami/rabbitmq-operator] Sync CRDs

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 2.4.0
+version: 2.5.0

--- a/bitnami/rabbitmq-cluster-operator/crds/crd-rabbitmq-cluster.yaml
+++ b/bitnami/rabbitmq-cluster-operator/crds/crd-rabbitmq-cluster.yaml
@@ -1,8 +1,10 @@
+# Source: https://github.com/rabbitmq/cluster-operator/tree/main/config/crd
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: rabbitmqclusters.rabbitmq.com
   labels:
     app.kubernetes.io/component: rabbitmq-operator
@@ -12,6 +14,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: RabbitmqCluster
     listKind: RabbitmqClusterList
     plural: rabbitmqclusters
@@ -33,21 +36,13 @@ spec:
       name: v1beta1
       schema:
         openAPIV3Schema:
-          description:
-            RabbitmqCluster is the Schema for the RabbitmqCluster API. Each
-            instance of this object corresponds to a single RabbitMQ cluster.
+          description: RabbitmqCluster is the Schema for the RabbitmqCluster API. Each instance of this object corresponds to a single RabbitMQ cluster.
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -58,68 +53,29 @@ spec:
                   description: Affinity scheduling rules to be applied on created Pods.
                   properties:
                     nodeAffinity:
-                      description:
-                        Describes node affinity scheduling rules for the
-                        pod.
+                      description: Describes node affinity scheduling rules for the pod.
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            The scheduler will prefer to schedule pods to
-                            nodes that satisfy the affinity expressions specified by
-                            this field, but it may choose a node that violates one or
-                            more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node matches
-                            the corresponding matchExpressions; the node(s) with the
-                            highest sum are the most preferred.
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                           items:
-                            description:
-                              An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects (i.e.
-                              is also a no-op).
+                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                             properties:
                               preference:
-                                description:
-                                  A node selector term, associated with the
-                                  corresponding weight.
+                                description: A node selector term, associated with the corresponding weight.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      A list of node selector requirements
-                                      by node's labels.
+                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description:
-                                        A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            The label key that the selector
-                                            applies to.
+                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description:
-                                            An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -129,38 +85,18 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description:
-                                      A list of node selector requirements
-                                      by node's fields.
+                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description:
-                                        A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            The label key that the selector
-                                            applies to.
+                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description:
-                                            An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -171,9 +107,7 @@ spec:
                                     type: array
                                 type: object
                               weight:
-                                description:
-                                  Weight associated with matching the corresponding
-                                  nodeSelectorTerm, in the range 1-100.
+                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -182,58 +116,26 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not be
-                            scheduled onto the node. If the affinity requirements specified
-                            by this field cease to be met at some point during pod execution
-                            (e.g. due to an update), the system may or may not try to
-                            eventually evict the pod from its node.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                           properties:
                             nodeSelectorTerms:
-                              description:
-                                Required. A list of node selector terms.
-                                The terms are ORed.
+                              description: Required. A list of node selector terms. The terms are ORed.
                               items:
-                                description:
-                                  A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed. The
-                                  TopologySelectorTerm type implements a subset of the
-                                  NodeSelectorTerm.
+                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      A list of node selector requirements
-                                      by node's labels.
+                                    description: A list of node selector requirements by node's labels.
                                     items:
-                                      description:
-                                        A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            The label key that the selector
-                                            applies to.
+                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description:
-                                            An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -243,38 +145,18 @@ spec:
                                       type: object
                                     type: array
                                   matchFields:
-                                    description:
-                                      A list of node selector requirements
-                                      by node's fields.
+                                    description: A list of node selector requirements by node's fields.
                                     items:
-                                      description:
-                                        A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            The label key that the selector
-                                            applies to.
+                                          description: The label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description:
-                                            An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -290,71 +172,32 @@ spec:
                           type: object
                       type: object
                     podAffinity:
-                      description:
-                        Describes pod affinity scheduling rules (e.g. co-locate
-                        this pod in the same node, zone, etc. as some other pod(s)).
+                      description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            The scheduler will prefer to schedule pods to
-                            nodes that satisfy the affinity expressions specified by
-                            this field, but it may choose a node that violates one or
-                            more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node has
-                            pods which matches the corresponding podAffinityTerm; the
-                            node(s) with the highest sum are the most preferred.
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                           items:
-                            description:
-                              The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                             properties:
                               podAffinityTerm:
-                                description:
-                                  Required. A pod affinity term, associated
-                                  with the corresponding weight.
+                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description:
-                                      A label query over a set of resources,
-                                      in this case pods.
+                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description:
-                                            A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description:
-                                                operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description:
-                                                values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -366,60 +209,25 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description:
-                                          matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaceSelector:
-                                    description:
-                                      A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces. This field is beta-level
-                                      and is only honored when PodAffinityNamespaceSelector
-                                      feature is enabled.
+                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                     properties:
                                       matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description:
-                                            A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description:
-                                                operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description:
-                                                values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -431,43 +239,22 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description:
-                                          matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description:
-                                      namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace"
+                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description:
-                                      This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description:
-                                  weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
+                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -476,60 +263,26 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not be
-                            scheduled onto the node. If the affinity requirements specified
-                            by this field cease to be met at some point during pod execution
-                            (e.g. due to a pod label update), the system may or may
-                            not try to eventually evict the pod from its node. When
-                            there are multiple elements, the lists of nodes corresponding
-                            to each podAffinityTerm are intersected, i.e. all terms
-                            must be satisfied.
+                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                           items:
-                            description:
-                              Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not co-located
-                              (anti-affinity) with, where co-located is defined as running
-                              on a node whose value of the label with key <topologyKey>
-                              matches that of any node on which a pod of the set of
-                              pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                             properties:
                               labelSelector:
-                                description:
-                                  A label query over a set of resources,
-                                  in this case pods.
+                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
-                                      selector requirements. The requirements are ANDed.
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
-                                            selector applies to.
+                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -541,55 +294,25 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                               namespaceSelector:
-                                description:
-                                  A label query over the set of namespaces
-                                  that the term applies to. The term is applied to the
-                                  union of the namespaces selected by this field and
-                                  the ones listed in the namespaces field. null selector
-                                  and null or empty namespaces list means "this pod's
-                                  namespace". An empty selector ({}) matches all namespaces.
-                                  This field is beta-level and is only honored when
-                                  PodAffinityNamespaceSelector feature is enabled.
+                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
-                                      selector requirements. The requirements are ANDed.
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
-                                            selector applies to.
+                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -601,35 +324,16 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                               namespaces:
-                                description:
-                                  namespaces specifies a static list of namespace
-                                  names that the term applies to. The term is applied
-                                  to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector. null or
-                                  empty namespaces list and null namespaceSelector means
-                                  "this pod's namespace"
+                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description:
-                                  This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where
-                                  co-located is defined as running on a node whose value
-                                  of the label with key topologyKey matches that of
-                                  any node on which any of the selected pods is running.
-                                  Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                 type: string
                             required:
                               - topologyKey
@@ -637,72 +341,32 @@ spec:
                           type: array
                       type: object
                     podAntiAffinity:
-                      description:
-                        Describes pod anti-affinity scheduling rules (e.g.
-                        avoid putting this pod in the same node, zone, etc. as some
-                        other pod(s)).
+                      description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            The scheduler will prefer to schedule pods to
-                            nodes that satisfy the anti-affinity expressions specified
-                            by this field, but it may choose a node that violates one
-                            or more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling anti-affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node has
-                            pods which matches the corresponding podAffinityTerm; the
-                            node(s) with the highest sum are the most preferred.
+                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                           items:
-                            description:
-                              The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred node(s)
+                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                             properties:
                               podAffinityTerm:
-                                description:
-                                  Required. A pod affinity term, associated
-                                  with the corresponding weight.
+                                description: Required. A pod affinity term, associated with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description:
-                                      A label query over a set of resources,
-                                      in this case pods.
+                                    description: A label query over a set of resources, in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description:
-                                            A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description:
-                                                operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description:
-                                                values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -714,60 +378,25 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description:
-                                          matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaceSelector:
-                                    description:
-                                      A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces. This field is beta-level
-                                      and is only honored when PodAffinityNamespaceSelector
-                                      feature is enabled.
+                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                     properties:
                                       matchExpressions:
-                                        description:
-                                          matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description:
-                                            A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description:
-                                                key is the label key that
-                                                the selector applies to.
+                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description:
-                                                operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description:
-                                                values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -779,43 +408,22 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description:
-                                          matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description:
-                                      namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace"
+                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description:
-                                      This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
+                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description:
-                                  weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
+                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -824,60 +432,26 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description:
-                            If the anti-affinity requirements specified by
-                            this field are not met at scheduling time, the pod will
-                            not be scheduled onto the node. If the anti-affinity requirements
-                            specified by this field cease to be met at some point during
-                            pod execution (e.g. due to a pod label update), the system
-                            may or may not try to eventually evict the pod from its
-                            node. When there are multiple elements, the lists of nodes
-                            corresponding to each podAffinityTerm are intersected, i.e.
-                            all terms must be satisfied.
+                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                           items:
-                            description:
-                              Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not co-located
-                              (anti-affinity) with, where co-located is defined as running
-                              on a node whose value of the label with key <topologyKey>
-                              matches that of any node on which a pod of the set of
-                              pods is running
+                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                             properties:
                               labelSelector:
-                                description:
-                                  A label query over a set of resources,
-                                  in this case pods.
+                                description: A label query over a set of resources, in this case pods.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
-                                      selector requirements. The requirements are ANDed.
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
-                                            selector applies to.
+                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -889,55 +463,25 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                               namespaceSelector:
-                                description:
-                                  A label query over the set of namespaces
-                                  that the term applies to. The term is applied to the
-                                  union of the namespaces selected by this field and
-                                  the ones listed in the namespaces field. null selector
-                                  and null or empty namespaces list means "this pod's
-                                  namespace". An empty selector ({}) matches all namespaces.
-                                  This field is beta-level and is only honored when
-                                  PodAffinityNamespaceSelector feature is enabled.
+                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
                                 properties:
                                   matchExpressions:
-                                    description:
-                                      matchExpressions is a list of label
-                                      selector requirements. The requirements are ANDed.
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                     items:
-                                      description:
-                                        A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                       properties:
                                         key:
-                                          description:
-                                            key is the label key that the
-                                            selector applies to.
+                                          description: key is the label key that the selector applies to.
                                           type: string
                                         operator:
-                                          description:
-                                            operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description:
-                                            values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -949,35 +493,16 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description:
-                                      matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                               namespaces:
-                                description:
-                                  namespaces specifies a static list of namespace
-                                  names that the term applies to. The term is applied
-                                  to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector. null or
-                                  empty namespaces list and null namespaceSelector means
-                                  "this pod's namespace"
+                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description:
-                                  This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where
-                                  co-located is defined as running on a node whose value
-                                  of the label with key topologyKey matches that of
-                                  any node on which any of the selected pods is running.
-                                  Empty topologyKey is not allowed.
+                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                 type: string
                             required:
                               - topologyKey
@@ -986,25 +511,15 @@ spec:
                       type: object
                   type: object
                 image:
-                  description:
-                    Image is the name of the RabbitMQ docker image to use
-                    for RabbitMQ nodes in the RabbitmqCluster. Must be provided together
-                    with ImagePullSecrets in order to use an image in a private registry.
+                  description: Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster. Must be provided together with ImagePullSecrets in order to use an image in a private registry.
                   type: string
                 imagePullSecrets:
-                  description:
-                    List of Secret resource containing access credentials
-                    to the registry for the RabbitMQ image. Required if the docker registry
-                    is private.
+                  description: List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
                   items:
-                    description:
-                      LocalObjectReference contains enough information to
-                      let you locate the referenced object inside the same namespace.
+                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                     properties:
                       name:
-                        description:
-                          "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?"
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
                   type: array
@@ -1747,6 +1262,16 @@ spec:
                                               failureThreshold:
                                                 format: int32
                                                 type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
                                               httpGet:
                                                 properties:
                                                   host:
@@ -1841,6 +1366,16 @@ spec:
                                               failureThreshold:
                                                 format: int32
                                                 type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
                                               httpGet:
                                                 properties:
                                                   host:
@@ -1989,6 +1524,16 @@ spec:
                                               failureThreshold:
                                                 format: int32
                                                 type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
                                               httpGet:
                                                 properties:
                                                   host:
@@ -2328,6 +1873,16 @@ spec:
                                               failureThreshold:
                                                 format: int32
                                                 type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
                                               httpGet:
                                                 properties:
                                                   host:
@@ -2406,6 +1961,10 @@ spec:
                                                 - containerPort
                                               type: object
                                             type: array
+                                            x-kubernetes-list-map-keys:
+                                              - containerPort
+                                              - protocol
+                                            x-kubernetes-list-type: map
                                           readinessProbe:
                                             properties:
                                               exec:
@@ -2418,6 +1977,16 @@ spec:
                                               failureThreshold:
                                                 format: int32
                                                 type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
                                               httpGet:
                                                 properties:
                                                   host:
@@ -2566,6 +2135,16 @@ spec:
                                               failureThreshold:
                                                 format: int32
                                                 type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
                                               httpGet:
                                                 properties:
                                                   host:
@@ -2909,6 +2488,16 @@ spec:
                                               failureThreshold:
                                                 format: int32
                                                 type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
                                               httpGet:
                                                 properties:
                                                   host:
@@ -3003,6 +2592,16 @@ spec:
                                               failureThreshold:
                                                 format: int32
                                                 type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
                                               httpGet:
                                                 properties:
                                                   host:
@@ -3151,6 +2750,16 @@ spec:
                                               failureThreshold:
                                                 format: int32
                                                 type: integer
+                                              grpc:
+                                                properties:
+                                                  port:
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
                                               httpGet:
                                                 properties:
                                                   host:
@@ -3262,6 +2871,13 @@ spec:
                                         type: string
                                       type: object
                                       x-kubernetes-map-type: atomic
+                                    os:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
                                     overhead:
                                       additionalProperties:
                                         anyOf:
@@ -4232,46 +3848,29 @@ spec:
                 persistence:
                   default:
                     storage: 10Gi
-                  description:
-                    The desired persistent storage configuration for each
-                    Pod in the cluster.
+                  description: The desired persistent storage configuration for each Pod in the cluster.
                   properties:
                     storage:
                       anyOf:
                         - type: integer
                         - type: string
                       default: 10Gi
-                      description:
-                        The requested size of the persistent volume attached
-                        to each Pod in the RabbitmqCluster. The format of this field
-                        matches that defined by kubernetes/apimachinery. See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity
-                        for more info on the format of this field.
+                      description: The requested size of the persistent volume attached to each Pod in the RabbitmqCluster. The format of this field matches that defined by kubernetes/apimachinery. See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity for more info on the format of this field.
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
                     storageClassName:
-                      description:
-                        The name of the StorageClass to claim a PersistentVolume
-                        from.
+                      description: The name of the StorageClass to claim a PersistentVolume from.
                       type: string
                   type: object
                 rabbitmq:
-                  description:
-                    Configuration options for RabbitMQ Pods created in the
-                    cluster.
+                  description: Configuration options for RabbitMQ Pods created in the cluster.
                   properties:
                     additionalConfig:
-                      description:
-                        Modify to add to the rabbitmq.conf file in addition
-                        to default configurations set by the operator. Modifying this
-                        property on an existing RabbitmqCluster will trigger a StatefulSet
-                        rolling restart and will cause rabbitmq downtime. For more information
-                        on this config, see https://www.rabbitmq.com/configure.html#config-file
+                      description: Modify to add to the rabbitmq.conf file in addition to default configurations set by the operator. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime. For more information on this config, see https://www.rabbitmq.com/configure.html#config-file
                       maxLength: 2000
                       type: string
                     additionalPlugins:
-                      description:
-                        "List of plugins to enable in addition to essential
-                        plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s."
+                      description: 'List of plugins to enable in addition to essential plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.'
                       items:
                         description: A Plugin to enable on the RabbitmqCluster.
                         maxLength: 100
@@ -4280,29 +3879,17 @@ spec:
                       maxItems: 100
                       type: array
                     advancedConfig:
-                      description:
-                        Specify any rabbitmq advanced.config configurations
-                        to apply to the cluster. For more information on advanced config,
-                        see https://www.rabbitmq.com/configure.html#advanced-config-file
+                      description: Specify any rabbitmq advanced.config configurations to apply to the cluster. For more information on advanced config, see https://www.rabbitmq.com/configure.html#advanced-config-file
                       maxLength: 100000
                       type: string
                     envConfig:
-                      description:
-                        Modify to add to the rabbitmq-env.conf file. Modifying
-                        this property on an existing RabbitmqCluster will trigger a
-                        StatefulSet rolling restart and will cause rabbitmq downtime.
-                        For more information on env config, see https://www.rabbitmq.com/man/rabbitmq-env.conf.5.html
+                      description: Modify to add to the rabbitmq-env.conf file. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime. For more information on env config, see https://www.rabbitmq.com/man/rabbitmq-env.conf.5.html
                       maxLength: 100000
                       type: string
                   type: object
                 replicas:
                   default: 1
-                  description:
-                    Replicas is the number of nodes in the RabbitMQ cluster.
-                    Each node is deployed as a Replica in a StatefulSet. Only 1, 3,
-                    5 replicas clusters are tested. This value should be an odd number
-                    to ensure the resultant cluster can establish exactly one quorum
-                    of nodes in the event of a fragmenting network partition.
+                  description: Replicas is the number of nodes in the RabbitMQ cluster. Each node is deployed as a Replica in a StatefulSet. Only 1, 3, 5 replicas clusters are tested. This value should be an odd number to ensure the resultant cluster can establish exactly one quorum of nodes in the event of a fragmenting network partition.
                   format: int32
                   minimum: 0
                   type: integer
@@ -4314,9 +3901,7 @@ spec:
                     requests:
                       cpu: 1000m
                       memory: 2Gi
-                  description:
-                    The desired compute resource requirements of Pods in
-                    the cluster.
+                  description: The desired compute resource requirements of Pods in the cluster.
                   properties:
                     limits:
                       additionalProperties:
@@ -4325,9 +3910,7 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description:
-                        "Limits describes the maximum amount of compute resources
-                        allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                       type: object
                     requests:
                       additionalProperties:
@@ -4336,85 +3919,42 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description:
-                        "Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/"
+                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                       type: object
                   type: object
                 secretBackend:
-                  description:
-                    Secret backend configuration for the RabbitmqCluster.
-                    Enables to fetch default user credentials and certificates from
-                    K8s external secret stores.
+                  description: Secret backend configuration for the RabbitmqCluster. Enables to fetch default user credentials and certificates from K8s external secret stores.
                   properties:
                     vault:
-                      description:
-                        VaultSpec will add Vault annotations (see https://www.vaultproject.io/docs/platform/k8s/injector/annotations)
-                        to RabbitMQ Pods. It requires a Vault Agent Sidecar Injector
-                        (https://www.vaultproject.io/docs/platform/k8s/injector) to
-                        be installed in the K8s cluster. The injector is a K8s Mutation
-                        Webhook Controller that alters RabbitMQ Pod specifications (based
-                        on the added Vault annotations) to include Vault Agent containers
-                        that render Vault secrets to the volume.
+                      description: VaultSpec will add Vault annotations (see https://www.vaultproject.io/docs/platform/k8s/injector/annotations) to RabbitMQ Pods. It requires a Vault Agent Sidecar Injector (https://www.vaultproject.io/docs/platform/k8s/injector) to be installed in the K8s cluster. The injector is a K8s Mutation Webhook Controller that alters RabbitMQ Pod specifications (based on the added Vault annotations) to include Vault Agent containers that render Vault secrets to the volume.
                       properties:
                         annotations:
                           additionalProperties:
                             type: string
-                          description:
-                            Vault annotations that override the Vault annotations
-                            set by the cluster-operator. For a list of valid Vault annotations,
-                            see https://www.vaultproject.io/docs/platform/k8s/injector/annotations
+                          description: Vault annotations that override the Vault annotations set by the cluster-operator. For a list of valid Vault annotations, see https://www.vaultproject.io/docs/platform/k8s/injector/annotations
                           type: object
                         defaultUserPath:
-                          description:
-                            Path in Vault to access a KV (Key-Value) secret
-                            with the fields username and password for the default user.
-                            For example "secret/data/rabbitmq/config".
+                          description: Path in Vault to access a KV (Key-Value) secret with the fields username and password for the default user. For example "secret/data/rabbitmq/config".
                           type: string
                         defaultUserUpdaterImage:
-                          description:
-                            Sidecar container that updates the default user's
-                            password in RabbitMQ when it changes in Vault. Additionally,
-                            it updates /var/lib/rabbitmq/.rabbitmqadmin.conf (used by
-                            rabbitmqadmin CLI). Set to empty string to disable the sidecar
-                            container.
+                          description: Sidecar container that updates the default user's password in RabbitMQ when it changes in Vault. Additionally, it updates /var/lib/rabbitmq/.rabbitmqadmin.conf (used by rabbitmqadmin CLI). Set to empty string to disable the sidecar container.
                           type: string
                         role:
-                          description:
-                            Role in Vault. If vault.defaultUserPath is set,
-                            this role must have capability to read the pre-created default
-                            user credential in Vault. If vault.tls is set, this role
-                            must have capability to create and update certificates in
-                            the Vault PKI engine for the domains "<namespace>" and "<namespace>.svc".
+                          description: Role in Vault. If vault.defaultUserPath is set, this role must have capability to read the pre-created default user credential in Vault. If vault.tls is set, this role must have capability to create and update certificates in the Vault PKI engine for the domains "<namespace>" and "<namespace>.svc".
                           type: string
                         tls:
                           properties:
                             altNames:
-                              description:
-                                'Specifies the requested Subject Alternative
-                                Names (SANs), in a comma-delimited list. These will
-                                be appended to the SANs added by the cluster-operator.
-                                The cluster-operator will add SANs: "<RabbitmqCluster
-                                name>-server-<index>.<RabbitmqCluster name>-nodes.<namespace>"
-                                for each pod, e.g. "myrabbit-server-0.myrabbit-nodes.default".'
+                              description: 'Specifies the requested Subject Alternative Names (SANs), in a comma-delimited list. These will be appended to the SANs added by the cluster-operator. The cluster-operator will add SANs: "<RabbitmqCluster name>-server-<index>.<RabbitmqCluster name>-nodes.<namespace>" for each pod, e.g. "myrabbit-server-0.myrabbit-nodes.default".'
                               type: string
                             commonName:
-                              description:
-                                Specifies the requested certificate Common
-                                Name (CN). Defaults to <serviceName>.<namespace>.svc
-                                if not provided.
+                              description: Specifies the requested certificate Common Name (CN). Defaults to <serviceName>.<namespace>.svc if not provided.
                               type: string
                             ipSans:
-                              description:
-                                Specifies the requested IP Subject Alternative
-                                Names, in a comma-delimited list.
+                              description: Specifies the requested IP Subject Alternative Names, in a comma-delimited list.
                               type: string
                             pkiIssuerPath:
-                              description:
-                                Path in Vault PKI engine. For example "pki/issue/hashicorp-com".
-                                required
+                              description: Path in Vault PKI engine. For example "pki/issue/hashicorp-com". required
                               type: string
                           type: object
                       type: object
@@ -4422,9 +3962,7 @@ spec:
                 service:
                   default:
                     type: ClusterIP
-                  description:
-                    The desired state of the Kubernetes Service to create
-                    for the cluster.
+                  description: The desired state of the Kubernetes Service to create for the cluster.
                   properties:
                     annotations:
                       additionalProperties:
@@ -4433,10 +3971,7 @@ spec:
                       type: object
                     type:
                       default: ClusterIP
-                      description:
-                        "Type of Service to create for the cluster. Must
-                        be one of: ClusterIP, LoadBalancer, NodePort. For more info
-                        see https://pkg.go.dev/k8s.io/api/core/v1#ServiceType"
+                      description: 'Type of Service to create for the cluster. Must be one of: ClusterIP, LoadBalancer, NodePort. For more info see https://pkg.go.dev/k8s.io/api/core/v1#ServiceType'
                       enum:
                         - ClusterIP
                         - LoadBalancer
@@ -4444,20 +3979,11 @@ spec:
                       type: string
                   type: object
                 skipPostDeploySteps:
-                  description:
-                    If unset, or set to false, the cluster will run `rabbitmq-queues
-                    rebalance all` whenever the cluster is updated. Set to true to prevent
-                    the operator rebalancing queue leaders after a cluster update. Has
-                    no effect if the cluster only consists of one node. For more information,
-                    see https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
+                  description: If unset, or set to false, the cluster will run `rabbitmq-queues rebalance all` whenever the cluster is updated. Set to true to prevent the operator rebalancing queue leaders after a cluster update. Has no effect if the cluster only consists of one node. For more information, see https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
                   type: boolean
                 terminationGracePeriodSeconds:
                   default: 604800
-                  description:
-                    "TerminationGracePeriodSeconds is the timeout that each
-                    rabbitmqcluster pod will have to terminate gracefully. It defaults
-                    to 604800 seconds ( a week long) to ensure that the container preStop
-                    lifecycle hook can finish running. For more information, see: https://github.com/rabbitmq/cluster-operator/blob/main/docs/design/20200520-graceful-pod-termination.md"
+                  description: 'TerminationGracePeriodSeconds is the timeout that each rabbitmqcluster pod will have to terminate gracefully. It defaults to 604800 seconds ( a week long) to ensure that the container preStop lifecycle hook can finish running. For more information, see: https://github.com/rabbitmq/cluster-operator/blob/main/docs/design/20200520-graceful-pod-termination.md'
                   format: int64
                   minimum: 0
                   type: integer
@@ -4465,75 +3991,35 @@ spec:
                   description: TLS-related configuration for the RabbitMQ cluster.
                   properties:
                     caSecretName:
-                      description:
-                        Name of a Secret in the same Namespace as the RabbitmqCluster,
-                        containing the Certificate Authority's public certificate for
-                        TLS. The Secret must store this as ca.crt. This Secret can be
-                        created by running `kubectl create secret generic ca-secret
-                        --from-file=ca.crt=path/to/ca.cert` Used for mTLS, and TLS for
-                        rabbitmq_web_stomp and rabbitmq_web_mqtt.
+                      description: Name of a Secret in the same Namespace as the RabbitmqCluster, containing the Certificate Authority's public certificate for TLS. The Secret must store this as ca.crt. This Secret can be created by running `kubectl create secret generic ca-secret --from-file=ca.crt=path/to/ca.cert` Used for mTLS, and TLS for rabbitmq_web_stomp and rabbitmq_web_mqtt.
                       type: string
                     disableNonTLSListeners:
-                      description:
-                        "When set to true, the RabbitmqCluster disables non-TLS
-                        listeners for RabbitMQ, management plugin and for any enabled
-                        plugins in the following list: stomp, mqtt, web_stomp, web_mqtt.
-                        Only TLS-enabled clients will be able to connect."
+                      description: 'When set to true, the RabbitmqCluster disables non-TLS listeners for RabbitMQ, management plugin and for any enabled plugins in the following list: stomp, mqtt, web_stomp, web_mqtt. Only TLS-enabled clients will be able to connect.'
                       type: boolean
                     secretName:
-                      description:
-                        Name of a Secret in the same Namespace as the RabbitmqCluster,
-                        containing the server's private key & public certificate for
-                        TLS. The Secret must store these as tls.key and tls.crt, respectively.
-                        This Secret can be created by running `kubectl create secret
-                        tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key`
+                      description: Name of a Secret in the same Namespace as the RabbitmqCluster, containing the server's private key & public certificate for TLS. The Secret must store these as tls.key and tls.crt, respectively. This Secret can be created by running `kubectl create secret tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key`
                       type: string
                   type: object
                 tolerations:
-                  description:
-                    Tolerations is the list of Toleration resources attached
-                    to each Pod in the RabbitmqCluster.
+                  description: Tolerations is the list of Toleration resources attached to each Pod in the RabbitmqCluster.
                   items:
-                    description:
-                      The pod this Toleration is attached to tolerates any
-                      taint that matches the triple <key,value,effect> using the matching
-                      operator <operator>.
+                    description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                     properties:
                       effect:
-                        description:
-                          Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                         type: string
                       key:
-                        description:
-                          Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match all
-                          values and all keys.
+                        description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                         type: string
                       operator:
-                        description:
-                          Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to Equal.
-                          Exists is equivalent to wildcard for value, so that a pod
-                          can tolerate all taints of a particular category.
+                        description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                         type: string
                       tolerationSeconds:
-                        description:
-                          TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default, it
-                          is not set, which means tolerate the taint forever (do not
-                          evict). Zero and negative values will be treated as 0 (evict
-                          immediately) by the system.
+                        description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                         format: int64
                         type: integer
                       value:
-                        description:
-                          Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
+                        description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                         type: string
                     type: object
                   type: array
@@ -4542,21 +4028,14 @@ spec:
               description: Status presents the observed state of RabbitmqCluster
               properties:
                 binding:
-                  description:
-                    "Binding exposes a secret containing the binding information
-                    for this RabbitmqCluster. It implements the service binding Provisioned
-                    Service duck type. See: https://github.com/servicebinding/spec#provisioned-service"
+                  description: 'Binding exposes a secret containing the binding information for this RabbitmqCluster. It implements the service binding Provisioned Service duck type. See: https://github.com/servicebinding/spec#provisioned-service'
                   properties:
                     name:
-                      description:
-                        "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?"
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 conditions:
-                  description:
-                    Set of Conditions describing the current state of the
-                    RabbitmqCluster
+                  description: Set of Conditions describing the current state of the RabbitmqCluster
                   items:
                     properties:
                       lastTransitionTime:
@@ -4567,17 +4046,13 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
-                          of the condition.
+                        description: One word, camel-case reason for current status of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of RabbitmqCluster status
-                          addressed by the condition.
+                        description: Type indicates the scope of RabbitmqCluster status addressed by the condition.
                         type: string
                     required:
                       - status
@@ -4588,26 +4063,18 @@ spec:
                   description: Identifying information on internal resources
                   properties:
                     secretReference:
-                      description:
-                        Reference to the Kubernetes Secret containing the
-                        credentials of the default user.
+                      description: Reference to the Kubernetes Secret containing the credentials of the default user.
                       properties:
                         keys:
                           additionalProperties:
                             type: string
-                          description:
-                            Key-value pairs in the Secret corresponding to
-                            `username`, `password`, `host`, and `port`
+                          description: Key-value pairs in the Secret corresponding to `username`, `password`, `host`, and `port`
                           type: object
                         name:
-                          description:
-                            Name of the Secret containing the default user
-                            credentials
+                          description: Name of the Secret containing the default user credentials
                           type: string
                         namespace:
-                          description:
-                            Namespace of the Secret containing the default
-                            user credentials
+                          description: Namespace of the Secret containing the default user credentials
                           type: string
                       required:
                         - keys
@@ -4629,10 +4096,7 @@ spec:
                       type: object
                   type: object
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
-                    observed for this RabbitmqCluster. It corresponds to the RabbitmqCluster's
-                    generation, which is updated on mutation by the API Server.
+                  description: observedGeneration is the most recent successful generation observed for this RabbitmqCluster. It corresponds to the RabbitmqCluster's generation, which is updated on mutation by the API Server.
                   format: int64
                   type: integer
               required:

--- a/bitnami/rabbitmq-cluster-operator/crds/crds-messaging-topology-operator.yaml
+++ b/bitnami/rabbitmq-cluster-operator/crds/crds-messaging-topology-operator.yaml
@@ -48,8 +48,8 @@ spec:
                 destinationType:
                   description: Cannot be updated
                   enum:
-                  - exchange
-                  - queue
+                    - exchange
+                    - queue
                   type: string
                 rabbitmqClusterReference:
                   description: Reference to the RabbitmqCluster that the binding will
@@ -86,7 +86,7 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-              - rabbitmqClusterReference
+                - rabbitmqClusterReference
               type: object
             status:
               description: BindingStatus defines the observed state of Binding
@@ -113,8 +113,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 observedGeneration:
@@ -220,8 +220,8 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-              - name
-              - rabbitmqClusterReference
+                - name
+                - rabbitmqClusterReference
               type: object
             status:
               description: ExchangeStatus defines the observed state of Exchange
@@ -248,8 +248,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 observedGeneration:
@@ -313,9 +313,9 @@ spec:
               properties:
                 ackMode:
                   enum:
-                  - on-confirm
-                  - on-publish
-                  - no-ack
+                    - on-confirm
+                    - on-publish
+                    - no-ack
                   type: string
                 exchange:
                   type: string
@@ -375,9 +375,9 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-              - name
-              - rabbitmqClusterReference
-              - uriSecret
+                - name
+                - rabbitmqClusterReference
+                - uriSecret
               type: object
             status:
               description: FederationStatus defines the observed state of Federation
@@ -404,8 +404,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 observedGeneration:
@@ -520,9 +520,9 @@ spec:
                     be updated
                   type: string
               required:
-              - permissions
-              - rabbitmqClusterReference
-              - vhost
+                - permissions
+                - rabbitmqClusterReference
+                - vhost
               type: object
             status:
               description: PermissionStatus defines the observed state of Permission
@@ -549,8 +549,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 observedGeneration:
@@ -616,9 +616,9 @@ spec:
                   description: 'What this policy applies to: ''queues'', ''exchanges'',
                     or ''all''. Default to ''all''.'
                   enum:
-                  - queues
-                  - exchanges
-                  - all
+                    - queues
+                    - exchanges
+                    - all
                   type: string
                 definition:
                   description: Policy definition. Required property.
@@ -666,10 +666,10 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-              - definition
-              - name
-              - pattern
-              - rabbitmqClusterReference
+                - definition
+                - name
+                - pattern
+                - rabbitmqClusterReference
               type: object
             status:
               description: PolicyStatus defines the observed state of Policy
@@ -696,8 +696,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 observedGeneration:
@@ -806,8 +806,8 @@ spec:
                   description: Default to vhost '/'
                   type: string
               required:
-              - name
-              - rabbitmqClusterReference
+                - name
+                - rabbitmqClusterReference
               type: object
             status:
               description: QueueStatus defines the observed state of Queue
@@ -834,8 +834,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 observedGeneration:
@@ -963,8 +963,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 observedGeneration:
@@ -1028,9 +1028,9 @@ spec:
               properties:
                 ackMode:
                   enum:
-                  - on-confirm
-                  - on-publish
-                  - no-ack
+                    - on-confirm
+                    - on-publish
+                    - no-ack
                   type: string
                 addForwardHeaders:
                   type: boolean
@@ -1117,9 +1117,9 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-              - name
-              - rabbitmqClusterReference
-              - uriSecret
+                - name
+                - rabbitmqClusterReference
+                - uriSecret
               type: object
             status:
               description: ShovelStatus defines the observed state of Shovel
@@ -1146,8 +1146,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 observedGeneration:
@@ -1252,8 +1252,8 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-              - name
-              - rabbitmqClusterReference
+                - name
+                - rabbitmqClusterReference
               type: object
             status:
               description: SuperStreamStatus defines the observed state of SuperStream
@@ -1280,8 +1280,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 observedGeneration:
@@ -1397,10 +1397,10 @@ spec:
                     description: UserTag defines the level of access to the management
                       UI allocated to the user. For more information, see https://www.rabbitmq.com/management.html#permissions.
                     enum:
-                    - management
-                    - policymaker
-                    - monitoring
-                    - administrator
+                      - management
+                      - policymaker
+                      - monitoring
+                      - administrator
                     type: string
                   type: array
               required:
@@ -1431,8 +1431,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 credentials:
@@ -1454,7 +1454,7 @@ spec:
                   description: Provide rabbitmq Username
                   type: string
               required:
-              - username
+                - username
               type: object
           type: object
       served: true
@@ -1541,8 +1541,8 @@ spec:
                 tracing:
                   type: boolean
               required:
-              - name
-              - rabbitmqClusterReference
+                - name
+                - rabbitmqClusterReference
               type: object
             status:
               description: VhostStatus defines the observed state of Vhost
@@ -1569,8 +1569,8 @@ spec:
                           status addressed by the condition.
                         type: string
                     required:
-                    - status
-                    - type
+                      - status
+                      - type
                     type: object
                   type: array
                 observedGeneration:

--- a/bitnami/rabbitmq-cluster-operator/crds/crds-messaging-topology-operator.yaml
+++ b/bitnami/rabbitmq-cluster-operator/crds/crds-messaging-topology-operator.yaml
@@ -936,7 +936,7 @@ spec:
                       type: string
                   type: object
               required:
-              - rabbitmqClusterReference
+                - rabbitmqClusterReference
               type: object
             status:
               description: SchemaReplicationStatus defines the observed state of SchemaReplication
@@ -1404,7 +1404,7 @@ spec:
                     type: string
                   type: array
               required:
-              - rabbitmqClusterReference
+                - rabbitmqClusterReference
               type: object
             status:
               description: Status exposes the observed state of the User object.

--- a/bitnami/rabbitmq-cluster-operator/crds/crds-messaging-topology-operator.yaml
+++ b/bitnami/rabbitmq-cluster-operator/crds/crds-messaging-topology-operator.yaml
@@ -1,8 +1,9 @@
+# Source: https://github.com/rabbitmq/messaging-topology-operator/tree/main/config/crd
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: bindings.rabbitmq.com
 spec:
@@ -10,6 +11,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: Binding
     listKind: BindingList
     plural: bindings
@@ -22,16 +24,14 @@ spec:
           description: Binding is the Schema for the bindings API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -48,24 +48,32 @@ spec:
                 destinationType:
                   description: Cannot be updated
                   enum:
-                    - exchange
-                    - queue
+                  - exchange
+                  - queue
                   type: string
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that the binding will
+                  description: Reference to the RabbitmqCluster that the binding will
                     be created in. Required property.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 routingKey:
                   description: Cannot be updated
@@ -78,7 +86,7 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-                - rabbitmqClusterReference
+              - rabbitmqClusterReference
               type: object
             status:
               description: BindingStatus defines the observed state of Binding
@@ -94,26 +102,23 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this Binding. It corresponds to the Binding's generation,
                     which is updated on mutation by the API Server.
                   format: int64
@@ -135,7 +140,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: exchanges.rabbitmq.com
 spec:
@@ -143,6 +148,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: Exchange
     listKind: ExchangeList
     plural: exchanges
@@ -155,16 +161,14 @@ spec:
           description: Exchange is the Schema for the exchanges API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -184,20 +188,28 @@ spec:
                   description: Required property; cannot be updated
                   type: string
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that the exchange will
+                  description: Reference to the RabbitmqCluster that the exchange will
                     be created in. Required property.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 type:
                   default: direct
@@ -208,8 +220,8 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-                - name
-                - rabbitmqClusterReference
+              - name
+              - rabbitmqClusterReference
               type: object
             status:
               description: ExchangeStatus defines the observed state of Exchange
@@ -225,26 +237,23 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this Exchange. It corresponds to the Exchange's generation,
                     which is updated on mutation by the API Server.
                   format: int64
@@ -266,7 +275,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: federations.rabbitmq.com
 spec:
@@ -274,6 +283,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: Federation
     listKind: FederationList
     plural: federations
@@ -286,29 +296,26 @@ spec:
           description: Federation is the Schema for the federations API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
-              description:
-                "FederationSpec defines the desired state of Federation For
-                how to configure federation upstreams, see: https://www.rabbitmq.com/federation-reference.html."
+              description: 'FederationSpec defines the desired state of Federation For
+                how to configure federation upstreams, see: https://www.rabbitmq.com/federation-reference.html.'
               properties:
                 ackMode:
                   enum:
-                    - on-confirm
-                    - on-publish
-                    - no-ack
+                  - on-confirm
+                  - on-publish
+                  - no-ack
                   type: string
                 exchange:
                   type: string
@@ -326,35 +333,41 @@ spec:
                 queue:
                   type: string
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that this federation
+                  description: Reference to the RabbitmqCluster that this federation
                     upstream will be created in. Required property.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 reconnectDelay:
                   type: integer
                 trustUserId:
                   type: boolean
                 uriSecret:
-                  description:
-                    Secret contains the AMQP URI(s) for the upstream. The
+                  description: Secret contains the AMQP URI(s) for the upstream. The
                     Secret must contain the key `uri` or operator will error. `uri`
                     should be one or multiple uris separated by ','. Required property.
                   properties:
                     name:
-                      description:
-                        "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?"
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 vhost:
@@ -362,9 +375,9 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-                - name
-                - rabbitmqClusterReference
-                - uriSecret
+              - name
+              - rabbitmqClusterReference
+              - uriSecret
               type: object
             status:
               description: FederationStatus defines the observed state of Federation
@@ -380,26 +393,23 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this Federation. It corresponds to the Federation's
                     generation, which is updated on mutation by the API Server.
                   format: int64
@@ -421,7 +431,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: permissions.rabbitmq.com
 spec:
@@ -429,6 +439,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: Permission
     listKind: PermissionList
     plural: permissions
@@ -441,16 +452,14 @@ spec:
           description: Permission is the Schema for the permissions API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -458,9 +467,8 @@ spec:
               description: PermissionSpec defines the desired state of Permission
               properties:
                 permissions:
-                  description:
-                    "Permissions to grant to the user in the specific vhost;
-                    required property. See RabbitMQ doc for more information: https://www.rabbitmq.com/access-control.html#user-management"
+                  description: 'Permissions to grant to the user in the specific vhost;
+                    required property. See RabbitMQ doc for more information: https://www.rabbitmq.com/access-control.html#user-management'
                   properties:
                     configure:
                       type: string
@@ -470,47 +478,51 @@ spec:
                       type: string
                   type: object
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that both the provided
+                  description: Reference to the RabbitmqCluster that both the provided
                     user and vhost are. Required property.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 user:
-                  description:
-                    Name of an existing user; must provide user or userReference,
+                  description: Name of an existing user; must provide user or userReference,
                     else create/update will fail; cannot be updated
                   type: string
                 userReference:
-                  description:
-                    Reference to an existing user.rabbitmq.com object; must
+                  description: Reference to an existing user.rabbitmq.com object; must
                     provide user or userReference, else create/update will fail; cannot
                     be updated
                   properties:
                     name:
-                      description:
-                        "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?"
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 vhost:
-                  description:
-                    Name of an existing vhost; required property; cannot
+                  description: Name of an existing vhost; required property; cannot
                     be updated
                   type: string
               required:
-                - permissions
-                - rabbitmqClusterReference
-                - vhost
+              - permissions
+              - rabbitmqClusterReference
+              - vhost
               type: object
             status:
               description: PermissionStatus defines the observed state of Permission
@@ -526,26 +538,23 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this Permission. It corresponds to the Permission's
                     generation, which is updated on mutation by the API Server.
                   format: int64
@@ -567,7 +576,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: policies.rabbitmq.com
 spec:
@@ -575,6 +584,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: Policy
     listKind: PolicyList
     plural: policies
@@ -587,16 +597,14 @@ spec:
           description: Policy is the Schema for the policies API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -605,13 +613,12 @@ spec:
               properties:
                 applyTo:
                   default: all
-                  description:
-                    "What this policy applies to: 'queues', 'exchanges',
-                    or 'all'. Default to 'all'."
+                  description: 'What this policy applies to: ''queues'', ''exchanges'',
+                    or ''all''. Default to ''all''.'
                   enum:
-                    - queues
-                    - exchanges
-                    - all
+                  - queues
+                  - exchanges
+                  - all
                   type: string
                 definition:
                   description: Policy definition. Required property.
@@ -621,42 +628,48 @@ spec:
                   description: Required property; cannot be updated
                   type: string
                 pattern:
-                  description:
-                    Regular expression pattern used to match queues and exchanges,
+                  description: Regular expression pattern used to match queues and exchanges,
                     e.g. "^amq.". Required property.
                   type: string
                 priority:
                   default: 0
-                  description:
-                    Default to '0'. In the event that more than one policy
+                  description: Default to '0'. In the event that more than one policy
                     can match a given exchange or queue, the policy with the greatest
                     priority applies.
                   type: integer
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that the exchange will
+                  description: Reference to the RabbitmqCluster that the exchange will
                     be created in. Required property.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 vhost:
                   default: /
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-                - definition
-                - name
-                - pattern
-                - rabbitmqClusterReference
+              - definition
+              - name
+              - pattern
+              - rabbitmqClusterReference
               type: object
             status:
               description: PolicyStatus defines the observed state of Policy
@@ -672,26 +685,23 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this Policy. It corresponds to the Policy's generation,
                     which is updated on mutation by the API Server.
                   format: int64
@@ -713,7 +723,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: queues.rabbitmq.com
 spec:
@@ -721,6 +731,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: Queue
     listKind: QueueList
     plural: queues
@@ -733,16 +744,14 @@ spec:
           description: Queue is the Schema for the queues API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -750,16 +759,14 @@ spec:
               description: QueueSpec defines the desired state of Queue
               properties:
                 arguments:
-                  description:
-                    "Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit:
+                  description: 'Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit:
                     10000. Configuring queues through arguments is not recommended because
                     they cannot be updated once set; we recommend configuring queues
-                    through policies instead."
+                    through policies instead.'
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 autoDelete:
-                  description:
-                    when set to true, queues that have had at least one consumer
+                  description: when set to true, queues that have had at least one consumer
                     before are deleted after the last consumer unsubscribes.
                   type: boolean
                 durable:
@@ -769,20 +776,28 @@ spec:
                   description: Name of the queue; required property.
                   type: string
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that the queue will
+                  description: Reference to the RabbitmqCluster that the queue will
                     be created in. Required property.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 type:
                   type: string
@@ -791,8 +806,8 @@ spec:
                   description: Default to vhost '/'
                   type: string
               required:
-                - name
-                - rabbitmqClusterReference
+              - name
+              - rabbitmqClusterReference
               type: object
             status:
               description: QueueStatus defines the observed state of Queue
@@ -808,26 +823,23 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this Queue. It corresponds to the Queue's generation,
                     which is updated on mutation by the API Server.
                   format: int64
@@ -849,7 +861,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: schemareplications.rabbitmq.com
 spec:
@@ -864,22 +876,19 @@ spec:
     - name: v1beta1
       schema:
         openAPIV3Schema:
-          description:
-            "SchemaReplication is the Schema for the schemareplications API
+          description: 'SchemaReplication is the Schema for the schemareplications API
             This feature requires Tanzu RabbitMQ with schema replication plugin. For
-            more information, see: https://tanzu.vmware.com/rabbitmq and https://www.rabbitmq.com/definitions-standby.html."
+            more information, see: https://tanzu.vmware.com/rabbitmq and https://www.rabbitmq.com/definitions-standby.html.'
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -887,42 +896,47 @@ spec:
               description: SchemaReplicationSpec defines the desired state of SchemaReplication
               properties:
                 endpoints:
-                  description:
-                    endpoints should be one or multiple endpoints separated
+                  description: endpoints should be one or multiple endpoints separated
                     by ','. Must provide either spec.endpoints or endpoints in spec.upstreamSecret.
                     When endpoints are provided in both spec.endpoints and spec.upstreamSecret,
                     spec.endpoints takes precedence.
                   type: string
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that schema replication
+                  description: Reference to the RabbitmqCluster that schema replication
                     would be set for. Must be an existing cluster.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 upstreamSecret:
-                  description:
-                    Defines a Secret which contains credentials to be used
+                  description: Defines a Secret which contains credentials to be used
                     for schema replication. The Secret must contain the keys `username`
                     and `password` in its Data field, or operator will error.
                   properties:
                     name:
-                      description:
-                        "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?"
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
               required:
-                - rabbitmqClusterReference
+              - rabbitmqClusterReference
               type: object
             status:
               description: SchemaReplicationStatus defines the observed state of SchemaReplication
@@ -938,26 +952,23 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this Queue. It corresponds to the Queue's generation,
                     which is updated on mutation by the API Server.
                   format: int64
@@ -979,7 +990,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: shovels.rabbitmq.com
 spec:
@@ -987,6 +998,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: Shovel
     listKind: ShovelList
     plural: shovels
@@ -999,29 +1011,26 @@ spec:
           description: Shovel is the Schema for the shovels API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
-              description:
-                "ShovelSpec defines the desired state of Shovel For how to
-                configure Shovel, see: https://www.rabbitmq.com/shovel.html."
+              description: 'ShovelSpec defines the desired state of Shovel For how to
+                configure Shovel, see: https://www.rabbitmq.com/shovel.html.'
               properties:
                 ackMode:
                   enum:
-                    - on-confirm
-                    - on-publish
-                    - no-ack
+                  - on-confirm
+                  - on-publish
+                  - no-ack
                   type: string
                 addForwardHeaders:
                   type: boolean
@@ -1053,20 +1062,28 @@ spec:
                 prefetchCount:
                   type: integer
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that this Shovel will
+                  description: Reference to the RabbitmqCluster that this Shovel will
                     be created in. Required property.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 reconnectDelay:
                   type: integer
@@ -1085,16 +1102,14 @@ spec:
                 srcQueue:
                   type: string
                 uriSecret:
-                  description:
-                    Secret contains the AMQP URI(s) to configure Shovel destination
+                  description: Secret contains the AMQP URI(s) to configure Shovel destination
                     and source. The Secret must contain the key `destUri` and `srcUri`
                     or operator will error. Both fields should be one or multiple uris
                     separated by ','. Required property.
                   properties:
                     name:
-                      description:
-                        "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?"
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 vhost:
@@ -1102,9 +1117,9 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-                - name
-                - rabbitmqClusterReference
-                - uriSecret
+              - name
+              - rabbitmqClusterReference
+              - uriSecret
               type: object
             status:
               description: ShovelStatus defines the observed state of Shovel
@@ -1120,26 +1135,23 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this Shovel. It corresponds to the Shovel's generation,
                     which is updated on mutation by the API Server.
                   format: int64
@@ -1161,7 +1173,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: superstreams.rabbitmq.com
 spec:
@@ -1169,6 +1181,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: SuperStream
     listKind: SuperStreamList
     plural: superstreams
@@ -1181,16 +1194,14 @@ spec:
           description: SuperStream is the Schema for the queues API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -1202,29 +1213,35 @@ spec:
                   type: string
                 partitions:
                   default: 3
-                  description:
-                    Number of partitions to create within this super stream.
+                  description: Number of partitions to create within this super stream.
                     Defaults to '3'.
                   type: integer
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that the SuperStream
+                  description: Reference to the RabbitmqCluster that the SuperStream
                     will be created in. Required property.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 routingKeys:
-                  description:
-                    Routing keys to use for each of the partitions in the
+                  description: Routing keys to use for each of the partitions in the
                     SuperStream If unset, the routing keys for the partitions will be
                     set to the index of the partitions
                   items:
@@ -1235,8 +1252,8 @@ spec:
                   description: Default to vhost '/'; cannot be updated
                   type: string
               required:
-                - name
-                - rabbitmqClusterReference
+              - name
+              - rabbitmqClusterReference
               type: object
             status:
               description: SuperStreamStatus defines the observed state of SuperStream
@@ -1252,33 +1269,29 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this SuperStream. It corresponds to the SuperStream's
                     generation, which is updated on mutation by the API Server.
                   format: int64
                   type: integer
                 partitions:
-                  description:
-                    Partitions are a list of the stream queue names which
+                  description: Partitions are a list of the stream queue names which
                     form the partitions of this SuperStream.
                   items:
                     type: string
@@ -1300,7 +1313,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: users.rabbitmq.com
 spec:
@@ -1308,6 +1321,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: User
     listKind: UserList
     plural: users
@@ -1320,16 +1334,14 @@ spec:
           description: User is the Schema for the users API.
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -1337,8 +1349,7 @@ spec:
               description: Spec configures the desired state of the User object.
               properties:
                 importCredentialsSecret:
-                  description:
-                    Defines a Secret used to pre-define the username and
+                  description: Defines a Secret used to pre-define the username and
                     password set for this User. User objects created with this field
                     set will not have randomly-generated credentials, and will instead
                     import the username/password values from this Secret. The Secret
@@ -1347,48 +1358,53 @@ spec:
                     time, and is ignored once a password has been set on a User.
                   properties:
                     name:
-                      description:
-                        "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?"
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that the user will be
+                  description: Reference to the RabbitmqCluster that the user will be
                     created for. This cluster must exist for the User object to be created.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 tags:
-                  description:
-                    List of permissions tags to associate with the user.
+                  description: List of permissions tags to associate with the user.
                     This determines the level of access to the RabbitMQ management UI
                     granted to the user. Omitting this field will lead to a user than
                     can still connect to the cluster through messaging protocols, but
                     cannot perform any management actions. For more information, see
                     https://www.rabbitmq.com/management.html#permissions.
                   items:
-                    description:
-                      UserTag defines the level of access to the management
+                    description: UserTag defines the level of access to the management
                       UI allocated to the user. For more information, see https://www.rabbitmq.com/management.html#permissions.
                     enum:
-                      - management
-                      - policymaker
-                      - monitoring
-                      - administrator
+                    - management
+                    - policymaker
+                    - monitoring
+                    - administrator
                     type: string
                   type: array
               required:
-                - rabbitmqClusterReference
+              - rabbitmqClusterReference
               type: object
             status:
               description: Status exposes the observed state of the User object.
@@ -1404,41 +1420,41 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 credentials:
-                  description:
-                    Provides a reference to a Secret object containing the
+                  description: Provides a reference to a Secret object containing the
                     user credentials.
                   properties:
                     name:
-                      description:
-                        "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?"
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
                       type: string
                   type: object
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this User. It corresponds to the User's generation,
                     which is updated on mutation by the API Server.
                   format: int64
                   type: integer
+                username:
+                  description: Provide rabbitmq Username
+                  type: string
+              required:
+              - username
               type: object
           type: object
       served: true
@@ -1456,7 +1472,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: vhosts.rabbitmq.com
 spec:
@@ -1464,6 +1480,7 @@ spec:
   names:
     categories:
       - all
+      - rabbitmq
     kind: Vhost
     listKind: VhostList
     plural: vhosts
@@ -1476,16 +1493,14 @@ spec:
           description: Vhost is the Schema for the vhosts API
           properties:
             apiVersion:
-              description:
-                "APIVersion defines the versioned schema of this representation
+              description: 'APIVersion defines the versioned schema of this representation
                 of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description:
-                "Kind is a string value representing the REST resource this
+              description: 'Kind is a string value representing the REST resource this
                 object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
@@ -1496,20 +1511,28 @@ spec:
                   description: Name of the vhost; see https://www.rabbitmq.com/vhosts.html.
                   type: string
                 rabbitmqClusterReference:
-                  description:
-                    Reference to the RabbitmqCluster that the vhost will
+                  description: Reference to the RabbitmqCluster that the vhost will
                     be created in. Required property.
                   properties:
+                    connectionSecret:
+                      description: Secret contains the http management uri for the RabbitMQ
+                        cluster. The Secret must contain the key `uri`, `username` and
+                        `password` or operator will error. Have to set either name or
+                        connectionSecret, but not both.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
                     name:
-                      description: The name of the RabbitMQ cluster to reference.
+                      description: The name of the RabbitMQ cluster to reference. Have
+                        to set either name or connectionSecret, but not both.
                       type: string
                     namespace:
-                      description:
-                        The namespace of the RabbitMQ cluster to reference.
+                      description: The namespace of the RabbitMQ cluster to reference.
                         Defaults to the namespace of the requested resource if omitted.
                       type: string
-                  required:
-                    - name
                   type: object
                 tags:
                   items:
@@ -1518,8 +1541,8 @@ spec:
                 tracing:
                   type: boolean
               required:
-                - name
-                - rabbitmqClusterReference
+              - name
+              - rabbitmqClusterReference
               type: object
             status:
               description: VhostStatus defines the observed state of Vhost
@@ -1535,26 +1558,23 @@ spec:
                         description: Full text reason for current status of the condition.
                         type: string
                       reason:
-                        description:
-                          One word, camel-case reason for current status
+                        description: One word, camel-case reason for current status
                           of the condition.
                         type: string
                       status:
                         description: True, False, or Unknown
                         type: string
                       type:
-                        description:
-                          Type indicates the scope of the custom resource
+                        description: Type indicates the scope of the custom resource
                           status addressed by the condition.
                         type: string
                     required:
-                      - status
-                      - type
+                    - status
+                    - type
                     type: object
                   type: array
                 observedGeneration:
-                  description:
-                    observedGeneration is the most recent successful generation
+                  description: observedGeneration is the most recent successful generation
                     observed for this Vhost. It corresponds to the Vhost's generation,
                     which is updated on mutation by the API Server.
                   format: int64

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/validating-webhook-configuration.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/validating-webhook-configuration.yaml
@@ -118,8 +118,8 @@ webhooks:
       caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
       {{- end }}
       service:
-        name: webhook-service
-        namespace: rabbitmq-system
+        name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
+        namespace: {{ .Release.Namespace | quote }}
         path: /validate-rabbitmq-com-v1alpha1-superstream
     failurePolicy: Fail
     name: vsuperstream.kb.io

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -55,7 +55,7 @@ extraDeploy: []
 rabbitmqImage:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.27-debian-10-r58
+  tag: 3.8.28-debian-10-r1
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-rabbitmqImage-private-registry/
@@ -97,7 +97,7 @@ clusterOperator:
   image:
     registry: docker.io
     repository: bitnami/rabbitmq-cluster-operator
-    tag: 1.12.1-scratch-r1
+    tag: 1.12.1-scratch-r2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -451,7 +451,7 @@ msgTopologyOperator:
   image:
     registry: docker.io
     repository: bitnami/rmq-messaging-topology-operator
-    tag: 1.4.1-scratch-r0
+    tag: 1.5.0-scratch-r0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <carlosrh@vmware.com>

**Description of the change**

Sync CRDs with https://github.com/rabbitmq/cluster-operator/tree/main/config/crd and https://github.com/rabbitmq/messaging-topology-operator/tree/main/config/crd

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #9513

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)