### PR TITLE
[bitnami/rabbitmq-cluster-operator] Allow to install CRDs as part of the Helm chart templates

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -25,4 +25,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 2.4.0
+version: 2.5.0

--- a/bitnami/rabbitmq-cluster-operator/README.md
+++ b/bitnami/rabbitmq-cluster-operator/README.md
@@ -142,15 +142,16 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 
 ### Common parameters
 
-| Name                | Description                                        | Value           |
-| ------------------- | -------------------------------------------------- | --------------- |
-| `kubeVersion`       | Override Kubernetes version                        | `""`            |
-| `nameOverride`      | String to partially override common.names.fullname | `""`            |
-| `fullnameOverride`  | String to fully override common.names.fullname     | `""`            |
-| `commonLabels`      | Labels to add to all deployed objects              | `{}`            |
-| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`            |
-| `clusterDomain`     | Kubernetes cluster domain name                     | `cluster.local` |
-| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`            |
+| Name                | Description                                                                              | Value           |
+| ------------------- | ---------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`       | Override Kubernetes version                                                              | `""`            |
+| `nameOverride`      | String to partially override common.names.fullname                                       | `""`            |
+| `fullnameOverride`  | String to fully override common.names.fullname                                           | `""`            |
+| `commonLabels`      | Labels to add to all deployed objects                                                    | `{}`            |
+| `commonAnnotations` | Annotations to add to all deployed objects                                               | `{}`            |
+| `clusterDomain`     | Kubernetes cluster domain name                                                           | `cluster.local` |
+| `extraDeploy`       | Array of extra objects to deploy with the release                                        | `[]`            |
+| `installCRDs`       | Specifies whether to install the CRDs as part of the chart templates. Defaults to false. | `false`         |
 
 
 ### RabbitMQ Cluster Operator Parameters
@@ -159,7 +160,7 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
 | `rabbitmqImage.registry`                                          | RabbitMQ Image registry                                                                                 | `docker.io`                              |
 | `rabbitmqImage.repository`                                        | RabbitMQ Image repository                                                                               | `bitnami/rabbitmq`                       |
-| `rabbitmqImage.tag`                                               | RabbitMQ Image tag (immutable tags are recommended)                                                     | `3.8.27-debian-10-r49`                   |
+| `rabbitmqImage.tag`                                               | RabbitMQ Image tag (immutable tags are recommended)                                                     | `3.8.27-debian-10-r58`                   |
 | `rabbitmqImage.pullSecrets`                                       | RabbitMQ Image pull secrets                                                                             | `[]`                                     |
 | `credentialUpdaterImage.registry`                                 | RabbitMQ Default User Credential Updater Image registry                                                 | `docker.io`                              |
 | `credentialUpdaterImage.repository`                               | RabbitMQ Default User Credential Updater Image repository                                               | `bitnami/rmq-default-credential-updater` |
@@ -167,7 +168,7 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 | `credentialUpdaterImage.pullSecrets`                              | RabbitMQ Default User Credential Updater Image pull secrets                                             | `[]`                                     |
 | `clusterOperator.image.registry`                                  | RabbitMQ Cluster Operator image registry                                                                | `docker.io`                              |
 | `clusterOperator.image.repository`                                | RabbitMQ Cluster Operator image repository                                                              | `bitnami/rabbitmq-cluster-operator`      |
-| `clusterOperator.image.tag`                                       | RabbitMQ Cluster Operator image tag (immutable tags are recommended)                                    | `1.12.1-scratch-r0`                      |
+| `clusterOperator.image.tag`                                       | RabbitMQ Cluster Operator image tag (immutable tags are recommended)                                    | `1.12.1-scratch-r1`                      |
 | `clusterOperator.image.pullPolicy`                                | RabbitMQ Cluster Operator image pull policy                                                             | `IfNotPresent`                           |
 | `clusterOperator.image.pullSecrets`                               | RabbitMQ Cluster Operator image pull secrets                                                            | `[]`                                     |
 | `clusterOperator.replicaCount`                                    | Number of RabbitMQ Cluster Operator replicas to deploy                                                  | `1`                                      |

--- a/bitnami/rabbitmq-cluster-operator/ci/installCRDs-values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/ci/installCRDs-values.yaml
@@ -1,0 +1,1 @@
+installCRDs: true

--- a/bitnami/rabbitmq-cluster-operator/templates/crds.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/crds.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.installCRDs }}
+{{ $root := .}}
+{{ range $path, $_ :=  .Files.Glob  "crds/*.yaml" }}
+---
+    {{- with $root }}
+        {{- .Files.Get $path | nindent 0 }}
+    {{- end }}
+{{ end }}
+{{- end }}

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -41,6 +41,13 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param installCRDs Specifies whether to install the CRDs as part of the chart templates. Defaults to false.
+## This is particularly useful for upgrades, as the CRDs are only install and updated when the chart is installed for the first time.
+## For more details see:
+## - https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations
+## - https://github.com/helm/helm/issues/7735
+##
+installCRDs: false
 
 ## @section RabbitMQ Cluster Operator Parameters
 ##


### PR DESCRIPTION
**Description of the change**

This change allows installing and upgrading CRDs as part of the RabbitMQ Cluster Operator chart

**Benefits**

No manual intervention is required.
CRDs are up to date
Missing CRDs put the operators on crashloopbackoff state which could happen across many clusters at the same time when using GitOps and manual intervention might not be an option

**Possible drawbacks**

Uninstalling the chart release or disabling the flag after it is enabled would delete the CRDs from the cluster deleting resources in cascade first... maybe causing the operator to see the Cluster, User, Exchange... definitions being deleted causing the operator to delete these resources too before crashing.
Personally, I always approach removing operators from clusters as 3 steps process

If I want to do a full clean up:
- Delete CRD definitions and let the operators clean things up
- Scale the operators deployment to 0 replicas
- Remove Helm Release

If I want to keep the created resources
- Scale the operators deployment to 0 replicas
- Delete CRD definitions and let the operators clean things up
- Remove Helm Release


**Applicable issues**

  - fixes #9513

**Additional information**

As indicated on the Helm documentation... another approach is to create a different Helm chart with the CRDs under `templates` so you need both to get it working

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)