### PR TITLE
[bitnami/rabbitmq-cluster-operator] Chart standardised

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.lock
+++ b/bitnami/rabbitmq-cluster-operator/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.12.0
-digest: sha256:7e484480451778c273e7a165dbfaa5594ec1c9a63a114ce9d458626cadd28893
-generated: "2022-03-18T14:09:29.606467378Z"
+  version: 1.13.0
+digest: sha256:e83af41b39942278f8389623671732e624f28c6f1ad6ac2d937e210c5f354a18
+generated: "2022-04-18T17:44:21.418565+02:00"

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -26,4 +26,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 2.5.2
+version: 2.6.0

--- a/bitnami/rabbitmq-cluster-operator/README.md
+++ b/bitnami/rabbitmq-cluster-operator/README.md
@@ -142,15 +142,18 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 
 ### Common parameters
 
-| Name                | Description                                        | Value           |
-| ------------------- | -------------------------------------------------- | --------------- |
-| `kubeVersion`       | Override Kubernetes version                        | `""`            |
-| `nameOverride`      | String to partially override common.names.fullname | `""`            |
-| `fullnameOverride`  | String to fully override common.names.fullname     | `""`            |
-| `commonLabels`      | Labels to add to all deployed objects              | `{}`            |
-| `commonAnnotations` | Annotations to add to all deployed objects         | `{}`            |
-| `clusterDomain`     | Kubernetes cluster domain name                     | `cluster.local` |
-| `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`            |
+| Name                     | Description                                                                             | Value           |
+| ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
+| `nameOverride`           | String to partially override common.names.fullname                                      | `""`            |
+| `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
+| `commonLabels`           | Labels to add to all deployed objects                                                   | `{}`            |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
+| `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the the deployment(s)/statefulset(s)              | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the the deployment(s)/statefulset(s)                 | `["infinity"]`  |
 
 
 ### RabbitMQ Cluster Operator Parameters
@@ -159,7 +162,7 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
 | `rabbitmqImage.registry`                                          | RabbitMQ Image registry                                                                                 | `docker.io`                              |
 | `rabbitmqImage.repository`                                        | RabbitMQ Image repository                                                                               | `bitnami/rabbitmq`                       |
-| `rabbitmqImage.tag`                                               | RabbitMQ Image tag (immutable tags are recommended)                                                     | `3.8.27-debian-10-r49`                   |
+| `rabbitmqImage.tag`                                               | RabbitMQ Image tag (immutable tags are recommended)                                                     | `3.8.28-debian-10-r1`                    |
 | `rabbitmqImage.pullSecrets`                                       | RabbitMQ Image pull secrets                                                                             | `[]`                                     |
 | `credentialUpdaterImage.registry`                                 | RabbitMQ Default User Credential Updater Image registry                                                 | `docker.io`                              |
 | `credentialUpdaterImage.repository`                               | RabbitMQ Default User Credential Updater Image repository                                               | `bitnami/rmq-default-credential-updater` |
@@ -167,12 +170,13 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 | `credentialUpdaterImage.pullSecrets`                              | RabbitMQ Default User Credential Updater Image pull secrets                                             | `[]`                                     |
 | `clusterOperator.image.registry`                                  | RabbitMQ Cluster Operator image registry                                                                | `docker.io`                              |
 | `clusterOperator.image.repository`                                | RabbitMQ Cluster Operator image repository                                                              | `bitnami/rabbitmq-cluster-operator`      |
-| `clusterOperator.image.tag`                                       | RabbitMQ Cluster Operator image tag (immutable tags are recommended)                                    | `1.12.1-scratch-r0`                      |
+| `clusterOperator.image.tag`                                       | RabbitMQ Cluster Operator image tag (immutable tags are recommended)                                    | `1.12.1-scratch-r2`                      |
 | `clusterOperator.image.pullPolicy`                                | RabbitMQ Cluster Operator image pull policy                                                             | `IfNotPresent`                           |
 | `clusterOperator.image.pullSecrets`                               | RabbitMQ Cluster Operator image pull secrets                                                            | `[]`                                     |
 | `clusterOperator.replicaCount`                                    | Number of RabbitMQ Cluster Operator replicas to deploy                                                  | `1`                                      |
 | `clusterOperator.schedulerName`                                   | Alternative scheduler                                                                                   | `""`                                     |
 | `clusterOperator.topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment                                                          | `[]`                                     |
+| `clusterOperator.terminationGracePeriodSeconds`                   | In seconds, time the given to the %%MAIN_CONTAINER_NAME%% pod needs to terminate gracefully             | `""`                                     |
 | `clusterOperator.livenessProbe.enabled`                           | Enable livenessProbe on RabbitMQ Cluster Operator nodes                                                 | `true`                                   |
 | `clusterOperator.livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                 | `5`                                      |
 | `clusterOperator.livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                        | `30`                                     |
@@ -247,15 +251,18 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 | `clusterOperator.metrics.service.loadBalancerSourceRanges` | RabbitMQ Cluster Operator metrics service Load Balancer sources             | `[]`                     |
 | `clusterOperator.metrics.service.externalTrafficPolicy`    | RabbitMQ Cluster Operator metrics service external traffic policy           | `Cluster`                |
 | `clusterOperator.metrics.service.annotations`              | Additional custom annotations for RabbitMQ Cluster Operator metrics service | `{}`                     |
+| `clusterOperator.metrics.service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"        | `None`                   |
+| `clusterOperator.metrics.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                 | `{}`                     |
 | `clusterOperator.metrics.serviceMonitor.enabled`           | Specify if a servicemonitor will be deployed for prometheus-operator        | `false`                  |
+| `clusterOperator.metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                    | `""`                     |
 | `clusterOperator.metrics.serviceMonitor.jobLabel`          | Specify the jobLabel to use for the prometheus-operator                     | `app.kubernetes.io/name` |
 | `clusterOperator.metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                        | `false`                  |
 | `clusterOperator.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                         | `{}`                     |
 | `clusterOperator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                     | `""`                     |
 | `clusterOperator.metrics.serviceMonitor.interval`          | Scrape interval. If not set, the Prometheus default scrape interval is used | `""`                     |
-| `clusterOperator.metrics.serviceMonitor.additionalLabels`  | Used to pass Labels that are required by the installed Prometheus Operator  | `{}`                     |
 | `clusterOperator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                    | `[]`                     |
 | `clusterOperator.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                  | `[]`                     |
+| `clusterOperator.metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                         | `{}`                     |
 
 
 ### RabbitMQ Messaging Topology Operator Parameters
@@ -264,12 +271,13 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
 | `msgTopologyOperator.image.registry`                                  | RabbitMQ Messaging Topology Operator image registry                                                                | `docker.io`                               |
 | `msgTopologyOperator.image.repository`                                | RabbitMQ Messaging Topology Operator image repository                                                              | `bitnami/rmq-messaging-topology-operator` |
-| `msgTopologyOperator.image.tag`                                       | RabbitMQ Messaging Topology Operator image tag (immutable tags are recommended)                                    | `1.4.1-scratch-r0`                        |
+| `msgTopologyOperator.image.tag`                                       | RabbitMQ Messaging Topology Operator image tag (immutable tags are recommended)                                    | `1.5.0-scratch-r0`                        |
 | `msgTopologyOperator.image.pullPolicy`                                | RabbitMQ Messaging Topology Operator image pull policy                                                             | `IfNotPresent`                            |
 | `msgTopologyOperator.image.pullSecrets`                               | RabbitMQ Messaging Topology Operator image pull secrets                                                            | `[]`                                      |
 | `msgTopologyOperator.replicaCount`                                    | Number of RabbitMQ Messaging Topology Operator replicas to deploy                                                  | `1`                                       |
 | `msgTopologyOperator.topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment                                                                     | `[]`                                      |
 | `msgTopologyOperator.schedulerName`                                   | Alternative scheduler                                                                                              | `""`                                      |
+| `msgTopologyOperator.terminationGracePeriodSeconds`                   | In seconds, time the given to the %%MAIN_CONTAINER_NAME%% pod needs to terminate gracefully                        | `""`                                      |
 | `msgTopologyOperator.livenessProbe.enabled`                           | Enable livenessProbe on RabbitMQ Messaging Topology Operator nodes                                                 | `true`                                    |
 | `msgTopologyOperator.livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                            | `5`                                       |
 | `msgTopologyOperator.livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                                   | `30`                                      |
@@ -335,6 +343,8 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 | `msgTopologyOperator.service.loadBalancerSourceRanges`                | RabbitMQ Messaging Topology Operator webhook service Load Balancer sources                                         | `[]`                                      |
 | `msgTopologyOperator.service.externalTrafficPolicy`                   | RabbitMQ Messaging Topology Operator webhook service external traffic policy                                       | `Cluster`                                 |
 | `msgTopologyOperator.service.annotations`                             | Additional custom annotations for RabbitMQ Messaging Topology Operator webhook service                             | `{}`                                      |
+| `msgTopologyOperator.service.sessionAffinity`                         | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                               | `None`                                    |
+| `msgTopologyOperator.service.sessionAffinityConfig`                   | Additional settings for the sessionAffinity                                                                        | `{}`                                      |
 | `msgTopologyOperator.rbac.create`                                     | Specifies whether RBAC resources should be created                                                                 | `true`                                    |
 | `msgTopologyOperator.serviceAccount.create`                           | Specifies whether a ServiceAccount should be created                                                               | `true`                                    |
 | `msgTopologyOperator.serviceAccount.name`                             | The name of the ServiceAccount to use.                                                                             | `""`                                      |
@@ -356,15 +366,18 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 | `msgTopologyOperator.metrics.service.loadBalancerSourceRanges` | RabbitMQ Cluster Operator metrics service Load Balancer sources             | `[]`                     |
 | `msgTopologyOperator.metrics.service.externalTrafficPolicy`    | RabbitMQ Cluster Operator metrics service external traffic policy           | `Cluster`                |
 | `msgTopologyOperator.metrics.service.annotations`              | Additional custom annotations for RabbitMQ Cluster Operator metrics service | `{}`                     |
+| `msgTopologyOperator.metrics.service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"        | `None`                   |
+| `msgTopologyOperator.metrics.service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                 | `{}`                     |
 | `msgTopologyOperator.metrics.serviceMonitor.enabled`           | Specify if a servicemonitor will be deployed for prometheus-operator        | `false`                  |
+| `msgTopologyOperator.metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                    | `""`                     |
 | `msgTopologyOperator.metrics.serviceMonitor.jobLabel`          | Specify the jobLabel to use for the prometheus-operator                     | `app.kubernetes.io/name` |
-| `msgTopologyOperator.metrics.serviceMonitor.additionalLabels`  | Used to pass Labels that are required by the installed Prometheus Operator  | `{}`                     |
 | `msgTopologyOperator.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                         | `{}`                     |
 | `msgTopologyOperator.metrics.serviceMonitor.honorLabels`       | Honor metrics labels                                                        | `false`                  |
 | `msgTopologyOperator.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                     | `""`                     |
 | `msgTopologyOperator.metrics.serviceMonitor.interval`          | Scrape interval. If not set, the Prometheus default scrape interval is used | `""`                     |
 | `msgTopologyOperator.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                    | `[]`                     |
 | `msgTopologyOperator.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                  | `[]`                     |
+| `msgTopologyOperator.metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                         | `{}`                     |
 
 
 ### cert-manager parameters

--- a/bitnami/rabbitmq-cluster-operator/README.md
+++ b/bitnami/rabbitmq-cluster-operator/README.md
@@ -142,18 +142,16 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 
 ### Common parameters
 
-| Name                     | Description                                                                             | Value           |
-| ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
-| `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
-| `nameOverride`           | String to partially override common.names.fullname                                      | `""`            |
-| `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
-| `commonLabels`           | Labels to add to all deployed objects                                                   | `{}`            |
-| `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
-| `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
-| `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
-| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
-| `diagnosticMode.command` | Command to override all containers in the the deployment(s)/statefulset(s)              | `["sleep"]`     |
-| `diagnosticMode.args`    | Args to override all containers in the the deployment(s)/statefulset(s)                 | `["infinity"]`  |
+| Name                     | Description                                          | Value           |
+| ------------------------ | ---------------------------------------------------- | --------------- |
+| `kubeVersion`            | Override Kubernetes version                          | `""`            |
+| `nameOverride`           | String to partially override common.names.fullname   | `""`            |
+| `fullnameOverride`       | String to fully override common.names.fullname       | `""`            |
+| `commonLabels`           | Labels to add to all deployed objects                | `{}`            |
+| `commonAnnotations`      | Annotations to add to all deployed objects           | `{}`            |
+| `clusterDomain`          | Kubernetes cluster domain name                       | `cluster.local` |
+| `extraDeploy`            | Array of extra objects to deploy with the release    | `[]`            |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled) | `false`         |
 
 
 ### RabbitMQ Cluster Operator Parameters

--- a/bitnami/rabbitmq-cluster-operator/templates/NOTES.txt
+++ b/bitnami/rabbitmq-cluster-operator/templates/NOTES.txt
@@ -6,7 +6,7 @@ APP VERSION: {{ .Chart.AppVersion }}
 
 Watch the RabbitMQ Cluster Operator and RabbitMQ Messaging Topology Operator Deployment status using the command:
 
-    kubectl get deploy -w --namespace {{ .Release.Namespace }} -l app.kubernetes.io/name={{ include "common.names.name" . }},app.kubernetes.io/instance={{ .Release.Name }}
+    kubectl get deploy -w --namespace {{ include "common.names.namespace" . }} -l app.kubernetes.io/name={{ include "common.names.name" . }},app.kubernetes.io/instance={{ .Release.Name }}
 
 {{ include "common.warnings.rollingTag" .Values.clusterOperator.image }}
 {{ include "common.warnings.rollingTag" .Values.msgTopologyOperator.image }}

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/clusterrolebinding.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/clusterrolebinding.yaml
@@ -19,5 +19,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "rmqco.clusterOperator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "rmqco.clusterOperator.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: rabbitmq-operator
     app.kubernetes.io/part-of: rabbitmq
@@ -63,9 +63,12 @@ spec:
       {{- if .Values.clusterOperator.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.clusterOperator.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.clusterOperator.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.clusterOperator.terminationGracePeriodSeconds }}
+      {{- end }}
       initContainers:
         {{- if .Values.clusterOperator.initContainers }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
         - name: rabbitmq-cluster-operator
@@ -74,13 +77,17 @@ spec:
           {{- if .Values.clusterOperator.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.clusterOperator.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.clusterOperator.command }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.clusterOperator.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - /manager
           {{- end }}
-          {{- if .Values.clusterOperator.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.clusterOperator.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.args "context" $) | nindent 12 }}
           {{- else }}
           args:
@@ -114,44 +121,31 @@ spec:
           {{- if .Values.clusterOperator.resources }}
           resources: {{- toYaml .Values.clusterOperator.resources | nindent 12 }}
           {{- end }}
+          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.clusterOperator.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.clusterOperator.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: http
-            initialDelaySeconds: {{ .Values.clusterOperator.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.clusterOperator.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.clusterOperator.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.clusterOperator.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.clusterOperator.livenessProbe.failureThreshold }}
           {{- else if .Values.clusterOperator.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.clusterOperator.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.clusterOperator.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: http
-            initialDelaySeconds: {{ .Values.clusterOperator.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.clusterOperator.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.clusterOperator.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.clusterOperator.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.clusterOperator.readinessProbe.failureThreshold }}
           {{- else if .Values.clusterOperator.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.clusterOperator.startupProbe.enabled }}
-          startupProbe:
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.clusterOperator.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: http
-            initialDelaySeconds: {{ .Values.clusterOperator.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.clusterOperator.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.clusterOperator.startupProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.clusterOperator.startupProbe.successThreshold }}
-            failureThreshold: {{ .Values.clusterOperator.startupProbe.failureThreshold }}
           {{- else if .Values.clusterOperator.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.clusterOperator.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/deployment.yaml
@@ -77,17 +77,13 @@ spec:
           {{- if .Values.clusterOperator.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.clusterOperator.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.diagnosticMode.enabled }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
-          {{- else if .Values.clusterOperator.command }}
+          {{- if .Values.clusterOperator.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - /manager
           {{- end }}
-          {{- if .Values.diagnosticMode.enabled }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
-          {{- else if .Values.clusterOperator.args }}
+          {{- if .Values.clusterOperator.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.args "context" $) | nindent 12 }}
           {{- else }}
           args:

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/metrics-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/metrics-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.clusterOperator.metrics.enabled }}
+{{- if .Values.clusterOperator.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,8 +8,8 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ template "rmqco.clusterOperator.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace | quote }}
+  name: {{ printf "%s-metrics" (include "rmqco.clusterOperator.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if or .Values.commonAnnotations .Values.clusterOperator.metrics.service.annotations }}
   annotations:
     {{- if .Values.clusterOperator.metrics.service.annotations }}
@@ -24,14 +24,20 @@ spec:
   {{- if (or (eq .Values.clusterOperator.metrics.service.type "LoadBalancer") (eq .Values.clusterOperator.metrics.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.clusterOperator.metrics.service.externalTrafficPolicy | quote }}
   {{- end }}
-  {{ if .Values.clusterOperator.metrics.service.clusterIP }}
+  {{- if .Values.clusterOperator.metrics.service.clusterIP }}
   clusterIP: {{ .Values.clusterOperator.metrics.service.clusterIP }}
-  {{ end }}
-  {{ if eq .Values.clusterOperator.metrics.service.type "LoadBalancer" }}
+  {{- end }}
+  {{- if eq .Values.clusterOperator.metrics.service.type "LoadBalancer" }}
   loadBalancerSourceRanges: {{ .Values.clusterOperator.metrics.service.loadBalancerSourceRanges }}
-  {{ end }}
+  {{- end }}
   {{- if (and (eq .Values.clusterOperator.metrics.service.type "LoadBalancer") (not (empty .Values.clusterOperator.metrics.service.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.clusterOperator.metrics.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.clusterOperator.metrics.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.clusterOperator.metrics.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.clusterOperator.metrics.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.metrics.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
     - name: http

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/role.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/role.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.clusterOperator.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/rolebinding.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.clusterOperator.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -20,5 +20,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "rmqco.clusterOperator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/service-account.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/service-account.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.clusterOperator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if or .Values.commonAnnotations .Values.clusterOperator.serviceAccount.annotations }}
   annotations:
     {{- if .Values.clusterOperator.serviceAccount.annotations }}

--- a/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/servicemonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/cluster-operator/servicemonitor.yaml
@@ -9,10 +9,13 @@ metadata:
     {{- if .Values.clusterOperator.metrics.serviceMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.clusterOperator.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.clusterOperator.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
+    {{- end }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.clusterOperator.metrics.serviceMonitor.namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -26,7 +29,7 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "common.names.namespace" . | quote }}
   endpoints:
     - port: http
       {{- if .Values.clusterOperator.metrics.serviceMonitor.interval }}

--- a/bitnami/rabbitmq-cluster-operator/templates/issuer.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/issuer.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.useCertManager }}
+{{- if .Values.useCertManager }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -8,7 +8,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   selfSigned: {}
 {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/certificate.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/certificate.yaml
@@ -1,4 +1,4 @@
-{{ if and (.Values.useCertManager) (not .Values.msgTopologyOperator.existingWebhookCertSecret) }}
+{{- if and (.Values.useCertManager) (not .Values.msgTopologyOperator.existingWebhookCertSecret) }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -9,14 +9,14 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
   dnsNames:
-    - {{ printf "%s.%s.svc" (include "rmqco.msgTopologyOperator.webhook.fullname" .) .Release.Namespace }}
-    - {{ printf "%s.%s.svc.%s" (include "rmqco.msgTopologyOperator.webhook.fullname" .) .Release.Namespace .Values.clusterDomain }}
+    - {{ printf "%s.%s.svc" (include "rmqco.msgTopologyOperator.webhook.fullname" .) (include "common.names.namespace" .) }}
+    - {{ printf "%s.%s.svc.%s" (include "rmqco.msgTopologyOperator.webhook.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain }}
   issuerRef:
     kind: Issuer
     name: {{ template "common.names.fullname" . }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrolebinding.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrolebinding.yaml
@@ -19,5 +19,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "rmqco.msgTopologyOperator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "rmqco.msgTopologyOperator.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: messaging-topology-operator
     app.kubernetes.io/part-of: rabbitmq
@@ -63,9 +63,12 @@ spec:
       {{- if .Values.msgTopologyOperator.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.msgTopologyOperator.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.msgTopologyOperator.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.msgTopologyOperator.terminationGracePeriodSeconds }}
+      {{- end }}
       initContainers:
         {{- if .Values.msgTopologyOperator.initContainers }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
         - name: rabbitmq-cluster-operator
@@ -74,13 +77,17 @@ spec:
           {{- if .Values.msgTopologyOperator.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.msgTopologyOperator.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.msgTopologyOperator.command }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.msgTopologyOperator.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - /manager
           {{- end }}
-          {{- if .Values.msgTopologyOperator.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.msgTopologyOperator.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.args "context" $) | nindent 12 }}
           {{- else }}
           args:
@@ -106,44 +113,38 @@ spec:
           {{- if .Values.msgTopologyOperator.resources }}
           resources: {{- toYaml .Values.msgTopologyOperator.resources | nindent 12 }}
           {{- end }}
+          ports:
+            - name: http-webhook
+              containerPort: 9443
+              protocol: TCP
+            - name: http-metrics
+              containerPort: {{ .Values.msgTopologyOperator.containerPorts.metrics }}
+              protocol: TCP
+          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.msgTopologyOperator.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.msgTopologyOperator.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: http-metrics
-            initialDelaySeconds: {{ .Values.msgTopologyOperator.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.msgTopologyOperator.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.msgTopologyOperator.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.msgTopologyOperator.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.msgTopologyOperator.livenessProbe.failureThreshold }}
           {{- else if .Values.msgTopologyOperator.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.msgTopologyOperator.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.msgTopologyOperator.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: http-metrics
-            initialDelaySeconds: {{ .Values.msgTopologyOperator.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.msgTopologyOperator.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.msgTopologyOperator.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.msgTopologyOperator.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.msgTopologyOperator.readinessProbe.failureThreshold }}
           {{- else if .Values.msgTopologyOperator.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.msgTopologyOperator.startupProbe.enabled }}
-          startupProbe:
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.msgTopologyOperator.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: http-metrics
-            initialDelaySeconds: {{ .Values.msgTopologyOperator.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.msgTopologyOperator.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.msgTopologyOperator.startupProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.msgTopologyOperator.startupProbe.successThreshold }}
-            failureThreshold: {{ .Values.msgTopologyOperator.startupProbe.failureThreshold }}
           {{- else if .Values.msgTopologyOperator.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
           {{- if .Values.msgTopologyOperator.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.lifecycleHooks "context" $) | nindent 12 }}
@@ -155,13 +156,6 @@ spec:
             {{- if .Values.msgTopologyOperator.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
-          ports:
-            - name: http-webhook
-              containerPort: 9443
-              protocol: TCP
-            - name: http-metrics
-              containerPort: {{ .Values.msgTopologyOperator.containerPorts.metrics }}
-              protocol: TCP
         {{- if .Values.msgTopologyOperator.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.msgTopologyOperator.sidecars "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/deployment.yaml
@@ -77,17 +77,13 @@ spec:
           {{- if .Values.msgTopologyOperator.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.msgTopologyOperator.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.diagnosticMode.enabled }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
-          {{- else if .Values.msgTopologyOperator.command }}
+          {{- if .Values.msgTopologyOperator.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - /manager
           {{- end }}
-          {{- if .Values.diagnosticMode.enabled }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
-          {{- else if .Values.msgTopologyOperator.args }}
+          {{- if .Values.msgTopologyOperator.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.args "context" $) | nindent 12 }}
           {{- else }}
           args:

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/metrics-service.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.msgTopologyOperator.metrics.enabled }}
+{{- if .Values.msgTopologyOperator.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,8 +9,8 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ template "rmqco.msgTopologyOperator.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace | quote }}
+  name: {{ printf "%s-metrics" (include "rmqco.msgTopologyOperator.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if or .Values.commonAnnotations .Values.msgTopologyOperator.metrics.service.annotations }}
   annotations:
     {{- if .Values.msgTopologyOperator.metrics.service.annotations }}
@@ -25,14 +25,20 @@ spec:
   {{- if (or (eq .Values.msgTopologyOperator.metrics.service.type "LoadBalancer") (eq .Values.msgTopologyOperator.metrics.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.msgTopologyOperator.metrics.service.externalTrafficPolicy | quote }}
   {{- end }}
-  {{ if .Values.msgTopologyOperator.metrics.service.clusterIP }}
+  {{- if .Values.msgTopologyOperator.metrics.service.clusterIP }}
   clusterIP: {{ .Values.msgTopologyOperator.metrics.service.clusterIP }}
-  {{ end }}
-  {{ if eq .Values.msgTopologyOperator.metrics.service.type "LoadBalancer" }}
+  {{- end }}
+  {{- if eq .Values.msgTopologyOperator.metrics.service.type "LoadBalancer" }}
   loadBalancerSourceRanges: {{ .Values.msgTopologyOperator.metrics.service.loadBalancerSourceRanges }}
-  {{ end }}
+  {{- end }}
   {{- if (and (eq .Values.msgTopologyOperator.metrics.service.type "LoadBalancer") (not (empty .Values.msgTopologyOperator.metrics.service.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.msgTopologyOperator.metrics.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.msgTopologyOperator.metrics.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.msgTopologyOperator.metrics.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.msgTopologyOperator.metrics.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.metrics.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
     - name: http

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/role.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/role.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.msgTopologyOperator.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/rolebinding.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/rolebinding.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.msgTopologyOperator.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -20,5 +20,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "rmqco.msgTopologyOperator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/service-account.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/service-account.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.msgTopologyOperator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if or .Values.commonAnnotations .Values.msgTopologyOperator.serviceAccount.annotations }}
   annotations:
     {{- if .Values.msgTopologyOperator.serviceAccount.annotations }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/servicemonitor.yaml
@@ -9,10 +9,13 @@ metadata:
     {{- if .Values.msgTopologyOperator.metrics.serviceMonitor.additionalLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.metrics.serviceMonitor.additionalLabels "context" $) | nindent 4 }}
     {{- end }}
+    {{- if .Values.msgTopologyOperator.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.metrics.serviceMonitor.labels "context" $) | nindent 4 }}
+    {{- end }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.msgTopologyOperator.metrics.serviceMonitor.namespace | quote }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
@@ -28,7 +31,7 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "common.names.namespace" . | quote }}
   endpoints:
     - port: http
       {{- if .Values.msgTopologyOperator.metrics.serviceMonitor.interval }}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/validating-webhook-configuration.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/validating-webhook-configuration.yaml
@@ -2,14 +2,14 @@
     If the user does not have cert-manager and is not providing a secret with the certificates, the chart needs to generate the secret
   */}}
 {{- $ca := genCA "rmq-msg-topology-ca" 365 }}
-{{- $cert := genSignedCert (include "rmqco.msgTopologyOperator.fullname" .) nil (list (printf "%s.%s.svc" (include "rmqco.msgTopologyOperator.webhook.fullname" .) .Release.Namespace) (printf "%s.%s.svc.%s" (include "rmqco.msgTopologyOperator.webhook.fullname" .) .Release.Namespace .Values.clusterDomain)) 365 $ca }}
+{{- $cert := genSignedCert (include "rmqco.msgTopologyOperator.fullname" .) nil (list (printf "%s.%s.svc" (include "rmqco.msgTopologyOperator.webhook.fullname" .) (include "common.names.namespace" .)) (printf "%s.%s.svc.%s" (include "rmqco.msgTopologyOperator.webhook.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain)) 365 $ca }}
 
 {{- if and (not .Values.useCertManager) (not .Values.msgTopologyOperator.existingWebhookCertSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -35,7 +35,7 @@ metadata:
     {{- end }}
   annotations:
     {{- if .Values.useCertManager }}
-    cert-manager.io/inject-ca-from: {{ printf "%s/%s" .Release.Namespace ( include "rmqco.msgTopologyOperator.webhook.secretName" . ) }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s" (include "common.names.namespace" .) ( include "rmqco.msgTopologyOperator.webhook.secretName" . ) }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -50,7 +50,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-binding
     failurePolicy: Fail
     name: vbinding.kb.io
@@ -73,7 +73,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-exchange
     failurePolicy: Fail
     name: vexchange.kb.io
@@ -96,7 +96,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-federation
     failurePolicy: Fail
     name: vfederation.kb.io
@@ -119,7 +119,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1alpha1-superstream
     failurePolicy: Fail
     name: vsuperstream.kb.io
@@ -142,7 +142,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-permission
     failurePolicy: Fail
     name: vpermission.kb.io
@@ -165,7 +165,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-policy
     failurePolicy: Fail
     name: vpolicy.kb.io
@@ -188,7 +188,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-queue
     failurePolicy: Fail
     name: vqueue.kb.io
@@ -211,7 +211,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-schemareplication
     failurePolicy: Fail
     name: vschemareplication.kb.io
@@ -234,7 +234,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-shovel
     failurePolicy: Fail
     name: vshovel.kb.io
@@ -257,7 +257,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-user
     failurePolicy: Fail
     name: vuser.kb.io
@@ -280,7 +280,7 @@ webhooks:
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-        namespace: {{ .Release.Namespace | quote }}
+        namespace: {{ include "common.names.namespace" . | quote }}
         path: /validate-rabbitmq-com-v1beta1-vhost
     failurePolicy: Fail
     name: vvhost.kb.io

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/webhook-service.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/webhook-service.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- if or .Values.commonAnnotations .Values.msgTopologyOperator.service.annotations }}
   annotations:
     {{- if .Values.msgTopologyOperator.service.annotations }}
@@ -23,14 +23,20 @@ spec:
   {{- if (or (eq .Values.msgTopologyOperator.service.type "LoadBalancer") (eq .Values.msgTopologyOperator.service.type "NodePort")) }}
   externalTrafficPolicy: {{ .Values.msgTopologyOperator.service.externalTrafficPolicy | quote }}
   {{- end }}
-  {{ if .Values.msgTopologyOperator.service.clusterIP }}
+  {{- if .Values.msgTopologyOperator.service.clusterIP }}
   clusterIP: {{ .Values.msgTopologyOperator.service.clusterIP }}
-  {{ end }}
-  {{ if eq .Values.msgTopologyOperator.service.type "LoadBalancer" }}
+  {{- end }}
+  {{- if eq .Values.msgTopologyOperator.service.type "LoadBalancer" }}
   loadBalancerSourceRanges: {{ .Values.msgTopologyOperator.service.loadBalancerSourceRanges }}
-  {{ end }}
+  {{- end }}
   {{- if (and (eq .Values.msgTopologyOperator.service.type "LoadBalancer") (not (empty .Values.msgTopologyOperator.service.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.msgTopologyOperator.service.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.msgTopologyOperator.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.msgTopologyOperator.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.msgTopologyOperator.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
     - name: http
@@ -42,5 +48,8 @@ spec:
       {{- else if eq .Values.msgTopologyOperator.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.msgTopologyOperator.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.msgTopologyOperator.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: messaging-topology-operator

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -41,6 +41,20 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## Enable diagnostic mode in the deployment(s)/statefulset(s)
+##
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ##
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the the deployment(s)/statefulset(s)
+  ##
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the the deployment(s)/statefulset(s)
+  ##
+  args:
+    - infinity
 
 ## @section RabbitMQ Cluster Operator Parameters
 ##
@@ -123,6 +137,10 @@ clusterOperator:
   ## The value is evaluated as a template
   ##
   topologySpreadConstraints: []
+  ## @param clusterOperator.terminationGracePeriodSeconds In seconds, time the given to the %%MAIN_CONTAINER_NAME%% pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  ##
+  terminationGracePeriodSeconds: ""
   ## Configure extra options for RabbitMQ Cluster Operator containers' liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
   ## @param clusterOperator.livenessProbe.enabled Enable livenessProbe on RabbitMQ Cluster Operator nodes
@@ -399,10 +417,26 @@ clusterOperator:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.clusterOperator.metrics.service.ports.http }}"
+      ## @param clusterOperator.metrics.service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
+      ## If "ClientIP", consecutive client requests will be directed to the same Pod
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+      ##
+      sessionAffinity: None
+      ## @param clusterOperator.metrics.service.sessionAffinityConfig Additional settings for the sessionAffinity
+      ## sessionAffinityConfig:
+      ##   clientIP:
+      ##     timeoutSeconds: 300
+      ##
+      sessionAffinityConfig: {}
     serviceMonitor:
       ## @param clusterOperator.metrics.serviceMonitor.enabled Specify if a servicemonitor will be deployed for prometheus-operator
       ##
       enabled: false
+      ## @param clusterOperator.metrics.serviceMonitor.namespace Namespace which Prometheus is running in
+      ## e.g:
+      ## namespace: monitoring
+      ##
+      namespace: ""
       ## @param clusterOperator.metrics.serviceMonitor.jobLabel Specify the jobLabel to use for the prometheus-operator
       ##
       jobLabel: app.kubernetes.io/name
@@ -426,16 +460,20 @@ clusterOperator:
       ## @param clusterOperator.metrics.serviceMonitor.interval Scrape interval. If not set, the Prometheus default scrape interval is used
       ##
       interval: ""
-      ## @param clusterOperator.metrics.serviceMonitor.additionalLabels Used to pass Labels that are required by the installed Prometheus Operator
-      ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
-      ##
-      additionalLabels: {}
+
+      ## DEPRECATED: Use clusterOperator.metrics.serviceMonitor.labels instead
+      ## This value will be removed in a future release
+      ## additionalLabels: {}
+
       ## @param clusterOperator.metrics.serviceMonitor.metricRelabelings Specify additional relabeling of metrics
       ##
       metricRelabelings: []
       ## @param clusterOperator.metrics.serviceMonitor.relabelings Specify general relabeling
       ##
       relabelings: []
+      ## @param clusterOperator.metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+      ##
+      labels: {}
 
 ## @section RabbitMQ Messaging Topology Operator Parameters
 ##
@@ -477,6 +515,10 @@ msgTopologyOperator:
   ## @param msgTopologyOperator.schedulerName Alternative scheduler
   ##
   schedulerName: ""
+  ## @param msgTopologyOperator.terminationGracePeriodSeconds In seconds, time the given to the %%MAIN_CONTAINER_NAME%% pod needs to terminate gracefully
+  ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+  ##
+  terminationGracePeriodSeconds: ""
   ## Configure extra options for RabbitMQ Messaging Topology Operator containers' liveness and readiness probes
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
   ## @param msgTopologyOperator.livenessProbe.enabled Enable livenessProbe on RabbitMQ Messaging Topology Operator nodes
@@ -733,6 +775,17 @@ msgTopologyOperator:
     ## @param msgTopologyOperator.service.annotations Additional custom annotations for RabbitMQ Messaging Topology Operator webhook service
     ##
     annotations: {}
+    ## @param msgTopologyOperator.service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
+    ## If "ClientIP", consecutive client requests will be directed to the same Pod
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+    ##
+    sessionAffinity: None
+    ## @param msgTopologyOperator.service.sessionAffinityConfig Additional settings for the sessionAffinity
+    ## sessionAffinityConfig:
+    ##   clientIP:
+    ##     timeoutSeconds: 300
+    ##
+    sessionAffinityConfig: {}
 
   ## RBAC configuration
   ##
@@ -808,17 +861,34 @@ msgTopologyOperator:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.msgTopologyOperator.metrics.service.ports.http }}"
+      ## @param msgTopologyOperator.metrics.service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
+      ## If "ClientIP", consecutive client requests will be directed to the same Pod
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+      ##
+      sessionAffinity: None
+      ## @param msgTopologyOperator.metrics.service.sessionAffinityConfig Additional settings for the sessionAffinity
+      ## sessionAffinityConfig:
+      ##   clientIP:
+      ##     timeoutSeconds: 300
+      ##
+      sessionAffinityConfig: {}
     serviceMonitor:
       ## @param msgTopologyOperator.metrics.serviceMonitor.enabled Specify if a servicemonitor will be deployed for prometheus-operator
       ##
       enabled: false
+      ## @param msgTopologyOperator.metrics.serviceMonitor.namespace Namespace which Prometheus is running in
+      ## e.g:
+      ## namespace: monitoring
+      ##
+      namespace: ""
       ## @param msgTopologyOperator.metrics.serviceMonitor.jobLabel Specify the jobLabel to use for the prometheus-operator
       ##
       jobLabel: app.kubernetes.io/name
-      ## @param msgTopologyOperator.metrics.serviceMonitor.additionalLabels Used to pass Labels that are required by the installed Prometheus Operator
-      ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
-      ##
-      additionalLabels: {}
+
+      ## DEPRECATED: Use msgTopologyOperator.metrics.serviceMonitor.labels instead.
+      ## This value will be removed in a future release
+      ## additionalLabels: {}
+
       ## @param msgTopologyOperator.metrics.serviceMonitor.selector Prometheus instance selector labels
       ## ref: https://github.com/bitnami/charts/tree/master/bitnami/prometheus-operator#prometheus-configuration
       ## e.g:
@@ -845,6 +915,9 @@ msgTopologyOperator:
       ## @param msgTopologyOperator.metrics.serviceMonitor.relabelings Specify general relabeling
       ##
       relabelings: []
+      ## @param msgTopologyOperator.metrics.serviceMonitor.labels Extra labels for the ServiceMonitor
+      ##
+      labels: {}
 
 ## @section cert-manager parameters
 ##

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -44,17 +44,9 @@ extraDeploy: []
 ## Enable diagnostic mode in the deployment(s)/statefulset(s)
 ##
 diagnosticMode:
-  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled)
   ##
   enabled: false
-  ## @param diagnosticMode.command Command to override all containers in the the deployment(s)/statefulset(s)
-  ##
-  command:
-    - sleep
-  ## @param diagnosticMode.args Args to override all containers in the the deployment(s)/statefulset(s)
-  ##
-  args:
-    - infinity
 
 ## @section RabbitMQ Cluster Operator Parameters
 ##

--- a/bitnami/rabbitmq-cluster-operator/values.yaml
+++ b/bitnami/rabbitmq-cluster-operator/values.yaml
@@ -61,7 +61,7 @@ diagnosticMode:
 rabbitmqImage:
   registry: docker.io
   repository: bitnami/rabbitmq
-  tag: 3.8.28-debian-10-r1
+  tag: 3.8.29-debian-10-r7
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-rabbitmqImage-private-registry/
@@ -81,7 +81,7 @@ rabbitmqImage:
 credentialUpdaterImage:
   registry: docker.io
   repository: bitnami/rmq-default-credential-updater
-  tag: 1.0.2-scratch-r0
+  tag: 1.0.2-scratch-r2
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-credentialUpdaterImage-private-registry/
@@ -103,7 +103,7 @@ clusterOperator:
   image:
     registry: docker.io
     repository: bitnami/rabbitmq-cluster-operator
-    tag: 1.12.1-scratch-r2
+    tag: 1.12.1-scratch-r7
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -481,7 +481,7 @@ msgTopologyOperator:
   image:
     registry: docker.io
     repository: bitnami/rmq-messaging-topology-operator
-    tag: 1.5.0-scratch-r0
+    tag: 1.5.0-scratch-r2
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
**Description of the change**

This PR standardizes the bitnami/rabbitmq-cluster-operator chart to be in line with the rest of the catalog.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
