### PR TITLE
[bitnami/nginx-ingress-controller] Validation for autoscalling

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -26,4 +26,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 9.1.14
+version: 9.1.16

--- a/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.autoscaling.enabled (eq .Values.kind "Deployment") }}
+{{- if semverCompare "<1.23-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: autoscaling/v2beta1
+{{- else }}
+apiVersion: autoscaling/v2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "common.names.fullname" . }}

--- a/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.autoscaling.enabled (eq .Values.kind "Deployment") }}
-{{- if semverCompare "<1.23-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
 apiVersion: autoscaling/v2beta1
 {{- else }}
 apiVersion: autoscaling/v2


### PR DESCRIPTION
**Description of the change**

Added kubernetes version to euse the autoscalling v2 instead of v2beta.

**Checklist**
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)