### PR TITLE
[bitnami/redis] Support dnsConfig

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.7.0
+version: 16.7.1

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -178,6 +178,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.nodeSelector`                       | Node labels for Redis&trade; master pods assignment                                               | `{}`                     |
 | `master.tolerations`                        | Tolerations for Redis&trade; master pods assignment                                               | `[]`                     |
 | `master.topologySpreadConstraints`          | Spread Constraints for Redis&trade; master pod assignment                                         | `[]`                     |
+| `master.dnsConfig`                          | DNS configuration for Redis&trade; master pod                                                     | `{}`                     |
 | `master.lifecycleHooks`                     | for the Redis&trade; master container(s) to automate configuration before or after startup        | `{}`                     |
 | `master.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis&trade; master pod(s)            | `[]`                     |
 | `master.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis&trade; master container(s) | `[]`                     |
@@ -269,6 +270,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replica.nodeSelector`                       | Node labels for Redis&trade; replicas pods assignment                                               | `{}`                     |
 | `replica.tolerations`                        | Tolerations for Redis&trade; replicas pods assignment                                               | `[]`                     |
 | `replica.topologySpreadConstraints`          | Spread Constraints for Redis&trade; replicas pod assignment                                         | `[]`                     |
+| `replica.dnsConfig`                          | DNS configuration for Redis&trade; replica pod(s)                                                   | `{}`                     |
 | `replica.lifecycleHooks`                     | for the Redis&trade; replica container(s) to automate configuration before or after startup         | `{}`                     |
 | `replica.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis&trade; replicas pod(s)            | `[]`                     |
 | `replica.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis&trade; replicas container(s) | `[]`                     |

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -85,6 +85,9 @@ spec:
       {{- if .Values.master.schedulerName }}
       schedulerName: {{ .Values.master.schedulerName | quote }}
       {{- end }}
+      {{- if .Values.master.dnsConfig }}
+      dnsConfig: {{- include "common.tplvalues.render" (dict "value" .Values.master.dnsConfig "context" $) | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.master.terminationGracePeriodSeconds }}
       containers:
         - name: redis

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -84,6 +84,9 @@ spec:
       {{- if .Values.replica.schedulerName }}
       schedulerName: {{ .Values.replica.schedulerName | quote }}
       {{- end }}
+      {{- if .Values.replica.dnsConfig }}
+      dnsConfig: {{- include "common.tplvalues.render" (dict "value" .Values.replica.dnsConfig "context" $) | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.replica.terminationGracePeriodSeconds }}
       containers:
         - name: redis

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -83,6 +83,9 @@ spec:
       {{- if .Values.replica.schedulerName }}
       schedulerName: {{ .Values.replica.schedulerName | quote }}
       {{- end }}
+      {{- if .Values.replica.dnsConfig }}
+      dnsConfig: {{- include "common.tplvalues.render" (dict "value" .Values.replica.dnsConfig "context" $) | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.sentinel.terminationGracePeriodSeconds }}
       containers:
         - name: redis


### PR DESCRIPTION
**Description of the change**

Updated to optionally support specifying dnsConfig.  

**Benefits**

Sentinel perform quite a few dns resolves and tuning of DNS configuration can help to ensure resolves are handled as expected.

**Possible drawbacks**

None

**Applicable issues**

**Additional information**

**Checklist**
- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)