### PR TITLE
[bitnami/cassandra] Fix typo in Certificate Handling

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -23,4 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/bitnami-docker-cassandra
   - http://cassandra.apache.org
-version: 9.1.15
+version: 9.1.16

--- a/bitnami/cassandra/templates/_helpers.tpl
+++ b/bitnami/cassandra/templates/_helpers.tpl
@@ -235,7 +235,7 @@ otherwise it generates a new one.
     {{- if $tlsCert }}
         {{- $ca = (get $tlsCert "ca.crt" | b64dec) -}}
         {{- $crt = (get $tlsCert "tls.crt" | b64dec) -}}
-        {{- $key = (get $tlsCert "tls.keye" | b64dec) -}}
+        {{- $key = (get $tlsCert "tls.key" | b64dec) -}}
     {{- else -}}
         {{- $caFull := genCA "cassandra-ca" 365 }}
         {{- $fullname := include "common.names.fullname" . }}


### PR DESCRIPTION
Dear Bitnami-Team,

we are using the Cassandra-Helm chart with autogenerated Certificates.
However, after every update, we encounter the following Error with the `init-certs`-Container

```
unable to load private key
140359890613568:error:0909006C:PEM routines:get_name:no start line:../crypto/pem/pem_lib.c:745:Expecting: ANY PRIVATE KEY
stream closed
```

The reason can be found in the `cassandra-crt`-Secret
The Key-Section is empty.

The Reason is a typo here:
https://github.com/bitnami/charts/blob/master/bitnami/cassandra/templates/_helpers.tpl#L238

please also see
https://github.com/bitnami/charts/issues/9687

## This PR will
* fix the typo in `templates/_helpers.tpl`

Signed-off-by: Espe0n <christoph.andre89@gmx.de>

**Description of the change**

Fix of a Typo in `templates/_helpers.tpl`
```
        {{- $key = (get $tlsCert "tls.keye" | b64dec) -}}
```
To
```
        {{- $key = (get $tlsCert "tls.key" | b64dec) -}}
```

**Benefits**
Certificate generation should not result in an empty Private-Key-Field

**Possible drawbacks**
-

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #9687

**Additional information**
-

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] ~~Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)~~ (Not applicable)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)