### PR TITLE
bitnami/rabbitmq - Fixed ingress bug with extraHosts in RabbitMQ chart.

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 8.32.0
+version: 8.32.1

--- a/bitnami/rabbitmq/templates/ingress.yaml
+++ b/bitnami/rabbitmq/templates/ingress.yaml
@@ -41,7 +41,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" .Values.service.managerPortName "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" $.Values.service.managerPortName "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: Hans Erik Heggem <hans.erik.heggem@gmail.com>

**Description of the change**

Fixed ingress bug with the extraHosts option.
Setting extraHosts results in this helm template error:
```bash
Error: template: rabbitmq/templates/ingress.yaml:44:135: executing "rabbitmq/templates/ingress.yaml" at <.Values.service.managerPortName>: nil pointer evaluating interface {}.service
```

The bug was simply caused by not using a '$' sign in a 'range' loop to fetch a value.

**Benefits**

Makes it possible to use the extraHosts option.

**Possible drawbacks**

Should not cause any drawbacks.

**Applicable issues**

**Additional information**

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)