### PR TITLE
[bitnami/dataplatform-bp2] Update kafka

### DIFF
--- a/bitnami/dataplatform-bp2/Chart.lock
+++ b/bitnami/dataplatform-bp2/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: wavefront
   repository: https://charts.bitnami.com/bitnami
-  version: 3.2.2
+  version: 3.3.0
 - name: spark
   repository: https://charts.bitnami.com/bitnami
-  version: 5.9.4
+  version: 5.9.5
 - name: logstash
   repository: https://charts.bitnami.com/bitnami
   version: 3.8.2
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 15.5.0
+  version: 16.0.0
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 17.9.15
+  version: 17.9.16
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.12.0
-digest: sha256:42ea1f5c14017a53ebd09bdbbad16dfd5cbfb9e903b8d8e4edacbb7e6e8c474a
-generated: "2022-03-21T07:12:07.475169366Z"
+  version: 1.13.0
+digest: sha256:f936d7f9fc9ba856b944973b0ee9488b8b6d166fb2d07064127bd80c89f26257
+generated: "2022-03-25T11:46:56.892465+01:00"

--- a/bitnami/dataplatform-bp2/Chart.yaml
+++ b/bitnami/dataplatform-bp2/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
   - condition: kafka.enabled
     name: kafka
     repository: https://charts.bitnami.com/bitnami
-    version: 15.x.x
+    version: 16.x.x
   - condition: elasticsearch.enabled
     name: elasticsearch
     repository: https://charts.bitnami.com/bitnami
@@ -58,4 +58,4 @@ sources:
   - https://www.elastic.co/products/logstash
   - https://zookeeper.apache.org/
   - https://github.com/bitnami/bitnami-docker-zookeeper
-version: 11.0.3
+version: 12.0.0

--- a/bitnami/dataplatform-bp2/README.md
+++ b/bitnami/dataplatform-bp2/README.md
@@ -542,6 +542,10 @@ Regular upgrade is compatible from previous versions.
 
 ## Upgrading
 
+### To 12.0.0
+
+This major updates the Kafka subchart to it newest major, 16.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/kafka#to-1600) you can find more information about the changes introduced in that version.
+
 ### To 10.0.0
 
 This major release updates the Kafka subchart to its newest major `15.x.x`, which contain several changes in the supported values and bumps Kafka major version to `3.x` series (check the [upgrade notes](https://github.com/bitnami/charts/blob/master/bitnami/kafka/README.md#to-1500) to obtain more information).


### PR DESCRIPTION
Signed-off-by: David Gomez <dgomezleon@vmware.com>

**Description of the change**

Update zookeeper dependency to use version 3.8

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)