### PR TITLE
[bitnami/zookeeper] set zookeeper directory ownership to 1001

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 9.0.4
+version: 9.0.5

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -85,7 +85,7 @@ spec:
             - -ec
             - |
               mkdir -p /bitnami/zookeeper
-              find /bitnami/zookeeper -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
+              find /bitnami -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" -name "zookeeper" | xargs -r chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
               {{- if .Values.dataLogDir }}
               mkdir -p {{ .Values.dataLogDir }}
               find {{ .Values.dataLogDir }} -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}


### PR DESCRIPTION
**Description of the change**
In order for zookeeper process to be able to create the `data` directory, the `zookeeper` directory should be owned by user `1001`
Fixes startup error:
```
mkdir: cannot create directory ‘data’: Permission denied
```
Issue reproducible when PV is of `hostPath` on minikube / kubernetes setup by kubeadm
```
helm install my-release zookeeper --set volumePermissions.enabled=true
```

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)