### PR TITLE
[bitnami/etcd] PodDisruptionBudget should be enabled by default

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -24,4 +24,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 8.0.2
+version: 8.0.3

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -24,4 +24,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/bitnami-docker-etcd
   - https://coreos.com/etcd/
-version: 8.0.3
+version: 8.1.0

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -297,8 +297,8 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                 | Description                                                    | Value   |
 | -------------------- | -------------------------------------------------------------- | ------- |
-| `pdb.create`         | Enable/disable a Pod Disruption Budget creation                | `false` |
-| `pdb.minAvailable`   | Minimum number/percentage of pods that should remain scheduled | `1`     |
+| `pdb.create`         | Enable/disable a Pod Disruption Budget creation                | `true` |
+| `pdb.minAvailable`   | Minimum number/percentage of pods that should remain scheduled | `51%`     |
 | `pdb.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable | `""`    |
 
 

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -83,7 +83,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | -------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`                       | etcd image registry                                                                             | `docker.io`          |
 | `image.repository`                     | etcd image name                                                                                 | `bitnami/etcd`       |
-| `image.tag`                            | etcd image tag                                                                                  | `3.5.3-debian-10-r4` |
+| `image.tag`                            | etcd image tag                                                                                  | `3.5.4-debian-10-r0` |
 | `image.pullPolicy`                     | etcd image pull policy                                                                          | `IfNotPresent`       |
 | `image.pullSecrets`                    | etcd image pull secrets                                                                         | `[]`                 |
 | `image.debug`                          | Enable image debug mode                                                                         | `false`              |
@@ -226,7 +226,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`            | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                     | `docker.io`             |
 | `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                         | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                          | `10-debian-10-r400`     |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                          | `10-debian-10-r405`     |
 | `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                  | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                     | `[]`                    |
 | `volumePermissions.resources.limits`   | Init container volume-permissions resource  limits                                                                   | `{}`                    |
@@ -295,11 +295,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other parameters
 
-| Name                 | Description                                                    | Value   |
-| -------------------- | -------------------------------------------------------------- | ------- |
+| Name                 | Description                                                    | Value  |
+| -------------------- | -------------------------------------------------------------- | ------ |
 | `pdb.create`         | Enable/disable a Pod Disruption Budget creation                | `true` |
-| `pdb.minAvailable`   | Minimum number/percentage of pods that should remain scheduled | `51%`     |
-| `pdb.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable | `""`    |
+| `pdb.minAvailable`   | Minimum number/percentage of pods that should remain scheduled | `51%`  |
+| `pdb.maxUnavailable` | Maximum number/percentage of pods that may be made unavailable | `""`   |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -821,10 +821,10 @@ serviceAccount:
 pdb:
   ## @param pdb.create Enable/disable a Pod Disruption Budget creation
   ##
-  create: false
+  create: true
   ## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
   ##
-  minAvailable: 1
+  minAvailable: 51%
   ## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
   ##
   maxUnavailable: ""


### PR DESCRIPTION
**Description of the change**

Without PDBs, every time a cluster is updated, since Kubernetes is not aware of how to handle the application without PDB, it may cause a majority failure. 

According to [the etcd docs on Majority Failure](https://etcd.io/docs/v3.5/op-guide/failures/#majority-failure):
> When the majority members of the cluster fail, the etcd cluster fails and cannot accept more writes.
>
>The etcd cluster can only recover from a majority failure once the majority of members become available. If a majority of members cannot come back online, then the operator must start disaster recovery to recover the cluster.

This means that manual intervention is needed.

**Benefits**

Enabling this by default instructs the Kubernetes cluster and operators that at least 51% must remain available during voluntary disruptions, such as cluster upgrades.

<!-- Describe any known limitations with your change -->

**Possible drawbacks**
None as far as I can see

**Applicable issues**
  - fixes #9927

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)