### PR TITLE
[bitnami/mongodb-sharded] Fix typo in shard-data-poddisruptionbudget

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 4.0.15
+version: 4.0.16

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml
@@ -2,7 +2,7 @@
 {{- $replicas := .Values.shards | int -}}
 {{- range $i, $e := until $replicas -}}
 kind: PodDisruptionBudget
-apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" $ }}
 metadata:
   name: {{ printf "%s-shard%d-data" (include "common.names.fullname" $ ) $i }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: Vinay Pulim <v@pulim.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fixes a typo in shard-data-poddisruptionbudget.yaml that results in the following helm error after adding `shardsvr.pdb.enabled=true`:
```
Error: template: mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml:5:15: executing "mongodb-sharded/templates/shard/shard-data-poddisruptionbudget.yaml" at <include "common.capabilities.policy.apiVersion" .>: error calling include: template: mongodb-sharded/charts/common/templates/_capabilities.tpl:22:32: executing "common.capabilities.policy.apiVersion" at <include "common.capabilities.kubeVersion" .>: error calling include: template: mongodb-sharded/charts/common/templates/_capabilities.tpl:7:14: executing "common.capabilities.kubeVersion" at <.Values.global>: can't evaluate field Values in type int
```

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)