### PR TITLE
[bitnami/argo-cd] Fix Prometheus Operator integration

### DIFF
--- a/bitnami/argo-cd/Chart.lock
+++ b/bitnami/argo-cd/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.8.7
+  version: 16.8.9
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.13.0
-digest: sha256:e1466752aeb62f61682dfca300a2af8e48ab9a1a35bda4aa00b9290e64497455
-generated: "2022-04-22T16:15:15.814774355Z"
+  version: 1.13.1
+digest: sha256:12a0028687affc7c941ebfcf61c2f0ed009dd6736a0bc1f0a3f2fa79f5915887
+generated: "2022-04-28T16:10:58.006105383Z"

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/bitnami-docker-dex
   - https://github.com/dexidp/dex
-version: 3.1.14
+version: 3.1.15

--- a/bitnami/argo-cd/templates/application-controller/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/application-controller/metrics-svc.yaml
@@ -5,7 +5,8 @@ metadata:
   name: {{ include "argocd.application-controller" . }}-metrics
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: controller
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: controller
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -39,7 +40,7 @@ spec:
   sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.controller.metrics.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
-    - name: metrics
+    - name: http-metrics
       port: {{ .Values.controller.metrics.service.port }}
       protocol: TCP
       {{- if (and (or (eq .Values.controller.service.type "NodePort") (eq .Values.controller.service.type "LoadBalancer")) (not (empty .Values.controller.metrics.service.nodePort))) }}

--- a/bitnami/argo-cd/templates/application-controller/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/application-controller/servicemonitor.yaml
@@ -44,6 +44,7 @@ spec:
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: controller
+      app.kubernetes.io/component: metrics
+      app.kubernetes.io/part-of: controller
 {{- end }}
 

--- a/bitnami/argo-cd/templates/repo-server/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/repo-server/metrics-svc.yaml
@@ -5,7 +5,8 @@ metadata:
   name: {{ include "argocd.repo-server" . }}-metrics
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: repo-server
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: repo-server
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -37,7 +38,7 @@ spec:
   sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.metrics.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
-    - name: metrics
+    - name: http-metrics
       targetPort: metrics
       port: {{ .Values.repoServer.metrics.service.port }}
       protocol: TCP

--- a/bitnami/argo-cd/templates/repo-server/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/repo-server/servicemonitor.yaml
@@ -45,6 +45,7 @@ spec:
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: repo-server
+      app.kubernetes.io/component: metrics
+      app.kubernetes.io/part-of: repo-server
 {{- end }}
 

--- a/bitnami/argo-cd/templates/server/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/server/metrics-svc.yaml
@@ -5,7 +5,8 @@ metadata:
   name: {{ include "argocd.server" . }}-metrics
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: server
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: server
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -39,7 +40,7 @@ spec:
   sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.server.metrics.service.sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
   ports:
-    - name: metrics
+    - name: http-metrics
       targetPort: metrics
       port: {{ .Values.server.metrics.service.port }}
       protocol: TCP

--- a/bitnami/argo-cd/templates/server/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/server/servicemonitor.yaml
@@ -45,6 +45,7 @@ spec:
   selector:
     matchLabels:
       {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: server
+      app.kubernetes.io/component: metrics
+      app.kubernetes.io/part-of: server
 {{- end }}
 

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -54,7 +54,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/argo-cd
-  tag: 2.3.3-debian-10-r19
+  tag: 2.3.3-debian-10-r24
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1656,7 +1656,7 @@ dex:
   image:
     registry: docker.io
     repository: bitnami/dex
-    tag: 2.31.1-debian-10-r28
+    tag: 2.31.1-debian-10-r33
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2239,7 +2239,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r404
+    tag: 10-debian-10-r409
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2290,7 +2290,7 @@ redis:
   image:
     registry: docker.io
     repository: bitnami/redis
-    tag: 6.2.6-debian-10-r195
+    tag: 6.2.7-debian-10-r0
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
Signed-off-by: juan131 <juan.ariza.1311993@gmail.com>

**Description of the change**

This PR fixes the integration of Argo CD metrics with Prometheus Operator via Servicemonitor.

**Benefits**

Integration with Prometheus Operator works.

**Possible drawbacks**

None

**Applicable issues**

Currently, both the `argo-cd-XXX` and `argo-cd-XXX-metrics` services (where XXX is one of the ArgoCD components: `app-controller`, `server` or `repo-server`) have the same labels, see:

```console
$ kubectl get svc -n argocd -l app.kubernetes.io/component=controller,app.kubernetes.io/instance=argo-cd,app.kubernetes.io/name=argo-cd
NAME                             TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
argo-cd-app-controller           ClusterIP   10.3.243.63    <none>        8082/TCP   15h
argo-cd-app-controller-metrics   ClusterIP   10.3.244.170   <none>        8082/TCP   15h
```

Therefore, the Prometheus Operator (integrated with ArgoCD via ServiceMonitor) can't distinguish between services when it tries to scrape metrics. Also, the current ServiceMonitor rules are pointing to the "http-metrics" port but the `argo-cd-XXX-metrics` services are missing the `http-`prefix in the port names.

**Additional information**

N/A

**Checklist**

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)