### PR TITLE
[bitnami/mediawiki] enable service accounts

### DIFF
--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -32,4 +32,4 @@ name: mediawiki
 sources:
   - https://github.com/bitnami/bitnami-docker-mediawiki
   - https://www.mediawiki.org/
-version: 13.0.20
+version: 13.1.0

--- a/bitnami/mediawiki/README.md
+++ b/bitnami/mediawiki/README.md
@@ -111,6 +111,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                    | Description                                                                               | Value                                             |
 | --------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | `updateStrategy.type`                   | StrategyType can be set to RollingUpdate or OnDelete                                      | `RollingUpdate`                                   |
+| `podServiceAccount.name    `            | Existing ServiceAccount to assign to the pod                                              | `""`                                              |
+| `podServiceAccount.automountToken`      | Whether or not to automount the Service Account Token                                     | `true`                                           |
 | `podSecurityContext.enabled`            | Enable Mediawiki pods' Security Context                                                   | `true`                                            |
 | `podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                       | `1001`                                            |
 | `containerSecurityContext.enabled`      | Enable Mediawiki containers' SecurityContext                                              | `true`                                            |

--- a/bitnami/mediawiki/README.md
+++ b/bitnami/mediawiki/README.md
@@ -78,32 +78,32 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Mediawiki parameters
 
-| Name                 | Description                                                                      | Value                  |
-| -------------------- | -------------------------------------------------------------------------------- | ---------------------- |
-| `image.registry`     | MediaWiki image registry                                                         | `docker.io`            |
-| `image.repository`   | MediaWiki image repository                                                       | `bitnami/mediawiki`    |
-| `image.tag`          | MediaWiki image tag (immutable tags are recommended)                             | `1.37.1-debian-10-r20` |
-| `image.pullPolicy`   | Image pull policy                                                                | `IfNotPresent`         |
-| `image.pullSecrets`  | Specify docker-registry secret names as an array                                 | `[]`                   |
-| `image.debug`        | Enable MediaWiki image debug mode                                                | `false`                |
-| `hostAliases`        | Deployment pod host aliases                                                      | `[]`                   |
-| `mediawikiUser`      | User of the application                                                          | `user`                 |
-| `mediawikiPassword`  | Application password                                                             | `""`                   |
-| `mediawikiEmail`     | Admin email                                                                      | `user@example.com`     |
-| `mediawikiName`      | Name for the wiki                                                                | `My Wiki`              |
-| `mediawikiHost`      | Mediawiki host to create application URLs                                        | `""`                   |
-| `allowEmptyPassword` | Allow DB blank passwords                                                         | `yes`                  |
-| `smtpHost`           | SMTP host                                                                        | `""`                   |
-| `smtpPort`           | SMTP port                                                                        | `""`                   |
-| `smtpHostID`         | SMTP host ID                                                                     | `""`                   |
-| `smtpUser`           | SMTP user                                                                        | `""`                   |
-| `smtpPassword`       | SMTP password                                                                    | `""`                   |
-| `command`            | Override default container command (useful when using custom images)             | `[]`                   |
-| `args`               | Override default container args (useful when using custom images)                | `[]`                   |
-| `lifecycleHooks`     | for the Mediawiki container(s) to automate configuration before or after startup | `{}`                   |
-| `extraEnvVars`       | Extra environment variables to be set on Mediawki container                      | `[]`                   |
-| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars                             | `""`                   |
-| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars                                | `""`                   |
+| Name                 | Description                                                                      | Value                 |
+| -------------------- | -------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`     | MediaWiki image registry                                                         | `docker.io`           |
+| `image.repository`   | MediaWiki image repository                                                       | `bitnami/mediawiki`   |
+| `image.tag`          | MediaWiki image tag (immutable tags are recommended)                             | `1.37.2-debian-10-r8` |
+| `image.pullPolicy`   | Image pull policy                                                                | `IfNotPresent`        |
+| `image.pullSecrets`  | Specify docker-registry secret names as an array                                 | `[]`                  |
+| `image.debug`        | Enable MediaWiki image debug mode                                                | `false`               |
+| `hostAliases`        | Deployment pod host aliases                                                      | `[]`                  |
+| `mediawikiUser`      | User of the application                                                          | `user`                |
+| `mediawikiPassword`  | Application password                                                             | `""`                  |
+| `mediawikiEmail`     | Admin email                                                                      | `user@example.com`    |
+| `mediawikiName`      | Name for the wiki                                                                | `My Wiki`             |
+| `mediawikiHost`      | Mediawiki host to create application URLs                                        | `""`                  |
+| `allowEmptyPassword` | Allow DB blank passwords                                                         | `yes`                 |
+| `smtpHost`           | SMTP host                                                                        | `""`                  |
+| `smtpPort`           | SMTP port                                                                        | `""`                  |
+| `smtpHostID`         | SMTP host ID                                                                     | `""`                  |
+| `smtpUser`           | SMTP user                                                                        | `""`                  |
+| `smtpPassword`       | SMTP password                                                                    | `""`                  |
+| `command`            | Override default container command (useful when using custom images)             | `[]`                  |
+| `args`               | Override default container args (useful when using custom images)                | `[]`                  |
+| `lifecycleHooks`     | for the Mediawiki container(s) to automate configuration before or after startup | `{}`                  |
+| `extraEnvVars`       | Extra environment variables to be set on Mediawki container                      | `[]`                  |
+| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars                             | `""`                  |
+| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars                                | `""`                  |
 
 
 ### Mediawiki deployment parameters
@@ -111,8 +111,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                    | Description                                                                               | Value                                             |
 | --------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------- |
 | `updateStrategy.type`                   | StrategyType can be set to RollingUpdate or OnDelete                                      | `RollingUpdate`                                   |
-| `podServiceAccount.name    `            | Existing ServiceAccount to assign to the pod                                              | `""`                                              |
-| `podServiceAccount.automountToken`      | Whether or not to automount the Service Account Token                                     | `true`                                           |
+| `podServiceAccount.name`                | Existing ServiceAccount to assign to the pods                                             | `""`                                              |
+| `podServiceAccount.automountToken`      | Whether or not to automount the Service Account Token                                     | `true`                                            |
 | `podSecurityContext.enabled`            | Enable Mediawiki pods' Security Context                                                   | `true`                                            |
 | `podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                       | `1001`                                            |
 | `containerSecurityContext.enabled`      | Enable Mediawiki containers' SecurityContext                                              | `true`                                            |
@@ -237,7 +237,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                          | Start a side-car prometheus exporter                                         | `false`                   |
 | `metrics.image.registry`                   | Apache exporter image registry                                               | `docker.io`               |
 | `metrics.image.repository`                 | Apache exporter image repository                                             | `bitnami/apache-exporter` |
-| `metrics.image.tag`                        | Apache exporter image tag (immutable tags are recommended)                   | `0.11.0-debian-10-r18`    |
+| `metrics.image.tag`                        | Apache exporter image tag (immutable tags are recommended)                   | `0.11.0-debian-10-r109`   |
 | `metrics.image.pullPolicy`                 | Image pull policy                                                            | `IfNotPresent`            |
 | `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                             | `[]`                      |
 | `metrics.resources`                        | Exporter resource requests/limit                                             | `{}`                      |

--- a/bitnami/mediawiki/templates/deployment.yaml
+++ b/bitnami/mediawiki/templates/deployment.yaml
@@ -57,6 +57,10 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
       {{- end }}
+      {{- if .Values.podServiceAccount.name }}
+      serviceAccountName: {{ .Values.podServiceAccount.name | quote }}
+      automountServiceAccountToken: {{ .Values.podServiceAccount.automountToken }}
+      {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}

--- a/bitnami/mediawiki/values.yaml
+++ b/bitnami/mediawiki/values.yaml
@@ -148,6 +148,14 @@ extraEnvVarsSecret: ""
 ##
 updateStrategy:
   type: RollingUpdate
+## Mediawiki pods' Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server
+## @param podServiceAccount.name Existing ServiceAccount to assign to the pods
+## @param podServiceAccount.automountToken Whether or not to automount the Service Account Token
+##
+podServiceAccount:
+  name: ''
+  automountToken: true
 ## Mediawiki pods' Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ## @param podSecurityContext.enabled Enable Mediawiki pods' Security Context


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add the ability to assign service accounts to MediaWiki.

**Benefits**

The ability to assign service accounts to MediaWiki.

**Possible drawbacks**

N/A

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)