### PR TITLE
[bitnami/redis] Add internalTrafficPolicy support on master and replicas

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.8.7
+version: 16.8.8

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -122,187 +122,189 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Redis&trade; master configuration parameters
 
-| Name                                        | Description                                                                                       | Value                    |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------ |
-| `master.configuration`                      | Configuration for Redis&trade; master nodes                                                       | `""`                     |
-| `master.disableCommands`                    | Array with Redis&trade; commands to disable on master nodes                                       | `["FLUSHDB","FLUSHALL"]` |
-| `master.command`                            | Override default container command (useful when using custom images)                              | `[]`                     |
-| `master.args`                               | Override default container args (useful when using custom images)                                 | `[]`                     |
-| `master.preExecCmds`                        | Additional commands to run prior to starting Redis&trade; master                                  | `[]`                     |
-| `master.extraFlags`                         | Array with additional command line flags for Redis&trade; master                                  | `[]`                     |
-| `master.extraEnvVars`                       | Array with extra environment variables to add to Redis&trade; master nodes                        | `[]`                     |
-| `master.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for Redis&trade; master nodes                | `""`                     |
-| `master.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for Redis&trade; master nodes                   | `""`                     |
-| `master.containerPorts.redis`               | Container port to open on Redis&trade; master nodes                                               | `6379`                   |
-| `master.startupProbe.enabled`               | Enable startupProbe on Redis&trade; master nodes                                                  | `false`                  |
-| `master.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                            | `20`                     |
-| `master.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                   | `5`                      |
-| `master.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                  | `5`                      |
-| `master.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                | `5`                      |
-| `master.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                | `1`                      |
-| `master.livenessProbe.enabled`              | Enable livenessProbe on Redis&trade; master nodes                                                 | `true`                   |
-| `master.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                           | `20`                     |
-| `master.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                  | `5`                      |
-| `master.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                 | `5`                      |
-| `master.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                               | `5`                      |
-| `master.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                               | `1`                      |
-| `master.readinessProbe.enabled`             | Enable readinessProbe on Redis&trade; master nodes                                                | `true`                   |
-| `master.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                          | `20`                     |
-| `master.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                 | `5`                      |
-| `master.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                | `1`                      |
-| `master.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                              | `5`                      |
-| `master.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                              | `1`                      |
-| `master.customStartupProbe`                 | Custom startupProbe that overrides the default one                                                | `{}`                     |
-| `master.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                               | `{}`                     |
-| `master.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                              | `{}`                     |
-| `master.resources.limits`                   | The resources limits for the Redis&trade; master containers                                       | `{}`                     |
-| `master.resources.requests`                 | The requested resources for the Redis&trade; master containers                                    | `{}`                     |
-| `master.podSecurityContext.enabled`         | Enabled Redis&trade; master pods' Security Context                                                | `true`                   |
-| `master.podSecurityContext.fsGroup`         | Set Redis&trade; master pod's Security Context fsGroup                                            | `1001`                   |
-| `master.containerSecurityContext.enabled`   | Enabled Redis&trade; master containers' Security Context                                          | `true`                   |
-| `master.containerSecurityContext.runAsUser` | Set Redis&trade; master containers' Security Context runAsUser                                    | `1001`                   |
-| `master.kind`                               | Use either Deployment or StatefulSet (default)                                                    | `StatefulSet`            |
-| `master.schedulerName`                      | Alternate scheduler for Redis&trade; master pods                                                  | `""`                     |
-| `master.updateStrategy.type`                | Redis&trade; master statefulset strategy type                                                     | `RollingUpdate`          |
-| `master.priorityClassName`                  | Redis&trade; master pods' priorityClassName                                                       | `""`                     |
-| `master.hostAliases`                        | Redis&trade; master pods host aliases                                                             | `[]`                     |
-| `master.podLabels`                          | Extra labels for Redis&trade; master pods                                                         | `{}`                     |
-| `master.podAnnotations`                     | Annotations for Redis&trade; master pods                                                          | `{}`                     |
-| `master.shareProcessNamespace`              | Share a single process namespace between all of the containers in Redis&trade; master pods        | `false`                  |
-| `master.podAffinityPreset`                  | Pod affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`        | `""`                     |
-| `master.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`   | `soft`                   |
-| `master.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`  | `""`                     |
-| `master.nodeAffinityPreset.key`             | Node label key to match. Ignored if `master.affinity` is set                                      | `""`                     |
-| `master.nodeAffinityPreset.values`          | Node label values to match. Ignored if `master.affinity` is set                                   | `[]`                     |
-| `master.affinity`                           | Affinity for Redis&trade; master pods assignment                                                  | `{}`                     |
-| `master.nodeSelector`                       | Node labels for Redis&trade; master pods assignment                                               | `{}`                     |
-| `master.tolerations`                        | Tolerations for Redis&trade; master pods assignment                                               | `[]`                     |
-| `master.topologySpreadConstraints`          | Spread Constraints for Redis&trade; master pod assignment                                         | `[]`                     |
-| `master.dnsPolicy`                          | DNS Policy for Redis&trade; master pod                                                            | `""`                     |
-| `master.dnsConfig`                          | DNS Configuration for Redis&trade; master pod                                                     | `{}`                     |
-| `master.lifecycleHooks`                     | for the Redis&trade; master container(s) to automate configuration before or after startup        | `{}`                     |
-| `master.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis&trade; master pod(s)            | `[]`                     |
-| `master.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis&trade; master container(s) | `[]`                     |
-| `master.sidecars`                           | Add additional sidecar containers to the Redis&trade; master pod(s)                               | `[]`                     |
-| `master.initContainers`                     | Add additional init containers to the Redis&trade; master pod(s)                                  | `[]`                     |
-| `master.persistence.enabled`                | Enable persistence on Redis&trade; master nodes using Persistent Volume Claims                    | `true`                   |
-| `master.persistence.medium`                 | Provide a medium for `emptyDir` volumes.                                                          | `""`                     |
-| `master.persistence.sizeLimit`              | Set this to enable a size limit for `emptyDir` volumes.                                           | `""`                     |
-| `master.persistence.path`                   | The path the volume will be mounted at on Redis&trade; master containers                          | `/data`                  |
-| `master.persistence.subPath`                | The subdirectory of the volume to mount on Redis&trade; master containers                         | `""`                     |
-| `master.persistence.storageClass`           | Persistent Volume storage class                                                                   | `""`                     |
-| `master.persistence.accessModes`            | Persistent Volume access modes                                                                    | `["ReadWriteOnce"]`      |
-| `master.persistence.size`                   | Persistent Volume size                                                                            | `8Gi`                    |
-| `master.persistence.annotations`            | Additional custom annotations for the PVC                                                         | `{}`                     |
-| `master.persistence.selector`               | Additional labels to match for the PVC                                                            | `{}`                     |
-| `master.persistence.dataSource`             | Custom PVC data source                                                                            | `{}`                     |
-| `master.persistence.existingClaim`          | Use a existing PVC which must be created manually before bound                                    | `""`                     |
-| `master.service.type`                       | Redis&trade; master service type                                                                  | `ClusterIP`              |
-| `master.service.ports.redis`                | Redis&trade; master service port                                                                  | `6379`                   |
-| `master.service.nodePorts.redis`            | Node port for Redis&trade; master                                                                 | `""`                     |
-| `master.service.externalTrafficPolicy`      | Redis&trade; master service external traffic policy                                               | `Cluster`                |
-| `master.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                    | `[]`                     |
-| `master.service.clusterIP`                  | Redis&trade; master service Cluster IP                                                            | `""`                     |
-| `master.service.loadBalancerIP`             | Redis&trade; master service Load Balancer IP                                                      | `""`                     |
-| `master.service.loadBalancerSourceRanges`   | Redis&trade; master service Load Balancer sources                                                 | `[]`                     |
-| `master.service.annotations`                | Additional custom annotations for Redis&trade; master service                                     | `{}`                     |
-| `master.terminationGracePeriodSeconds`      | Integer setting the termination grace period for the redis-master pods                            | `30`                     |
+| Name                                        | Description                                                                                             | Value                    |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `master.configuration`                      | Configuration for Redis&trade; master nodes                                                             | `""`                     |
+| `master.disableCommands`                    | Array with Redis&trade; commands to disable on master nodes                                             | `["FLUSHDB","FLUSHALL"]` |
+| `master.command`                            | Override default container command (useful when using custom images)                                    | `[]`                     |
+| `master.args`                               | Override default container args (useful when using custom images)                                       | `[]`                     |
+| `master.preExecCmds`                        | Additional commands to run prior to starting Redis&trade; master                                        | `[]`                     |
+| `master.extraFlags`                         | Array with additional command line flags for Redis&trade; master                                        | `[]`                     |
+| `master.extraEnvVars`                       | Array with extra environment variables to add to Redis&trade; master nodes                              | `[]`                     |
+| `master.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for Redis&trade; master nodes                      | `""`                     |
+| `master.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for Redis&trade; master nodes                         | `""`                     |
+| `master.containerPorts.redis`               | Container port to open on Redis&trade; master nodes                                                     | `6379`                   |
+| `master.startupProbe.enabled`               | Enable startupProbe on Redis&trade; master nodes                                                        | `false`                  |
+| `master.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                  | `20`                     |
+| `master.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                         | `5`                      |
+| `master.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                        | `5`                      |
+| `master.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                      | `5`                      |
+| `master.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                      | `1`                      |
+| `master.livenessProbe.enabled`              | Enable livenessProbe on Redis&trade; master nodes                                                       | `true`                   |
+| `master.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                 | `20`                     |
+| `master.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                        | `5`                      |
+| `master.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                       | `5`                      |
+| `master.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                     | `5`                      |
+| `master.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                     | `1`                      |
+| `master.readinessProbe.enabled`             | Enable readinessProbe on Redis&trade; master nodes                                                      | `true`                   |
+| `master.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                | `20`                     |
+| `master.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                       | `5`                      |
+| `master.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                      | `1`                      |
+| `master.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                    | `5`                      |
+| `master.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                    | `1`                      |
+| `master.customStartupProbe`                 | Custom startupProbe that overrides the default one                                                      | `{}`                     |
+| `master.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                     | `{}`                     |
+| `master.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                    | `{}`                     |
+| `master.resources.limits`                   | The resources limits for the Redis&trade; master containers                                             | `{}`                     |
+| `master.resources.requests`                 | The requested resources for the Redis&trade; master containers                                          | `{}`                     |
+| `master.podSecurityContext.enabled`         | Enabled Redis&trade; master pods' Security Context                                                      | `true`                   |
+| `master.podSecurityContext.fsGroup`         | Set Redis&trade; master pod's Security Context fsGroup                                                  | `1001`                   |
+| `master.containerSecurityContext.enabled`   | Enabled Redis&trade; master containers' Security Context                                                | `true`                   |
+| `master.containerSecurityContext.runAsUser` | Set Redis&trade; master containers' Security Context runAsUser                                          | `1001`                   |
+| `master.kind`                               | Use either Deployment or StatefulSet (default)                                                          | `StatefulSet`            |
+| `master.schedulerName`                      | Alternate scheduler for Redis&trade; master pods                                                        | `""`                     |
+| `master.updateStrategy.type`                | Redis&trade; master statefulset strategy type                                                           | `RollingUpdate`          |
+| `master.priorityClassName`                  | Redis&trade; master pods' priorityClassName                                                             | `""`                     |
+| `master.hostAliases`                        | Redis&trade; master pods host aliases                                                                   | `[]`                     |
+| `master.podLabels`                          | Extra labels for Redis&trade; master pods                                                               | `{}`                     |
+| `master.podAnnotations`                     | Annotations for Redis&trade; master pods                                                                | `{}`                     |
+| `master.shareProcessNamespace`              | Share a single process namespace between all of the containers in Redis&trade; master pods              | `false`                  |
+| `master.podAffinityPreset`                  | Pod affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`              | `""`                     |
+| `master.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`         | `soft`                   |
+| `master.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `master.affinity` is set. Allowed values: `soft` or `hard`        | `""`                     |
+| `master.nodeAffinityPreset.key`             | Node label key to match. Ignored if `master.affinity` is set                                            | `""`                     |
+| `master.nodeAffinityPreset.values`          | Node label values to match. Ignored if `master.affinity` is set                                         | `[]`                     |
+| `master.affinity`                           | Affinity for Redis&trade; master pods assignment                                                        | `{}`                     |
+| `master.nodeSelector`                       | Node labels for Redis&trade; master pods assignment                                                     | `{}`                     |
+| `master.tolerations`                        | Tolerations for Redis&trade; master pods assignment                                                     | `[]`                     |
+| `master.topologySpreadConstraints`          | Spread Constraints for Redis&trade; master pod assignment                                               | `[]`                     |
+| `master.dnsPolicy`                          | DNS Policy for Redis&trade; master pod                                                                  | `""`                     |
+| `master.dnsConfig`                          | DNS Configuration for Redis&trade; master pod                                                           | `{}`                     |
+| `master.lifecycleHooks`                     | for the Redis&trade; master container(s) to automate configuration before or after startup              | `{}`                     |
+| `master.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis&trade; master pod(s)                  | `[]`                     |
+| `master.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis&trade; master container(s)       | `[]`                     |
+| `master.sidecars`                           | Add additional sidecar containers to the Redis&trade; master pod(s)                                     | `[]`                     |
+| `master.initContainers`                     | Add additional init containers to the Redis&trade; master pod(s)                                        | `[]`                     |
+| `master.persistence.enabled`                | Enable persistence on Redis&trade; master nodes using Persistent Volume Claims                          | `true`                   |
+| `master.persistence.medium`                 | Provide a medium for `emptyDir` volumes.                                                                | `""`                     |
+| `master.persistence.sizeLimit`              | Set this to enable a size limit for `emptyDir` volumes.                                                 | `""`                     |
+| `master.persistence.path`                   | The path the volume will be mounted at on Redis&trade; master containers                                | `/data`                  |
+| `master.persistence.subPath`                | The subdirectory of the volume to mount on Redis&trade; master containers                               | `""`                     |
+| `master.persistence.storageClass`           | Persistent Volume storage class                                                                         | `""`                     |
+| `master.persistence.accessModes`            | Persistent Volume access modes                                                                          | `["ReadWriteOnce"]`      |
+| `master.persistence.size`                   | Persistent Volume size                                                                                  | `8Gi`                    |
+| `master.persistence.annotations`            | Additional custom annotations for the PVC                                                               | `{}`                     |
+| `master.persistence.selector`               | Additional labels to match for the PVC                                                                  | `{}`                     |
+| `master.persistence.dataSource`             | Custom PVC data source                                                                                  | `{}`                     |
+| `master.persistence.existingClaim`          | Use a existing PVC which must be created manually before bound                                          | `""`                     |
+| `master.service.type`                       | Redis&trade; master service type                                                                        | `ClusterIP`              |
+| `master.service.ports.redis`                | Redis&trade; master service port                                                                        | `6379`                   |
+| `master.service.nodePorts.redis`            | Node port for Redis&trade; master                                                                       | `""`                     |
+| `master.service.externalTrafficPolicy`      | Redis&trade; master service external traffic policy                                                     | `Cluster`                |
+| `master.service.internalTrafficPolicy`      | Redis&trade; master service internal traffic policy (requires Kubernetes v1.22 or greater to be usable) | `Cluster`                |
+| `master.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                          | `[]`                     |
+| `master.service.clusterIP`                  | Redis&trade; master service Cluster IP                                                                  | `""`                     |
+| `master.service.loadBalancerIP`             | Redis&trade; master service Load Balancer IP                                                            | `""`                     |
+| `master.service.loadBalancerSourceRanges`   | Redis&trade; master service Load Balancer sources                                                       | `[]`                     |
+| `master.service.annotations`                | Additional custom annotations for Redis&trade; master service                                           | `{}`                     |
+| `master.terminationGracePeriodSeconds`      | Integer setting the termination grace period for the redis-master pods                                  | `30`                     |
 
 
 ### Redis&trade; replicas configuration parameters
 
-| Name                                         | Description                                                                                         | Value                    |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------ |
-| `replica.replicaCount`                       | Number of Redis&trade; replicas to deploy                                                           | `3`                      |
-| `replica.configuration`                      | Configuration for Redis&trade; replicas nodes                                                       | `""`                     |
-| `replica.disableCommands`                    | Array with Redis&trade; commands to disable on replicas nodes                                       | `["FLUSHDB","FLUSHALL"]` |
-| `replica.command`                            | Override default container command (useful when using custom images)                                | `[]`                     |
-| `replica.args`                               | Override default container args (useful when using custom images)                                   | `[]`                     |
-| `replica.preExecCmds`                        | Additional commands to run prior to starting Redis&trade; replicas                                  | `[]`                     |
-| `replica.extraFlags`                         | Array with additional command line flags for Redis&trade; replicas                                  | `[]`                     |
-| `replica.extraEnvVars`                       | Array with extra environment variables to add to Redis&trade; replicas nodes                        | `[]`                     |
-| `replica.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for Redis&trade; replicas nodes                | `""`                     |
-| `replica.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for Redis&trade; replicas nodes                   | `""`                     |
-| `replica.externalMaster.enabled`             | Use external master for bootstrapping                                                               | `false`                  |
-| `replica.externalMaster.host`                | External master host to bootstrap from                                                              | `""`                     |
-| `replica.externalMaster.port`                | Port for Redis service external master host                                                         | `6379`                   |
-| `replica.containerPorts.redis`               | Container port to open on Redis&trade; replicas nodes                                               | `6379`                   |
-| `replica.startupProbe.enabled`               | Enable startupProbe on Redis&trade; replicas nodes                                                  | `true`                   |
-| `replica.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                              | `10`                     |
-| `replica.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                     | `10`                     |
-| `replica.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                    | `5`                      |
-| `replica.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                  | `22`                     |
-| `replica.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                  | `1`                      |
-| `replica.livenessProbe.enabled`              | Enable livenessProbe on Redis&trade; replicas nodes                                                 | `true`                   |
-| `replica.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                             | `20`                     |
-| `replica.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                    | `5`                      |
-| `replica.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                   | `5`                      |
-| `replica.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                 | `5`                      |
-| `replica.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                 | `1`                      |
-| `replica.readinessProbe.enabled`             | Enable readinessProbe on Redis&trade; replicas nodes                                                | `true`                   |
-| `replica.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                            | `20`                     |
-| `replica.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                   | `5`                      |
-| `replica.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                  | `1`                      |
-| `replica.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                | `5`                      |
-| `replica.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                | `1`                      |
-| `replica.customStartupProbe`                 | Custom startupProbe that overrides the default one                                                  | `{}`                     |
-| `replica.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                 | `{}`                     |
-| `replica.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                | `{}`                     |
-| `replica.resources.limits`                   | The resources limits for the Redis&trade; replicas containers                                       | `{}`                     |
-| `replica.resources.requests`                 | The requested resources for the Redis&trade; replicas containers                                    | `{}`                     |
-| `replica.podSecurityContext.enabled`         | Enabled Redis&trade; replicas pods' Security Context                                                | `true`                   |
-| `replica.podSecurityContext.fsGroup`         | Set Redis&trade; replicas pod's Security Context fsGroup                                            | `1001`                   |
-| `replica.containerSecurityContext.enabled`   | Enabled Redis&trade; replicas containers' Security Context                                          | `true`                   |
-| `replica.containerSecurityContext.runAsUser` | Set Redis&trade; replicas containers' Security Context runAsUser                                    | `1001`                   |
-| `replica.schedulerName`                      | Alternate scheduler for Redis&trade; replicas pods                                                  | `""`                     |
-| `replica.updateStrategy.type`                | Redis&trade; replicas statefulset strategy type                                                     | `RollingUpdate`          |
-| `replica.priorityClassName`                  | Redis&trade; replicas pods' priorityClassName                                                       | `""`                     |
-| `replica.podManagementPolicy`                | podManagementPolicy to manage scaling operation of %%MAIN_CONTAINER_NAME%% pods                     | `""`                     |
-| `replica.hostAliases`                        | Redis&trade; replicas pods host aliases                                                             | `[]`                     |
-| `replica.podLabels`                          | Extra labels for Redis&trade; replicas pods                                                         | `{}`                     |
-| `replica.podAnnotations`                     | Annotations for Redis&trade; replicas pods                                                          | `{}`                     |
-| `replica.shareProcessNamespace`              | Share a single process namespace between all of the containers in Redis&trade; replicas pods        | `false`                  |
-| `replica.podAffinityPreset`                  | Pod affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`         | `""`                     |
-| `replica.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`    | `soft`                   |
-| `replica.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`   | `""`                     |
-| `replica.nodeAffinityPreset.key`             | Node label key to match. Ignored if `replica.affinity` is set                                       | `""`                     |
-| `replica.nodeAffinityPreset.values`          | Node label values to match. Ignored if `replica.affinity` is set                                    | `[]`                     |
-| `replica.affinity`                           | Affinity for Redis&trade; replicas pods assignment                                                  | `{}`                     |
-| `replica.nodeSelector`                       | Node labels for Redis&trade; replicas pods assignment                                               | `{}`                     |
-| `replica.tolerations`                        | Tolerations for Redis&trade; replicas pods assignment                                               | `[]`                     |
-| `replica.topologySpreadConstraints`          | Spread Constraints for Redis&trade; replicas pod assignment                                         | `[]`                     |
-| `replica.dnsPolicy`                          | DNS Policy for Redis&trade; replica pods                                                            | `""`                     |
-| `replica.dnsConfig`                          | DNS Configuration for Redis&trade; replica pods                                                     | `{}`                     |
-| `replica.lifecycleHooks`                     | for the Redis&trade; replica container(s) to automate configuration before or after startup         | `{}`                     |
-| `replica.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis&trade; replicas pod(s)            | `[]`                     |
-| `replica.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis&trade; replicas container(s) | `[]`                     |
-| `replica.sidecars`                           | Add additional sidecar containers to the Redis&trade; replicas pod(s)                               | `[]`                     |
-| `replica.initContainers`                     | Add additional init containers to the Redis&trade; replicas pod(s)                                  | `[]`                     |
-| `replica.persistence.enabled`                | Enable persistence on Redis&trade; replicas nodes using Persistent Volume Claims                    | `true`                   |
-| `replica.persistence.medium`                 | Provide a medium for `emptyDir` volumes.                                                            | `""`                     |
-| `replica.persistence.path`                   | The path the volume will be mounted at on Redis&trade; replicas containers                          | `/data`                  |
-| `replica.persistence.subPath`                | The subdirectory of the volume to mount on Redis&trade; replicas containers                         | `""`                     |
-| `replica.persistence.storageClass`           | Persistent Volume storage class                                                                     | `""`                     |
-| `replica.persistence.accessModes`            | Persistent Volume access modes                                                                      | `["ReadWriteOnce"]`      |
-| `replica.persistence.size`                   | Persistent Volume size                                                                              | `8Gi`                    |
-| `replica.persistence.annotations`            | Additional custom annotations for the PVC                                                           | `{}`                     |
-| `replica.persistence.selector`               | Additional labels to match for the PVC                                                              | `{}`                     |
-| `replica.persistence.dataSource`             | Custom PVC data source                                                                              | `{}`                     |
-| `replica.service.type`                       | Redis&trade; replicas service type                                                                  | `ClusterIP`              |
-| `replica.service.ports.redis`                | Redis&trade; replicas service port                                                                  | `6379`                   |
-| `replica.service.nodePorts.redis`            | Node port for Redis&trade; replicas                                                                 | `""`                     |
-| `replica.service.externalTrafficPolicy`      | Redis&trade; replicas service external traffic policy                                               | `Cluster`                |
-| `replica.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                      | `[]`                     |
-| `replica.service.clusterIP`                  | Redis&trade; replicas service Cluster IP                                                            | `""`                     |
-| `replica.service.loadBalancerIP`             | Redis&trade; replicas service Load Balancer IP                                                      | `""`                     |
-| `replica.service.loadBalancerSourceRanges`   | Redis&trade; replicas service Load Balancer sources                                                 | `[]`                     |
-| `replica.service.annotations`                | Additional custom annotations for Redis&trade; replicas service                                     | `{}`                     |
-| `replica.terminationGracePeriodSeconds`      | Integer setting the termination grace period for the redis-replicas pods                            | `30`                     |
-| `replica.autoscaling.enabled`                | Enable replica autoscaling settings                                                                 | `false`                  |
-| `replica.autoscaling.minReplicas`            | Minimum replicas for the pod autoscaling                                                            | `1`                      |
-| `replica.autoscaling.maxReplicas`            | Maximum replicas for the pod autoscaling                                                            | `11`                     |
-| `replica.autoscaling.targetCPU`              | Percentage of CPU to consider when autoscaling                                                      | `""`                     |
-| `replica.autoscaling.targetMemory`           | Percentage of Memory to consider when autoscaling                                                   | `""`                     |
+| Name                                         | Description                                                                                               | Value                    |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `replica.replicaCount`                       | Number of Redis&trade; replicas to deploy                                                                 | `3`                      |
+| `replica.configuration`                      | Configuration for Redis&trade; replicas nodes                                                             | `""`                     |
+| `replica.disableCommands`                    | Array with Redis&trade; commands to disable on replicas nodes                                             | `["FLUSHDB","FLUSHALL"]` |
+| `replica.command`                            | Override default container command (useful when using custom images)                                      | `[]`                     |
+| `replica.args`                               | Override default container args (useful when using custom images)                                         | `[]`                     |
+| `replica.preExecCmds`                        | Additional commands to run prior to starting Redis&trade; replicas                                        | `[]`                     |
+| `replica.extraFlags`                         | Array with additional command line flags for Redis&trade; replicas                                        | `[]`                     |
+| `replica.extraEnvVars`                       | Array with extra environment variables to add to Redis&trade; replicas nodes                              | `[]`                     |
+| `replica.extraEnvVarsCM`                     | Name of existing ConfigMap containing extra env vars for Redis&trade; replicas nodes                      | `""`                     |
+| `replica.extraEnvVarsSecret`                 | Name of existing Secret containing extra env vars for Redis&trade; replicas nodes                         | `""`                     |
+| `replica.externalMaster.enabled`             | Use external master for bootstrapping                                                                     | `false`                  |
+| `replica.externalMaster.host`                | External master host to bootstrap from                                                                    | `""`                     |
+| `replica.externalMaster.port`                | Port for Redis service external master host                                                               | `6379`                   |
+| `replica.containerPorts.redis`               | Container port to open on Redis&trade; replicas nodes                                                     | `6379`                   |
+| `replica.startupProbe.enabled`               | Enable startupProbe on Redis&trade; replicas nodes                                                        | `true`                   |
+| `replica.startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                    | `10`                     |
+| `replica.startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                           | `10`                     |
+| `replica.startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                          | `5`                      |
+| `replica.startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                        | `22`                     |
+| `replica.startupProbe.successThreshold`      | Success threshold for startupProbe                                                                        | `1`                      |
+| `replica.livenessProbe.enabled`              | Enable livenessProbe on Redis&trade; replicas nodes                                                       | `true`                   |
+| `replica.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                   | `20`                     |
+| `replica.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                          | `5`                      |
+| `replica.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                         | `5`                      |
+| `replica.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                       | `5`                      |
+| `replica.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                       | `1`                      |
+| `replica.readinessProbe.enabled`             | Enable readinessProbe on Redis&trade; replicas nodes                                                      | `true`                   |
+| `replica.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                  | `20`                     |
+| `replica.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                         | `5`                      |
+| `replica.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                        | `1`                      |
+| `replica.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                      | `5`                      |
+| `replica.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                      | `1`                      |
+| `replica.customStartupProbe`                 | Custom startupProbe that overrides the default one                                                        | `{}`                     |
+| `replica.customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                       | `{}`                     |
+| `replica.customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                      | `{}`                     |
+| `replica.resources.limits`                   | The resources limits for the Redis&trade; replicas containers                                             | `{}`                     |
+| `replica.resources.requests`                 | The requested resources for the Redis&trade; replicas containers                                          | `{}`                     |
+| `replica.podSecurityContext.enabled`         | Enabled Redis&trade; replicas pods' Security Context                                                      | `true`                   |
+| `replica.podSecurityContext.fsGroup`         | Set Redis&trade; replicas pod's Security Context fsGroup                                                  | `1001`                   |
+| `replica.containerSecurityContext.enabled`   | Enabled Redis&trade; replicas containers' Security Context                                                | `true`                   |
+| `replica.containerSecurityContext.runAsUser` | Set Redis&trade; replicas containers' Security Context runAsUser                                          | `1001`                   |
+| `replica.schedulerName`                      | Alternate scheduler for Redis&trade; replicas pods                                                        | `""`                     |
+| `replica.updateStrategy.type`                | Redis&trade; replicas statefulset strategy type                                                           | `RollingUpdate`          |
+| `replica.priorityClassName`                  | Redis&trade; replicas pods' priorityClassName                                                             | `""`                     |
+| `replica.podManagementPolicy`                | podManagementPolicy to manage scaling operation of %%MAIN_CONTAINER_NAME%% pods                           | `""`                     |
+| `replica.hostAliases`                        | Redis&trade; replicas pods host aliases                                                                   | `[]`                     |
+| `replica.podLabels`                          | Extra labels for Redis&trade; replicas pods                                                               | `{}`                     |
+| `replica.podAnnotations`                     | Annotations for Redis&trade; replicas pods                                                                | `{}`                     |
+| `replica.shareProcessNamespace`              | Share a single process namespace between all of the containers in Redis&trade; replicas pods              | `false`                  |
+| `replica.podAffinityPreset`                  | Pod affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`               | `""`                     |
+| `replica.podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`          | `soft`                   |
+| `replica.nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `replica.affinity` is set. Allowed values: `soft` or `hard`         | `""`                     |
+| `replica.nodeAffinityPreset.key`             | Node label key to match. Ignored if `replica.affinity` is set                                             | `""`                     |
+| `replica.nodeAffinityPreset.values`          | Node label values to match. Ignored if `replica.affinity` is set                                          | `[]`                     |
+| `replica.affinity`                           | Affinity for Redis&trade; replicas pods assignment                                                        | `{}`                     |
+| `replica.nodeSelector`                       | Node labels for Redis&trade; replicas pods assignment                                                     | `{}`                     |
+| `replica.tolerations`                        | Tolerations for Redis&trade; replicas pods assignment                                                     | `[]`                     |
+| `replica.topologySpreadConstraints`          | Spread Constraints for Redis&trade; replicas pod assignment                                               | `[]`                     |
+| `replica.dnsPolicy`                          | DNS Policy for Redis&trade; replica pods                                                                  | `""`                     |
+| `replica.dnsConfig`                          | DNS Configuration for Redis&trade; replica pods                                                           | `{}`                     |
+| `replica.lifecycleHooks`                     | for the Redis&trade; replica container(s) to automate configuration before or after startup               | `{}`                     |
+| `replica.extraVolumes`                       | Optionally specify extra list of additional volumes for the Redis&trade; replicas pod(s)                  | `[]`                     |
+| `replica.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for the Redis&trade; replicas container(s)       | `[]`                     |
+| `replica.sidecars`                           | Add additional sidecar containers to the Redis&trade; replicas pod(s)                                     | `[]`                     |
+| `replica.initContainers`                     | Add additional init containers to the Redis&trade; replicas pod(s)                                        | `[]`                     |
+| `replica.persistence.enabled`                | Enable persistence on Redis&trade; replicas nodes using Persistent Volume Claims                          | `true`                   |
+| `replica.persistence.medium`                 | Provide a medium for `emptyDir` volumes.                                                                  | `""`                     |
+| `replica.persistence.path`                   | The path the volume will be mounted at on Redis&trade; replicas containers                                | `/data`                  |
+| `replica.persistence.subPath`                | The subdirectory of the volume to mount on Redis&trade; replicas containers                               | `""`                     |
+| `replica.persistence.storageClass`           | Persistent Volume storage class                                                                           | `""`                     |
+| `replica.persistence.accessModes`            | Persistent Volume access modes                                                                            | `["ReadWriteOnce"]`      |
+| `replica.persistence.size`                   | Persistent Volume size                                                                                    | `8Gi`                    |
+| `replica.persistence.annotations`            | Additional custom annotations for the PVC                                                                 | `{}`                     |
+| `replica.persistence.selector`               | Additional labels to match for the PVC                                                                    | `{}`                     |
+| `replica.persistence.dataSource`             | Custom PVC data source                                                                                    | `{}`                     |
+| `replica.service.type`                       | Redis&trade; replicas service type                                                                        | `ClusterIP`              |
+| `replica.service.ports.redis`                | Redis&trade; replicas service port                                                                        | `6379`                   |
+| `replica.service.nodePorts.redis`            | Node port for Redis&trade; replicas                                                                       | `""`                     |
+| `replica.service.externalTrafficPolicy`      | Redis&trade; replicas service external traffic policy                                                     | `Cluster`                |
+| `replica.service.internalTrafficPolicy`      | Redis&trade; replicas service internal traffic policy (requires Kubernetes v1.22 or greater to be usable) | `Cluster`                |
+| `replica.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                            | `[]`                     |
+| `replica.service.clusterIP`                  | Redis&trade; replicas service Cluster IP                                                                  | `""`                     |
+| `replica.service.loadBalancerIP`             | Redis&trade; replicas service Load Balancer IP                                                            | `""`                     |
+| `replica.service.loadBalancerSourceRanges`   | Redis&trade; replicas service Load Balancer sources                                                       | `[]`                     |
+| `replica.service.annotations`                | Additional custom annotations for Redis&trade; replicas service                                           | `{}`                     |
+| `replica.terminationGracePeriodSeconds`      | Integer setting the termination grace period for the redis-replicas pods                                  | `30`                     |
+| `replica.autoscaling.enabled`                | Enable replica autoscaling settings                                                                       | `false`                  |
+| `replica.autoscaling.minReplicas`            | Minimum replicas for the pod autoscaling                                                                  | `1`                      |
+| `replica.autoscaling.maxReplicas`            | Maximum replicas for the pod autoscaling                                                                  | `11`                     |
+| `replica.autoscaling.targetCPU`              | Percentage of CPU to consider when autoscaling                                                            | `""`                     |
+| `replica.autoscaling.targetMemory`           | Percentage of Memory to consider when autoscaling                                                         | `""`                     |
 
 
 ### Redis&trade; Sentinel configuration parameters

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -99,7 +99,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------- | ------------------------------------------------------- | ---------------------- |
 | `image.registry`    | Redis&trade; image registry                             | `docker.io`            |
 | `image.repository`  | Redis&trade; image repository                           | `bitnami/redis`        |
-| `image.tag`         | Redis&trade; image tag (immutable tags are recommended) | `6.2.6-debian-10-r169` |
+| `image.tag`         | Redis&trade; image tag (immutable tags are recommended) | `6.2.6-debian-10-r192` |
 | `image.pullPolicy`  | Redis&trade; image pull policy                          | `IfNotPresent`         |
 | `image.pullSecrets` | Redis&trade; image pull secrets                         | `[]`                   |
 | `image.debug`       | Enable image debug mode                                 | `false`                |
@@ -314,7 +314,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sentinel.enabled`                            | Use Redis&trade; Sentinel on Redis&trade; pods.                                                                                             | `false`                  |
 | `sentinel.image.registry`                     | Redis&trade; Sentinel image registry                                                                                                        | `docker.io`              |
 | `sentinel.image.repository`                   | Redis&trade; Sentinel image repository                                                                                                      | `bitnami/redis-sentinel` |
-| `sentinel.image.tag`                          | Redis&trade; Sentinel image tag (immutable tags are recommended)                                                                            | `6.2.6-debian-10-r167`   |
+| `sentinel.image.tag`                          | Redis&trade; Sentinel image tag (immutable tags are recommended)                                                                            | `6.2.6-debian-10-r189`   |
 | `sentinel.image.pullPolicy`                   | Redis&trade; Sentinel image pull policy                                                                                                     | `IfNotPresent`           |
 | `sentinel.image.pullSecrets`                  | Redis&trade; Sentinel image pull secrets                                                                                                    | `[]`                     |
 | `sentinel.image.debug`                        | Enable image debug mode                                                                                                                     | `false`                  |
@@ -424,7 +424,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                            | Start a sidecar prometheus exporter to expose Redis&trade; metrics                               | `false`                  |
 | `metrics.image.registry`                     | Redis&trade; Exporter image registry                                                             | `docker.io`              |
 | `metrics.image.repository`                   | Redis&trade; Exporter image repository                                                           | `bitnami/redis-exporter` |
-| `metrics.image.tag`                          | Redis&trade; Redis&trade; Exporter image tag (immutable tags are recommended)                    | `1.37.0-debian-10-r9`    |
+| `metrics.image.tag`                          | Redis&trade; Redis&trade; Exporter image tag (immutable tags are recommended)                    | `1.37.0-debian-10-r31`   |
 | `metrics.image.pullPolicy`                   | Redis&trade; Exporter image pull policy                                                          | `IfNotPresent`           |
 | `metrics.image.pullSecrets`                  | Redis&trade; Exporter image pull secrets                                                         | `[]`                     |
 | `metrics.command`                            | Override default metrics container init command (useful when using custom images)                | `[]`                     |
@@ -467,7 +467,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                    | `docker.io`             |
 | `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r378`     |
+| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r400`     |
 | `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                | `[]`                    |
 | `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                    |
@@ -476,7 +476,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `sysctl.enabled`                                       | Enable init container to modify Kernel settings                                                 | `false`                 |
 | `sysctl.image.registry`                                | Bitnami Shell image registry                                                                    | `docker.io`             |
 | `sysctl.image.repository`                              | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `sysctl.image.tag`                                     | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r378`     |
+| `sysctl.image.tag`                                     | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r400`     |
 | `sysctl.image.pullPolicy`                              | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
 | `sysctl.image.pullSecrets`                             | Bitnami Shell image pull secrets                                                                | `[]`                    |
 | `sysctl.command`                                       | Override default init-sysctl container command (useful when using custom images)                | `[]`                    |

--- a/bitnami/redis/templates/master/service.yaml
+++ b/bitnami/redis/templates/master/service.yaml
@@ -23,6 +23,9 @@ spec:
   {{ if eq .Values.master.service.type "LoadBalancer" }}
   externalTrafficPolicy: {{ .Values.master.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if (semverCompare ">=1.22-0" (include "common.capabilities.kubeVersion" .)) }}
+  internalTrafficPolicy: {{ .Values.master.service.internalTrafficPolicy }}
+  {{- end }}
   {{- if and (eq .Values.master.service.type "LoadBalancer") .Values.master.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.master.service.loadBalancerIP }}
   {{- end }}

--- a/bitnami/redis/templates/replicas/service.yaml
+++ b/bitnami/redis/templates/replicas/service.yaml
@@ -23,6 +23,9 @@ spec:
   {{- if eq .Values.replica.service.type "LoadBalancer" }}
   externalTrafficPolicy: {{ .Values.replica.service.externalTrafficPolicy }}
   {{- end }}
+  {{- if (semverCompare ">=1.22-0" (include "common.capabilities.kubeVersion" .)) }}
+  internalTrafficPolicy: {{ .Values.replica.service.internalTrafficPolicy }}
+  {{- end }}
   {{- if and (eq .Values.replica.service.type "LoadBalancer") .Values.replica.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.replica.service.loadBalancerIP }}
   {{- end }}

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -465,6 +465,10 @@ master:
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
     externalTrafficPolicy: Cluster
+    ## @param master.service.internalTrafficPolicy Redis&trade; master service internal traffic policy (requires Kubernetes v1.22 or greater to be usable)
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    ##
+    internalTrafficPolicy: Cluster
     ## @param master.service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
     ##
     extraPorts: []
@@ -825,6 +829,10 @@ replica:
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##
     externalTrafficPolicy: Cluster
+    ## @param replica.service.internalTrafficPolicy Redis&trade; replicas service internal traffic policy (requires Kubernetes v1.22 or greater to be usable)
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/
+    ##
+    internalTrafficPolicy: Cluster
     ## @param replica.service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
     ##
     extraPorts: []


### PR DESCRIPTION
Signed-off-by: Eduardo Semprebon <eduardobr@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Add support for Service Internal Traffic Policy to master and replicas:
https://kubernetes.io/docs/concepts/services-networking/service-traffic-policy/

Alpha in K8s v1.21, beta from v1.22 on:
https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/

**Benefits**

Allow restricting internal traffic of master and/or replicas pods to node.

**Possible drawbacks**

None

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)