### PR TITLE
[bitnami/airflow] feat: Airflow extraEnvVarsSecrets list

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 12.1.9
+version: 12.2.0

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -121,7 +121,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `web.extraEnvVars`                          | Array with extra environment variables to add Airflow web pods                                                           | `[]`                  |
 | `web.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow web pods                                                    | `""`                  |
 | `web.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow web pods                           | `""`                  |
-| `web.extraEnvVarsSecrets`                   | List of secret names with extra environment variables for for Airflow web pods                                           | `[]`                  |
+| `web.extraEnvVarsSecrets`                   | List of secret names with extra environment variables for Airflow web pods                                           | `[]`                  |
 | `web.containerPorts.http`                   | Airflow web HTTP container port                                                                                          | `8080`                |
 | `web.replicaCount`                          | Number of Airflow web replicas                                                                                           | `1`                   |
 | `web.livenessProbe.enabled`                 | Enable livenessProbe on Airflow web containers                                                                           | `true`                |

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -97,6 +97,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraEnvVars`           | Add extra environment variables for all the Airflow pods                                                                                       | `[]`                    |
 | `extraEnvVarsCM`         | ConfigMap with extra environment variables for all the Airflow pods                                                                            | `""`                    |
 | `extraEnvVarsSecret`     | Secret with extra environment variables for all the Airflow pods                                                                               | `""`                    |
+| `extraEnvVarsSecrets`    | List of secret names with extra environment variables for all the Airflow pods                                                                 | `[]`                    |
 | `sidecars`               | Add additional sidecar containers to all the Airflow pods                                                                                      | `[]`                    |
 | `initContainers`         | Add additional init containers to all the Airflow pods                                                                                         | `[]`                    |
 | `extraVolumeMounts`      | Optionally specify extra list of additional volumeMounts for all the Airflow pods                                                              | `[]`                    |
@@ -120,6 +121,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `web.extraEnvVars`                          | Array with extra environment variables to add Airflow web pods                                                           | `[]`                  |
 | `web.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow web pods                                                    | `""`                  |
 | `web.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow web pods                           | `""`                  |
+| `web.extraEnvVarsSecrets`                   | List of secret names with extra environment variables for for Airflow web pods                                           | `[]`                  |
 | `web.containerPorts.http`                   | Airflow web HTTP container port                                                                                          | `8080`                |
 | `web.replicaCount`                          | Number of Airflow web replicas                                                                                           | `1`                   |
 | `web.livenessProbe.enabled`                 | Enable livenessProbe on Airflow web containers                                                                           | `true`                |
@@ -193,6 +195,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scheduler.extraEnvVars`                          | Add extra environment variables                                                                                          | `[]`                        |
 | `scheduler.extraEnvVarsCM`                        | ConfigMap with extra environment variables                                                                               | `""`                        |
 | `scheduler.extraEnvVarsSecret`                    | Secret with extra environment variables                                                                                  | `""`                        |
+| `scheduler.extraEnvVarsSecrets`                   | List of secret names with extra environment variables for Airflow scheduler pods                                         | `[]`                        |
 | `scheduler.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                                      | `{}`                        |
 | `scheduler.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                                     | `{}`                        |
 | `scheduler.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                                       | `{}`                        |
@@ -245,6 +248,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.extraEnvVars`                          | Array with extra environment variables to add Airflow worker pods                                                        | `[]`                     |
 | `worker.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow worker pods                                                 | `""`                     |
 | `worker.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow worker pods                        | `""`                     |
+| `worker.extraEnvVarsSecrets`                   | List of secret names with extra environment variables for Airflow worker pods                                            | `[]`                     |
 | `worker.containerPorts.http`                   | Airflow worker HTTP container port                                                                                       | `8793`                   |
 | `worker.replicaCount`                          | Number of Airflow worker replicas                                                                                        | `1`                      |
 | `worker.livenessProbe.enabled`                 | Enable livenessProbe on Airflow worker containers                                                                        | `true`                   |

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -91,7 +91,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dags.existingConfigmap` | Name of an existing ConfigMap with all the DAGs files you want to load in Airflow                                                              | `""`                    |
 | `dags.image.registry`    | Init container load-dags image registry                                                                                                        | `docker.io`             |
 | `dags.image.repository`  | Init container load-dags image repository                                                                                                      | `bitnami/bitnami-shell` |
-| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `10-debian-10-r388`     |
+| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `10-debian-10-r399`     |
 | `dags.image.pullPolicy`  | Init container load-dags image pull policy                                                                                                     | `IfNotPresent`          |
 | `dags.image.pullSecrets` | Init container load-dags image pull secrets                                                                                                    | `[]`                    |
 | `extraEnvVars`           | Add extra environment variables for all the Airflow pods                                                                                       | `[]`                    |
@@ -106,77 +106,77 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Airflow web parameters
 
-| Name                                        | Description                                                                                                              | Value                |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------- |
-| `web.image.registry`                        | Airflow image registry                                                                                                   | `docker.io`          |
-| `web.image.repository`                      | Airflow image repository                                                                                                 | `bitnami/airflow`    |
-| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.2.5-debian-10-r2` |
-| `web.image.pullPolicy`                      | Airflow image pull policy                                                                                                | `IfNotPresent`       |
-| `web.image.pullSecrets`                     | Airflow image pull secrets                                                                                               | `[]`                 |
-| `web.image.debug`                           | Enable image debug mode                                                                                                  | `false`              |
-| `web.baseUrl`                               | URL used to access to Airflow web ui                                                                                     | `""`                 |
-| `web.existingConfigmap`                     | Name of an existing config map containing the Airflow web config file                                                    | `""`                 |
-| `web.command`                               | Override default container command (useful when using custom images)                                                     | `[]`                 |
-| `web.args`                                  | Override default container args (useful when using custom images)                                                        | `[]`                 |
-| `web.extraEnvVars`                          | Array with extra environment variables to add Airflow web pods                                                           | `[]`                 |
-| `web.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow web pods                                                    | `""`                 |
-| `web.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow web pods                           | `""`                 |
-| `web.extraEnvVarsSecrets`                   | List of secrets with extra environment variables for Airflow web pods                                                    | `[]`                 |
-| `web.containerPorts.http`                   | Airflow web HTTP container port                                                                                          | `8080`               |
-| `web.replicaCount`                          | Number of Airflow web replicas                                                                                           | `1`                  |
-| `web.livenessProbe.enabled`                 | Enable livenessProbe on Airflow web containers                                                                           | `true`               |
-| `web.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `180`                |
-| `web.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `20`                 |
-| `web.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `5`                  |
-| `web.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `6`                  |
-| `web.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                  |
-| `web.readinessProbe.enabled`                | Enable readinessProbe on Airflow web containers                                                                          | `true`               |
-| `web.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `30`                 |
-| `web.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                 |
-| `web.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `5`                  |
-| `web.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `6`                  |
-| `web.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                  |
-| `web.startupProbe.enabled`                  | Enable startupProbe on Airflow web containers                                                                            | `false`              |
-| `web.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `60`                 |
-| `web.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `10`                 |
-| `web.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `1`                  |
-| `web.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `15`                 |
-| `web.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                  |
-| `web.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                                      | `{}`                 |
-| `web.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                                     | `{}`                 |
-| `web.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                                       | `{}`                 |
-| `web.resources.limits`                      | The resources limits for the Airflow web containers                                                                      | `{}`                 |
-| `web.resources.requests`                    | The requested resources for the Airflow web containers                                                                   | `{}`                 |
-| `web.podSecurityContext.enabled`            | Enabled Airflow web pods' Security Context                                                                               | `true`               |
-| `web.podSecurityContext.fsGroup`            | Set Airflow web pod's Security Context fsGroup                                                                           | `1001`               |
-| `web.containerSecurityContext.enabled`      | Enabled Airflow web containers' Security Context                                                                         | `true`               |
-| `web.containerSecurityContext.runAsUser`    | Set Airflow web containers' Security Context runAsUser                                                                   | `1001`               |
-| `web.containerSecurityContext.runAsNonRoot` | Set Airflow web containers' Security Context runAsNonRoot                                                                | `true`               |
-| `web.lifecycleHooks`                        | for the Airflow web container(s) to automate configuration before or after startup                                       | `{}`                 |
-| `web.hostAliases`                           | Deployment pod host aliases                                                                                              | `[]`                 |
-| `web.podLabels`                             | Add extra labels to the Airflow web pods                                                                                 | `{}`                 |
-| `web.podAnnotations`                        | Add extra annotations to the Airflow web pods                                                                            | `{}`                 |
-| `web.affinity`                              | Affinity for Airflow web pods assignment (evaluated as a template)                                                       | `{}`                 |
-| `web.nodeAffinityPreset.key`                | Node label key to match. Ignored if `web.affinity` is set.                                                               | `""`                 |
-| `web.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                            | `""`                 |
-| `web.nodeAffinityPreset.values`             | Node label values to match. Ignored if `web.affinity` is set.                                                            | `[]`                 |
-| `web.nodeSelector`                          | Node labels for Airflow web pods assignment                                                                              | `{}`                 |
-| `web.podAffinityPreset`                     | Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.                                 | `""`                 |
-| `web.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.                            | `soft`               |
-| `web.tolerations`                           | Tolerations for Airflow web pods assignment                                                                              | `[]`                 |
-| `web.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                 |
-| `web.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                 |
-| `web.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                 |
-| `web.terminationGracePeriodSeconds`         | Seconds Airflow web pod needs to terminate gracefully                                                                    | `""`                 |
-| `web.updateStrategy.type`                   | Airflow web deployment strategy type                                                                                     | `RollingUpdate`      |
-| `web.updateStrategy.rollingUpdate`          | Airflow web deployment rolling update configuration parameters                                                           | `{}`                 |
-| `web.sidecars`                              | Add additional sidecar containers to the Airflow web pods                                                                | `[]`                 |
-| `web.initContainers`                        | Add additional init containers to the Airflow web pods                                                                   | `[]`                 |
-| `web.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Airflow web pods                                        | `[]`                 |
-| `web.extraVolumes`                          | Optionally specify extra list of additional volumes for the Airflow web pods                                             | `[]`                 |
-| `web.pdb.create`                            | Deploy a pdb object for the Airflow web pods                                                                             | `false`              |
-| `web.pdb.minAvailable`                      | Maximum number/percentage of unavailable Airflow web replicas                                                            | `1`                  |
-| `web.pdb.maxUnavailable`                    | Maximum number/percentage of unavailable Airflow web replicas                                                            | `""`                 |
+| Name                                        | Description                                                                                                              | Value                 |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------- |
+| `web.image.registry`                        | Airflow image registry                                                                                                   | `docker.io`           |
+| `web.image.repository`                      | Airflow image repository                                                                                                 | `bitnami/airflow`     |
+| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.2.5-debian-10-r13` |
+| `web.image.pullPolicy`                      | Airflow image pull policy                                                                                                | `IfNotPresent`        |
+| `web.image.pullSecrets`                     | Airflow image pull secrets                                                                                               | `[]`                  |
+| `web.image.debug`                           | Enable image debug mode                                                                                                  | `false`               |
+| `web.baseUrl`                               | URL used to access to Airflow web ui                                                                                     | `""`                  |
+| `web.existingConfigmap`                     | Name of an existing config map containing the Airflow web config file                                                    | `""`                  |
+| `web.command`                               | Override default container command (useful when using custom images)                                                     | `[]`                  |
+| `web.args`                                  | Override default container args (useful when using custom images)                                                        | `[]`                  |
+| `web.extraEnvVars`                          | Array with extra environment variables to add Airflow web pods                                                           | `[]`                  |
+| `web.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow web pods                                                    | `""`                  |
+| `web.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow web pods                           | `""`                  |
+| `web.extraEnvVarsSecrets`                   | List of secrets with extra environment variables for Airflow web pods                                                    | `[]`                  |
+| `web.containerPorts.http`                   | Airflow web HTTP container port                                                                                          | `8080`                |
+| `web.replicaCount`                          | Number of Airflow web replicas                                                                                           | `1`                   |
+| `web.livenessProbe.enabled`                 | Enable livenessProbe on Airflow web containers                                                                           | `true`                |
+| `web.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `180`                 |
+| `web.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `20`                  |
+| `web.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `5`                   |
+| `web.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `6`                   |
+| `web.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                   |
+| `web.readinessProbe.enabled`                | Enable readinessProbe on Airflow web containers                                                                          | `true`                |
+| `web.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `30`                  |
+| `web.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                  |
+| `web.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `5`                   |
+| `web.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `6`                   |
+| `web.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                   |
+| `web.startupProbe.enabled`                  | Enable startupProbe on Airflow web containers                                                                            | `false`               |
+| `web.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `60`                  |
+| `web.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `10`                  |
+| `web.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `1`                   |
+| `web.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `15`                  |
+| `web.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                   |
+| `web.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                                      | `{}`                  |
+| `web.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                                     | `{}`                  |
+| `web.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                                       | `{}`                  |
+| `web.resources.limits`                      | The resources limits for the Airflow web containers                                                                      | `{}`                  |
+| `web.resources.requests`                    | The requested resources for the Airflow web containers                                                                   | `{}`                  |
+| `web.podSecurityContext.enabled`            | Enabled Airflow web pods' Security Context                                                                               | `true`                |
+| `web.podSecurityContext.fsGroup`            | Set Airflow web pod's Security Context fsGroup                                                                           | `1001`                |
+| `web.containerSecurityContext.enabled`      | Enabled Airflow web containers' Security Context                                                                         | `true`                |
+| `web.containerSecurityContext.runAsUser`    | Set Airflow web containers' Security Context runAsUser                                                                   | `1001`                |
+| `web.containerSecurityContext.runAsNonRoot` | Set Airflow web containers' Security Context runAsNonRoot                                                                | `true`                |
+| `web.lifecycleHooks`                        | for the Airflow web container(s) to automate configuration before or after startup                                       | `{}`                  |
+| `web.hostAliases`                           | Deployment pod host aliases                                                                                              | `[]`                  |
+| `web.podLabels`                             | Add extra labels to the Airflow web pods                                                                                 | `{}`                  |
+| `web.podAnnotations`                        | Add extra annotations to the Airflow web pods                                                                            | `{}`                  |
+| `web.affinity`                              | Affinity for Airflow web pods assignment (evaluated as a template)                                                       | `{}`                  |
+| `web.nodeAffinityPreset.key`                | Node label key to match. Ignored if `web.affinity` is set.                                                               | `""`                  |
+| `web.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                            | `""`                  |
+| `web.nodeAffinityPreset.values`             | Node label values to match. Ignored if `web.affinity` is set.                                                            | `[]`                  |
+| `web.nodeSelector`                          | Node labels for Airflow web pods assignment                                                                              | `{}`                  |
+| `web.podAffinityPreset`                     | Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.                                 | `""`                  |
+| `web.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.                            | `soft`                |
+| `web.tolerations`                           | Tolerations for Airflow web pods assignment                                                                              | `[]`                  |
+| `web.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                  |
+| `web.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                  |
+| `web.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                  |
+| `web.terminationGracePeriodSeconds`         | Seconds Airflow web pod needs to terminate gracefully                                                                    | `""`                  |
+| `web.updateStrategy.type`                   | Airflow web deployment strategy type                                                                                     | `RollingUpdate`       |
+| `web.updateStrategy.rollingUpdate`          | Airflow web deployment rolling update configuration parameters                                                           | `{}`                  |
+| `web.sidecars`                              | Add additional sidecar containers to the Airflow web pods                                                                | `[]`                  |
+| `web.initContainers`                        | Add additional init containers to the Airflow web pods                                                                   | `[]`                  |
+| `web.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Airflow web pods                                        | `[]`                  |
+| `web.extraVolumes`                          | Optionally specify extra list of additional volumes for the Airflow web pods                                             | `[]`                  |
+| `web.pdb.create`                            | Deploy a pdb object for the Airflow web pods                                                                             | `false`               |
+| `web.pdb.minAvailable`                      | Maximum number/percentage of unavailable Airflow web replicas                                                            | `1`                   |
+| `web.pdb.maxUnavailable`                    | Maximum number/percentage of unavailable Airflow web replicas                                                            | `""`                  |
 
 
 ### Airflow scheduler parameters
@@ -185,7 +185,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
 | `scheduler.image.registry`                        | Airflow Scheduler image registry                                                                                         | `docker.io`                 |
 | `scheduler.image.repository`                      | Airflow Scheduler image repository                                                                                       | `bitnami/airflow-scheduler` |
-| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.2.5-debian-10-r1`        |
+| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.2.5-debian-10-r13`       |
 | `scheduler.image.pullPolicy`                      | Airflow Scheduler image pull policy                                                                                      | `IfNotPresent`              |
 | `scheduler.image.pullSecrets`                     | Airflow Scheduler image pull secrets                                                                                     | `[]`                        |
 | `scheduler.image.debug`                           | Enable image debug mode                                                                                                  | `false`                     |
@@ -239,7 +239,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | `worker.image.registry`                        | Airflow Worker image registry                                                                                            | `docker.io`              |
 | `worker.image.repository`                      | Airflow Worker image repository                                                                                          | `bitnami/airflow-worker` |
-| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.2.5-debian-10-r1`     |
+| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.2.5-debian-10-r13`    |
 | `worker.image.pullPolicy`                      | Airflow Worker image pull policy                                                                                         | `IfNotPresent`           |
 | `worker.image.pullSecrets`                     | Airflow Worker image pull secrets                                                                                        | `[]`                     |
 | `worker.image.debug`                           | Enable image debug mode                                                                                                  | `false`                  |
@@ -315,32 +315,32 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Airflow git sync parameters
 
-| Name                           | Description                                                                            | Value                  |
-| ------------------------------ | -------------------------------------------------------------------------------------- | ---------------------- |
-| `git.image.registry`           | Git image registry                                                                     | `docker.io`            |
-| `git.image.repository`         | Git image repository                                                                   | `bitnami/git`          |
-| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.35.1-debian-10-r68` |
-| `git.image.pullPolicy`         | Git image pull policy                                                                  | `IfNotPresent`         |
-| `git.image.pullSecrets`        | Git image pull secrets                                                                 | `[]`                   |
-| `git.dags.enabled`             | Enable in order to download DAG files from git repositories.                           | `false`                |
-| `git.dags.repositories`        | Array of repositories from which to download DAG files                                 | `[]`                   |
-| `git.plugins.enabled`          | Enable in order to download Plugins files from git repositories.                       | `false`                |
-| `git.plugins.repositories`     | Array of repositories from which to download DAG files                                 | `[]`                   |
-| `git.clone.command`            | Override cmd                                                                           | `[]`                   |
-| `git.clone.args`               | Override args                                                                          | `[]`                   |
-| `git.clone.extraVolumeMounts`  | Add extra volume mounts                                                                | `[]`                   |
-| `git.clone.extraEnvVars`       | Add extra environment variables                                                        | `[]`                   |
-| `git.clone.extraEnvVarsCM`     | ConfigMap with extra environment variables                                             | `""`                   |
-| `git.clone.extraEnvVarsSecret` | Secret with extra environment variables                                                | `""`                   |
-| `git.clone.resources`          | Clone init container resource requests and limits                                      | `{}`                   |
-| `git.sync.interval`            | Interval in seconds to pull the git repository containing the plugins and/or DAG files | `60`                   |
-| `git.sync.command`             | Override cmd                                                                           | `[]`                   |
-| `git.sync.args`                | Override args                                                                          | `[]`                   |
-| `git.sync.extraVolumeMounts`   | Add extra volume mounts                                                                | `[]`                   |
-| `git.sync.extraEnvVars`        | Add extra environment variables                                                        | `[]`                   |
-| `git.sync.extraEnvVarsCM`      | ConfigMap with extra environment variables                                             | `""`                   |
-| `git.sync.extraEnvVarsSecret`  | Secret with extra environment variables                                                | `""`                   |
-| `git.sync.resources`           | Sync sidecar container resource requests and limits                                    | `{}`                   |
+| Name                           | Description                                                                            | Value                 |
+| ------------------------------ | -------------------------------------------------------------------------------------- | --------------------- |
+| `git.image.registry`           | Git image registry                                                                     | `docker.io`           |
+| `git.image.repository`         | Git image repository                                                                   | `bitnami/git`         |
+| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.36.0-debian-10-r0` |
+| `git.image.pullPolicy`         | Git image pull policy                                                                  | `IfNotPresent`        |
+| `git.image.pullSecrets`        | Git image pull secrets                                                                 | `[]`                  |
+| `git.dags.enabled`             | Enable in order to download DAG files from git repositories.                           | `false`               |
+| `git.dags.repositories`        | Array of repositories from which to download DAG files                                 | `[]`                  |
+| `git.plugins.enabled`          | Enable in order to download Plugins files from git repositories.                       | `false`               |
+| `git.plugins.repositories`     | Array of repositories from which to download DAG files                                 | `[]`                  |
+| `git.clone.command`            | Override cmd                                                                           | `[]`                  |
+| `git.clone.args`               | Override args                                                                          | `[]`                  |
+| `git.clone.extraVolumeMounts`  | Add extra volume mounts                                                                | `[]`                  |
+| `git.clone.extraEnvVars`       | Add extra environment variables                                                        | `[]`                  |
+| `git.clone.extraEnvVarsCM`     | ConfigMap with extra environment variables                                             | `""`                  |
+| `git.clone.extraEnvVarsSecret` | Secret with extra environment variables                                                | `""`                  |
+| `git.clone.resources`          | Clone init container resource requests and limits                                      | `{}`                  |
+| `git.sync.interval`            | Interval in seconds to pull the git repository containing the plugins and/or DAG files | `60`                  |
+| `git.sync.command`             | Override cmd                                                                           | `[]`                  |
+| `git.sync.args`                | Override args                                                                          | `[]`                  |
+| `git.sync.extraVolumeMounts`   | Add extra volume mounts                                                                | `[]`                  |
+| `git.sync.extraEnvVars`        | Add extra environment variables                                                        | `[]`                  |
+| `git.sync.extraEnvVarsCM`      | ConfigMap with extra environment variables                                             | `""`                  |
+| `git.sync.extraEnvVarsSecret`  | Secret with extra environment variables                                                | `""`                  |
+| `git.sync.resources`           | Sync sidecar container resource requests and limits                                    | `{}`                  |
 
 
 ### Airflow ldap parameters
@@ -411,7 +411,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                               | Whether or not to create a standalone Airflow exporter to expose Airflow metrics                    | `false`                      |
 | `metrics.image.registry`                        | Airflow exporter image registry                                                                     | `docker.io`                  |
 | `metrics.image.repository`                      | Airflow exporter image repository                                                                   | `bitnami/airflow-exporter`   |
-| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-10-r25` |
+| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-10-r36` |
 | `metrics.image.pullPolicy`                      | Airflow exporter image pull policy                                                                  | `IfNotPresent`               |
 | `metrics.image.pullSecrets`                     | Airflow exporter image pull secrets                                                                 | `[]`                         |
 | `metrics.extraEnvVars`                          | Array with extra environment variables to add Airflow exporter pods                                 | `[]`                         |

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -91,13 +91,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dags.existingConfigmap` | Name of an existing ConfigMap with all the DAGs files you want to load in Airflow                                                              | `""`                    |
 | `dags.image.registry`    | Init container load-dags image registry                                                                                                        | `docker.io`             |
 | `dags.image.repository`  | Init container load-dags image repository                                                                                                      | `bitnami/bitnami-shell` |
-| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `10-debian-10-r378`     |
+| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `10-debian-10-r388`     |
 | `dags.image.pullPolicy`  | Init container load-dags image pull policy                                                                                                     | `IfNotPresent`          |
 | `dags.image.pullSecrets` | Init container load-dags image pull secrets                                                                                                    | `[]`                    |
 | `extraEnvVars`           | Add extra environment variables for all the Airflow pods                                                                                       | `[]`                    |
 | `extraEnvVarsCM`         | ConfigMap with extra environment variables for all the Airflow pods                                                                            | `""`                    |
 | `extraEnvVarsSecret`     | Secret with extra environment variables for all the Airflow pods                                                                               | `""`                    |
-| `extraEnvVarsSecrets`    | List of secret names with extra environment variables for all the Airflow pods                                                                 | `[]`                    |
+| `extraEnvVarsSecrets`    | List of secrets with extra environment variables for all the Airflow pods                                                                      | `[]`                    |
 | `sidecars`               | Add additional sidecar containers to all the Airflow pods                                                                                      | `[]`                    |
 | `initContainers`         | Add additional init containers to all the Airflow pods                                                                                         | `[]`                    |
 | `extraVolumeMounts`      | Optionally specify extra list of additional volumeMounts for all the Airflow pods                                                              | `[]`                    |
@@ -106,77 +106,77 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Airflow web parameters
 
-| Name                                        | Description                                                                                                              | Value                 |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------- |
-| `web.image.registry`                        | Airflow image registry                                                                                                   | `docker.io`           |
-| `web.image.repository`                      | Airflow image repository                                                                                                 | `bitnami/airflow`     |
-| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.2.4-debian-10-r19` |
-| `web.image.pullPolicy`                      | Airflow image pull policy                                                                                                | `IfNotPresent`        |
-| `web.image.pullSecrets`                     | Airflow image pull secrets                                                                                               | `[]`                  |
-| `web.image.debug`                           | Enable image debug mode                                                                                                  | `false`               |
-| `web.baseUrl`                               | URL used to access to Airflow web ui                                                                                     | `""`                  |
-| `web.existingConfigmap`                     | Name of an existing config map containing the Airflow web config file                                                    | `""`                  |
-| `web.command`                               | Override default container command (useful when using custom images)                                                     | `[]`                  |
-| `web.args`                                  | Override default container args (useful when using custom images)                                                        | `[]`                  |
-| `web.extraEnvVars`                          | Array with extra environment variables to add Airflow web pods                                                           | `[]`                  |
-| `web.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow web pods                                                    | `""`                  |
-| `web.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow web pods                           | `""`                  |
-| `web.extraEnvVarsSecrets`                   | List of secret names with extra environment variables for Airflow web pods                                           | `[]`                  |
-| `web.containerPorts.http`                   | Airflow web HTTP container port                                                                                          | `8080`                |
-| `web.replicaCount`                          | Number of Airflow web replicas                                                                                           | `1`                   |
-| `web.livenessProbe.enabled`                 | Enable livenessProbe on Airflow web containers                                                                           | `true`                |
-| `web.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `180`                 |
-| `web.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `20`                  |
-| `web.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `5`                   |
-| `web.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `6`                   |
-| `web.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                   |
-| `web.readinessProbe.enabled`                | Enable readinessProbe on Airflow web containers                                                                          | `true`                |
-| `web.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `30`                  |
-| `web.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                  |
-| `web.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `5`                   |
-| `web.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `6`                   |
-| `web.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                   |
-| `web.startupProbe.enabled`                  | Enable startupProbe on Airflow web containers                                                                            | `false`               |
-| `web.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `60`                  |
-| `web.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `10`                  |
-| `web.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `1`                   |
-| `web.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `15`                  |
-| `web.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                   |
-| `web.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                                      | `{}`                  |
-| `web.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                                     | `{}`                  |
-| `web.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                                       | `{}`                  |
-| `web.resources.limits`                      | The resources limits for the Airflow web containers                                                                      | `{}`                  |
-| `web.resources.requests`                    | The requested resources for the Airflow web containers                                                                   | `{}`                  |
-| `web.podSecurityContext.enabled`            | Enabled Airflow web pods' Security Context                                                                               | `true`                |
-| `web.podSecurityContext.fsGroup`            | Set Airflow web pod's Security Context fsGroup                                                                           | `1001`                |
-| `web.containerSecurityContext.enabled`      | Enabled Airflow web containers' Security Context                                                                         | `true`                |
-| `web.containerSecurityContext.runAsUser`    | Set Airflow web containers' Security Context runAsUser                                                                   | `1001`                |
-| `web.containerSecurityContext.runAsNonRoot` | Set Airflow web containers' Security Context runAsNonRoot                                                                | `true`                |
-| `web.lifecycleHooks`                        | for the Airflow web container(s) to automate configuration before or after startup                                       | `{}`                  |
-| `web.hostAliases`                           | Deployment pod host aliases                                                                                              | `[]`                  |
-| `web.podLabels`                             | Add extra labels to the Airflow web pods                                                                                 | `{}`                  |
-| `web.podAnnotations`                        | Add extra annotations to the Airflow web pods                                                                            | `{}`                  |
-| `web.affinity`                              | Affinity for Airflow web pods assignment (evaluated as a template)                                                       | `{}`                  |
-| `web.nodeAffinityPreset.key`                | Node label key to match. Ignored if `web.affinity` is set.                                                               | `""`                  |
-| `web.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                            | `""`                  |
-| `web.nodeAffinityPreset.values`             | Node label values to match. Ignored if `web.affinity` is set.                                                            | `[]`                  |
-| `web.nodeSelector`                          | Node labels for Airflow web pods assignment                                                                              | `{}`                  |
-| `web.podAffinityPreset`                     | Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.                                 | `""`                  |
-| `web.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.                            | `soft`                |
-| `web.tolerations`                           | Tolerations for Airflow web pods assignment                                                                              | `[]`                  |
-| `web.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                  |
-| `web.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                  |
-| `web.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                  |
-| `web.terminationGracePeriodSeconds`         | Seconds Airflow web pod needs to terminate gracefully                                                                    | `""`                  |
-| `web.updateStrategy.type`                   | Airflow web deployment strategy type                                                                                     | `RollingUpdate`       |
-| `web.updateStrategy.rollingUpdate`          | Airflow web deployment rolling update configuration parameters                                                           | `{}`                  |
-| `web.sidecars`                              | Add additional sidecar containers to the Airflow web pods                                                                | `[]`                  |
-| `web.initContainers`                        | Add additional init containers to the Airflow web pods                                                                   | `[]`                  |
-| `web.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Airflow web pods                                        | `[]`                  |
-| `web.extraVolumes`                          | Optionally specify extra list of additional volumes for the Airflow web pods                                             | `[]`                  |
-| `web.pdb.create`                            | Deploy a pdb object for the Airflow web pods                                                                             | `false`               |
-| `web.pdb.minAvailable`                      | Maximum number/percentage of unavailable Airflow web replicas                                                            | `1`                   |
-| `web.pdb.maxUnavailable`                    | Maximum number/percentage of unavailable Airflow web replicas                                                            | `""`                  |
+| Name                                        | Description                                                                                                              | Value                |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------- |
+| `web.image.registry`                        | Airflow image registry                                                                                                   | `docker.io`          |
+| `web.image.repository`                      | Airflow image repository                                                                                                 | `bitnami/airflow`    |
+| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.2.5-debian-10-r2` |
+| `web.image.pullPolicy`                      | Airflow image pull policy                                                                                                | `IfNotPresent`       |
+| `web.image.pullSecrets`                     | Airflow image pull secrets                                                                                               | `[]`                 |
+| `web.image.debug`                           | Enable image debug mode                                                                                                  | `false`              |
+| `web.baseUrl`                               | URL used to access to Airflow web ui                                                                                     | `""`                 |
+| `web.existingConfigmap`                     | Name of an existing config map containing the Airflow web config file                                                    | `""`                 |
+| `web.command`                               | Override default container command (useful when using custom images)                                                     | `[]`                 |
+| `web.args`                                  | Override default container args (useful when using custom images)                                                        | `[]`                 |
+| `web.extraEnvVars`                          | Array with extra environment variables to add Airflow web pods                                                           | `[]`                 |
+| `web.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow web pods                                                    | `""`                 |
+| `web.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow web pods                           | `""`                 |
+| `web.extraEnvVarsSecrets`                   | List of secrets with extra environment variables for Airflow web pods                                                    | `[]`                 |
+| `web.containerPorts.http`                   | Airflow web HTTP container port                                                                                          | `8080`               |
+| `web.replicaCount`                          | Number of Airflow web replicas                                                                                           | `1`                  |
+| `web.livenessProbe.enabled`                 | Enable livenessProbe on Airflow web containers                                                                           | `true`               |
+| `web.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `180`                |
+| `web.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `20`                 |
+| `web.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `5`                  |
+| `web.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `6`                  |
+| `web.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                  |
+| `web.readinessProbe.enabled`                | Enable readinessProbe on Airflow web containers                                                                          | `true`               |
+| `web.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `30`                 |
+| `web.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                 |
+| `web.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `5`                  |
+| `web.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `6`                  |
+| `web.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                  |
+| `web.startupProbe.enabled`                  | Enable startupProbe on Airflow web containers                                                                            | `false`              |
+| `web.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `60`                 |
+| `web.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `10`                 |
+| `web.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `1`                  |
+| `web.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `15`                 |
+| `web.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                  |
+| `web.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                                      | `{}`                 |
+| `web.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                                     | `{}`                 |
+| `web.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                                       | `{}`                 |
+| `web.resources.limits`                      | The resources limits for the Airflow web containers                                                                      | `{}`                 |
+| `web.resources.requests`                    | The requested resources for the Airflow web containers                                                                   | `{}`                 |
+| `web.podSecurityContext.enabled`            | Enabled Airflow web pods' Security Context                                                                               | `true`               |
+| `web.podSecurityContext.fsGroup`            | Set Airflow web pod's Security Context fsGroup                                                                           | `1001`               |
+| `web.containerSecurityContext.enabled`      | Enabled Airflow web containers' Security Context                                                                         | `true`               |
+| `web.containerSecurityContext.runAsUser`    | Set Airflow web containers' Security Context runAsUser                                                                   | `1001`               |
+| `web.containerSecurityContext.runAsNonRoot` | Set Airflow web containers' Security Context runAsNonRoot                                                                | `true`               |
+| `web.lifecycleHooks`                        | for the Airflow web container(s) to automate configuration before or after startup                                       | `{}`                 |
+| `web.hostAliases`                           | Deployment pod host aliases                                                                                              | `[]`                 |
+| `web.podLabels`                             | Add extra labels to the Airflow web pods                                                                                 | `{}`                 |
+| `web.podAnnotations`                        | Add extra annotations to the Airflow web pods                                                                            | `{}`                 |
+| `web.affinity`                              | Affinity for Airflow web pods assignment (evaluated as a template)                                                       | `{}`                 |
+| `web.nodeAffinityPreset.key`                | Node label key to match. Ignored if `web.affinity` is set.                                                               | `""`                 |
+| `web.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                            | `""`                 |
+| `web.nodeAffinityPreset.values`             | Node label values to match. Ignored if `web.affinity` is set.                                                            | `[]`                 |
+| `web.nodeSelector`                          | Node labels for Airflow web pods assignment                                                                              | `{}`                 |
+| `web.podAffinityPreset`                     | Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.                                 | `""`                 |
+| `web.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.                            | `soft`               |
+| `web.tolerations`                           | Tolerations for Airflow web pods assignment                                                                              | `[]`                 |
+| `web.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                 |
+| `web.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                 |
+| `web.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                 |
+| `web.terminationGracePeriodSeconds`         | Seconds Airflow web pod needs to terminate gracefully                                                                    | `""`                 |
+| `web.updateStrategy.type`                   | Airflow web deployment strategy type                                                                                     | `RollingUpdate`      |
+| `web.updateStrategy.rollingUpdate`          | Airflow web deployment rolling update configuration parameters                                                           | `{}`                 |
+| `web.sidecars`                              | Add additional sidecar containers to the Airflow web pods                                                                | `[]`                 |
+| `web.initContainers`                        | Add additional init containers to the Airflow web pods                                                                   | `[]`                 |
+| `web.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Airflow web pods                                        | `[]`                 |
+| `web.extraVolumes`                          | Optionally specify extra list of additional volumes for the Airflow web pods                                             | `[]`                 |
+| `web.pdb.create`                            | Deploy a pdb object for the Airflow web pods                                                                             | `false`              |
+| `web.pdb.minAvailable`                      | Maximum number/percentage of unavailable Airflow web replicas                                                            | `1`                  |
+| `web.pdb.maxUnavailable`                    | Maximum number/percentage of unavailable Airflow web replicas                                                            | `""`                 |
 
 
 ### Airflow scheduler parameters
@@ -185,7 +185,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
 | `scheduler.image.registry`                        | Airflow Scheduler image registry                                                                                         | `docker.io`                 |
 | `scheduler.image.repository`                      | Airflow Scheduler image repository                                                                                       | `bitnami/airflow-scheduler` |
-| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.2.4-debian-10-r31`       |
+| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.2.5-debian-10-r1`        |
 | `scheduler.image.pullPolicy`                      | Airflow Scheduler image pull policy                                                                                      | `IfNotPresent`              |
 | `scheduler.image.pullSecrets`                     | Airflow Scheduler image pull secrets                                                                                     | `[]`                        |
 | `scheduler.image.debug`                           | Enable image debug mode                                                                                                  | `false`                     |
@@ -195,7 +195,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scheduler.extraEnvVars`                          | Add extra environment variables                                                                                          | `[]`                        |
 | `scheduler.extraEnvVarsCM`                        | ConfigMap with extra environment variables                                                                               | `""`                        |
 | `scheduler.extraEnvVarsSecret`                    | Secret with extra environment variables                                                                                  | `""`                        |
-| `scheduler.extraEnvVarsSecrets`                   | List of secret names with extra environment variables for Airflow scheduler pods                                         | `[]`                        |
+| `scheduler.extraEnvVarsSecrets`                   | List of secrets with extra environment variables for Airflow scheduler pods                                              | `[]`                        |
 | `scheduler.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                                      | `{}`                        |
 | `scheduler.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                                     | `{}`                        |
 | `scheduler.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                                       | `{}`                        |
@@ -239,7 +239,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | `worker.image.registry`                        | Airflow Worker image registry                                                                                            | `docker.io`              |
 | `worker.image.repository`                      | Airflow Worker image repository                                                                                          | `bitnami/airflow-worker` |
-| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.2.4-debian-10-r32`    |
+| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.2.5-debian-10-r1`     |
 | `worker.image.pullPolicy`                      | Airflow Worker image pull policy                                                                                         | `IfNotPresent`           |
 | `worker.image.pullSecrets`                     | Airflow Worker image pull secrets                                                                                        | `[]`                     |
 | `worker.image.debug`                           | Enable image debug mode                                                                                                  | `false`                  |
@@ -248,7 +248,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.extraEnvVars`                          | Array with extra environment variables to add Airflow worker pods                                                        | `[]`                     |
 | `worker.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow worker pods                                                 | `""`                     |
 | `worker.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow worker pods                        | `""`                     |
-| `worker.extraEnvVarsSecrets`                   | List of secret names with extra environment variables for Airflow worker pods                                            | `[]`                     |
+| `worker.extraEnvVarsSecrets`                   | List of secrets with extra environment variables for Airflow worker pods                                                 | `[]`                     |
 | `worker.containerPorts.http`                   | Airflow worker HTTP container port                                                                                       | `8793`                   |
 | `worker.replicaCount`                          | Number of Airflow worker replicas                                                                                        | `1`                      |
 | `worker.livenessProbe.enabled`                 | Enable livenessProbe on Airflow worker containers                                                                        | `true`                   |
@@ -319,7 +319,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------ | -------------------------------------------------------------------------------------- | ---------------------- |
 | `git.image.registry`           | Git image registry                                                                     | `docker.io`            |
 | `git.image.repository`         | Git image repository                                                                   | `bitnami/git`          |
-| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.35.1-debian-10-r57` |
+| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.35.1-debian-10-r68` |
 | `git.image.pullPolicy`         | Git image pull policy                                                                  | `IfNotPresent`         |
 | `git.image.pullSecrets`        | Git image pull secrets                                                                 | `[]`                   |
 | `git.dags.enabled`             | Enable in order to download DAG files from git repositories.                           | `false`                |
@@ -411,7 +411,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                               | Whether or not to create a standalone Airflow exporter to expose Airflow metrics                    | `false`                      |
 | `metrics.image.registry`                        | Airflow exporter image registry                                                                     | `docker.io`                  |
 | `metrics.image.repository`                      | Airflow exporter image repository                                                                   | `bitnami/airflow-exporter`   |
-| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-10-r14` |
+| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-10-r25` |
 | `metrics.image.pullPolicy`                      | Airflow exporter image pull policy                                                                  | `IfNotPresent`               |
 | `metrics.image.pullSecrets`                     | Airflow exporter image pull secrets                                                                 | `[]`                         |
 | `metrics.extraEnvVars`                          | Array with extra environment variables to add Airflow exporter pods                                 | `[]`                         |

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -91,7 +91,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dags.existingConfigmap` | Name of an existing ConfigMap with all the DAGs files you want to load in Airflow                                                              | `""`                    |
 | `dags.image.registry`    | Init container load-dags image registry                                                                                                        | `docker.io`             |
 | `dags.image.repository`  | Init container load-dags image repository                                                                                                      | `bitnami/bitnami-shell` |
-| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `10-debian-10-r399`     |
+| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `10-debian-10-r400`     |
 | `dags.image.pullPolicy`  | Init container load-dags image pull policy                                                                                                     | `IfNotPresent`          |
 | `dags.image.pullSecrets` | Init container load-dags image pull secrets                                                                                                    | `[]`                    |
 | `extraEnvVars`           | Add extra environment variables for all the Airflow pods                                                                                       | `[]`                    |
@@ -110,7 +110,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------- |
 | `web.image.registry`                        | Airflow image registry                                                                                                   | `docker.io`           |
 | `web.image.repository`                      | Airflow image repository                                                                                                 | `bitnami/airflow`     |
-| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.2.5-debian-10-r13` |
+| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.2.5-debian-10-r14` |
 | `web.image.pullPolicy`                      | Airflow image pull policy                                                                                                | `IfNotPresent`        |
 | `web.image.pullSecrets`                     | Airflow image pull secrets                                                                                               | `[]`                  |
 | `web.image.debug`                           | Enable image debug mode                                                                                                  | `false`               |
@@ -185,7 +185,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
 | `scheduler.image.registry`                        | Airflow Scheduler image registry                                                                                         | `docker.io`                 |
 | `scheduler.image.repository`                      | Airflow Scheduler image repository                                                                                       | `bitnami/airflow-scheduler` |
-| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.2.5-debian-10-r13`       |
+| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.2.5-debian-10-r14`       |
 | `scheduler.image.pullPolicy`                      | Airflow Scheduler image pull policy                                                                                      | `IfNotPresent`              |
 | `scheduler.image.pullSecrets`                     | Airflow Scheduler image pull secrets                                                                                     | `[]`                        |
 | `scheduler.image.debug`                           | Enable image debug mode                                                                                                  | `false`                     |
@@ -239,7 +239,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | `worker.image.registry`                        | Airflow Worker image registry                                                                                            | `docker.io`              |
 | `worker.image.repository`                      | Airflow Worker image repository                                                                                          | `bitnami/airflow-worker` |
-| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.2.5-debian-10-r13`    |
+| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.2.5-debian-10-r14`    |
 | `worker.image.pullPolicy`                      | Airflow Worker image pull policy                                                                                         | `IfNotPresent`           |
 | `worker.image.pullSecrets`                     | Airflow Worker image pull secrets                                                                                        | `[]`                     |
 | `worker.image.debug`                           | Enable image debug mode                                                                                                  | `false`                  |
@@ -319,7 +319,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------ | -------------------------------------------------------------------------------------- | --------------------- |
 | `git.image.registry`           | Git image registry                                                                     | `docker.io`           |
 | `git.image.repository`         | Git image repository                                                                   | `bitnami/git`         |
-| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.36.0-debian-10-r0` |
+| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.36.0-debian-10-r1` |
 | `git.image.pullPolicy`         | Git image pull policy                                                                  | `IfNotPresent`        |
 | `git.image.pullSecrets`        | Git image pull secrets                                                                 | `[]`                  |
 | `git.dags.enabled`             | Enable in order to download DAG files from git repositories.                           | `false`               |
@@ -411,7 +411,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                               | Whether or not to create a standalone Airflow exporter to expose Airflow metrics                    | `false`                      |
 | `metrics.image.registry`                        | Airflow exporter image registry                                                                     | `docker.io`                  |
 | `metrics.image.repository`                      | Airflow exporter image repository                                                                   | `bitnami/airflow-exporter`   |
-| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-10-r36` |
+| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-10-r37` |
 | `metrics.image.pullPolicy`                      | Airflow exporter image pull policy                                                                  | `IfNotPresent`               |
 | `metrics.image.pullSecrets`                     | Airflow exporter image pull secrets                                                                 | `[]`                         |
 | `metrics.extraEnvVars`                          | Array with extra environment variables to add Airflow exporter pods                                 | `[]`                         |

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -131,7 +131,7 @@ data:
             {{- if .Values.worker.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsSecret .Values.worker.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
@@ -148,6 +148,18 @@ data:
             {{- if .Values.worker.extraEnvVarsSecret }}
             - secretRef:
                 name: {{ .Values.worker.extraEnvVarsSecret }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecrets }}
+            {{- range .Values.extraEnvVarsSecrets }}
+            - secretRef:
+                name: {{ .name }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.worker.extraEnvVarsSecrets }}
+            {{- range .Values.worker.extraEnvVarsSecrets }}
+            - secretRef:
+                name: {{ .name }}
+            {{- end }}
             {{- end }}
           {{- end }}
           ports:

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -152,13 +152,13 @@ data:
             {{- if .Values.extraEnvVarsSecrets }}
             {{- range .Values.extraEnvVarsSecrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . }}
             {{- end }}
             {{- end }}
             {{- if .Values.worker.extraEnvVarsSecrets }}
             {{- range .Values.worker.extraEnvVarsSecrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . }}
             {{- end }}
             {{- end }}
           {{- end }}

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -110,7 +110,7 @@ spec:
             {{- if .Values.scheduler.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.scheduler.extraEnvVarsCM .Values.scheduler.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          {{- if or .Values.scheduler.extraEnvVarsCM .Values.scheduler.extraEnvVarsSecret .Values.scheduler.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
@@ -127,6 +127,18 @@ spec:
             {{- if .Values.scheduler.extraEnvVarsSecret }}
             - secretRef:
                 name: {{ .Values.scheduler.extraEnvVarsSecret }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecrets }}
+            {{- range .Values.extraEnvVarsSecrets }}
+            - secretRef:
+                name: {{ .name }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.scheduler.extraEnvVarsSecrets }}
+            {{- range .Values.scheduler.extraEnvVarsSecrets }}
+            - secretRef:
+                name: {{ .name }}
+            {{- end }}
             {{- end }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -131,13 +131,13 @@ spec:
             {{- if .Values.extraEnvVarsSecrets }}
             {{- range .Values.extraEnvVarsSecrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . }}
             {{- end }}
             {{- end }}
             {{- if .Values.scheduler.extraEnvVarsSecrets }}
             {{- range .Values.scheduler.extraEnvVarsSecrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . }}
             {{- end }}
             {{- end }}
           {{- end }}

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -153,7 +153,7 @@ spec:
             {{- if .Values.web.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.web.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.web.extraEnvVarsCM .Values.web.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          {{- if or .Values.web.extraEnvVarsCM .Values.web.extraEnvVarsSecret .Values.web.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
@@ -170,6 +170,18 @@ spec:
             {{- if .Values.web.extraEnvVarsSecret }}
             - secretRef:
                 name: {{ .Values.web.extraEnvVarsSecret }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecrets }}
+            {{- range .Values.extraEnvVarsSecrets }}
+            - secretRef:
+                name: {{ .name }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.web.extraEnvVarsSecrets }}
+            {{- range .Values.web.extraEnvVarsSecrets }}
+            - secretRef:
+                name: {{ .name }}
+            {{- end }}
             {{- end }}
           {{- end }}
           ports:

--- a/bitnami/airflow/templates/web/deployment.yaml
+++ b/bitnami/airflow/templates/web/deployment.yaml
@@ -174,13 +174,13 @@ spec:
             {{- if .Values.extraEnvVarsSecrets }}
             {{- range .Values.extraEnvVarsSecrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . }}
             {{- end }}
             {{- end }}
             {{- if .Values.web.extraEnvVarsSecrets }}
             {{- range .Values.web.extraEnvVarsSecrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . }}
             {{- end }}
             {{- end }}
           {{- end }}

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
             {{- if .Values.worker.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
-          {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsSecret .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          {{- if or .Values.worker.extraEnvVarsCM .Values.worker.extraEnvVarsSecret .Values.worker.extraEnvVarsSecrets .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.extraEnvVarsSecrets }}
           envFrom:
             {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
@@ -130,6 +130,18 @@ spec:
             {{- if .Values.worker.extraEnvVarsSecret }}
             - secretRef:
                 name: {{ .Values.worker.extraEnvVarsSecret }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecrets }}
+            {{- range .Values.extraEnvVarsSecrets }}
+            - secretRef:
+                name: {{ .name }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.worker.extraEnvVarsSecrets }}
+            {{- range .Values.worker.extraEnvVarsSecrets }}
+            - secretRef:
+                name: {{ .name }}
+            {{- end }}
             {{- end }}
           {{- end }}
           ports:

--- a/bitnami/airflow/templates/worker/statefulset.yaml
+++ b/bitnami/airflow/templates/worker/statefulset.yaml
@@ -134,13 +134,13 @@ spec:
             {{- if .Values.extraEnvVarsSecrets }}
             {{- range .Values.extraEnvVarsSecrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . }}
             {{- end }}
             {{- end }}
             {{- if .Values.worker.extraEnvVarsSecrets }}
             {{- range .Values.worker.extraEnvVarsSecrets }}
             - secretRef:
-                name: {{ .name }}
+                name: {{ . }}
             {{- end }}
             {{- end }}
           {{- end }}

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -136,6 +136,9 @@ extraEnvVarsCM: ""
 ## @param extraEnvVarsSecret Secret with extra environment variables for all the Airflow pods
 ##
 extraEnvVarsSecret: ""
+## @param extraEnvVarsSecrets List of secrets with extra environment variables for all the Airflow pods
+##
+extraEnvVarsSecrets: []
 ## @param sidecars Add additional sidecar containers to all the Airflow pods
 ## Example:
 ## sidecars:
@@ -217,6 +220,9 @@ web:
   ## @param web.extraEnvVarsSecret Secret containing extra environment variables (in case of sensitive data) for Airflow web pods
   ##
   extraEnvVarsSecret: ""
+  ## @param web.extraEnvVarsSecrets List of secrets with extra environment variables for all the Airflow pods
+  ##
+  extraEnvVarsSecrets: []
   ## @param web.containerPorts.http Airflow web HTTP container port
   ##
   containerPorts:
@@ -467,6 +473,9 @@ scheduler:
   ## @param scheduler.extraEnvVarsSecret Secret with extra environment variables
   ##
   extraEnvVarsSecret: ""
+  ## @param scheduler.extraEnvVarsSecrets List of secrets with extra environment variables for all the Airflow pods
+  ##
+  extraEnvVarsSecrets: []
   ## @param scheduler.customLivenessProbe Custom livenessProbe that overrides the default one
   ##
   customLivenessProbe: {}
@@ -663,6 +672,9 @@ worker:
   ## @param worker.extraEnvVarsSecret Secret containing extra environment variables (in case of sensitive data) for Airflow worker pods
   ##
   extraEnvVarsSecret: ""
+  ## @param worker.extraEnvVarsSecrets List of secrets with extra environment variables for all the Airflow pods
+  ##
+  extraEnvVarsSecrets: []
   ## @param worker.containerPorts.http Airflow worker HTTP container port
   ##
   containerPorts:

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -220,7 +220,7 @@ web:
   ## @param web.extraEnvVarsSecret Secret containing extra environment variables (in case of sensitive data) for Airflow web pods
   ##
   extraEnvVarsSecret: ""
-  ## @param web.extraEnvVarsSecrets List of secrets with extra environment variables for all the Airflow pods
+  ## @param web.extraEnvVarsSecrets List of secrets with extra environment variables for Airflow web pods
   ##
   extraEnvVarsSecrets: []
   ## @param web.containerPorts.http Airflow web HTTP container port
@@ -473,7 +473,7 @@ scheduler:
   ## @param scheduler.extraEnvVarsSecret Secret with extra environment variables
   ##
   extraEnvVarsSecret: ""
-  ## @param scheduler.extraEnvVarsSecrets List of secrets with extra environment variables for all the Airflow pods
+  ## @param scheduler.extraEnvVarsSecrets List of secrets with extra environment variables for Airflow scheduler pods
   ##
   extraEnvVarsSecrets: []
   ## @param scheduler.customLivenessProbe Custom livenessProbe that overrides the default one
@@ -672,7 +672,7 @@ worker:
   ## @param worker.extraEnvVarsSecret Secret containing extra environment variables (in case of sensitive data) for Airflow worker pods
   ##
   extraEnvVarsSecret: ""
-  ## @param worker.extraEnvVarsSecrets List of secrets with extra environment variables for all the Airflow pods
+  ## @param worker.extraEnvVarsSecrets List of secrets with extra environment variables for Airflow worker pods
   ##
   extraEnvVarsSecrets: []
   ## @param worker.containerPorts.http Airflow worker HTTP container port


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Background: The `extraEnvVarsSecret` is a useful feature that allows for a single secret to be loaded into pods as an environment variable using the `envFrom:` capability of the pod spec. 

A use case I encountered was the need to securely add environment variables to our pods using the [External Secrets](https://github.com/external-secrets/kubernetes-external-secrets) custom resource definition, but without loading everything into a single secret. This posed a potential issue with multiple developers modifying the same secret with the chance of overwriting the values. 

The result was the `extraEnvVarsSecrets` list that can be set at the global, scheduler, web, and worker level. Each secret can be loaded by providing the name of the secret just as one would do if defining the pod resource by hand. ex:
```yaml
envFrom:
  - secretRef:
     name: my-secret
```

Format for leveraging the new list:
```yaml
extraEnvVarsSecrets:
  - name: my-secret1
  - name: my-secret2
```

**Benefits**

<!-- What benefits will be realized by the code change? -->
Benefits of this feature include the ability to push extra environment variables as secrets to all scopes already leveraging the `extraEnvVars...` functionality.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->
The functionality of this addition is somewhat limited in scope: The environment variables will be loaded from the Secret's keys and values without any ability to change the format via the chart. 

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)