### PR TITLE
[bitnami/nginx] possibility to add lifecycle hooks

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 9.9.7
+version: 9.10.7

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 9.10.7
+version: 9.10.0

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -122,6 +122,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `containerPorts.https`                  | Sets https port inside NGINX container                                                    | `""`    |
 | `resources.limits`                      | The resources limits for the NGINX container                                              | `{}`    |
 | `resources.requests`                    | The requested resources for the NGINX container                                           | `{}`    |
+| `lifecycle`                             | The lifecycle hooks for the NGINX container                                               | `{}`    |
 | `livenessProbe.enabled`                 | Enable livenessProbe                                                                      | `true`  |
 | `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                   | `30`    |
 | `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                          | `10`    |

--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -173,6 +173,9 @@ spec:
             - name: https
               containerPort: {{ .Values.containerPorts.https }}
             {{- end }}
+          {{- if .Values.lifecycle }}
+          lifecycle: {{- toYaml .Values.lifecycle | nindent 12 }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -216,6 +216,23 @@ resources:
   ##    cpu: 100m
   ##    memory: 128Mi
   requests: {}
+
+## NGINX containers' lifecycle hooks
+## ref: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
+## If you do want to specify lifecycle hooks, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces on 'lifecycle:{}'.
+lifecycle: {}
+  ## Example:
+  ## postStart:
+  ##   exec:
+  ##     command: ["/bin/sh", "-c", "echo Hello from the postStart handler > /usr/share/message"]
+  ## Example:
+  ## preStop:
+  ##   exec:
+  ##     command: ["/bin/sleep", "20"]
+  ##     command: ["/bin/sh","-c","nginx -s quit; while killall -0 nginx; do sleep 1; done"]
+
 ## NGINX containers' liveness probe.
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
 ## @param livenessProbe.enabled Enable livenessProbe

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 10.2.3
+version: 10.3.0

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -40,6 +40,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "bucketweb" "context" $) }}
+      automountServiceAccountToken: {{ .Values.bucketweb.automountServiceAccountToken }}
       {{- if .Values.bucketweb.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/compactor/deployment.yaml
+++ b/bitnami/thanos/templates/compactor/deployment.yaml
@@ -38,6 +38,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "compactor" "context" $) }}
+      automountServiceAccountToken: {{ .Values.compactor.automountServiceAccountToken }}
       {{- if .Values.compactor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/query-frontend/deployment.yaml
+++ b/bitnami/thanos/templates/query-frontend/deployment.yaml
@@ -45,6 +45,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "query-frontend" "context" $) }}
+      automountServiceAccountToken: {{ .Values.queryFrontend.automountServiceAccountToken }}
       {{- if .Values.queryFrontend.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -44,6 +44,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "query" "context" $) }}
+      automountServiceAccountToken: {{ .Values.query.automountServiceAccountToken }}
       {{- if .Values.query.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.query.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/receive-distributor/deployment.yaml
+++ b/bitnami/thanos/templates/receive-distributor/deployment.yaml
@@ -43,6 +43,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "receive" "context" $) }}
+      automountServiceAccountToken: {{ .Values.receiveDistributor.automountServiceAccountToken }}
       {{- if .Values.receiveDistributor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -45,6 +45,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "receive" "context" $) }}
+      automountServiceAccountToken: {{ .Values.receive.automountServiceAccountToken }}
       {{- if .Values.receive.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.receive.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -44,6 +44,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "ruler" "context" $) }}
+      automountServiceAccountToken: {{ .Values.ruler.automountServiceAccountToken }}
       {{- if .Values.ruler.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -59,6 +59,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" $ | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "storegateway" "context" $) }}
+      automountServiceAccountToken: {{ .Values.storegateway.automountServiceAccountToken }}      
       {{- if $.Values.storegateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -45,6 +45,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "storegateway" "context" $) }}
+      automountServiceAccountToken: {{ .Values.storegateway.automountServiceAccountToken }}            
       {{- if .Values.storegateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -440,6 +440,9 @@ query:
     ##
     additionalHeadless: false
   ## Autoscaling parameters
+  ## @param query.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the deployment
+  ##
+  automountServiceAccountToken: true
   ## ServiceAccount configuration
   ## @param query.serviceAccount.annotations Annotations for Thanos Query Service Account
   ## @param query.serviceAccount.existingServiceAccount Name for an existing Thanos Query Service Account
@@ -928,6 +931,9 @@ queryFrontend:
     ## @param queryFrontend.service.labelSelectorsOverride Selector for Thanos Query service
     ##
     labelSelectorsOverride: {}
+  ## @param queryFrontend.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the deployment
+  ##
+  automountServiceAccountToken: true
   ## ServiceAccount configuration
   ## @param queryFrontend.serviceAccount.annotations Annotations for Thanos Query Frontend Service Account
   ## @param queryFrontend.serviceAccount.existingServiceAccount Name for an existing Thanos Query Frontend Service Account
@@ -1329,6 +1335,9 @@ bucketweb:
     ## @param bucketweb.service.labelSelectorsOverride Selector for Thanos Query service
     ##
     labelSelectorsOverride: {}
+  ## @param bucketweb.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the deployment
+  ##
+  automountServiceAccountToken: true
   ## ServiceAccount configuration
   ## @param bucketweb.serviceAccount.annotations Annotations for Thanos Bucket Web Service Account
   ## @param bucketweb.serviceAccount.existingServiceAccount Name for an existing Thanos Bucket Web Service Account
@@ -1712,6 +1721,9 @@ compactor:
     ## @param compactor.service.labelSelectorsOverride Selector for Thanos Query service
     ##
     labelSelectorsOverride: {}
+  ## @param compactor.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the deployment
+  ##
+  automountServiceAccountToken: true
   ## ServiceAccount configuration
   ## @param compactor.serviceAccount.annotations Annotations for Thanos Compactor Service Account
   ## @param compactor.serviceAccount.existingServiceAccount Name for an existing Thanos Compactor Service Account
@@ -2165,6 +2177,9 @@ storegateway:
     ## If defined, PVC must be created manually before volume will be bound
     ##
     existingClaim: ""
+  ## @param storegateway.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the sts
+  ##
+  automountServiceAccountToken: true    
   ## ServiceAccount configuration
   ## @param storegateway.serviceAccount.annotations Annotations for Thanos Store Gateway Service Account
   ## @param storegateway.serviceAccount.existingServiceAccount Name for an existing Thanos Store Gateway Service Account
@@ -2738,6 +2753,9 @@ ruler:
     ## If defined, PVC must be created manually before volume will be bound
     ##
     existingClaim: ""
+  ## @param ruler.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the sts
+  ##
+  automountServiceAccountToken: true  
   ## ServiceAccount configuration
   ## @param ruler.serviceAccount.annotations Annotations for Thanos Ruler Service Account
   ## @param ruler.serviceAccount.existingServiceAccount Name for an existing Thanos Ruler Service Account
@@ -3173,6 +3191,9 @@ receive:
     ## @param receive.service.additionalHeadless Additional Headless service
     ##
     additionalHeadless: false
+  ## @param receive.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the sts
+  ##
+  automountServiceAccountToken: true
   ## ServiceAccount configuration
   ## @param receive.serviceAccount.annotations Annotations for Thanos Receive Service Account
   ## @param receive.serviceAccount.existingServiceAccount Name for an existing Thanos Receive Service Account
@@ -3537,6 +3558,9 @@ receiveDistributor:
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
   topologySpreadConstraints: []
+  ## @param receiveDistributor.automountServiceAccountToken Enable/disable auto mounting of the service account token only for the deployment
+  ##
+  automountServiceAccountToken: true  
   ## ServiceAccount configuration
   ## @param receiveDistributor.serviceAccount.annotations Annotations for Thanos Receive Distributor Service Account
   ## @param receiveDistributor.serviceAccount.existingServiceAccount Name for an existing Thanos Receive Distributor Service Account


### PR DESCRIPTION
**Description of the change**

Add the possibility to add lifecycle hooks: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
e.g. https://news.ycombinator.com/item?id=30771149 the implementation prevents ingress routes to send requests to terminating nginx which would else result in 502 errors.

**Benefits**
Following snippet provides a 100% uptime during a deployment restart of nginx with 2 replicas.

```
lifecycle:
  preStop:
    exec:
      command: ["/bin/sleep", "20"]
```
tested with 

`siege -v -H "Authorization: Bearer XXXXXXX" <URL> -c 2`

**Possible drawbacks**

Implementation of `{{- toYaml .Values.lifecycle | nindent 12 }}` fits best for different use-cases from my point of view but also could end in syntax errors if configured incorrectly.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)