### PR TITLE
[bitnami/mysql] Fix missing environment variable in NOTES

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 8.9.2
+version: 8.9.3

--- a/bitnami/mysql/templates/NOTES.txt
+++ b/bitnami/mysql/templates/NOTES.txt
@@ -44,7 +44,7 @@ To connect to your database:
 
   1. Run a pod that you can use as a client:
 
-      kubectl run {{ include "common.names.fullname" . }}-client --rm --tty -i --restart='Never' --image  {{ template "mysql.image" . }} --namespace {{ .Release.Namespace }} --command -- bash
+      kubectl run {{ include "common.names.fullname" . }}-client --rm --tty -i --restart='Never' --image  {{ template "mysql.image" . }} --namespace {{ .Release.Namespace }} --env MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD --command -- bash
 
   2. To connect to primary service (read/write):
 


### PR DESCRIPTION
**Description of the change**

The pod described in NOTES.txt to be run as a client was missing the import of `MYSQL_ROOT_PASSWORD`, which led to `mysql` asking for credentials when following the installation instructions.

**Benefits**

The `mysql-client` ephemeral pod has now access to the `MYSQL_ROOT_PASSWORD` environment variable and does not ask for the password.

**Possible drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - relates to #9746

**Additional information**

None

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)