### PR TITLE
[bitnami/grafana-operator] Add missing RBAC resource for OpenShift routes

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 2.3.5
+version: 2.3.6

--- a/bitnami/grafana-operator/templates/rbac.yaml
+++ b/bitnami/grafana-operator/templates/rbac.yaml
@@ -228,6 +228,7 @@ rules:
       - route.openshift.io
     resources:
       - routes
+      - routes/custom-host
     verbs:
       - create
       - delete


### PR DESCRIPTION
Add missing RBAC resource for OpenShift routes with custom hostnames (routes/custom-host)

**Description of the change**
Addresses this issue #9731
In this commit https://github.com/bitnami/charts/commit/d87dec202858e218f08470a8a28d5397426b6a6c?diff=split#r70792073 the resource "routes/custom-host" has been removed from the RBAC configuration.
We assume this is a mistake, the official grafana-operator RBAC configuration contains this resource https://github.com/grafana-operator/grafana-operator/blob/v4.2.0/config/rbac/role.yaml#L154

**Benefits**

Allows the grafana-operator to manage OpenShift routes with custom hostnames again

**Applicable issues**

  - fixes  #9731

**Additional information**

We were uncertain whether this PR

**Checklist**
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)]