### PR TITLE
[bitnami/kong] fix kong missing templating indicator

### DIFF
--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -34,4 +34,4 @@ name: kong
 sources:
   - https://github.com/bitnami/bitnami-docker-kong
   - https://konghq.com/
-version: 6.1.17
+version: 6.1.18

--- a/bitnami/kong/templates/kong-prometheus-rolebinding.yaml
+++ b/bitnami/kong/templates/kong-prometheus-rolebinding.yaml
@@ -2,12 +2,12 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
-  name: printf "%s-prometheus" (include "common.names.fullname" .)
+  name: {{ printf "%s-prometheus" (include "common.names.fullname" .) }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: printf "%s-prometheus" (include "common.names.fullname" .)
+  name: {{ printf "%s-prometheus" (include "common.names.fullname" .) }}
 subjects:
   - namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace }}
     kind: ServiceAccount


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Adding missing {{ }} 

### Benefits

The current code result in invalid YAML when using serviceMonitor 

### Possible drawbacks

None


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
