### PR TITLE
[bitnami/sonarqube] wrong secret name called in deployment

### DIFF
--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -28,4 +28,4 @@ name: sonarqube
 sources:
   - https://github.com/bitnami/bitnami-docker-sonarqube
   - https://github.com/SonarSource/sonarqube
-version: 1.0.11
+version: 1.0.12

--- a/bitnami/sonarqube/templates/_helpers.tpl
+++ b/bitnami/sonarqube/templates/_helpers.tpl
@@ -123,7 +123,7 @@ Return the Database Secret Name
         {{- default (include "sonarqube.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
     {{- end -}}
 {{- else -}}
-    {{- default (printf "%s-externaldb" .Release.Name) (tpl .Values.externalDatabase.existingSecret $) -}}
+    {{- default (printf "%s-externaldb" (include "common.names.fullname" .)) (tpl .Values.externalDatabase.existingSecret $) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION

hello i woud like to contribute at fixing a small error, the error happens when existing secret is not provided and plain password are used in the chart the secret named is generated correctly but is being called with wrong name caused by this error , the variable affected is  SONARQUBE_DATABASE_PASSWORD in the deployment.yaml for sonarqube

https://github.com/bitnami/charts/blob/master/bitnami/sonarqube/templates/deployment.yaml

```- name: SONARQUBE_DATABASE_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: {{ include "sonarqube.database.secretName" . }}
                  key: password
```

**Benefits**

Secret  for sonarqube database password will be called correctly when user doesnt set existing secret 

**Possible drawbacks**

NONE

**Applicable issues**

NONE

**Additional information**

it can help deploying the chart easily when you cant write secret to the cluster due to not enough privileges 

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)