### PR TITLE
[bitnami/memcached] fix missing volumesPermissions parameters use in memcached statefulset

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 6.0.16
+version: 6.0.17

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
       serviceAccountName: {{ template "memcached.serviceAccountName" . }}
       {{- if or .Values.persistence.enabled .Values.initContainers }}
       initContainers:
-        {{- if .Values.persistence.enabled }}
+        {{- if and .Values.persistence.enabled .Values.volumePermissions.enabled }}
         - name: volume-permissions
           image: {{ include "memcached.volumePermissions.image" . }}
           imagePullPolicy: {{ .Values.volumePermissions.image.pullPolicy | quote }}
@@ -82,7 +82,7 @@ spec:
               touch /cache-state/memory_file
               find /cache-state -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | xargs -r chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
           securityContext:
-            runAsUser: 0
+            runAsUser: {{ .Values.volumePermissions.containerSecurityContext.runAsUser }}
           {{- if .Values.volumePermissions.resources }}
           resources: {{- toYaml .Values.volumePermissions.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
fix missing volumesPermissions parameters use in memcached statefulset


Signed-off-by: greg-azi <gregoire.pheline@swedbank.se>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

In statefulset :

- volume-permissions container will be conditioned by value volumePermissions.enabled

- volume-permissions container securityContext.runAsUser value will be taken from value volumePermissions.containerSecurityContext.runAsUser 


### Benefits

Increase parameterization 
Allow disabling volume-permissions container
Allow customized user from volume-permissions container

### Possible drawbacks

No known drawbacks

### Applicable issues

/

### Additional information

/

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
