### PR TITLE
[bitnami/thanos] fix(thanos-storegateway): error in accessed value

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 10.3.3
+version: 10.3.4

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -59,7 +59,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" $ | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "storegateway" "context" $) }}
-      automountServiceAccountToken: {{ .Values.storegateway.automountServiceAccountToken }}      
+      automountServiceAccountToken: {{ $.Values.storegateway.automountServiceAccountToken }}      
       {{- if $.Values.storegateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
**Description of the change**

Ever since https://github.com/bitnami/charts/commit/ebc73d5903e68e731ae3a3a651ccd9bc8cec8a1f it is no longer possible to install thanos with a sharded storegateway. The following error is printed:

```
│ Error: template: thanos/templates/storegateway/statefulset-sharded.yaml:62:46: executing "thanos/templates/storegateway/statefulset-sharded.yaml" at <.Values.storegateway.automountServiceAccountToken>: can't evaluate field Values in type int
```

**Benefits**

This PR should make the chart installable again.

**Possible drawbacks**

N/A

**Applicable issues**

N/A

**Additional information**

N/A

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)