### PR TITLE
bitnami/grafana-tempo Add extraPorts value to query-frontend headless service

### DIFF
--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -28,4 +28,4 @@ name: grafana-tempo
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana-tempo
   - https://github.com/grafana/tempo/
-version: 1.0.18
+version: 1.0.19

--- a/bitnami/grafana-tempo/templates/query-frontend/headless-service.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/headless-service.yaml
@@ -25,5 +25,8 @@ spec:
       port: {{ .Values.queryFrontend.service.ports.grpc }}
       targetPort: grpc
       protocol: TCP
+    {{- if .Values.queryFrontend.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend


### PR DESCRIPTION
**Description of the change**

In `bitnami/grafana-tempo` Helm chart, copy/paste extraPorts customization from query-frontend service manifest to query-frontend headless service manifest.

**Benefits**

This configuration is mandatory in order to fix an error raised by Tempo Querier. This error can be reproduced with chart version 1.0.18, seen in Querier Deployment logs: msg="failed DNS SRV record lookup" err="lookup _grpclb._tcp.tempo-query-frontend-headless on 10.X.0.X:53: no such host".

The fix for this error is to add this lines in the chart values:

```yaml
  queryFrontend:
    service:
      extraPorts:
        - name: grpclb
          port: 9096
          targetPort: grpc
          protocol: TCP
```

**Possible drawbacks**

None.

**Applicable issues**

None reported.

**Additional information**

None.

**Checklist**

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)