### PR TITLE
[bitnami/spark] Provide environment variables to driver command

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -22,4 +22,4 @@ name: spark
 sources:
   - https://github.com/bitnami/bitnami-docker-spark
   - https://spark.apache.org/
-version: 5.9.8
+version: 5.9.9

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -7,7 +7,7 @@ Apache Spark is a high-performance engine for large-scale computing tasks, such 
 [Overview of Apache Spark](https://spark.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-
+                           
 ## TL;DR
 
 ```console

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -7,7 +7,7 @@ Apache Spark is a high-performance engine for large-scale computing tasks, such 
 [Overview of Apache Spark](https://spark.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -297,13 +297,14 @@ These values can be set at the same time in a single ConfigMap or using two Conf
 
 To submit an application to the Apache Spark cluster, use the `spark-submit` script, which is available at [https://github.com/apache/spark/tree/master/bin](https://github.com/apache/spark/tree/master/bin).
 
-The command below illustrates the process of deploying one of the sample applications included with Apache Spark. Replace the `k8s-apiserver-host` and `k8s-apiserver-port` placeholders with the correct master host/IP address and port for your deployment.
+The command below illustrates the process of deploying one of the sample applications included with Apache Spark. Replace the `k8s-apiserver-host`, `k8s-apiserver-port`, `spark-master-svc`, and `spark-master-port` placeholders with the correct master host/IP address and port for your deployment.
 
 ```bash
 $ ./bin/spark-submit \
     --class org.apache.spark.examples.SparkPi \
     --conf spark.kubernetes.container.image=bitnami/spark:3 \
     --master k8s://https://k8s-apiserver-host:k8s-apiserver-port \
+    --conf spark.kubernetes.driverEnv.SPARK_MASTER_URL=spark://spark-master-svc:spark-master-port \
     --deploy-mode cluster \
     ./examples/jars/spark-examples_2.12-3.2.0.jar 1000
 ```

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -58,7 +58,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/spark
-  tag: 3.2.1-debian-10-r64
+  tag: 3.2.1-debian-10-r71
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: Gonzalo Gomez Gracia <gonzalog@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Update the 'submit an application' section by adding the `spark.kubernetes.driverEnv.SPARK_MASTER_URL` config parameter for the new driver pod to properly find the spark master service.

**Benefits**

Example works.

**Possible drawbacks**

Not expected.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Related to [bitnami-docker-spark/issues/56](https://github.com/bitnami/bitnami-docker-spark/issues/56)

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)