### PR TITLE
[bitnami/metallb] correct dictionary used to render tolerations

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/bitnami-docker-metallb
   - https://metallb.universe.tf
-version: 3.0.0
+version: 3.0.1

--- a/bitnami/metallb/templates/speaker/daemonset.yaml
+++ b/bitnami/metallb/templates/speaker/daemonset.yaml
@@ -48,7 +48,7 @@ spec:
         {{- end }}
         "kubernetes.io/os": linux
       {{- if .Values.speaker.tolerations }}
-      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.tolerations $) | nindent 8 }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.speaker.tolerations "context" $) | nindent 8 }}
       {{- end }}
       hostNetwork: true
       {{- if .Values.speaker.priorityClassName }}


### PR DESCRIPTION
Signed-off-by: Branden Cash <203336+ammmze@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Fixes regression from the 3.0.0 chart release**

The 3.0.0 chart for MetalLB broke when using tolerations. The dictionary used for the `common.tplvalues.render` was incomplete and lead to the following error:

```
Error: template: metallb/templates/speaker/daemonset.yaml:51:23: executing "metallb/templates/speaker/daemonset.yaml" at <include "common.tplvalues.render" (dict "value" .Values.speaker.tolerations $)>: error calling include: template: metallb/charts/common/templates/_tplvalues.tpl:11:34: executing "common.tplvalues.render" at <.context>: wrong type for value; expected chartutil.Values; got interface {}
```

**Benefits**

Allows use of tolerations again.

**Possible drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #9913

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)