### PR TITLE
[bitnami/rabbitmq] Allow both definitions and setting credentials

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.30.4
+version: 8.31.0

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -62,14 +62,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### RabbitMQ Image parameters
 
-| Name                | Description                                                    | Value                  |
-| ------------------- | -------------------------------------------------------------- | ---------------------- |
-| `image.registry`    | RabbitMQ image registry                                        | `docker.io`            |
-| `image.repository`  | RabbitMQ image repository                                      | `bitnami/rabbitmq`     |
-| `image.tag`         | RabbitMQ image tag (immutable tags are recommended)            | `3.9.13-debian-10-r38` |
-| `image.pullPolicy`  | RabbitMQ image pull policy                                     | `IfNotPresent`         |
-| `image.pullSecrets` | Specify docker-registry secret names as an array               | `[]`                   |
-| `image.debug`       | Set to true if you would like to see extra information on logs | `false`                |
+| Name                | Description                                                    | Value                 |
+| ------------------- | -------------------------------------------------------------- | --------------------- |
+| `image.registry`    | RabbitMQ image registry                                        | `docker.io`           |
+| `image.repository`  | RabbitMQ image repository                                      | `bitnami/rabbitmq`    |
+| `image.tag`         | RabbitMQ image tag (immutable tags are recommended)            | `3.9.14-debian-10-r5` |
+| `image.pullPolicy`  | RabbitMQ image pull policy                                     | `IfNotPresent`        |
+| `image.pullSecrets` | Specify docker-registry secret names as an array               | `[]`                  |
+| `image.debug`       | Set to true if you would like to see extra information on logs | `false`               |
 
 
 ### Common parameters
@@ -116,6 +116,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `clustering.forceBoot`             | Force boot of an unexpectedly shut down cluster (in an unexpected order).                                                                | `false`                                           |
 | `clustering.partitionHandling`     | Switch Partition Handling Strategy. Either `autoheal` or `pause-minority` or `pause-if-all-down` or `ignore`                             | `autoheal`                                        |
 | `loadDefinition.enabled`           | Enable loading a RabbitMQ definitions file to configure RabbitMQ                                                                         | `false`                                           |
+| `loadDefinition.file`              | Name of the definitions file                                                                                                             | `/app/load_definition.json`                       |
 | `loadDefinition.existingSecret`    | Existing secret with the load definitions file                                                                                           | `""`                                              |
 | `command`                          | Override default container command (useful when using custom images)                                                                     | `[]`                                              |
 | `args`                             | Override default container args (useful when using custom images)                                                                        | `[]`                                              |
@@ -296,7 +297,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`            | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                     | `docker.io`             |
 | `volumePermissions.image.repository`   | Init container volume-permissions image repository                                                                   | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                          | `10-debian-10-r349`     |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                          | `10-debian-10-r378`     |
 | `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                  | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                     | `[]`                    |
 | `volumePermissions.resources.limits`   | Init container volume-permissions resource limits                                                                    | `{}`                    |

--- a/bitnami/rabbitmq/templates/secrets.yaml
+++ b/bitnami/rabbitmq/templates/secrets.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if and (not .Values.auth.existingPasswordSecret) (not .Values.loadDefinition.enabled) }}
+  {{- if not .Values.auth.existingPasswordSecret }}
   {{- if .Values.auth.password }}
   rabbitmq-password: {{ .Values.auth.password | b64enc | quote }}
   {{- else }}

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -183,11 +183,12 @@ spec:
             {{- if .Values.loadDefinition.enabled }}
             - name: RABBITMQ_LOAD_DEFINITIONS
               value: "yes"
-            - name: RABBITMQ_SECURE_PASSWORD
-              value: "no"
+            - name: RABBITMQ_DEFINITIONS_FILE
+              value: {{ .Values.loadDefinition.file | quote }}
             {{- else }}
             - name: RABBITMQ_LOAD_DEFINITIONS
               value: "no"
+            {{- end }}
             - name: RABBITMQ_SECURE_PASSWORD
               value: "yes"
             - name: RABBITMQ_USERNAME
@@ -197,7 +198,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "rabbitmq.secretPasswordName" . }}
                   key: rabbitmq-password
-            {{- end }}
             - name: RABBITMQ_PLUGINS
               value: {{ include "rabbitmq.plugins" . | quote }}
             {{- if .Values.communityPlugins }}

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -180,15 +180,10 @@ spec:
             - name: RABBITMQ_CLUSTER_REBALANCE
               value: "true"
             {{- end }}
-            {{- if .Values.loadDefinition.enabled }}
             - name: RABBITMQ_LOAD_DEFINITIONS
-              value: "yes"
+              value: {{ ternary "yes" "no" .Values.loadDefinition.enabled | quote }}
             - name: RABBITMQ_DEFINITIONS_FILE
               value: {{ .Values.loadDefinition.file | quote }}
-            {{- else }}
-            - name: RABBITMQ_LOAD_DEFINITIONS
-              value: "no"
-            {{- end }}
             - name: RABBITMQ_SECURE_PASSWORD
               value: "yes"
             - name: RABBITMQ_USERNAME

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -30,7 +30,7 @@ global:
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.9.14-debian-10-r5
+  tag: 3.9.14-debian-10-r10
 
   ## set to true if you would like to see extra information on logs
   ## It turns BASH and/or NAMI debugging in the image
@@ -1178,7 +1178,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r378
+    tag: 10-debian-10-r382
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -2,6 +2,7 @@
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+##
 
 ## @param global.imageRegistry Global Docker image registry
 ## @param global.imagePullSecrets Global Docker registry secret names as an array
@@ -51,6 +52,7 @@ image:
   pullSecrets: []
 
 ## @section Common parameters
+##
 
 ## @param nameOverride String to partially override rabbitmq.fullname template (will maintain the release name)
 ##
@@ -229,6 +231,9 @@ loadDefinition:
   ## @param loadDefinition.enabled Enable loading a RabbitMQ definitions file to configure RabbitMQ
   ##
   enabled: false
+  ## @para loadDefinition.file Name of the definitions file
+  ##
+  file: "/app/load_definition.json"
   ## @param loadDefinition.existingSecret Existing secret with the load definitions file
   ## Can be templated if needed, e.g:
   ## existingSecret: "{{ .Release.Name }}-load-definition"
@@ -239,6 +244,7 @@ loadDefinition:
 ##
 command: []
 ## @param args Override default container args (useful when using custom images)
+##
 args: []
 
 ## @param terminationGracePeriodSeconds Default duration in seconds k8s waits for container to exit before sending kill signal.
@@ -275,12 +281,10 @@ extraContainerPorts: []
 ## To add more configuration, use `extraConfiguration` of `advancedConfiguration` instead
 ##
 configuration: |-
-  {{- if not .Values.loadDefinition.enabled -}}
   ## Username and password
   ##
   default_user = {{ .Values.auth.username }}
   default_pass = CHANGEME
-  {{- end }}
   {{- if .Values.clustering.enabled }}
   ## Clustering
   ##
@@ -289,6 +293,9 @@ configuration: |-
   cluster_formation.node_cleanup.interval = 10
   cluster_formation.node_cleanup.only_log_warning = true
   cluster_partition_handling = {{ .Values.clustering.partitionHandling }}
+  {{- end }}
+  {{- if .Values.loadDefinition.enabled }}
+  load_definitions = {{ .Values.loadDefinition.file }}
   {{- end }}
   # queue master locator
   queue_master_locator = min-masters
@@ -333,7 +340,6 @@ configuration: |-
 extraConfiguration: |-
   #default_vhost = {{ .Release.Namespace }}-vhost
   #disk_free_limit.absolute = 50MB
-  #load_definitions = /app/load_definition.json
 
 ## @param advancedConfiguration Configuration file content: advanced configuration
 ## Use this as additional configuration in classic config format (Erlang term configuration format)
@@ -409,6 +415,7 @@ extraSecrets: {}
 extraSecretsPrependReleaseName: false
 
 ## @section Statefulset parameters
+##
 
 ## @param replicaCount Number of RabbitMQ replicas to deploy
 ##
@@ -543,11 +550,13 @@ resources:
   ## limits:
   ##    cpu: 1000m
   ##    memory: 2Gi
+  ##
   limits: {}
   ## Examples:
   ## requests:
   ##    cpu: 1000m
   ##    memory: 2Gi
+  ##
   requests: {}
 
 ## Configure RabbitMQ containers' extra options for liveness probe
@@ -635,6 +644,7 @@ pdb:
   maxUnavailable: ""
 
 ## @section RBAC parameters
+##
 
 ## RabbitMQ pods ServiceAccount
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -662,6 +672,7 @@ rbac:
   create: true
 
 ## @section Persistence parameters
+##
 
 persistence:
   ## @param persistence.enabled Enable RabbitMQ data persistence using PVC
@@ -717,6 +728,7 @@ persistence:
   annotations: {}
 
 ## @section Exposure parameters
+##
 
 ## Kubernetes service type
 ##
@@ -726,6 +738,7 @@ service:
   type: ClusterIP
 
   ## @param service.portEnabled Amqp port. Cannot be disabled when `auth.tls.enabled` is `false`. Listener can be disabled with `listeners.tcp = none`.
+  ##
   portEnabled: true
 
   ## @param service.port Amqp port
@@ -1002,6 +1015,7 @@ networkPolicy:
   additionalRules: []
 
 ## @section Metrics Parameters
+##
 
 ## Prometheus Metrics
 ##
@@ -1067,6 +1081,7 @@ metrics:
     podTargetLabels: {}
     ## @param metrics.serviceMonitor.path Define the path used by ServiceMonitor to scrap metrics
     ## Could be /metrics for aggregated metrics or /metrics/per-object for more details
+    ##
     path: ""
 
   ## Custom PrometheusRule to be defined
@@ -1144,6 +1159,7 @@ metrics:
     rules: []
 
 ## @section Init Container Parameters
+##
 
 ## Init Container parameters
 ## Change the owner and group of the persistent volume(s) mountpoint(s) to 'runAsUser:fsGroup' on each component
@@ -1189,9 +1205,11 @@ volumePermissions:
     ## limits:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     limits: {}
     ## Examples:
     ## requests:
     ##    cpu: 100m
     ##    memory: 128Mi
+    ##
     requests: {}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -231,7 +231,7 @@ loadDefinition:
   ## @param loadDefinition.enabled Enable loading a RabbitMQ definitions file to configure RabbitMQ
   ##
   enabled: false
-  ## @para loadDefinition.file Name of the definitions file
+  ## @param loadDefinition.file Name of the definitions file
   ##
   file: "/app/load_definition.json"
   ## @param loadDefinition.existingSecret Existing secret with the load definitions file


### PR DESCRIPTION
Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Up until now, the load definitions and the RabbitMQ credentials were incompatible. In the latest revision of the container we will allow setting both elements. If the "users" section inside the loadDefinitions file is set, then the credentials will be ignored.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/charts/issues/5976

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)