### PR TITLE
Handle auth.existingSecret as a template.

### DIFF
--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -122,7 +122,7 @@ Get the credentials secret.
 */}}
 {{- define "minio.secretName" -}}
 {{- if .Values.auth.existingSecret -}}
-    {{- printf "%s" .Values.auth.existingSecret -}}
+    {{- printf "%s" (tpl .Values.auth.existingSecret $) -}}
 {{- else -}}
     {{- printf "%s" (include "common.names.fullname" .) -}}
 {{- end -}}


### PR DESCRIPTION
The scope of the change is nearly insignificant. However, it does allow for other charts to more easily define secrets.