### PR TITLE
[bitnami/haproxy-intel] Add bitnami/haproxy-intel umbrella chart

### DIFF
--- a/.github/workflows/vib-publish.yaml
+++ b/.github/workflows/vib-publish.yaml
@@ -6,6 +6,7 @@ on: # rebuild any PRs and main branch changes
     paths:
       - 'bitnami/wordpress/Chart.yaml'
       - 'bitnami/grafana-loki/Chart.yaml'
+      - 'bitnami/haproxy-intel/Chart.yaml'
       - 'bitnami/sealed-secrets/Chart.yaml'
 env:
   CSP_API_URL: https://console.cloud.vmware.com

--- a/.vib/haproxy-intel/vib-publish.json
+++ b/.vib/haproxy-intel/vib-publish.json
@@ -1,0 +1,66 @@
+{
+  "phases": {
+    "package": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/haproxy-intel"
+        }
+      },
+      "actions": [
+        {
+          "action_id": "helm-package"
+        },
+        {
+          "action_id": "helm-lint"
+        }
+      ]
+    },
+    "verify": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/haproxy-intel"
+        },
+        "target_platform": {
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
+          "size": {
+            "name": "S4"
+          }
+        }
+      },
+      "actions": [
+        {
+          "action_id": "trivy",
+          "params": {
+            "threshold": "CRITICAL",
+            "vuln_type": [
+              "OS"
+            ]
+          }
+        },
+        {
+          "action_id": "health-check",
+          "params": {
+            "endpoint": "lb-haproxy-intel-http"
+          }
+        }
+      ]
+    },
+    "publish": {
+      "actions": [
+        {
+          "action_id": "helm-publish",
+          "params": {
+            "repository": {
+              "kind": "S3",
+              "url": "{VIB_ENV_S3_URL}",
+              "username": "{VIB_ENV_S3_USERNAME}",
+              "password": "{VIB_ENV_S3_PASSWORD}"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.vib/haproxy-intel/vib-publish.json
+++ b/.vib/haproxy-intel/vib-publish.json
@@ -22,6 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/haproxy-intel"
         },
+        "runtime_parameters": "aGFwcm94eToKICBzZXJ2aWNlOgogICAgdHlwZTogTG9hZEJhbGFuY2VyCiAgICBwb3J0czoKICAgICAgLSBuYW1lOiBodHRwCiAgICAgICAgcHJvdG9jb2w6IFRDUAogICAgICAgIHBvcnQ6IDgwCiAgICAgICAgdGFyZ2V0UG9ydDogaHR0cAo=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {

--- a/.vib/haproxy-intel/vib-verify.json
+++ b/.vib/haproxy-intel/vib-verify.json
@@ -1,0 +1,49 @@
+{
+  "phases": {
+    "package": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/haproxy-intel"
+        }
+      },
+      "actions": [
+        {
+          "action_id": "helm-package"
+        },
+        {
+          "action_id": "helm-lint"
+        }
+      ]
+    },
+    "verify": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/haproxy-intel"
+        },
+        "target_platform": {
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
+          "size": {
+            "name": "S4"
+          }
+        }
+      },
+      "actions": [
+        {
+          "action_id": "trivy",
+          "params": {
+            "threshold": "CRITICAL",
+            "vuln_type": ["OS"]
+          }
+        },
+        {
+          "action_id": "health-check",
+          "params": {
+            "endpoint": "lb-haproxy-intel-http"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.vib/haproxy-intel/vib-verify.json
+++ b/.vib/haproxy-intel/vib-verify.json
@@ -22,6 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/haproxy-intel"
         },
+        "runtime_parameters": "aGFwcm94eToKICBzZXJ2aWNlOgogICAgdHlwZTogTG9hZEJhbGFuY2VyCiAgICBwb3J0czoKICAgICAgLSBuYW1lOiBodHRwCiAgICAgICAgcHJvdG9jb2w6IFRDUAogICAgICAgIHBvcnQ6IDgwCiAgICAgICAgdGFyZ2V0UG9ydDogaHR0cAo=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {

--- a/bitnami/haproxy-intel/Chart.lock
+++ b/bitnami/haproxy-intel/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: haproxy
   repository: https://charts.bitnami.com/bitnami
-  version: 0.3.10
+  version: 0.3.23
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.12.0
-digest: sha256:93fb393a22f1e23b5405f65fd6e270a3f32c1a7cb075d6c3cec1029f82e3b7f2
-generated: "2022-03-24T15:54:02.090104+01:00"
+  version: 1.14.1
+digest: sha256:a02b9572941593879628986e4739268be4600672d93d8da40b81a8653ea7777b
+generated: "2022-05-25T15:14:27.12995+02:00"

--- a/bitnami/haproxy-intel/Chart.lock
+++ b/bitnami/haproxy-intel/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: haproxy
+  repository: https://charts.bitnami.com/bitnami
+  version: 0.3.10
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.12.0
+digest: sha256:93fb393a22f1e23b5405f65fd6e270a3f32c1a7cb075d6c3cec1029f82e3b7f2
+generated: "2022-03-24T15:54:02.090104+01:00"

--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -1,0 +1,31 @@
+annotations:
+  category: Infrastructure
+apiVersion: v2
+appVersion: 2.5.3
+dependencies:
+- name: haproxy
+  repository: https://charts.bitnami.com/bitnami
+  version: 0.x.x
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  tags:
+  - bitnami-common
+  version: 1.x.x
+description: HAProxy is a TCP proxy and a HTTP reverse proxy. It supports SSL termination
+  and offloading, TCP and HTTP normalization, traffic regulation, caching and protection
+  against DDoS attacks.
+home: https://www.haproxy.org/
+icon: https://bitnami.com/assets/stacks/haproxy/img/haproxy-stack-220x234.png
+keywords:
+- haproxy
+- proxy
+- infrastructure
+- intel
+maintainers:
+- email: containers@bitnami.com
+  name: Bitnami
+name: haproxy-intel
+sources:
+- https://github.com/bitnami/bitnami-docker-haproxy-intel
+- https://github.com/haproxytech/haproxy
+version: 0.1.0

--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 2.5.3
+appVersion: 2.5.7
 dependencies:
 - name: haproxy
   repository: https://charts.bitnami.com/bitnami

--- a/bitnami/haproxy-intel/README.md
+++ b/bitnami/haproxy-intel/README.md
@@ -63,15 +63,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
 
-### HAProxy parameters
+### HAProxy chart parameters
 
-| Name                        | Description                                        | Value                                       |
-| --------------------------- | -------------------------------------------------- | ------------------------------------------- |
-| `haproxy.image.registry`    | HAProxy image registry                             | `projects.registry.vmware.com/mktp-giralda` |
-| `haproxy.image.repository`  | HAProxy image repository                           | `bitnami/haproxy-intel`                     |
-| `haproxy.image.tag`         | HAProxy image tag (immutable tags are recommended) | `2.5.3-r0`                                  |
-| `haproxy.image.pullPolicy`  | HAProxy image pull policy                          | `IfNotPresent`                              |
-| `haproxy.image.pullSecrets` | HAProxy image pull secrets                         | `[]`                                        |
+| Name                        | Description                                        | Value                   |
+| --------------------------- | -------------------------------------------------- | ----------------------- |
+| `haproxy.image.registry`    | HAProxy image registry                             | `docker.io`             |
+| `haproxy.image.repository`  | HAProxy image repository                           | `bitnami/haproxy-intel` |
+| `haproxy.image.tag`         | HAProxy image tag (immutable tags are recommended) | `2.5.7-debian-10-r4`    |
+| `haproxy.image.pullPolicy`  | HAProxy image pull policy                          | `IfNotPresent`          |
+| `haproxy.image.pullSecrets` | HAProxy image pull secrets                         | `[]`                    |
 
 
 HAProxy is installed as a subchart, meaning that the whole list of parameters is defined in [bitnami/haproxy](https://github.com/bitnami/charts/tree/master/bitnami/haproxy). Please, note that parameters from the subchart should be prefixed with `haproxy.` in this chart.

--- a/bitnami/haproxy-intel/README.md
+++ b/bitnami/haproxy-intel/README.md
@@ -1,0 +1,159 @@
+<!--- app-name: HAProxy for Intel -->
+
+# HAProxy for Intel packaged by Bitnami
+
+HAProxy is a TCP proxy and a HTTP reverse proxy. It supports SSL termination and offloading, TCP and HTTP normalization, traffic regulation, caching and protection against DDoS attacks.
+
+[Overview of HAProxy](http://www.haproxy.org/)
+
+Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
+                           
+## TL;DR
+
+```console
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm install my-release bitnami/haproxy-intel --render-subchart-notes
+```
+
+## Introduction
+
+Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
+
+This chart bootstraps a [HAProxy](https://github.com/haproxytech/haproxy) Deployment in a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This Helm chart has been tested on top of [Bitnami Kubernetes Production Runtime](https://kubeprod.io/) (BKPR). Deploy BKPR to get automated TLS certificates, logging and monitoring for your applications.
+
+[Learn more about the default configuration of the chart](https://docs.bitnami.com/kubernetes/infrastructure/haproxy/get-started/).
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+helm install my-release bitnami/haproxy-intel
+```
+
+The command deploys haproxy on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `""`  |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
+
+
+### HAProxy parameters
+
+| Name                        | Description                                        | Value                                       |
+| --------------------------- | -------------------------------------------------- | ------------------------------------------- |
+| `haproxy.image.registry`    | HAProxy image registry                             | `projects.registry.vmware.com/mktp-giralda` |
+| `haproxy.image.repository`  | HAProxy image repository                           | `bitnami/haproxy-intel`                     |
+| `haproxy.image.tag`         | HAProxy image tag (immutable tags are recommended) | `2.5.3-r0`                                  |
+| `haproxy.image.pullPolicy`  | HAProxy image pull policy                          | `IfNotPresent`                              |
+| `haproxy.image.pullSecrets` | HAProxy image pull secrets                         | `[]`                                        |
+
+
+HAProxy is installed as a subchart, meaning that the whole list of parameters is defined in [bitnami/haproxy](https://github.com/bitnami/charts/tree/master/bitnami/haproxy). Please, note that parameters from the subchart should be prefixed with `haproxy.` in this chart.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+helm install my-release \
+  --set haproxy.service.type=LoadBalancer \
+    bitnami/haproxy-intel --render-subchart-notes
+```
+
+The above command sets the HAProxy service type as LoadBalancer.
+
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+helm install my-release -f values.yaml bitnami/haproxy-intel --render-subchart-notes
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Configuration and installation details
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Configure HAProxy
+
+By default, HAProxy is deployed with a sample, non-functional, configuration. You will need to edit the following values to adapt it to your use case:
+
+* Set the configuration to be injected in the `haproxy.cfg` file by changing the `haproxy.configuration` parameter. Alternatively, you can provide an existing ConfigMap with `haproxy.cfg` by using the `haproxy.existingConfigmap` parameter.
+* Based on your HAProxy configuration, edit the `haproxy.containerPorts` and `haproxy.service.ports` parameters. In the `haproxy.containerPorts` parameter, set all the ports that the HAProxy configuration uses, and in the `haproxy.service.ports` parameter, set the ports to be externally exposed.
+
+Refer to the [chart documentation for a more detailed configuration example](https://docs.bitnami.com/kubernetes/infrastructure/haproxy/get-started/configure-proxy).
+
+### Add extra environment variables
+
+To add extra environment variables (useful for advanced operations like custom init scripts), use the `haproxy.extraEnvVars` property.
+
+```yaml
+haproxy:
+  extraEnvVars:
+    - name: LOG_LEVEL
+      value: error
+```
+
+Alternatively, use a ConfigMap or a Secret with the environment variables. To do so, use the `haproxy.extraEnvVarsCM` or the `haproxy.extraEnvVarsSecret` values.
+
+### Use Sidecars and Init Containers
+
+If additional containers are needed in the same pod (such as additional metrics or logging exporters), they can be defined using the `haproxy.sidecars` config parameter. Similarly, extra init containers can be added using the `haproxy.initContainers` parameter.
+
+Refer to the chart documentation for more information on, and examples of, configuring and using [sidecars and init containers](https://docs.bitnami.com/kubernetes/infrastructure/haproxy/configuration/configure-sidecar-init-containers/).
+
+### Set Pod affinity
+
+This chart allows you to set custom Pod affinity using the `haproxy.affinity` parameter. Find more information about Pod affinity in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, use one of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `haproxy.podAffinityPreset`, `haproxy.podAntiAffinityPreset`, or `haproxy.nodeAffinityPreset` parameters.
+
+## Troubleshooting
+
+Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## License
+
+Copyright &copy; 2022 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/bitnami/haproxy-intel/README.md
+++ b/bitnami/haproxy-intel/README.md
@@ -2,7 +2,7 @@
 
 # HAProxy for Intel packaged by Bitnami
 
-HAProxy is a TCP proxy and a HTTP reverse proxy. It supports SSL termination and offloading, TCP and HTTP normalization, traffic regulation, caching and protection against DDoS attacks.
+HAProxy is a high-performance, open-source load balancer and reverse proxy for TCP and HTTP applications. This image is optimized with Intel® QuickAssist Technology OpenSSL* Engine (QAT_Engine).
 
 [Overview of HAProxy](http://www.haproxy.org/)
 
@@ -85,6 +85,8 @@ helm install my-release \
 ```
 
 The above command sets the HAProxy service type as LoadBalancer.
+
+You can use the `configuration` or `existingConfigmap` parameters to set your own configuration file. You can read more about configuration in the [container's readme](https://github.com/bitnami/bitnami-docker-haproxy-intel#configuration).
 
 > NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
 

--- a/bitnami/haproxy-intel/ci/ct-values.yaml
+++ b/bitnami/haproxy-intel/ci/ct-values.yaml
@@ -1,3 +1,0 @@
-haproxy:
-  service:
-    type: ClusterIP

--- a/bitnami/haproxy-intel/ci/ct-values.yaml
+++ b/bitnami/haproxy-intel/ci/ct-values.yaml
@@ -1,0 +1,3 @@
+haproxy:
+  service:
+    type: ClusterIP

--- a/bitnami/haproxy-intel/templates/NOTES.txt
+++ b/bitnami/haproxy-intel/templates/NOTES.txt
@@ -1,0 +1,7 @@
+CHART NAME: {{ .Chart.Name }}
+CHART VERSION: {{ .Chart.Version }}
+APP VERSION: {{ .Chart.AppVersion }}
+
+** Please be patient while the chart is being deployed **
+
+This chart deploys HA Proxy as a subchart. To display the notes for the subcharts, please add the '--render-subchart-notes' to your install command.

--- a/bitnami/haproxy-intel/values.yaml
+++ b/bitnami/haproxy-intel/values.yaml
@@ -33,7 +33,7 @@ haproxy:
   image:
     registry: docker.io
     repository: bitnami/haproxy-intel
-    tag: 2.5.7-r4
+    tag: 2.5.7-debian-10-r4
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/haproxy-intel/values.yaml
+++ b/bitnami/haproxy-intel/values.yaml
@@ -33,7 +33,7 @@ haproxy:
   image:
     registry: docker.io
     repository: bitnami/haproxy-intel
-    tag: 2.5.3-r0
+    tag: 2.5.7-r4
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/haproxy-intel/values.yaml
+++ b/bitnami/haproxy-intel/values.yaml
@@ -1,0 +1,49 @@
+## @section Global parameters
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+##
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry: ""
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass: ""
+
+## @section HAProxy chart parameters
+## Parameters for the bitnami/haproxy chart deployed by this chart
+## For a full list, see: https://github.com/bitnami/charts/tree/master/bitnami/haproxy
+## Note that parameters from the bitnami/haproxy chart should be prefixed with 'haproxy.'
+##
+
+## @param haproxy.image.registry HAProxy image registry
+## @param haproxy.image.repository HAProxy image repository
+## @param haproxy.image.tag HAProxy image tag (immutable tags are recommended)
+## @param haproxy.image.pullPolicy HAProxy image pull policy
+## @param haproxy.image.pullSecrets HAProxy image pull secrets
+##
+haproxy:
+  image:
+    registry: projects.registry.vmware.com/mktp-giralda
+    repository: bitnami/haproxy-intel
+    tag: 2.5.3-r0
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []

--- a/bitnami/haproxy-intel/values.yaml
+++ b/bitnami/haproxy-intel/values.yaml
@@ -31,7 +31,7 @@ global:
 ##
 haproxy:
   image:
-    registry: projects.registry.vmware.com/mktp-giralda
+    registry: docker.io
     repository: bitnami/haproxy-intel
     tag: 2.5.3-r0
     ## Specify a imagePullPolicy


### PR DESCRIPTION
Signed-off-by: Alejandro Moreno <amorenoc@vmware.com>

**Description of the change**
Add an umbrella chart for the HAProxy chart that uses an Intel optimized image instead for HAProxy.

**Benefits**
- New chart added to the catalog.
- Umbrella approach makes it easier to maintain.

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)