### PR TITLE
[bitnami/thanos] Add support for specifying objstore as YAML object

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Analytics
 apiVersion: v2
-appVersion: 0.25.2
+appVersion: 0.26.0
 dependencies:
   - condition: minio.enabled
     name: minio

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Analytics
 apiVersion: v2
-appVersion: 0.26.0
+appVersion: 0.25.2
 dependencies:
   - condition: minio.enabled
     name: minio
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 10.3.4
+version: 10.4.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -111,7 +111,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | ----------------------------- | ----------------------------------------------------------------------------------------- | ------------------- |
 | `image.registry`              | Thanos image registry                                                                     | `docker.io`         |
 | `image.repository`            | Thanos image repository                                                                   | `bitnami/thanos`    |
-| `image.tag`                   | Thanos image tag (immutable tags are recommended)                                         | `0.25.0-scratch-r1` |
+| `image.tag`                   | Thanos image tag (immutable tags are recommended)                                         | `0.25.2-scratch-r2` |
 | `image.pullPolicy`            | Thanos image pull policy                                                                  | `IfNotPresent`      |
 | `image.pullSecrets`           | Specify docker-registry secret names as an array                                          | `[]`                |
 | `objstore`                    | The [objstore configuration](https://thanos.io/tip/thanos/storage.md/)                    | `{}`                |
@@ -220,6 +220,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `query.service.extraPorts`                                | Extra ports to expose in the Thanos Query service                                                                                       | `[]`                     |
 | `query.service.labelSelectorsOverride`                    | Selector for Thanos Query service                                                                                                       | `{}`                     |
 | `query.service.additionalHeadless`                        | Additional Headless service                                                                                                             | `false`                  |
+| `query.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the deployment                                                       | `true`                   |
 | `query.serviceAccount.annotations`                        | Annotations for Thanos Query Service Account                                                                                            | `{}`                     |
 | `query.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Query Service Account                                                                                       | `""`                     |
 | `query.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                               | `true`                   |
@@ -336,6 +337,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `queryFrontend.service.annotations`                               | Annotations for Thanos Query Frontend service                                                                                    | `{}`                     |
 | `queryFrontend.service.extraPorts`                                | Extra ports to expose in the Thanos Query Frontend service                                                                       | `[]`                     |
 | `queryFrontend.service.labelSelectorsOverride`                    | Selector for Thanos Query service                                                                                                | `{}`                     |
+| `queryFrontend.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the deployment                                                | `true`                   |
 | `queryFrontend.serviceAccount.annotations`                        | Annotations for Thanos Query Frontend Service Account                                                                            | `{}`                     |
 | `queryFrontend.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Query Frontend Service Account                                                                       | `""`                     |
 | `queryFrontend.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                        | `true`                   |
@@ -440,6 +442,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `bucketweb.service.annotations`                               | Annotations for Thanos Bucket Web service                                                                                        | `{}`                     |
 | `bucketweb.service.extraPorts`                                | Extra ports to expose in the Thanos Bucket Web service                                                                           | `[]`                     |
 | `bucketweb.service.labelSelectorsOverride`                    | Selector for Thanos Query service                                                                                                | `{}`                     |
+| `bucketweb.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the deployment                                                | `true`                   |
 | `bucketweb.serviceAccount.annotations`                        | Annotations for Thanos Bucket Web Service Account                                                                                | `{}`                     |
 | `bucketweb.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Bucket Web Service Account                                                                           | `""`                     |
 | `bucketweb.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                        | `true`                   |
@@ -542,6 +545,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `compactor.service.annotations`                               | Annotations for Thanos Compactor service                                                                                         | `{}`                     |
 | `compactor.service.extraPorts`                                | Extra ports to expose in the Thanos Compactor service                                                                            | `[]`                     |
 | `compactor.service.labelSelectorsOverride`                    | Selector for Thanos Query service                                                                                                | `{}`                     |
+| `compactor.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the deployment                                                | `true`                   |
 | `compactor.serviceAccount.annotations`                        | Annotations for Thanos Compactor Service Account                                                                                 | `{}`                     |
 | `compactor.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Compactor Service Account                                                                            | `""`                     |
 | `compactor.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                        | `true`                   |
@@ -657,6 +661,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `storegateway.persistence.size`                                  | PVC Storage Request for data volume                                                                                                      | `8Gi`                       |
 | `storegateway.persistence.annotations`                           | Annotations for the PVC                                                                                                                  | `{}`                        |
 | `storegateway.persistence.existingClaim`                         | Name of an existing PVC to use                                                                                                           | `""`                        |
+| `storegateway.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the sts                                                               | `true`                      |
 | `storegateway.serviceAccount.annotations`                        | Annotations for Thanos Store Gateway Service Account                                                                                     | `{}`                        |
 | `storegateway.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Store Gateway Service Account                                                                                | `""`                        |
 | `storegateway.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                                | `true`                      |
@@ -793,6 +798,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `ruler.persistence.size`                                  | PVC Storage Request for data volume                                                                                              | `8Gi`                    |
 | `ruler.persistence.annotations`                           | Annotations for the PVC                                                                                                          | `{}`                     |
 | `ruler.persistence.existingClaim`                         | Name of an existing PVC to use                                                                                                   | `""`                     |
+| `ruler.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the sts                                                       | `true`                   |
 | `ruler.serviceAccount.annotations`                        | Annotations for Thanos Ruler Service Account                                                                                     | `{}`                     |
 | `ruler.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Ruler Service Account                                                                                | `""`                     |
 | `ruler.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                        | `true`                   |
@@ -909,6 +915,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `receive.service.extraPorts`                                | Extra ports to expose in the Thanos Receive service                                                                              | `[]`                     |
 | `receive.service.labelSelectorsOverride`                    | Selector for Thanos receive service                                                                                              | `{}`                     |
 | `receive.service.additionalHeadless`                        | Additional Headless service                                                                                                      | `false`                  |
+| `receive.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the sts                                                       | `true`                   |
 | `receive.serviceAccount.annotations`                        | Annotations for Thanos Receive Service Account                                                                                   | `{}`                     |
 | `receive.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Receive Service Account                                                                              | `""`                     |
 | `receive.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                        | `true`                   |
@@ -1006,6 +1013,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `receiveDistributor.priorityClassName`                                 | Thanos Receive Distributor priorityClassName                                                                                | `""`            |
 | `receiveDistributor.schedulerName`                                     | Name of the k8s scheduler (other than default) for Thanos Receive Distributor pods                                          | `""`            |
 | `receiveDistributor.topologySpreadConstraints`                         | Topology Spread Constraints for Thanos Receive Distributor pods assignment spread across your cluster among failure-domains | `[]`            |
+| `receiveDistributor.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the deployment                                           | `true`          |
 | `receiveDistributor.serviceAccount.annotations`                        | Annotations for Thanos Receive Distributor Service Account                                                                  | `{}`            |
 | `receiveDistributor.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Receive Distributor Service Account                                                             | `""`            |
 | `receiveDistributor.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                   | `true`          |
@@ -1046,7 +1054,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `volumePermissions.enabled`           | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`    | Init container volume-permissions image registry                                                | `docker.io`             |
 | `volumePermissions.image.repository`  | Init container volume-permissions image repository                                              | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`         | Init container volume-permissions image tag                                                     | `10-debian-10-r358`     |
+| `volumePermissions.image.tag`         | Init container volume-permissions image tag                                                     | `10-debian-10-r387`     |
 | `volumePermissions.image.pullPolicy`  | Init container volume-permissions image pull policy                                             | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets` | Specify docker-registry secret names as an array                                                | `[]`                    |
 

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -114,6 +114,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `image.tag`                   | Thanos image tag (immutable tags are recommended)                                         | `0.25.0-scratch-r1` |
 | `image.pullPolicy`            | Thanos image pull policy                                                                  | `IfNotPresent`      |
 | `image.pullSecrets`           | Specify docker-registry secret names as an array                                          | `[]`                |
+| `objstore`                    | The [objstore configuration](https://thanos.io/tip/thanos/storage.md/)                    | `{}`                |
 | `objstoreConfig`              | The [objstore configuration](https://thanos.io/tip/thanos/storage.md/)                    | `""`                |
 | `indexCacheConfig`            | The [index cache configuration](https://thanos.io/tip/components/store.md/)               | `""`                |
 | `bucketCacheConfig`           | The [bucket cache configuration](https://thanos.io/tip/components/store.md/)              | `""`                |

--- a/bitnami/thanos/ci/values-with-bucketweb-compactor-storegateway-and-minio-objstore.yaml
+++ b/bitnami/thanos/ci/values-with-bucketweb-compactor-storegateway-and-minio-objstore.yaml
@@ -1,0 +1,28 @@
+# Test values file for generating all of the yaml and check that
+# the rendering is correct
+
+objstoreConfig:
+  type: s3
+  config:
+    bucket: thanos
+    endpoint: "{{ include "thanos.minio.fullname" . }}.monitoring.svc.cluster.local:9000"
+    access_key: minio
+    secret_key: minio123
+    insecure: true
+
+bucketweb:
+  enabled: true
+
+compactor:
+  enabled: true
+
+storegateway:
+  enabled: true
+
+minio:
+  enabled: true
+  accessKey:
+    password: "minio"
+  secretKey:
+    password: "minio123"
+  defaultBuckets: "thanos"

--- a/bitnami/thanos/ci/values-with-bucketweb-compactor-storegateway-and-minio-objstore.yaml
+++ b/bitnami/thanos/ci/values-with-bucketweb-compactor-storegateway-and-minio-objstore.yaml
@@ -5,7 +5,8 @@ objstore:
   type: s3
   config:
     bucket: thanos
-    endpoint: "{{ include "thanos.minio.fullname" . }}.monitoring.svc.cluster.local:9000"
+    endpoint: |-
+      {{ include "thanos.minio.fullname" . }}.monitoring.svc.cluster.local:9000
     access_key: minio
     secret_key: minio123
     insecure: true

--- a/bitnami/thanos/ci/values-with-bucketweb-compactor-storegateway-and-minio-objstore.yaml
+++ b/bitnami/thanos/ci/values-with-bucketweb-compactor-storegateway-and-minio-objstore.yaml
@@ -1,7 +1,7 @@
 # Test values file for generating all of the yaml and check that
 # the rendering is correct
 
-objstoreConfig:
+objstore:
   type: s3
   config:
     bucket: thanos

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -52,7 +52,7 @@ Return the Thanos Objstore configuration secret.
 Return true if a secret object should be created
 */}}
 {{- define "thanos.createObjstoreSecret" -}}
-{{- if and (or .Values.objstoreConfig  .Values.objstore) (not .Values.existingObjstoreSecret) }}
+{{- if and (or .Values.objstoreConfig .Values.objstore) (not .Values.existingObjstoreSecret) }}
     {{- true -}}
 {{- else -}}
 {{- end -}}

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -52,7 +52,7 @@ Return the Thanos Objstore configuration secret.
 Return true if a secret object should be created
 */}}
 {{- define "thanos.createObjstoreSecret" -}}
-{{- if and .Values.objstoreConfig (not .Values.existingObjstoreSecret) }}
+{{- if and (or .Values.objstoreConfig  .Values.objstore) (not .Values.existingObjstoreSecret) }}
     {{- true -}}
 {{- else -}}
 {{- end -}}
@@ -203,7 +203,7 @@ thanos: objstore configuration
     When enabling Bucket Web, Compactor, Ruler, Store or Receive Gateway component,
     you must provide a valid objstore configuration.
     There are three alternatives to provide it:
-      1) Provide it using the 'objstoreConfig' parameter
+      1) Provide it using the 'objstore' or 'objstoreConfig' parameter
       2) Provide it using an existing Secret and using the 'existingObjstoreSecret' parameter
       3) Put your objstore.yml under the 'files/conf/' directory
 {{- end -}}

--- a/bitnami/thanos/templates/objstore-secret.yaml
+++ b/bitnami/thanos/templates/objstore-secret.yaml
@@ -10,7 +10,8 @@ metadata:
     {{- end }}
 data:
 {{- if .Values.objstore }}
-  objstore.yml: {{- toYaml .Values.objstore | b64enc | nindent 4 }}
+  objstore.yml:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.objstore "context" $) | b64enc | nindent 4 }}
 {{- else }}
   objstore.yml: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.objstoreConfig "context" $) | b64enc | nindent 4 }}

--- a/bitnami/thanos/templates/objstore-secret.yaml
+++ b/bitnami/thanos/templates/objstore-secret.yaml
@@ -23,3 +23,4 @@ data:
   bucket-cache.yml: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.bucketCacheConfig "context" $) | b64enc | nindent 4 }}
 {{- end }}
+{{ end }}

--- a/bitnami/thanos/templates/objstore-secret.yaml
+++ b/bitnami/thanos/templates/objstore-secret.yaml
@@ -9,8 +9,12 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
 data:
+{{- if .Values.objstore }}
+  objstore.yml: {{- toYaml .Values.objstore | b64enc | nindent 4 }}
+{{- else }}
   objstore.yml: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.objstoreConfig "context" $) | b64enc | nindent 4 }}
+{{- end }}
 {{- if .Values.indexCacheConfig }}
   index-cache.yml: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.indexCacheConfig "context" $) | b64enc | nindent 4 }}
@@ -19,4 +23,3 @@ data:
   bucket-cache.yml: |-
     {{- include "common.tplvalues.render" (dict "value" .Values.bucketCacheConfig "context" $) | b64enc | nindent 4 }}
 {{- end }}
-{{ end }}

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -66,6 +66,9 @@ image:
   ##   - myRegistryKeySecretName
   ##
   pullSecrets: []
+## @param objstore The [objstore configuration](https://thanos.io/tip/thanos/storage.md/)
+##
+objstore: {}
 ## @param objstoreConfig The [objstore configuration](https://thanos.io/tip/thanos/storage.md/)
 ## Specify content for objstore.yml
 ##


### PR DESCRIPTION
Signed-off-by: Devin Buhl <devin@buhl.casa>

**Description of the change**

Add support for specifying objStore as YAML object

**Benefits**

Allows for specifying `objstore` as an object not a multiline string e.g.

```yaml
objstore:
  type: s3
  config:
    bucket: thanos
    endpoint: https://minio.awesome
    access_key: minio
    secret_key: minio123
    insecure: false
```

More importantly, this allows for specifying config that can be used with Flux `valuesFrom` in a `Helmrelease`, this is helpful when consuming an existing secret and configmap that is created by Ceph `ObjectBucketClaim`

e.g.

```yaml
---
apiVersion: helm.toolkit.fluxcd.io/v2beta1
kind: HelmRelease
metadata:
  name: thanos
  namespace: monitoring
spec:
  interval: 5m
  chart:
    spec:
      chart: thanos
      version: 10.3.3
      sourceRef:
        kind: HelmRepository
        name: bitnami-charts
        namespace: flux-system
      interval: 5m
  install:
    createNamespace: true
  values:
    objstore:
      type: s3
      config:
        insecure: true
...
  valuesFrom:
    - kind: ConfigMap
      name: thanos-ceph-bucket
      valuesKey: BUCKET_NAME
      targetPath: objstore.config.bucket
    - kind: ConfigMap
      name: thanos-ceph-bucket
      valuesKey: BUCKET_HOST
      targetPath: objstore.config.endpoint
    - kind: ConfigMap
      name: thanos-ceph-bucket
      valuesKey: BUCKET_REGION
      targetPath: objstore.config.region
    - kind: Secret
      name: thanos-ceph-bucket
      valuesKey: AWS_ACCESS_KEY_ID
      targetPath: objstore.config.access_key
    - kind: Secret
      name: thanos-ceph-bucket
      valuesKey: AWS_SECRET_ACCESS_KEY
      targetPath: objstore.config.secret_key
```

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)