### PR TITLE
[bitnami/wordpress] Add VIB wordpress publish pipeline

### DIFF
--- a/.vib/wordpress/vib-publish.json
+++ b/.vib/wordpress/vib-publish.json
@@ -1,0 +1,112 @@
+{
+  "phases": {
+    "package": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/wordpress"
+        }
+      },
+      "actions": [
+        {
+          "action_id": "helm-package"
+        },
+        {
+          "action_id": "helm-lint"
+        }
+      ]
+    },
+    "verify": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/wordpress"
+        },
+        "runtime_parameters": "d29yZHByZXNzVXNlcm5hbWU6IHRlc3RfdXNlcgp3b3JkcHJlc3NQYXNzd29yZDogQ29tcGxpY2F0ZWRQYXNzd29yZDEyMyE0CndvcmRwcmVzc0VtYWlsOiB0ZXN0X3VzZXJfZW1haWxAZW1haWwuY29tCndvcmRwcmVzc0ZpcnN0TmFtZTogVGVzdE5hbWUKd29yZHByZXNzTGFzdE5hbWU6IFRlc3RMYXN0TmFtZQp3b3JkcHJlc3NCbG9nTmFtZTogVGVzdF9Vc2VycydzIEJsb2chCnNtdHBIb3N0OiBtYWlsLnNlcnZlci5jb20Kc210cFBvcnQ6IDEyMApzbXRwVXNlcjogdGVzdF9tYWlsX3VzZXIKc210cFBhc3N3b3JkOiB0ZXN0X21haWxfcGFzc3dvcmQKbWFyaWFkYjoKICBhdXRoOgogICAgZGF0YWJhc2U6IHRlc3Rfd29yZHByZXNzX2RhdGFiYXNlCiAgICB1c2VybmFtZTogdGVzdF93b3JkcHJlc3NfdXNlcm5hbWUKICAgIHBhc3N3b3JkOiB0ZXN0X3dvcmRwcmVzc19wYXNzd29yZAp3b3JkcHJlc3NQbHVnaW5zOiBhbGwKY29udGFpbmVyU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBydW5Bc1VzZXI6IDEwMDIKICBydW5Bc05vblJvb3Q6IHRydWUKd29yZHByZXNzVGFibGVQcmVmaXg6IHdvcmRwcmVzc18K",
+        "target_platform": {
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
+          "size": {
+            "name": "S4"
+          }
+        }
+      },
+      "actions": [
+        {
+          "action_id": "trivy",
+          "params": {
+            "threshold": "CRITICAL",
+            "vuln_type": [
+              "OS"
+            ]
+          }
+        },
+        {
+          "action_id": "health-check",
+          "params": {
+            "endpoint": "lb-wordpress-http",
+            "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/wordpress/goss"
+            },
+            "remote": {
+              "workload": "deploy-wordpress"
+            },
+            "wait": {
+              "file": "goss-wait.yaml"
+            }
+          }
+        },
+        {
+          "action_id": "cypress",
+          "params": {
+            "resources": {
+              "path": "/.vib/wordpress/cypress"
+            },
+            "endpoint": "lb-wordpress-https",
+            "app_protocol": "HTTPS",
+            "env": {
+              "username": "test_user",
+              "password": "ComplicatedPassword123!4"
+            }
+          }
+        },
+        {
+          "action_id": "jmeter",
+          "params": {
+            "resources": {
+              "path": "/.vib/wordpress/jmeter"
+            },
+            "test_plan_file": "wordpress.jmx",
+            "endpoint": "lb-wordpress-https",
+            "app_protocol": "HTTPS",
+            "env": {
+              "wordpress.username": "test_user",
+              "wordpress.password": "ComplicatedPassword123!4"
+            }
+          }
+        }
+      ]
+    },
+    "publish": {
+      "actions": [
+        {
+          "action_id": "helm-publish",
+          "params": {
+            "repository": {
+              "kind": "S3",
+              "url": "{VIB_ENV_S3_URL}",
+              "username": "{VIB_ENV_S3_USERNAME}",
+              "password": "{VIB_ENV_S3_PASSWORD}",
+              "role": "{VIB_ENV_S3_ROLE}"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Description of the change

This PR adds the VIB publish pipeline definition for WordPress. Together with https://github.com/bitnami/charts/pull/9939, it will  enable the verification and publishing of the WordPress chart (first chart) using VIB (VMware Image Builder)

### Benefits

Easy integration with VIB to verify and publish Bitnami WordPress chart.

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

None

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
