### PR TITLE
Remove quote in common.secrets.passwords.manage

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - https://www.bitnami.com/
 type: library
-version: 1.13.0
+version: 1.13.1

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -98,7 +98,7 @@ The order in which this function returns a secret password:
     {{- printf "\nPASSWORDS ERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
   {{- end -}}
 {{- else if $providedPasswordValue }}
-  {{- $password = $providedPasswordValue | toString | b64enc | quote }}
+  {{- $password = $providedPasswordValue | toString | b64enc }}
 {{- else }}
 
   {{- if .context.Values.enabled }}
@@ -114,9 +114,9 @@ The order in which this function returns a secret password:
     {{- $subStr := list (lower (randAlpha 1)) (randNumeric 1) (upper (randAlpha 1)) | join "_" }}
     {{- $password = randAscii $passwordLength }}
     {{- $password = regexReplaceAllLiteral "\\W" $password "@" | substr 5 $passwordLength }}
-    {{- $password = printf "%s%s" $subStr $password | toString | shuffle | b64enc | quote }}
+    {{- $password = printf "%s%s" $subStr $password | toString | shuffle | b64enc }}
   {{- else }}
-    {{- $password = randAlphaNum $passwordLength | b64enc | quote }}
+    {{- $password = randAlphaNum $passwordLength | b64enc }}
   {{- end }}
 {{- end -}}
 {{- printf "%s" $password -}}


### PR DESCRIPTION
**Description of the change**

This change removes the `quote` function from the definition of the `password` variable in `common.secrets.passwords.manage`.

**Benefits**

With `quote`, I'm constantly getting a diff (in my deployment of bitnami/harbor version 12.3.1) because the applied secret value never has quotes while the template does have quotes, so `helm diff` reports an diff even though there's nothing to apply really.

**Possible drawbacks**

I think there should be no drawbacks. Since the value is base64, it should be safe to not quote it. But since it's a common library, it is hard for me to verify all places where it's used.

Whether or not this is a breaking change is a matter of preference. I think it's not a breaking change, since I can't think of a reason where the quotes makes a difference for how the value should be parsed. But someone may have a different view on this than I have. [Knowing what's breaking or not is hard.](https://xkcd.com/1172/)

**Applicable issues**

- Previously discussed in #5620 with no clear resolution.

**Additional information**

As far as I can tell, quoting a value for a Kubernetes Secret has no effect:

<table>
<tr>
<th>noquotes.yaml</th>
<th>quotes.yaml</th>
</tr>
<tr>
<td>

```yaml
apiVersion: v1
data:
  foo: YmFy
kind: Secret
metadata:
  name: test
```
</td>
<td>

```yaml
apiVersion: v1
data:
  foo: "YmFy"
kind: Secret
metadata:
  name: test
```
</td>
</tr>
</table>

```console
$ kubectl apply -f noquotes.yaml --dry-run=client -o jsonpath='{ .data.foo }'
YmFy
$ kubectl apply -f quotes.yaml --dry-run=client -o jsonpath='{ .data.foo }'
YmFy
```


**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)