### PR TITLE
[bitnami/nginx bitnami/nginx-intel] Clarify nginx-ldap-auth-daemon deprecation

### DIFF
--- a/bitnami/nginx-intel/README.md
+++ b/bitnami/nginx-intel/README.md
@@ -358,7 +358,7 @@ This major release no longer uses the bitnami/nginx-ldap-auth-daemon container a
 
 Bitnami’s NGINX Intel Helm chart from version 0.0.1 to 0.1.11 includes a `ldapDaemon.enabled` option **disabled by default** that allows to configure it with the [bitnami-docker-nginx-ldap-auth-daemon](https://github.com/bitnami/bitnami-docker-nginx-ldap-auth-daemon) following [NGINX’s reference implementation](https://www.nginx.com/blog/nginx-plus-authenticate-users/).
 
-On 9 April 2022, security vulnerabilities in the [NGINX LDAP reference implementation](https://github.com/nginxinc/nginx-ldap-auth) were publicly shared. *Although the deprecation of this container from the Bitnami catalog was not related to this security issue, [here](https://docs.bitnami.com/general/security/security-2022_04_12/) you can find more information from the Bitnami security team*
+On 9 April 2022, security vulnerabilities in the [NGINX LDAP reference implementation](https://github.com/nginxinc/nginx-ldap-auth) were publicly shared. **Although the deprecation of this container from the Bitnami catalog was not related to this security issue, [here](https://docs.bitnami.com/general/security/security-2022_04_12/) you can find more information from the Bitnami security team.**
 
 ## Bitnami Kubernetes Documentation
 

--- a/bitnami/nginx-intel/README.md
+++ b/bitnami/nginx-intel/README.md
@@ -7,7 +7,7 @@ NGINX Open Source for Intel is a lightweight server, combined with cryptography 
 [Overview of NGINX Open Source for Intel](https://github.com/intel/asynch_mode_nginx)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -353,6 +353,12 @@ Find more information about how to deal with common errors related to Bitnami's 
 ### To 1.0.0
 
 This major release no longer uses the bitnami/nginx-ldap-auth-daemon container as a dependency since its upstream project is not actively maintained.
+
+*2022-04-12 edit*:
+
+Bitnami’s NGINX Intel Helm chart from version 0.0.1 to 0.1.11 includes a `ldapDaemon.enabled` option **disabled by default** that allows to configure it with the [bitnami-docker-nginx-ldap-auth-daemon](https://github.com/bitnami/bitnami-docker-nginx-ldap-auth-daemon) following [NGINX’s reference implementation](https://www.nginx.com/blog/nginx-plus-authenticate-users/).
+
+On 9 April 2022, security vulnerabilities in the [NGINX LDAP reference implementation](https://github.com/nginxinc/nginx-ldap-auth) were publicly shared. *Although the deprecation of this container from the Bitnami catalog was not related to this security issue, [here](https://docs.bitnami.com/general/security/security-2022_04_12/) you can find more information from the Bitnami security team*
 
 ## Bitnami Kubernetes Documentation
 

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -361,7 +361,7 @@ This major release no longer uses the bitnami/nginx-ldap-auth-daemon container a
 
 Bitnami’s NGINX Helm chart from version 5.6.0 to 9.9.9 includes a `ldapDaemon.enabled` option **disabled by default** that allows to configure it with the [bitnami-docker-nginx-ldap-auth-daemon](https://github.com/bitnami/bitnami-docker-nginx-ldap-auth-daemon) following [NGINX’s reference implementation](https://www.nginx.com/blog/nginx-plus-authenticate-users/).
 
-On 9 April 2022, security vulnerabilities in the [NGINX LDAP reference implementation](https://github.com/nginxinc/nginx-ldap-auth) were publicly shared. *Although the deprecation of this container from the Bitnami catalog was not related to this security issue, [here](https://docs.bitnami.com/general/security/security-2022_04_12/) you can find more information from the Bitnami security team*
+On 9 April 2022, security vulnerabilities in the [NGINX LDAP reference implementation](https://github.com/nginxinc/nginx-ldap-auth) were publicly shared. **Although the deprecation of this container from the Bitnami catalog was not related to this security issue, [here](https://docs.bitnami.com/general/security/security-2022_04_12/) you can find more information from the Bitnami security team.**
 
 ### To 8.0.0
 

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -7,7 +7,7 @@ NGINX Open Source is a web server that can be also used as a reverse proxy, load
 [Overview of NGINX Open Source](http://nginx.org)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+ 
 ## TL;DR
 
 ```bash
@@ -356,6 +356,12 @@ Find more information about how to deal with common errors related to Bitnami's 
 ### To 10.0.0
 
 This major release no longer uses the bitnami/nginx-ldap-auth-daemon container as a dependency since its upstream project is not actively maintained.
+
+*2022-04-12 edit*:
+
+Bitnami’s NGINX Helm chart from version 5.6.0 to 9.9.9 includes a `ldapDaemon.enabled` option **disabled by default** that allows to configure it with the [bitnami-docker-nginx-ldap-auth-daemon](https://github.com/bitnami/bitnami-docker-nginx-ldap-auth-daemon) following [NGINX’s reference implementation](https://www.nginx.com/blog/nginx-plus-authenticate-users/).
+
+On 9 April 2022, security vulnerabilities in the [NGINX LDAP reference implementation](https://github.com/nginxinc/nginx-ldap-auth) were publicly shared. *Although the deprecation of this container from the Bitnami catalog was not related to this security issue, [here](https://docs.bitnami.com/general/security/security-2022_04_12/) you can find more information from the Bitnami security team*
 
 ### To 8.0.0
 


### PR DESCRIPTION
Update the note for the major version bump adding more info about the deprecation of the container that has coincided in time with a security bug in the same component