### PR TITLE
[bitnami/elasticsearch] Make metrics work again in non-TLS clusters

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 17.9.22
+version: 17.9.23

--- a/bitnami/elasticsearch/templates/metrics-deploy.yaml
+++ b/bitnami/elasticsearch/templates/metrics-deploy.yaml
@@ -41,7 +41,7 @@ spec:
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else }}
           args:
-            {{- $protocol := (ternary "https" "http" .Values.security.tls.restEncryption) }}
+            {{- $protocol := (ternary "https" "http" (and .Values.security.enabled .Values.security.tls.restEncryption)) }}
             {{- if gt (int .Values.coordinating.replicas) 0 }}
             # Prefer coordinating only nodes to do the initial metrics query
             - --es.uri={{$protocol}}://{{ template "elasticsearch.coordinating.fullname" . }}:{{ .Values.coordinating.service.port }}


### PR DESCRIPTION
With the current combination of defaults it will be impossible for the metrics pod to connect unless at least one of these settings has been altered.