### PR TITLE
[bitnami/airflow] Add common values for all pods

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 12.0.16
+version: 12.1.0

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -91,9 +91,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dags.existingConfigmap` | Name of an existing ConfigMap with all the DAGs files you want to load in Airflow                                                              | `""`                    |
 | `dags.image.registry`    | Init container load-dags image registry                                                                                                        | `docker.io`             |
 | `dags.image.repository`  | Init container load-dags image repository                                                                                                      | `bitnami/bitnami-shell` |
-| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `10-debian-10-r326`     |
+| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `10-debian-10-r378`     |
 | `dags.image.pullPolicy`  | Init container load-dags image pull policy                                                                                                     | `IfNotPresent`          |
 | `dags.image.pullSecrets` | Init container load-dags image pull secrets                                                                                                    | `[]`                    |
+| `extraEnvVars`           | Add extra environment variables for all the Airflow pods                                                                                       | `[]`                    |
+| `extraEnvVarsCM`         | ConfigMap with extra environment variables for all the Airflow pods                                                                            | `""`                    |
+| `extraEnvVarsSecret`     | Secret with extra environment variables for all the Airflow pods                                                                               | `""`                    |
+| `sidecars`               | Add additional sidecar containers to all the Airflow pods                                                                                      | `[]`                    |
+| `initContainers`         | Add additional init containers to all the Airflow pods                                                                                         | `[]`                    |
+| `extraVolumeMounts`      | Optionally specify extra list of additional volumeMounts for all the Airflow pods                                                              | `[]`                    |
+| `extraVolumes`           | Optionally specify extra list of additional volumes for the all the Airflow pods                                                               | `[]`                    |
 
 
 ### Airflow web parameters
@@ -102,7 +109,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------- |
 | `web.image.registry`                        | Airflow image registry                                                                                                   | `docker.io`           |
 | `web.image.repository`                      | Airflow image repository                                                                                                 | `bitnami/airflow`     |
-| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.2.3-debian-10-r16` |
+| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.2.4-debian-10-r19` |
 | `web.image.pullPolicy`                      | Airflow image pull policy                                                                                                | `IfNotPresent`        |
 | `web.image.pullSecrets`                     | Airflow image pull secrets                                                                                               | `[]`                  |
 | `web.image.debug`                           | Enable image debug mode                                                                                                  | `false`               |
@@ -143,6 +150,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `web.containerSecurityContext.enabled`      | Enabled Airflow web containers' Security Context                                                                         | `true`                |
 | `web.containerSecurityContext.runAsUser`    | Set Airflow web containers' Security Context runAsUser                                                                   | `1001`                |
 | `web.containerSecurityContext.runAsNonRoot` | Set Airflow web containers' Security Context runAsNonRoot                                                                | `true`                |
+| `web.lifecycleHooks`                        | for the Airflow web container(s) to automate configuration before or after startup                                       | `{}`                  |
 | `web.hostAliases`                           | Deployment pod host aliases                                                                                              | `[]`                  |
 | `web.podLabels`                             | Add extra labels to the Airflow web pods                                                                                 | `{}`                  |
 | `web.podAnnotations`                        | Add extra annotations to the Airflow web pods                                                                            | `{}`                  |
@@ -175,7 +183,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
 | `scheduler.image.registry`                        | Airflow Scheduler image registry                                                                                         | `docker.io`                 |
 | `scheduler.image.repository`                      | Airflow Scheduler image repository                                                                                       | `bitnami/airflow-scheduler` |
-| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.2.3-debian-10-r14`       |
+| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.2.4-debian-10-r31`       |
 | `scheduler.image.pullPolicy`                      | Airflow Scheduler image pull policy                                                                                      | `IfNotPresent`              |
 | `scheduler.image.pullSecrets`                     | Airflow Scheduler image pull secrets                                                                                     | `[]`                        |
 | `scheduler.image.debug`                           | Enable image debug mode                                                                                                  | `false`                     |
@@ -195,6 +203,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scheduler.containerSecurityContext.enabled`      | Enabled Airflow scheduler containers' Security Context                                                                   | `true`                      |
 | `scheduler.containerSecurityContext.runAsUser`    | Set Airflow scheduler containers' Security Context runAsUser                                                             | `1001`                      |
 | `scheduler.containerSecurityContext.runAsNonRoot` | Set Airflow scheduler containers' Security Context runAsNonRoot                                                          | `true`                      |
+| `scheduler.lifecycleHooks`                        | for the Airflow scheduler container(s) to automate configuration before or after startup                                 | `{}`                        |
 | `scheduler.hostAliases`                           | Deployment pod host aliases                                                                                              | `[]`                        |
 | `scheduler.podLabels`                             | Add extra labels to the Airflow scheduler pods                                                                           | `{}`                        |
 | `scheduler.podAnnotations`                        | Add extra annotations to the Airflow scheduler pods                                                                      | `{}`                        |
@@ -227,7 +236,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | `worker.image.registry`                        | Airflow Worker image registry                                                                                            | `docker.io`              |
 | `worker.image.repository`                      | Airflow Worker image repository                                                                                          | `bitnami/airflow-worker` |
-| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.2.3-debian-10-r14`    |
+| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.2.4-debian-10-r32`    |
 | `worker.image.pullPolicy`                      | Airflow Worker image pull policy                                                                                         | `IfNotPresent`           |
 | `worker.image.pullSecrets`                     | Airflow Worker image pull secrets                                                                                        | `[]`                     |
 | `worker.image.debug`                           | Enable image debug mode                                                                                                  | `false`                  |
@@ -266,6 +275,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.containerSecurityContext.enabled`      | Enabled Airflow worker containers' Security Context                                                                      | `true`                   |
 | `worker.containerSecurityContext.runAsUser`    | Set Airflow worker containers' Security Context runAsUser                                                                | `1001`                   |
 | `worker.containerSecurityContext.runAsNonRoot` | Set Airflow worker containers' Security Context runAsNonRoot                                                             | `true`                   |
+| `worker.lifecycleHooks`                        | for the Airflow worker container(s) to automate configuration before or after startup                                    | `{}`                     |
 | `worker.hostAliases`                           | Deployment pod host aliases                                                                                              | `[]`                     |
 | `worker.podLabels`                             | Add extra labels to the Airflow worker pods                                                                              | `{}`                     |
 | `worker.podAnnotations`                        | Add extra annotations to the Airflow worker pods                                                                         | `{}`                     |
@@ -305,7 +315,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------ | -------------------------------------------------------------------------------------- | ---------------------- |
 | `git.image.registry`           | Git image registry                                                                     | `docker.io`            |
 | `git.image.repository`         | Git image repository                                                                   | `bitnami/git`          |
-| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.34.1-debian-10-r39` |
+| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.35.1-debian-10-r57` |
 | `git.image.pullPolicy`         | Git image pull policy                                                                  | `IfNotPresent`         |
 | `git.image.pullSecrets`        | Git image pull secrets                                                                 | `[]`                   |
 | `git.dags.enabled`             | Enable in order to download DAG files from git repositories.                           | `false`                |
@@ -364,10 +374,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.annotations`              | Additional custom annotations for Airflow service                                                                                | `{}`                     |
 | `service.extraPorts`               | Extra port to expose on Airflow service                                                                                          | `[]`                     |
 | `ingress.enabled`                  | Enable ingress record generation for Airflow                                                                                     | `false`                  |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
 | `ingress.hostname`                 | Default host for the ingress record                                                                                              | `airflow.local`          |
-| `ingress.path`                     | Default path for the ingress record                                                                                              | `/pulse`                 |
+| `ingress.path`                     | Default path for the ingress record                                                                                              | `/`                      |
 | `ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                     |
 | `ingress.tls`                      | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                  |
 | `ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                  |
@@ -375,7 +386,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                     |
 | `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                     |
 | `ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`                     |
-| `networkPolicies.enabled`          | Switch to enable network policies                                                                                                | `false`                  |
 
 
 ### Other Parameters
@@ -384,7 +394,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------- | ---------------------------------------------------------------------- | ------- |
 | `serviceAccount.create`                       | Enable creation of ServiceAccount for Airflow pods                     | `false` |
 | `serviceAccount.name`                         | The name of the ServiceAccount to use.                                 | `""`    |
-| `serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created | `false` |
+| `serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created | `true`  |
 | `serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                   | `{}`    |
 | `rbac.create`                                 | Create Role and RoleBinding                                            | `false` |
 | `rbac.rules`                                  | Custom RBAC rules to set                                               | `[]`    |
@@ -392,48 +402,52 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Airflow metrics parameters
 
-| Name                                            | Description                                                                                       | Value                         |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------- |
-| `metrics.enabled`                               | Whether or not to create a standalone Airflow exporter to expose Airflow metrics                  | `false`                       |
-| `metrics.image.registry`                        | Airflow Exporter image registry                                                                   | `docker.io`                   |
-| `metrics.image.repository`                      | Airflow Exporter image repository                                                                 | `bitnami/airflow-exporter`    |
-| `metrics.image.tag`                             | Airflow Exporter image tag (immutable tags are recommended)                                       | `0.20210126.0-debian-10-r326` |
-| `metrics.image.pullPolicy`                      | Airflow Exporter image pull policy                                                                | `IfNotPresent`                |
-| `metrics.image.pullSecrets`                     | Airflow Exporter image pull secrets                                                               | `[]`                          |
-| `metrics.containerPorts.http`                   | Airflow exporter metrics container port                                                           | `9112`                        |
-| `metrics.resources.limits`                      | The resources limits for the container                                                            | `{}`                          |
-| `metrics.resources.requests`                    | The requested resources for the container                                                         | `{}`                          |
-| `metrics.podSecurityContext.enabled`            | Enable security context for the pods                                                              | `true`                        |
-| `metrics.podSecurityContext.fsGroup`            | Set Airflow Exporter pod's Security Context fsGroup                                               | `1001`                        |
-| `metrics.containerSecurityContext.enabled`      | Enable Airflow Exporter containers' Security Context                                              | `true`                        |
-| `metrics.containerSecurityContext.runAsUser`    | Set Airflow Exporter containers' Security Context runAsUser                                       | `1001`                        |
-| `metrics.containerSecurityContext.runAsNonRoot` | Set Airflow Exporter containers' Security Context runAsNonRoot                                    | `true`                        |
-| `metrics.hostAliases`                           | Airflow Exporter pods host aliases                                                                | `[]`                          |
-| `metrics.podLabels`                             | Extra labels for Airflow Exporter pods                                                            | `{}`                          |
-| `metrics.podAnnotations`                        | Extra annotations for Airflow Exporter pods                                                       | `{}`                          |
-| `metrics.podAffinityPreset`                     | Pod affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`       | `""`                          |
-| `metrics.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                        |
-| `metrics.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard` | `""`                          |
-| `metrics.nodeAffinityPreset.key`                | Node label key to match Ignored if `metrics.affinity` is set.                                     | `""`                          |
-| `metrics.nodeAffinityPreset.values`             | Node label values to match. Ignored if `metrics.affinity` is set.                                 | `[]`                          |
-| `metrics.affinity`                              | Affinity for pod assignment                                                                       | `{}`                          |
-| `metrics.nodeSelector`                          | Node labels for pod assignment                                                                    | `{}`                          |
-| `metrics.tolerations`                           | Tolerations for pod assignment                                                                    | `[]`                          |
-| `metrics.schedulerName`                         | Name of the k8s scheduler (other than default) for Airflow Exporter                               | `""`                          |
-| `metrics.service.ports.http`                    | Airflow Exporter metrics service port                                                             | `9112`                        |
-| `metrics.service.clusterIP`                     | Static clusterIP or None for headless services                                                    | `""`                          |
-| `metrics.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                  | `None`                        |
-| `metrics.service.annotations`                   | Annotations for the Airflow Exporter service                                                      | `{}`                          |
-| `metrics.serviceMonitor.enabled`                | if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.enabled` to be `true`) | `false`                       |
-| `metrics.serviceMonitor.namespace`              | Namespace in which Prometheus is running                                                          | `""`                          |
-| `metrics.serviceMonitor.interval`               | Interval at which metrics should be scraped                                                       | `""`                          |
-| `metrics.serviceMonitor.scrapeTimeout`          | Timeout after which the scrape is ended                                                           | `""`                          |
-| `metrics.serviceMonitor.labels`                 | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus             | `{}`                          |
-| `metrics.serviceMonitor.selector`               | Prometheus instance selector labels                                                               | `{}`                          |
-| `metrics.serviceMonitor.relabelings`            | RelabelConfigs to apply to samples before scraping                                                | `[]`                          |
-| `metrics.serviceMonitor.metricRelabelings`      | MetricRelabelConfigs to apply to samples before ingestion                                         | `[]`                          |
-| `metrics.serviceMonitor.honorLabels`            | Specify honorLabels parameter to add the scrape endpoint                                          | `false`                       |
-| `metrics.serviceMonitor.jobLabel`               | The name of the label on the target service to use as the job name in prometheus.                 | `""`                          |
+| Name                                            | Description                                                                                         | Value                        |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `metrics.enabled`                               | Whether or not to create a standalone Airflow exporter to expose Airflow metrics                    | `false`                      |
+| `metrics.image.registry`                        | Airflow exporter image registry                                                                     | `docker.io`                  |
+| `metrics.image.repository`                      | Airflow exporter image repository                                                                   | `bitnami/airflow-exporter`   |
+| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-10-r14` |
+| `metrics.image.pullPolicy`                      | Airflow exporter image pull policy                                                                  | `IfNotPresent`               |
+| `metrics.image.pullSecrets`                     | Airflow exporter image pull secrets                                                                 | `[]`                         |
+| `metrics.extraEnvVars`                          | Array with extra environment variables to add Airflow exporter pods                                 | `[]`                         |
+| `metrics.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow exporter pods                          | `""`                         |
+| `metrics.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow exporter pods | `""`                         |
+| `metrics.containerPorts.http`                   | Airflow exporter metrics container port                                                             | `9112`                       |
+| `metrics.resources.limits`                      | The resources limits for the container                                                              | `{}`                         |
+| `metrics.resources.requests`                    | The requested resources for the container                                                           | `{}`                         |
+| `metrics.podSecurityContext.enabled`            | Enable security context for the pods                                                                | `true`                       |
+| `metrics.podSecurityContext.fsGroup`            | Set Airflow exporter pod's Security Context fsGroup                                                 | `1001`                       |
+| `metrics.containerSecurityContext.enabled`      | Enable Airflow exporter containers' Security Context                                                | `true`                       |
+| `metrics.containerSecurityContext.runAsUser`    | Set Airflow exporter containers' Security Context runAsUser                                         | `1001`                       |
+| `metrics.containerSecurityContext.runAsNonRoot` | Set Airflow exporter containers' Security Context runAsNonRoot                                      | `true`                       |
+| `metrics.lifecycleHooks`                        | for the Airflow exporter container(s) to automate configuration before or after startup             | `{}`                         |
+| `metrics.hostAliases`                           | Airflow exporter pods host aliases                                                                  | `[]`                         |
+| `metrics.podLabels`                             | Extra labels for Airflow exporter pods                                                              | `{}`                         |
+| `metrics.podAnnotations`                        | Extra annotations for Airflow exporter pods                                                         | `{}`                         |
+| `metrics.podAffinityPreset`                     | Pod affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`         | `""`                         |
+| `metrics.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`    | `soft`                       |
+| `metrics.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`   | `""`                         |
+| `metrics.nodeAffinityPreset.key`                | Node label key to match Ignored if `metrics.affinity` is set.                                       | `""`                         |
+| `metrics.nodeAffinityPreset.values`             | Node label values to match. Ignored if `metrics.affinity` is set.                                   | `[]`                         |
+| `metrics.affinity`                              | Affinity for pod assignment                                                                         | `{}`                         |
+| `metrics.nodeSelector`                          | Node labels for pod assignment                                                                      | `{}`                         |
+| `metrics.tolerations`                           | Tolerations for pod assignment                                                                      | `[]`                         |
+| `metrics.schedulerName`                         | Name of the k8s scheduler (other than default) for Airflow exporter                                 | `""`                         |
+| `metrics.service.ports.http`                    | Airflow exporter metrics service port                                                               | `9112`                       |
+| `metrics.service.clusterIP`                     | Static clusterIP or None for headless services                                                      | `""`                         |
+| `metrics.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                    | `None`                       |
+| `metrics.service.annotations`                   | Annotations for the Airflow exporter service                                                        | `{}`                         |
+| `metrics.serviceMonitor.enabled`                | if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.enabled` to be `true`)   | `false`                      |
+| `metrics.serviceMonitor.namespace`              | Namespace in which Prometheus is running                                                            | `""`                         |
+| `metrics.serviceMonitor.interval`               | Interval at which metrics should be scraped                                                         | `""`                         |
+| `metrics.serviceMonitor.scrapeTimeout`          | Timeout after which the scrape is ended                                                             | `""`                         |
+| `metrics.serviceMonitor.labels`                 | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus               | `{}`                         |
+| `metrics.serviceMonitor.selector`               | Prometheus instance selector labels                                                                 | `{}`                         |
+| `metrics.serviceMonitor.relabelings`            | RelabelConfigs to apply to samples before scraping                                                  | `[]`                         |
+| `metrics.serviceMonitor.metricRelabelings`      | MetricRelabelConfigs to apply to samples before ingestion                                           | `[]`                         |
+| `metrics.serviceMonitor.honorLabels`            | Specify honorLabels parameter to add the scrape endpoint                                            | `false`                      |
+| `metrics.serviceMonitor.jobLabel`               | The name of the label on the target service to use as the job name in prometheus.                   | `""`                         |
 
 
 ### Airflow database parameters

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -100,6 +100,9 @@ data:
           volumeMounts:
             - name: k8s-executor-config
               mountPath: /opt/bitnami/airflow/k8s-executor-config
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | trim | nindent 8 }}
+        {{- end }}
         {{- if .Values.worker.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | trim | nindent 8 }}
         {{- end }}
@@ -122,11 +125,22 @@ data:
               value: {{ include "common.names.fullname" . }}
             - name: AIRFLOW_WEBSERVER_PORT_NUMBER
               value: {{ .Values.service.ports.http | quote }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
             {{- if .Values.worker.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsSecret }}
           envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+            {{- end }}
             {{- if .Values.worker.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ .Values.worker.extraEnvVarsCM }}
@@ -183,10 +197,16 @@ data:
               mountPath: /opt/bitnami/airflow/airflow.cfg
               subPath: airflow.cfg
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
             {{- if .Values.worker.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
             {{- include "airflow.git.maincontainer.volumeMounts" . | trim | nindent 12 }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | trim | nindent 8 }}
+        {{- end }}
         {{- if .Values.worker.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.sidecars "context" $) | trim | nindent 8 }}
         {{- end }}
@@ -202,6 +222,9 @@ data:
         - name: custom-configuration-file
           configMap:
             name: {{ include "airflow.configMapName"  . }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.worker.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -69,6 +69,9 @@ spec:
         {{- if .Values.dags.existingConfigmap }}
         {{- include "airflow.loadDAGsInitContainer" (dict "component" "scheduler" "context" . ) | trim | nindent 8 }}
         {{- end }}
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | trim | nindent 8 }}
+        {{- end }}
         {{- if .Values.scheduler.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.initContainers "context" $) | trim | nindent 8 }}
         {{- end }}
@@ -101,11 +104,22 @@ spec:
               value: {{ include "common.names.fullname" . }}
             - name: AIRFLOW_WEBSERVER_PORT_NUMBER
               value: {{ .Values.service.ports.http | quote }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
             {{- if .Values.scheduler.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           {{- if or .Values.scheduler.extraEnvVarsCM .Values.scheduler.extraEnvVarsSecret }}
           envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+            {{- end }}
             {{- if .Values.scheduler.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ .Values.scheduler.extraEnvVarsCM }}
@@ -133,45 +147,54 @@ spec:
           resources: {{- toYaml .Values.scheduler.resources | nindent 12 }}
           {{- end }}
           volumeMounts:
-          {{- if .Files.Glob "files/dags/*.py" }}
+            {{- if .Files.Glob "files/dags/*.py" }}
             - name: local-dag-files
               mountPath: /opt/bitnami/airflow/dags/local
-          {{- end }}
-          {{- if .Values.dags.existingConfigmap }}
+            {{- end }}
+            {{- if .Values.dags.existingConfigmap }}
             - name: external-dag-files
               mountPath: /opt/bitnami/airflow/dags/external
-          {{- end }}
-          {{- if or .Values.configuration .Values.existingConfigmap }}
+            {{- end }}
+            {{- if or .Values.configuration .Values.existingConfigmap }}
             - name: custom-configuration-file
               mountPath: /opt/bitnami/airflow/airflow.cfg
               subPath: airflow.cfg
-          {{- end }}
-          {{- if $kube }}
+            {{- end }}
+            {{- if $kube }}
             - name: custom-configuration-file
               mountPath: /opt/bitnami/airflow/pod_template.yaml
               subPath: pod_template.yaml
-          {{- end }}
-          {{- if .Values.scheduler.extraVolumeMounts }}
+            {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+            {{- if .Values.scheduler.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.extraVolumeMounts "context" $) | nindent 12 }}
-          {{- end }}
+            {{- end }}
             {{- include "airflow.git.maincontainer.volumeMounts" . | trim | nindent 12 }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | trim | nindent 8 }}
+        {{- end }}
         {{- if .Values.scheduler.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.sidecars "context" $) | trim | nindent 8 }}
         {{- end }}
       volumes:
-      {{- if .Values.dags.existingConfigmap }}
+        {{- if .Values.dags.existingConfigmap }}
         - name: load-external-dag-files
           configMap:
             name: {{ tpl .Values.dags.existingConfigmap $ }}
         - name: external-dag-files
           emptyDir: {}
-      {{- end }}
-      {{- if or .Values.configuration .Values.existingConfigmap $kube }}
+        {{- end }}
+        {{- if or .Values.configuration .Values.existingConfigmap $kube }}
         - name: custom-configuration-file
           configMap:
             name: {{ include "airflow.configMapName"  . }}
-      {{- end }}
-      {{- if .Values.scheduler.extraVolumes }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.scheduler.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.extraVolumes "context" $) | nindent 8 }}
-      {{- end }}
+        {{- end }}
         {{- include "airflow.git.volumes" . | trim | nindent 8 }}

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -68,6 +68,9 @@ spec:
         {{- if .Values.dags.existingConfigmap }}
         {{- include "airflow.loadDAGsInitContainer" (dict "component" "web" "context" . ) | trim | nindent 8 }}
         {{- end }}
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | trim | nindent 8 }}
+        {{- end }}
         {{- if .Values.web.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.web.initContainers "context" $) | trim | nindent 8 }}
         {{- end }}
@@ -144,11 +147,22 @@ spec:
               value: {{ include "airflow.ldapCAFilename" . | quote }}
             {{- end }}
             {{- end }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
             {{- if .Values.web.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.web.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           {{- if or .Values.web.extraEnvVarsCM .Values.web.extraEnvVarsSecret }}
           envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+            {{- end }}
             {{- if .Values.web.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ .Values.web.extraEnvVarsCM }}
@@ -226,10 +240,16 @@ spec:
               mountPath: /opt/bitnami/airflow/conf/certs/
               readOnly: true
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
             {{- if .Values.web.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.web.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
             {{- include "airflow.git.maincontainer.volumeMounts" . | trim | nindent 12 }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | trim | nindent 8 }}
+        {{- end }}
         {{- if .Values.web.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.web.sidecars "context" $) | trim | nindent 8 }}
         {{- end }}
@@ -256,6 +276,9 @@ spec:
           secret:
             secretName: {{ required "A secret containing the LDAP CA certificate. It is required when SSL in enabled" .Values.ldap.tls.CAcertificateSecret }}
             defaultMode: 256
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.web.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.web.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -73,6 +73,9 @@ spec:
         {{- if .Values.dags.existingConfigmap }}
         {{- include "airflow.loadDAGsInitContainer" (dict "component" "worker" "context" . ) | trim | nindent 8 }}
         {{- end }}
+        {{- if .Values.initContainers }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | trim | nindent 8 }}
+        {{- end }}
         {{- if .Values.worker.initContainers }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.initContainers "context" $) | trim | nindent 8 }}
         {{- end }}
@@ -104,11 +107,22 @@ spec:
               value: {{ include "common.names.fullname" . }}
             - name: AIRFLOW_WEBSERVER_PORT_NUMBER
               value: {{ .Values.service.ports.http | quote }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
             {{- if .Values.worker.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsSecret }}
           envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ .Values.extraEnvVarsCM }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ .Values.extraEnvVarsSecret }}
+            {{- end }}
             {{- if .Values.worker.extraEnvVarsCM }}
             - configMapRef:
                 name: {{ .Values.worker.extraEnvVarsCM }}
@@ -165,9 +179,15 @@ spec:
               subPath: airflow.cfg
             {{- end }}
             {{- include "airflow.git.maincontainer.volumeMounts" . | trim | nindent 12 }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
             {{- if .Values.worker.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.sidecars "context" $) | trim | nindent 8 }}
+        {{- end }}
         {{- if .Values.worker.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.sidecars "context" $) | trim | nindent 8 }}
         {{- end }}
@@ -183,6 +203,9 @@ spec:
         - name: custom-configuration-file
           configMap:
             name: {{ include "airflow.configMapName"  . }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.worker.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -127,6 +127,43 @@ dags:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
+## @param extraEnvVars Add extra environment variables for all the Airflow pods
+##
+extraEnvVars: []
+## @param extraEnvVarsCM ConfigMap with extra environment variables for all the Airflow pods
+##
+extraEnvVarsCM: ""
+## @param extraEnvVarsSecret Secret with extra environment variables for all the Airflow pods
+##
+extraEnvVarsSecret: ""
+## @param sidecars Add additional sidecar containers to all the Airflow pods
+## Example:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: []
+## @param initContainers Add additional init containers to all the Airflow pods
+## Example:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: []
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for all the Airflow pods
+##
+extraVolumeMounts: []
+## @param extraVolumes Optionally specify extra list of additional volumes for the all the Airflow pods
+##
+extraVolumes: []
 
 ## @section Airflow web parameters
 


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

**Description of the change**

Add values `extraEnvVars`, `extraEnvVarsCM`, `extraEnvVarsSecret`, `sidecars`, `initContainers`, `extraVolumeMounts` and `extraVolumes`, that applies the same name values but for all airflow pods.

These values, with the exception of `extraVolumes` and `extraVolumeMounts`, were accidentally removed during the standardisation: #8909

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #9579.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)