### PR TITLE
[bitnami/argo-cd] Ensure default's container entrypoint is executed

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/bitnami-docker-dex
   - https://github.com/dexidp/dex
-version: 3.2.1
+version: 3.2.2

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -80,7 +80,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------- | -------------------------------------------------- | --------------------- |
 | `image.registry`    | Argo CD image registry                             | `docker.io`           |
 | `image.repository`  | Argo CD image repository                           | `bitnami/argo-cd`     |
-| `image.tag`         | Argo CD image tag (immutable tags are recommended) | `2.3.3-debian-10-r25` |
+| `image.tag`         | Argo CD image tag (immutable tags are recommended) | `2.3.3-debian-10-r29` |
 | `image.pullPolicy`  | Argo CD image pull policy                          | `IfNotPresent`        |
 | `image.pullSecrets` | Argo CD image pull secrets                         | `[]`                  |
 | `image.debug`       | Enable Argo CD image debug mode                    | `false`               |

--- a/bitnami/argo-cd/templates/application-controller/deployment.yaml
+++ b/bitnami/argo-cd/templates/application-controller/deployment.yaml
@@ -116,14 +116,12 @@ spec:
           {{- end }}
           {{- if .Values.controller.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.controller.command "context" $) | nindent 12 }}
-          {{- else }}
-          command:
-            - argocd-application-controller
           {{- end }}
           {{- if .Values.controller.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.controller.args "context" $) | nindent 12 }}
           {{- else }}
           args:
+            - argocd-application-controller
             - --status-processors
             - {{ .Values.controller.defaultArgs.statusProcessors | quote }}
             - --operation-processors

--- a/bitnami/argo-cd/templates/repo-server/deployment.yaml
+++ b/bitnami/argo-cd/templates/repo-server/deployment.yaml
@@ -134,14 +134,12 @@ spec:
           {{- end }}
           {{- if .Values.repoServer.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.command "context" $) | nindent 12 }}
-          {{- else }}
-          command:
-            - argocd-repo-server
           {{- end }}
           {{- if .Values.repoServer.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.args "context" $) | nindent 12 }}
           {{- else }}
           args:
+            - argocd-repo-server
             - --logformat
             - {{ .Values.repoServer.logFormat }}
             - --loglevel

--- a/bitnami/argo-cd/templates/server/deployment.yaml
+++ b/bitnami/argo-cd/templates/server/deployment.yaml
@@ -134,14 +134,12 @@ spec:
           {{- end }}
           {{- if .Values.server.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.server.command "context" $) | nindent 12 }}
-          {{- else }}
-          command:
-            - argocd-server
           {{- end }}
           {{- if .Values.server.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.server.args "context" $) | nindent 12 }}
           {{- else }}
           args:
+            - argocd-server
             - --staticassets
             - /opt/bitnami/argo-cd/app
             - --repo-server

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -54,7 +54,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/argo-cd
-  tag: 2.3.3-debian-10-r25
+  tag: 2.3.3-debian-10-r29
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juan.ariza.1311993@gmail.com>

**Description of the change**

This PR modifies the Argo CD - related components' deployments to ensure the default's container entrypoint is executed. This entrypoint is essential to setup the _nss_wrapper_ configuration.

**Benefits**

User/group is properly configured in the container so the Repository Server can clone repositories without facing permissions issues.

**Possible drawbacks**

None

**Applicable issues**

Check problem described at https://github.com/bitnami/bitnami-docker-argo-cd/pull/2

**Additional information**

NA

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)