### PR TITLE
[bitnami/argo-cd] Fix SSH repo bug: No user exists for uid 1001

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/bitnami-docker-dex
   - https://github.com/dexidp/dex
-version: 3.1.15
+version: 3.1.16

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -76,476 +76,487 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Argo CD image parameters
 
-| Name                | Description                                        | Value                |
-| ------------------- | -------------------------------------------------- | -------------------- |
-| `image.registry`    | Argo CD image registry                             | `docker.io`          |
-| `image.repository`  | Argo CD image repository                           | `bitnami/argo-cd`    |
-| `image.tag`         | Argo CD image tag (immutable tags are recommended) | `2.3.3-debian-10-r3` |
-| `image.pullPolicy`  | Argo CD image pull policy                          | `IfNotPresent`       |
-| `image.pullSecrets` | Argo CD image pull secrets                         | `[]`                 |
-| `image.debug`       | Enable Argo CD image debug mode                    | `false`              |
+| Name                | Description                                        | Value                 |
+| ------------------- | -------------------------------------------------- | --------------------- |
+| `image.registry`    | Argo CD image registry                             | `docker.io`           |
+| `image.repository`  | Argo CD image repository                           | `bitnami/argo-cd`     |
+| `image.tag`         | Argo CD image tag (immutable tags are recommended) | `2.3.3-debian-10-r24` |
+| `image.pullPolicy`  | Argo CD image pull policy                          | `IfNotPresent`        |
+| `image.pullSecrets` | Argo CD image pull secrets                         | `[]`                  |
+| `image.debug`       | Enable Argo CD image debug mode                    | `false`               |
 
 
 ### Argo CD application controller parameters
 
-| Name                                                     | Description                                                                                          | Value           |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------- |
-| `controller.replicaCount`                                | Number of Argo CD replicas to deploy                                                                 | `1`             |
-| `controller.startupProbe.enabled`                        | Enable startupProbe on Argo CD nodes                                                                 | `false`         |
-| `controller.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                               | `10`            |
-| `controller.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                      | `10`            |
-| `controller.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                     | `1`             |
-| `controller.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                   | `3`             |
-| `controller.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                   | `1`             |
-| `controller.livenessProbe.enabled`                       | Enable livenessProbe on Argo CD nodes                                                                | `true`          |
-| `controller.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                              | `10`            |
-| `controller.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                     | `10`            |
-| `controller.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                    | `1`             |
-| `controller.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                  | `3`             |
-| `controller.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                  | `1`             |
-| `controller.readinessProbe.enabled`                      | Enable readinessProbe on Argo CD nodes                                                               | `true`          |
-| `controller.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                             | `10`            |
-| `controller.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                    | `10`            |
-| `controller.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                   | `1`             |
-| `controller.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                 | `3`             |
-| `controller.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                 | `1`             |
-| `controller.customStartupProbe`                          | Custom startupProbe that overrides the default one                                                   | `{}`            |
-| `controller.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                  | `{}`            |
-| `controller.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                 | `{}`            |
-| `controller.resources.limits`                            | The resources limits for the Argo CD containers                                                      | `{}`            |
-| `controller.resources.requests`                          | The requested resources for the Argo CD containers                                                   | `{}`            |
-| `controller.podSecurityContext.enabled`                  | Enabled Argo CD pods' Security Context                                                               | `true`          |
-| `controller.podSecurityContext.fsGroup`                  | Set Argo CD pod's Security Context fsGroup                                                           | `1001`          |
-| `controller.containerSecurityContext.enabled`            | Enabled Argo CD containers' Security Context                                                         | `true`          |
-| `controller.containerSecurityContext.runAsUser`          | Set Argo CD containers' Security Context runAsUser                                                   | `1001`          |
-| `controller.containerSecurityContext.runAsNonRoot`       | Set Argo CD container's Security Context runAsNonRoot                                                | `true`          |
-| `controller.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                 | `true`          |
-| `controller.serviceAccount.name`                         | The name of the ServiceAccount to use.                                                               | `""`            |
-| `controller.serviceAccount.automountServiceAccountToken` | Automount service account token for the application controller service account                       | `true`          |
-| `controller.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.           | `{}`            |
-| `controller.clusterAdminAccess`                          | Enable K8s cluster admin access for the application controller                                       | `true`          |
-| `controller.clusterRoleRules`                            | Use custom rules for the application controller's cluster role                                       | `[]`            |
-| `controller.logFormat`                                   | Format for the Argo CD application controller logs. Options: [text, json]                            | `text`          |
-| `controller.logLevel`                                    | Log level for the Argo CD application controller                                                     | `info`          |
-| `controller.containerPorts.controller`                   | Argo CD application controller port number                                                           | `8082`          |
-| `controller.containerPorts.metrics`                      | Argo CD application controller metrics port number                                                   | `8082`          |
-| `controller.service.type`                                | Argo CD service type                                                                                 | `ClusterIP`     |
-| `controller.service.port`                                | Argo CD application controller service port                                                          | `8082`          |
-| `controller.service.nodePort`                            | Node port for Argo CD application controller service                                                 | `""`            |
-| `controller.service.clusterIP`                           | Argo CD application controller service Cluster IP                                                    | `""`            |
-| `controller.service.loadBalancerIP`                      | Argo CD application controller service Load Balancer IP                                              | `""`            |
-| `controller.service.loadBalancerSourceRanges`            | Argo CD application controller service Load Balancer sources                                         | `[]`            |
-| `controller.service.externalTrafficPolicy`               | Argo CD application controller service external traffic policy                                       | `Cluster`       |
-| `controller.service.annotations`                         | Additional custom annotations for Argo CD application controller service                             | `{}`            |
-| `controller.service.extraPorts`                          | Extra ports to expose (normally used with the `sidecar` value)                                       | `[]`            |
-| `controller.service.sessionAffinity`                     | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                 | `None`          |
-| `controller.service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                          | `{}`            |
-| `controller.metrics.enabled`                             | Enable Argo CD application controller metrics                                                        | `false`         |
-| `controller.metrics.service.type`                        | Argo CD application controller service type                                                          | `ClusterIP`     |
-| `controller.metrics.service.port`                        | Argo CD application controller metrics service port                                                  | `8082`          |
-| `controller.metrics.service.nodePort`                    | Node port for the application controller service                                                     | `""`            |
-| `controller.metrics.service.clusterIP`                   | Argo CD application controller metrics service Cluster IP                                            | `""`            |
-| `controller.metrics.service.loadBalancerIP`              | Argo CD application controller service Load Balancer IP                                              | `""`            |
-| `controller.metrics.service.loadBalancerSourceRanges`    | Argo CD application controller service Load Balancer sources                                         | `[]`            |
-| `controller.metrics.service.externalTrafficPolicy`       | Argo CD application controller service external traffic policy                                       | `Cluster`       |
-| `controller.metrics.service.annotations`                 | Additional custom annotations for Argo CD application controller service                             | `{}`            |
-| `controller.metrics.service.sessionAffinity`             | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                 | `None`          |
-| `controller.metrics.service.sessionAffinityConfig`       | Additional settings for the sessionAffinity                                                          | `{}`            |
-| `controller.metrics.serviceMonitor.enabled`              | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                         | `false`         |
-| `controller.metrics.serviceMonitor.namespace`            | Namespace which Prometheus is running in                                                             | `""`            |
-| `controller.metrics.serviceMonitor.jobLabel`             | The name of the label on the target service to use as the job name in prometheus.                    | `""`            |
-| `controller.metrics.serviceMonitor.interval`             | Interval at which metrics should be scraped                                                          | `30s`           |
-| `controller.metrics.serviceMonitor.scrapeTimeout`        | Timeout after which the scrape is ended                                                              | `10s`           |
-| `controller.metrics.serviceMonitor.relabelings`          | RelabelConfigs to apply to samples before scraping                                                   | `[]`            |
-| `controller.metrics.serviceMonitor.metricRelabelings`    | MetricRelabelConfigs to apply to samples before ingestion                                            | `[]`            |
-| `controller.metrics.serviceMonitor.selector`             | ServiceMonitor selector labels                                                                       | `{}`            |
-| `controller.metrics.serviceMonitor.honorLabels`          | honorLabels chooses the metric's labels on collisions with target labels                             | `false`         |
-| `controller.metrics.rules.enabled`                       | Enable render extra rules for PrometheusRule object                                                  | `false`         |
-| `controller.metrics.rules.spec`                          | Rules to render into the PrometheusRule object                                                       | `[]`            |
-| `controller.metrics.rules.selector`                      | Selector for the PrometheusRule object                                                               | `{}`            |
-| `controller.metrics.rules.namespace`                     | Namespace where to create the PrometheusRule object                                                  | `monitoring`    |
-| `controller.metrics.rules.additionalLabels`              | Additional lables to add to the PrometheusRule object                                                | `{}`            |
-| `controller.command`                                     | Override default container command (useful when using custom images)                                 | `[]`            |
-| `controller.defaultArgs.statusProcessors`                | Default status processors for Argo CD controller                                                     | `20`            |
-| `controller.defaultArgs.operationProcessors`             | Default operation processors for Argo CD controller                                                  | `10`            |
-| `controller.defaultArgs.appResyncPeriod`                 | Default application resync period for Argo CD controller                                             | `180`           |
-| `controller.defaultArgs.selfHealTimeout`                 | Default self heal timeout for Argo CD controller                                                     | `5`             |
-| `controller.args`                                        | Override default container args (useful when using custom images). Overrides the defaultArgs.        | `[]`            |
-| `controller.extraArgs`                                   | Add extra arguments to the default arguments for the Argo CD controller                              | `[]`            |
-| `controller.hostAliases`                                 | Argo CD pods host aliases                                                                            | `[]`            |
-| `controller.podLabels`                                   | Extra labels for Argo CD pods                                                                        | `{}`            |
-| `controller.podAnnotations`                              | Annotations for Argo CD pods                                                                         | `{}`            |
-| `controller.podAffinityPreset`                           | Pod affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
-| `controller.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
-| `controller.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
-| `controller.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `controller.affinity` is set                                     | `""`            |
-| `controller.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `controller.affinity` is set                                  | `[]`            |
-| `controller.affinity`                                    | Affinity for Argo CD pods assignment                                                                 | `{}`            |
-| `controller.nodeSelector`                                | Node labels for Argo CD pods assignment                                                              | `{}`            |
-| `controller.tolerations`                                 | Tolerations for Argo CD pods assignment                                                              | `[]`            |
-| `controller.schedulerName`                               | Name of the k8s scheduler (other than default)                                                       | `""`            |
-| `controller.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                       | `[]`            |
-| `controller.updateStrategy.type`                         | Argo CD statefulset strategy type                                                                    | `RollingUpdate` |
-| `controller.priorityClassName`                           | Argo CD pods' priorityClassName                                                                      | `""`            |
-| `controller.lifecycleHooks`                              | for the Argo CD container(s) to automate configuration before or after startup                       | `{}`            |
-| `controller.extraEnvVars`                                | Array with extra environment variables to add to Argo CD nodes                                       | `[]`            |
-| `controller.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Argo CD nodes                               | `""`            |
-| `controller.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Argo CD nodes                                  | `""`            |
-| `controller.extraVolumes`                                | Optionally specify extra list of additional volumes for the Argo CD pod(s)                           | `[]`            |
-| `controller.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Argo CD container(s)                | `[]`            |
-| `controller.sidecars`                                    | Add additional sidecar containers to the Argo CD pod(s)                                              | `[]`            |
-| `controller.initContainers`                              | Add additional init containers to the Argo CD pod(s)                                                 | `[]`            |
+| Name                                                           | Description                                                                                          | Value           |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------- |
+| `controller.replicaCount`                                      | Number of Argo CD replicas to deploy                                                                 | `1`             |
+| `controller.startupProbe.enabled`                              | Enable startupProbe on Argo CD nodes                                                                 | `false`         |
+| `controller.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                               | `10`            |
+| `controller.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                      | `10`            |
+| `controller.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                     | `1`             |
+| `controller.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                   | `3`             |
+| `controller.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                   | `1`             |
+| `controller.livenessProbe.enabled`                             | Enable livenessProbe on Argo CD nodes                                                                | `true`          |
+| `controller.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                              | `10`            |
+| `controller.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                     | `10`            |
+| `controller.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                    | `1`             |
+| `controller.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                  | `3`             |
+| `controller.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                  | `1`             |
+| `controller.readinessProbe.enabled`                            | Enable readinessProbe on Argo CD nodes                                                               | `true`          |
+| `controller.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                             | `10`            |
+| `controller.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                    | `10`            |
+| `controller.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                   | `1`             |
+| `controller.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                 | `3`             |
+| `controller.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                 | `1`             |
+| `controller.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                   | `{}`            |
+| `controller.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                  | `{}`            |
+| `controller.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                                 | `{}`            |
+| `controller.resources.limits`                                  | The resources limits for the Argo CD containers                                                      | `{}`            |
+| `controller.resources.requests`                                | The requested resources for the Argo CD containers                                                   | `{}`            |
+| `controller.podSecurityContext.enabled`                        | Enabled Argo CD pods' Security Context                                                               | `true`          |
+| `controller.podSecurityContext.fsGroup`                        | Set Argo CD pod's Security Context fsGroup                                                           | `1001`          |
+| `controller.containerSecurityContext.enabled`                  | Enabled Argo CD containers' Security Context                                                         | `true`          |
+| `controller.containerSecurityContext.runAsUser`                | Set Argo CD containers' Security Context runAsUser                                                   | `1001`          |
+| `controller.containerSecurityContext.allowPrivilegeEscalation` | Set Argo CD containers' Security Context allowPrivilegeEscalation                                    | `false`         |
+| `controller.containerSecurityContext.capabilities.drop`        | Set Argo CD containers' Security Context capabilities to be dropped                                  | `["all"]`       |
+| `controller.containerSecurityContext.readOnlyRootFilesystem`   | Set Argo CD containers' Security Context readOnlyRootFilesystem                                      | `true`          |
+| `controller.containerSecurityContext.runAsNonRoot`             | Set Argo CD container's Security Context runAsNonRoot                                                | `true`          |
+| `controller.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                 | `true`          |
+| `controller.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                               | `""`            |
+| `controller.serviceAccount.automountServiceAccountToken`       | Automount service account token for the application controller service account                       | `true`          |
+| `controller.serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.           | `{}`            |
+| `controller.clusterAdminAccess`                                | Enable K8s cluster admin access for the application controller                                       | `true`          |
+| `controller.clusterRoleRules`                                  | Use custom rules for the application controller's cluster role                                       | `[]`            |
+| `controller.logFormat`                                         | Format for the Argo CD application controller logs. Options: [text, json]                            | `text`          |
+| `controller.logLevel`                                          | Log level for the Argo CD application controller                                                     | `info`          |
+| `controller.containerPorts.controller`                         | Argo CD application controller port number                                                           | `8082`          |
+| `controller.containerPorts.metrics`                            | Argo CD application controller metrics port number                                                   | `8082`          |
+| `controller.service.type`                                      | Argo CD service type                                                                                 | `ClusterIP`     |
+| `controller.service.port`                                      | Argo CD application controller service port                                                          | `8082`          |
+| `controller.service.nodePort`                                  | Node port for Argo CD application controller service                                                 | `""`            |
+| `controller.service.clusterIP`                                 | Argo CD application controller service Cluster IP                                                    | `""`            |
+| `controller.service.loadBalancerIP`                            | Argo CD application controller service Load Balancer IP                                              | `""`            |
+| `controller.service.loadBalancerSourceRanges`                  | Argo CD application controller service Load Balancer sources                                         | `[]`            |
+| `controller.service.externalTrafficPolicy`                     | Argo CD application controller service external traffic policy                                       | `Cluster`       |
+| `controller.service.annotations`                               | Additional custom annotations for Argo CD application controller service                             | `{}`            |
+| `controller.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                       | `[]`            |
+| `controller.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                 | `None`          |
+| `controller.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                          | `{}`            |
+| `controller.metrics.enabled`                                   | Enable Argo CD application controller metrics                                                        | `false`         |
+| `controller.metrics.service.type`                              | Argo CD application controller service type                                                          | `ClusterIP`     |
+| `controller.metrics.service.port`                              | Argo CD application controller metrics service port                                                  | `8082`          |
+| `controller.metrics.service.nodePort`                          | Node port for the application controller service                                                     | `""`            |
+| `controller.metrics.service.clusterIP`                         | Argo CD application controller metrics service Cluster IP                                            | `""`            |
+| `controller.metrics.service.loadBalancerIP`                    | Argo CD application controller service Load Balancer IP                                              | `""`            |
+| `controller.metrics.service.loadBalancerSourceRanges`          | Argo CD application controller service Load Balancer sources                                         | `[]`            |
+| `controller.metrics.service.externalTrafficPolicy`             | Argo CD application controller service external traffic policy                                       | `Cluster`       |
+| `controller.metrics.service.annotations`                       | Additional custom annotations for Argo CD application controller service                             | `{}`            |
+| `controller.metrics.service.sessionAffinity`                   | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                 | `None`          |
+| `controller.metrics.service.sessionAffinityConfig`             | Additional settings for the sessionAffinity                                                          | `{}`            |
+| `controller.metrics.serviceMonitor.enabled`                    | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                         | `false`         |
+| `controller.metrics.serviceMonitor.namespace`                  | Namespace which Prometheus is running in                                                             | `""`            |
+| `controller.metrics.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in prometheus.                    | `""`            |
+| `controller.metrics.serviceMonitor.interval`                   | Interval at which metrics should be scraped                                                          | `30s`           |
+| `controller.metrics.serviceMonitor.scrapeTimeout`              | Timeout after which the scrape is ended                                                              | `10s`           |
+| `controller.metrics.serviceMonitor.relabelings`                | RelabelConfigs to apply to samples before scraping                                                   | `[]`            |
+| `controller.metrics.serviceMonitor.metricRelabelings`          | MetricRelabelConfigs to apply to samples before ingestion                                            | `[]`            |
+| `controller.metrics.serviceMonitor.selector`                   | ServiceMonitor selector labels                                                                       | `{}`            |
+| `controller.metrics.serviceMonitor.honorLabels`                | honorLabels chooses the metric's labels on collisions with target labels                             | `false`         |
+| `controller.metrics.rules.enabled`                             | Enable render extra rules for PrometheusRule object                                                  | `false`         |
+| `controller.metrics.rules.spec`                                | Rules to render into the PrometheusRule object                                                       | `[]`            |
+| `controller.metrics.rules.selector`                            | Selector for the PrometheusRule object                                                               | `{}`            |
+| `controller.metrics.rules.namespace`                           | Namespace where to create the PrometheusRule object                                                  | `monitoring`    |
+| `controller.metrics.rules.additionalLabels`                    | Additional lables to add to the PrometheusRule object                                                | `{}`            |
+| `controller.command`                                           | Override default container command (useful when using custom images)                                 | `[]`            |
+| `controller.defaultArgs.statusProcessors`                      | Default status processors for Argo CD controller                                                     | `20`            |
+| `controller.defaultArgs.operationProcessors`                   | Default operation processors for Argo CD controller                                                  | `10`            |
+| `controller.defaultArgs.appResyncPeriod`                       | Default application resync period for Argo CD controller                                             | `180`           |
+| `controller.defaultArgs.selfHealTimeout`                       | Default self heal timeout for Argo CD controller                                                     | `5`             |
+| `controller.args`                                              | Override default container args (useful when using custom images). Overrides the defaultArgs.        | `[]`            |
+| `controller.extraArgs`                                         | Add extra arguments to the default arguments for the Argo CD controller                              | `[]`            |
+| `controller.hostAliases`                                       | Argo CD pods host aliases                                                                            | `[]`            |
+| `controller.podLabels`                                         | Extra labels for Argo CD pods                                                                        | `{}`            |
+| `controller.podAnnotations`                                    | Annotations for Argo CD pods                                                                         | `{}`            |
+| `controller.podAffinityPreset`                                 | Pod affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
+| `controller.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `controller.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
+| `controller.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `controller.affinity` is set                                     | `""`            |
+| `controller.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `controller.affinity` is set                                  | `[]`            |
+| `controller.affinity`                                          | Affinity for Argo CD pods assignment                                                                 | `{}`            |
+| `controller.nodeSelector`                                      | Node labels for Argo CD pods assignment                                                              | `{}`            |
+| `controller.tolerations`                                       | Tolerations for Argo CD pods assignment                                                              | `[]`            |
+| `controller.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                       | `""`            |
+| `controller.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                       | `[]`            |
+| `controller.updateStrategy.type`                               | Argo CD statefulset strategy type                                                                    | `RollingUpdate` |
+| `controller.priorityClassName`                                 | Argo CD pods' priorityClassName                                                                      | `""`            |
+| `controller.lifecycleHooks`                                    | for the Argo CD container(s) to automate configuration before or after startup                       | `{}`            |
+| `controller.extraEnvVars`                                      | Array with extra environment variables to add to Argo CD nodes                                       | `[]`            |
+| `controller.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Argo CD nodes                               | `""`            |
+| `controller.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Argo CD nodes                                  | `""`            |
+| `controller.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Argo CD pod(s)                           | `[]`            |
+| `controller.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Argo CD container(s)                | `[]`            |
+| `controller.sidecars`                                          | Add additional sidecar containers to the Argo CD pod(s)                                              | `[]`            |
+| `controller.initContainers`                                    | Add additional init containers to the Argo CD pod(s)                                                 | `[]`            |
 
 
 ### Argo CD server Parameters
 
-| Name                                                 | Description                                                                                                                     | Value                    |
-| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `server.replicaCount`                                | Number of Argo CD server replicas to deploy                                                                                     | `1`                      |
-| `server.startupProbe.enabled`                        | Enable startupProbe on Argo CD server nodes                                                                                     | `false`                  |
-| `server.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                                          | `10`                     |
-| `server.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                                                 | `10`                     |
-| `server.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                                                | `1`                      |
-| `server.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                                              | `3`                      |
-| `server.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                                              | `1`                      |
-| `server.livenessProbe.enabled`                       | Enable livenessProbe on Argo CD server nodes                                                                                    | `true`                   |
-| `server.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                                         | `10`                     |
-| `server.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                                                | `10`                     |
-| `server.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                                               | `1`                      |
-| `server.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                                             | `3`                      |
-| `server.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                                             | `1`                      |
-| `server.readinessProbe.enabled`                      | Enable readinessProbe on Argo CD server nodes                                                                                   | `true`                   |
-| `server.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                                                        | `10`                     |
-| `server.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                                               | `10`                     |
-| `server.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                                              | `1`                      |
-| `server.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                                            | `3`                      |
-| `server.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                                            | `1`                      |
-| `server.customStartupProbe`                          | Custom startupProbe that overrides the default one                                                                              | `{}`                     |
-| `server.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                                             | `{}`                     |
-| `server.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                                            | `{}`                     |
-| `server.resources.limits`                            | The resources limits for the Argo CD server containers                                                                          | `{}`                     |
-| `server.resources.requests`                          | The requested resources for the Argo CD server containers                                                                       | `{}`                     |
-| `server.podSecurityContext.enabled`                  | Enabled Argo CD server pods' Security Context                                                                                   | `true`                   |
-| `server.podSecurityContext.fsGroup`                  | Set Argo CD server pod's Security Context fsGroup                                                                               | `1001`                   |
-| `server.containerSecurityContext.enabled`            | Enabled Argo CD server containers' Security Context                                                                             | `true`                   |
-| `server.containerSecurityContext.runAsUser`          | Set Argo CD server containers' Security Context runAsUser                                                                       | `1001`                   |
-| `server.containerSecurityContext.runAsNonRoot`       | Set Argo CD server containers' Security Context runAsNonRoot                                                                    | `true`                   |
-| `server.autoscaling.enabled`                         | Enable Argo CD server deployment autoscaling                                                                                    | `false`                  |
-| `server.autoscaling.minReplicas`                     | Argo CD server deployment autoscaling minimum number of replicas                                                                | `1`                      |
-| `server.autoscaling.maxReplicas`                     | Argo CD server deployment autoscaling maximum number of replicas                                                                | `5`                      |
-| `server.autoscaling.targetCPU`                       | Argo CD server deployment autoscaling target CPU percentage                                                                     | `50`                     |
-| `server.autoscaling.targetMemory`                    | Argo CD server deployment autoscaling target CPU memory                                                                         | `50`                     |
-| `server.insecure`                                    | Disable HTTPS redirection for Argo CD server                                                                                    | `false`                  |
-| `server.logFormat`                                   | ArgoCD server logs format. Options: [text, json]                                                                                | `text`                   |
-| `server.logLevel`                                    | ArgoCD server logs level                                                                                                        | `info`                   |
-| `server.configEnabled`                               | Enable Argo CD server config                                                                                                    | `true`                   |
-| `server.url`                                         | Argo CD server base URL. Required when configuring SSO. Required when enabling dex.                                             | `""`                     |
-| `server.config`                                      | Argo CD server configuration that will end on the argocd-cm Config Map                                                          | `{}`                     |
-| `server.ingress.enabled`                             | Enable the creation of an ingress for the Argo CD server                                                                        | `false`                  |
-| `server.ingress.pathType`                            | Path type for the Argo CD server ingress                                                                                        | `ImplementationSpecific` |
-| `server.ingress.apiVersion`                          | Ingress API version for the Argo CD server ingress                                                                              | `""`                     |
-| `server.ingress.hostname`                            | Ingress hostname for the Argo CD server ingress                                                                                 | `argocd.server.local`    |
-| `server.ingress.annotations`                         | Annotations for the Argo CD server ingress. To enable certificate autogeneration, place here your cert-manager annotations.     | `{}`                     |
-| `server.ingress.tls`                                 | Enable TLS for the Argo CD server ingress                                                                                       | `false`                  |
-| `server.ingress.extraHosts`                          | Extra hosts array for the Argo CD server ingress                                                                                | `[]`                     |
-| `server.ingress.path`                                | Path array for the Argo CD server ingress                                                                                       | `/`                      |
-| `server.ingress.extraPaths`                          | Extra paths for the Argo CD server ingress                                                                                      | `[]`                     |
-| `server.ingress.extraTls`                            | Extra TLS configuration for the Argo CD server ingress                                                                          | `[]`                     |
-| `server.ingress.secrets`                             | Secrets array to mount into the Ingress                                                                                         | `[]`                     |
-| `server.ingress.ingressClassName`                    | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                   | `""`                     |
-| `server.ingress.selfSigned`                          | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                    | `false`                  |
-| `server.metrics.enabled`                             | Enable metrics for the Argo CD server                                                                                           | `false`                  |
-| `server.metrics.service.type`                        | Argo CD server service type                                                                                                     | `ClusterIP`              |
-| `server.metrics.service.port`                        | Argo CD server metrics service port                                                                                             | `8083`                   |
-| `server.metrics.service.nodePort`                    | Node port for Argo CD server metrics service                                                                                    | `""`                     |
-| `server.metrics.service.clusterIP`                   | Argo CD server metrics service Cluster IP                                                                                       | `""`                     |
-| `server.metrics.service.loadBalancerIP`              | Argo CD server service Load Balancer IP                                                                                         | `""`                     |
-| `server.metrics.service.loadBalancerSourceRanges`    | Argo CD server service Load Balancer sources                                                                                    | `[]`                     |
-| `server.metrics.service.externalTrafficPolicy`       | Argo CD server service external traffic policy                                                                                  | `Cluster`                |
-| `server.metrics.service.annotations`                 | Additional custom annotations for Argo CD server service                                                                        | `{}`                     |
-| `server.metrics.service.sessionAffinity`             | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                            | `None`                   |
-| `server.metrics.service.sessionAffinityConfig`       | Additional settings for the sessionAffinity                                                                                     | `{}`                     |
-| `server.metrics.serviceMonitor.enabled`              | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                                    | `false`                  |
-| `server.metrics.serviceMonitor.namespace`            | Namespace which Prometheus is running in                                                                                        | `""`                     |
-| `server.metrics.serviceMonitor.jobLabel`             | The name of the label on the target service to use as the job name in prometheus.                                               | `""`                     |
-| `server.metrics.serviceMonitor.interval`             | Interval at which metrics should be scraped                                                                                     | `30s`                    |
-| `server.metrics.serviceMonitor.scrapeTimeout`        | Timeout after which the scrape is ended                                                                                         | `10s`                    |
-| `server.metrics.serviceMonitor.relabelings`          | RelabelConfigs to apply to samples before scraping                                                                              | `[]`                     |
-| `server.metrics.serviceMonitor.metricRelabelings`    | MetricRelabelConfigs to apply to samples before ingestion                                                                       | `[]`                     |
-| `server.metrics.serviceMonitor.selector`             | ServiceMonitor selector labels                                                                                                  | `{}`                     |
-| `server.metrics.serviceMonitor.honorLabels`          | honorLabels chooses the metric's labels on collisions with target labels                                                        | `false`                  |
-| `server.ingressGrpc.enabled`                         | Enable the creation of an ingress for the Argo CD gRPC server                                                                   | `false`                  |
-| `server.ingressGrpc.pathType`                        | Path type for the Argo CD gRPC server ingress                                                                                   | `ImplementationSpecific` |
-| `server.ingressGrpc.apiVersion`                      | Ingress API version for the Argo CD gRPC server ingress                                                                         | `""`                     |
-| `server.ingressGrpc.hostname`                        | Ingress hostname for the Argo CD gRPC server ingress                                                                            | `argocd.server.local`    |
-| `server.ingressGrpc.annotations`                     | Annotations for the Argo CD gRPC server ingress. To enable certificate autogeneration, place here your cert-manager annotations | `{}`                     |
-| `server.ingressGrpc.tls`                             | Enable TLS for the Argo CD server ingress                                                                                       | `false`                  |
-| `server.ingressGrpc.extraHosts`                      | Extra hosts array for the Argo CD gRPC server ingress                                                                           | `[]`                     |
-| `server.ingressGrpc.path`                            | Path array for the Argo CD gRPC server ingress                                                                                  | `/`                      |
-| `server.ingressGrpc.extraPaths`                      | Extra paths for the Argo CD gRPC server ingress                                                                                 | `[]`                     |
-| `server.ingressGrpc.extraTls`                        | Extra TLS configuration for the Argo CD gRPC server ingress                                                                     | `[]`                     |
-| `server.ingressGrpc.secrets`                         | Secrets array to mount into the Ingress                                                                                         | `[]`                     |
-| `server.ingressGrpc.ingressClassName`                | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                   | `""`                     |
-| `server.ingressGrpc.selfSigned`                      | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                    | `false`                  |
-| `server.containerPorts.http`                         | Argo CD server HTTP container port                                                                                              | `8080`                   |
-| `server.containerPorts.https`                        | Argo CD server HTTPS container port                                                                                             | `8443`                   |
-| `server.containerPorts.metrics`                      | Argo CD server metrics container port                                                                                           | `8083`                   |
-| `server.service.type`                                | Argo CD service type                                                                                                            | `ClusterIP`              |
-| `server.service.ports.http`                          | HTTP port for the gRPC ingress when enabled                                                                                     | `80`                     |
-| `server.service.ports.https`                         | HTTPS port for the gRPC ingress when enabled                                                                                    | `443`                    |
-| `server.service.nodePorts.http`                      | Node port for HTTP                                                                                                              | `""`                     |
-| `server.service.nodePorts.https`                     | Node port for HTTPS                                                                                                             | `""`                     |
-| `server.service.clusterIP`                           | Argo CD service Cluster IP                                                                                                      | `""`                     |
-| `server.service.loadBalancerIP`                      | Argo CD service Load Balancer IP                                                                                                | `""`                     |
-| `server.service.loadBalancerSourceRanges`            | Argo CD service Load Balancer sources                                                                                           | `[]`                     |
-| `server.service.externalTrafficPolicy`               | Argo CD service external traffic policy                                                                                         | `Cluster`                |
-| `server.service.annotations`                         | Additional custom annotations for Argo CD service                                                                               | `{}`                     |
-| `server.service.extraPorts`                          | Extra ports to expose (normally used with the `sidecar` value)                                                                  | `[]`                     |
-| `server.service.sessionAffinity`                     | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                            | `None`                   |
-| `server.service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                                                     | `{}`                     |
-| `server.command`                                     | Override default container command (useful when using custom images)                                                            | `[]`                     |
-| `server.args`                                        | Override default container args (useful when using custom images)                                                               | `[]`                     |
-| `server.extraArgs`                                   | concat to the default args                                                                                                      | `[]`                     |
-| `server.hostAliases`                                 | Argo CD server pods host aliases                                                                                                | `[]`                     |
-| `server.podLabels`                                   | Extra labels for Argo CD server pods                                                                                            | `{}`                     |
-| `server.podAnnotations`                              | Annotations for Argo CD server pods                                                                                             | `{}`                     |
-| `server.podAffinityPreset`                           | Pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                     |
-| `server.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                   |
-| `server.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                                | `""`                     |
-| `server.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `server.affinity` is set                                                                    | `""`                     |
-| `server.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `server.affinity` is set                                                                 | `[]`                     |
-| `server.affinity`                                    | Affinity for Argo CD server pods assignment                                                                                     | `{}`                     |
-| `server.nodeSelector`                                | Node labels for Argo CD server pods assignment                                                                                  | `{}`                     |
-| `server.tolerations`                                 | Tolerations for Argo CD server pods assignment                                                                                  | `[]`                     |
-| `server.schedulerName`                               | Name of the k8s scheduler (other than default)                                                                                  | `""`                     |
-| `server.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                                                  | `[]`                     |
-| `server.updateStrategy.type`                         | Argo CD server statefulset strategy type                                                                                        | `RollingUpdate`          |
-| `server.priorityClassName`                           | Argo CD server pods' priorityClassName                                                                                          | `""`                     |
-| `server.lifecycleHooks`                              | for the Argo CD server container(s) to automate configuration before or after startup                                           | `{}`                     |
-| `server.extraEnvVars`                                | Array with extra environment variables to add to Argo CD server nodes                                                           | `[]`                     |
-| `server.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Argo CD server nodes                                                   | `""`                     |
-| `server.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Argo CD server nodes                                                      | `""`                     |
-| `server.extraVolumes`                                | Optionally specify extra list of additional volumes for the Argo CD server pod(s)                                               | `[]`                     |
-| `server.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Argo CD server container(s)                                    | `[]`                     |
-| `server.sidecars`                                    | Add additional sidecar containers to the Argo CD server pod(s)                                                                  | `[]`                     |
-| `server.initContainers`                              | Add additional init containers to the Argo CD server pod(s)                                                                     | `[]`                     |
-| `server.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                            | `true`                   |
-| `server.serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                                          | `""`                     |
-| `server.serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                                                  | `true`                   |
-| `server.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                                      | `{}`                     |
+| Name                                                       | Description                                                                                                                     | Value                    |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `server.replicaCount`                                      | Number of Argo CD server replicas to deploy                                                                                     | `1`                      |
+| `server.startupProbe.enabled`                              | Enable startupProbe on Argo CD server nodes                                                                                     | `false`                  |
+| `server.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                                                          | `10`                     |
+| `server.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                                                 | `10`                     |
+| `server.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                                                | `1`                      |
+| `server.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                                              | `3`                      |
+| `server.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                                              | `1`                      |
+| `server.livenessProbe.enabled`                             | Enable livenessProbe on Argo CD server nodes                                                                                    | `true`                   |
+| `server.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                                         | `10`                     |
+| `server.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                                                | `10`                     |
+| `server.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                                               | `1`                      |
+| `server.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                                             | `3`                      |
+| `server.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                                             | `1`                      |
+| `server.readinessProbe.enabled`                            | Enable readinessProbe on Argo CD server nodes                                                                                   | `true`                   |
+| `server.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                                                        | `10`                     |
+| `server.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                                               | `10`                     |
+| `server.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                                              | `1`                      |
+| `server.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                                            | `3`                      |
+| `server.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                                            | `1`                      |
+| `server.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                                              | `{}`                     |
+| `server.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                                             | `{}`                     |
+| `server.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                                                            | `{}`                     |
+| `server.resources.limits`                                  | The resources limits for the Argo CD server containers                                                                          | `{}`                     |
+| `server.resources.requests`                                | The requested resources for the Argo CD server containers                                                                       | `{}`                     |
+| `server.podSecurityContext.enabled`                        | Enabled Argo CD server pods' Security Context                                                                                   | `true`                   |
+| `server.podSecurityContext.fsGroup`                        | Set Argo CD server pod's Security Context fsGroup                                                                               | `1001`                   |
+| `server.containerSecurityContext.enabled`                  | Enabled Argo CD server containers' Security Context                                                                             | `true`                   |
+| `server.containerSecurityContext.runAsUser`                | Set Argo CD server containers' Security Context runAsUser                                                                       | `1001`                   |
+| `server.containerSecurityContext.allowPrivilegeEscalation` | Set Argo CD server containers' Security Context allowPrivilegeEscalation                                                        | `false`                  |
+| `server.containerSecurityContext.capabilities.drop`        | Set Argo CD containers' server Security Context capabilities to be dropped                                                      | `["all"]`                |
+| `server.containerSecurityContext.readOnlyRootFilesystem`   | Set Argo CD containers' server Security Context readOnlyRootFilesystem                                                          | `true`                   |
+| `server.containerSecurityContext.runAsNonRoot`             | Set Argo CD server containers' Security Context runAsNonRoot                                                                    | `true`                   |
+| `server.autoscaling.enabled`                               | Enable Argo CD server deployment autoscaling                                                                                    | `false`                  |
+| `server.autoscaling.minReplicas`                           | Argo CD server deployment autoscaling minimum number of replicas                                                                | `1`                      |
+| `server.autoscaling.maxReplicas`                           | Argo CD server deployment autoscaling maximum number of replicas                                                                | `5`                      |
+| `server.autoscaling.targetCPU`                             | Argo CD server deployment autoscaling target CPU percentage                                                                     | `50`                     |
+| `server.autoscaling.targetMemory`                          | Argo CD server deployment autoscaling target CPU memory                                                                         | `50`                     |
+| `server.insecure`                                          | Disable HTTPS redirection for Argo CD server                                                                                    | `false`                  |
+| `server.logFormat`                                         | ArgoCD server logs format. Options: [text, json]                                                                                | `text`                   |
+| `server.logLevel`                                          | ArgoCD server logs level                                                                                                        | `info`                   |
+| `server.configEnabled`                                     | Enable Argo CD server config                                                                                                    | `true`                   |
+| `server.url`                                               | Argo CD server base URL. Required when configuring SSO. Required when enabling dex.                                             | `""`                     |
+| `server.config`                                            | Argo CD server configuration that will end on the argocd-cm Config Map                                                          | `{}`                     |
+| `server.ingress.enabled`                                   | Enable the creation of an ingress for the Argo CD server                                                                        | `false`                  |
+| `server.ingress.pathType`                                  | Path type for the Argo CD server ingress                                                                                        | `ImplementationSpecific` |
+| `server.ingress.apiVersion`                                | Ingress API version for the Argo CD server ingress                                                                              | `""`                     |
+| `server.ingress.hostname`                                  | Ingress hostname for the Argo CD server ingress                                                                                 | `argocd.server.local`    |
+| `server.ingress.annotations`                               | Annotations for the Argo CD server ingress. To enable certificate autogeneration, place here your cert-manager annotations.     | `{}`                     |
+| `server.ingress.tls`                                       | Enable TLS for the Argo CD server ingress                                                                                       | `false`                  |
+| `server.ingress.extraHosts`                                | Extra hosts array for the Argo CD server ingress                                                                                | `[]`                     |
+| `server.ingress.path`                                      | Path array for the Argo CD server ingress                                                                                       | `/`                      |
+| `server.ingress.extraPaths`                                | Extra paths for the Argo CD server ingress                                                                                      | `[]`                     |
+| `server.ingress.extraTls`                                  | Extra TLS configuration for the Argo CD server ingress                                                                          | `[]`                     |
+| `server.ingress.secrets`                                   | Secrets array to mount into the Ingress                                                                                         | `[]`                     |
+| `server.ingress.ingressClassName`                          | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                   | `""`                     |
+| `server.ingress.selfSigned`                                | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                    | `false`                  |
+| `server.metrics.enabled`                                   | Enable metrics for the Argo CD server                                                                                           | `false`                  |
+| `server.metrics.service.type`                              | Argo CD server service type                                                                                                     | `ClusterIP`              |
+| `server.metrics.service.port`                              | Argo CD server metrics service port                                                                                             | `8083`                   |
+| `server.metrics.service.nodePort`                          | Node port for Argo CD server metrics service                                                                                    | `""`                     |
+| `server.metrics.service.clusterIP`                         | Argo CD server metrics service Cluster IP                                                                                       | `""`                     |
+| `server.metrics.service.loadBalancerIP`                    | Argo CD server service Load Balancer IP                                                                                         | `""`                     |
+| `server.metrics.service.loadBalancerSourceRanges`          | Argo CD server service Load Balancer sources                                                                                    | `[]`                     |
+| `server.metrics.service.externalTrafficPolicy`             | Argo CD server service external traffic policy                                                                                  | `Cluster`                |
+| `server.metrics.service.annotations`                       | Additional custom annotations for Argo CD server service                                                                        | `{}`                     |
+| `server.metrics.service.sessionAffinity`                   | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                            | `None`                   |
+| `server.metrics.service.sessionAffinityConfig`             | Additional settings for the sessionAffinity                                                                                     | `{}`                     |
+| `server.metrics.serviceMonitor.enabled`                    | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                                    | `false`                  |
+| `server.metrics.serviceMonitor.namespace`                  | Namespace which Prometheus is running in                                                                                        | `""`                     |
+| `server.metrics.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in prometheus.                                               | `""`                     |
+| `server.metrics.serviceMonitor.interval`                   | Interval at which metrics should be scraped                                                                                     | `30s`                    |
+| `server.metrics.serviceMonitor.scrapeTimeout`              | Timeout after which the scrape is ended                                                                                         | `10s`                    |
+| `server.metrics.serviceMonitor.relabelings`                | RelabelConfigs to apply to samples before scraping                                                                              | `[]`                     |
+| `server.metrics.serviceMonitor.metricRelabelings`          | MetricRelabelConfigs to apply to samples before ingestion                                                                       | `[]`                     |
+| `server.metrics.serviceMonitor.selector`                   | ServiceMonitor selector labels                                                                                                  | `{}`                     |
+| `server.metrics.serviceMonitor.honorLabels`                | honorLabels chooses the metric's labels on collisions with target labels                                                        | `false`                  |
+| `server.ingressGrpc.enabled`                               | Enable the creation of an ingress for the Argo CD gRPC server                                                                   | `false`                  |
+| `server.ingressGrpc.pathType`                              | Path type for the Argo CD gRPC server ingress                                                                                   | `ImplementationSpecific` |
+| `server.ingressGrpc.apiVersion`                            | Ingress API version for the Argo CD gRPC server ingress                                                                         | `""`                     |
+| `server.ingressGrpc.hostname`                              | Ingress hostname for the Argo CD gRPC server ingress                                                                            | `argocd.server.local`    |
+| `server.ingressGrpc.annotations`                           | Annotations for the Argo CD gRPC server ingress. To enable certificate autogeneration, place here your cert-manager annotations | `{}`                     |
+| `server.ingressGrpc.tls`                                   | Enable TLS for the Argo CD server ingress                                                                                       | `false`                  |
+| `server.ingressGrpc.extraHosts`                            | Extra hosts array for the Argo CD gRPC server ingress                                                                           | `[]`                     |
+| `server.ingressGrpc.path`                                  | Path array for the Argo CD gRPC server ingress                                                                                  | `/`                      |
+| `server.ingressGrpc.extraPaths`                            | Extra paths for the Argo CD gRPC server ingress                                                                                 | `[]`                     |
+| `server.ingressGrpc.extraTls`                              | Extra TLS configuration for the Argo CD gRPC server ingress                                                                     | `[]`                     |
+| `server.ingressGrpc.secrets`                               | Secrets array to mount into the Ingress                                                                                         | `[]`                     |
+| `server.ingressGrpc.ingressClassName`                      | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                   | `""`                     |
+| `server.ingressGrpc.selfSigned`                            | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                    | `false`                  |
+| `server.containerPorts.http`                               | Argo CD server HTTP container port                                                                                              | `8080`                   |
+| `server.containerPorts.https`                              | Argo CD server HTTPS container port                                                                                             | `8443`                   |
+| `server.containerPorts.metrics`                            | Argo CD server metrics container port                                                                                           | `8083`                   |
+| `server.service.type`                                      | Argo CD service type                                                                                                            | `ClusterIP`              |
+| `server.service.ports.http`                                | HTTP port for the gRPC ingress when enabled                                                                                     | `80`                     |
+| `server.service.ports.https`                               | HTTPS port for the gRPC ingress when enabled                                                                                    | `443`                    |
+| `server.service.nodePorts.http`                            | Node port for HTTP                                                                                                              | `""`                     |
+| `server.service.nodePorts.https`                           | Node port for HTTPS                                                                                                             | `""`                     |
+| `server.service.clusterIP`                                 | Argo CD service Cluster IP                                                                                                      | `""`                     |
+| `server.service.loadBalancerIP`                            | Argo CD service Load Balancer IP                                                                                                | `""`                     |
+| `server.service.loadBalancerSourceRanges`                  | Argo CD service Load Balancer sources                                                                                           | `[]`                     |
+| `server.service.externalTrafficPolicy`                     | Argo CD service external traffic policy                                                                                         | `Cluster`                |
+| `server.service.annotations`                               | Additional custom annotations for Argo CD service                                                                               | `{}`                     |
+| `server.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                                                  | `[]`                     |
+| `server.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                            | `None`                   |
+| `server.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                                                     | `{}`                     |
+| `server.command`                                           | Override default container command (useful when using custom images)                                                            | `[]`                     |
+| `server.args`                                              | Override default container args (useful when using custom images)                                                               | `[]`                     |
+| `server.extraArgs`                                         | concat to the default args                                                                                                      | `[]`                     |
+| `server.hostAliases`                                       | Argo CD server pods host aliases                                                                                                | `[]`                     |
+| `server.podLabels`                                         | Extra labels for Argo CD server pods                                                                                            | `{}`                     |
+| `server.podAnnotations`                                    | Annotations for Argo CD server pods                                                                                             | `{}`                     |
+| `server.podAffinityPreset`                                 | Pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                     |
+| `server.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                   |
+| `server.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                                | `""`                     |
+| `server.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `server.affinity` is set                                                                    | `""`                     |
+| `server.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `server.affinity` is set                                                                 | `[]`                     |
+| `server.affinity`                                          | Affinity for Argo CD server pods assignment                                                                                     | `{}`                     |
+| `server.nodeSelector`                                      | Node labels for Argo CD server pods assignment                                                                                  | `{}`                     |
+| `server.tolerations`                                       | Tolerations for Argo CD server pods assignment                                                                                  | `[]`                     |
+| `server.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                                                  | `""`                     |
+| `server.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                                                  | `[]`                     |
+| `server.updateStrategy.type`                               | Argo CD server statefulset strategy type                                                                                        | `RollingUpdate`          |
+| `server.priorityClassName`                                 | Argo CD server pods' priorityClassName                                                                                          | `""`                     |
+| `server.lifecycleHooks`                                    | for the Argo CD server container(s) to automate configuration before or after startup                                           | `{}`                     |
+| `server.extraEnvVars`                                      | Array with extra environment variables to add to Argo CD server nodes                                                           | `[]`                     |
+| `server.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Argo CD server nodes                                                   | `""`                     |
+| `server.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Argo CD server nodes                                                      | `""`                     |
+| `server.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Argo CD server pod(s)                                               | `[]`                     |
+| `server.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Argo CD server container(s)                                    | `[]`                     |
+| `server.sidecars`                                          | Add additional sidecar containers to the Argo CD server pod(s)                                                                  | `[]`                     |
+| `server.initContainers`                                    | Add additional init containers to the Argo CD server pod(s)                                                                     | `[]`                     |
+| `server.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                                            | `true`                   |
+| `server.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                                                          | `""`                     |
+| `server.serviceAccount.automountServiceAccountToken`       | Automount service account token for the server service account                                                                  | `true`                   |
+| `server.serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                                      | `{}`                     |
 
 
 ### Argo CD repo server Parameters
 
-| Name                                                     | Description                                                                                          | Value           |
-| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------- |
-| `repoServer.replicaCount`                                | Number of Argo CD repo server replicas to deploy                                                     | `1`             |
-| `repoServer.startupProbe.enabled`                        | Enable startupProbe on Argo CD repo server nodes                                                     | `false`         |
-| `repoServer.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                               | `10`            |
-| `repoServer.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                      | `10`            |
-| `repoServer.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                     | `1`             |
-| `repoServer.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                   | `3`             |
-| `repoServer.startupProbe.successThreshold`               | Success threshold for startupProbe                                                                   | `1`             |
-| `repoServer.livenessProbe.enabled`                       | Enable livenessProbe on Argo CD repo server nodes                                                    | `true`          |
-| `repoServer.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                              | `10`            |
-| `repoServer.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                     | `10`            |
-| `repoServer.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                    | `1`             |
-| `repoServer.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                  | `3`             |
-| `repoServer.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                  | `1`             |
-| `repoServer.readinessProbe.enabled`                      | Enable readinessProbe on Argo CD repo server nodes                                                   | `true`          |
-| `repoServer.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                             | `10`            |
-| `repoServer.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                    | `10`            |
-| `repoServer.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                   | `1`             |
-| `repoServer.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                 | `3`             |
-| `repoServer.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                 | `1`             |
-| `repoServer.customStartupProbe`                          | Custom startupProbe that overrides the default one                                                   | `{}`            |
-| `repoServer.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                                  | `{}`            |
-| `repoServer.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                                 | `{}`            |
-| `repoServer.resources.limits`                            | The resources limits for the Argo CD repo server containers                                          | `{}`            |
-| `repoServer.resources.requests`                          | The requested resources for the Argo CD repo server containers                                       | `{}`            |
-| `repoServer.podSecurityContext.enabled`                  | Enabled Argo CD repo server pods' Security Context                                                   | `true`          |
-| `repoServer.podSecurityContext.fsGroup`                  | Set Argo CD repo server pod's Security Context fsGroup                                               | `1001`          |
-| `repoServer.containerSecurityContext.enabled`            | Enabled Argo CD repo server containers' Security Context                                             | `true`          |
-| `repoServer.containerSecurityContext.runAsUser`          | Set Argo CD repo server containers' Security Context runAsUser                                       | `1001`          |
-| `repoServer.containerSecurityContext.runAsNonRoot`       | Set Argo CD repo server containers' Security Context runAsNonRoot                                    | `true`          |
-| `repoServer.service.type`                                | Repo server service type                                                                             | `ClusterIP`     |
-| `repoServer.service.port`                                | Repo server service port                                                                             | `8081`          |
-| `repoServer.service.nodePort`                            | Node port for the repo server service                                                                | `""`            |
-| `repoServer.service.clusterIP`                           | Repo server service Cluster IP                                                                       | `""`            |
-| `repoServer.service.loadBalancerIP`                      | Repo server service Load Balancer IP                                                                 | `""`            |
-| `repoServer.service.loadBalancerSourceRanges`            | Repo server service Load Balancer sources                                                            | `[]`            |
-| `repoServer.service.externalTrafficPolicy`               | Repo server service external traffic policy                                                          | `Cluster`       |
-| `repoServer.service.annotations`                         | Additional custom annotations for Repo server service                                                | `{}`            |
-| `repoServer.service.extraPorts`                          | Extra ports to expose (normally used with the `sidecar` value)                                       | `[]`            |
-| `repoServer.service.sessionAffinity`                     | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                 | `None`          |
-| `repoServer.service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                          | `{}`            |
-| `repoServer.logFormat`                                   | Format for the Argo CD repo server logs. Options: [text, json]                                       | `text`          |
-| `repoServer.logLevel`                                    | Log level for the Argo CD repo server                                                                | `info`          |
-| `repoServer.containerPorts.repoServer`                   | Container port for Argo CD repo server                                                               | `8081`          |
-| `repoServer.containerPorts.metrics`                      | Metrics port for Argo CD repo server                                                                 | `8084`          |
-| `repoServer.metrics.enabled`                             | Enable metrics for the Argo CD repo server                                                           | `false`         |
-| `repoServer.metrics.service.type`                        | Argo CD repo server service type                                                                     | `ClusterIP`     |
-| `repoServer.metrics.service.port`                        | Argo CD repo server metrics service port                                                             | `8084`          |
-| `repoServer.metrics.service.nodePort`                    | Node port for the repo server metrics service                                                        | `""`            |
-| `repoServer.metrics.service.clusterIP`                   | Argo CD repo server metrics service Cluster IP                                                       | `""`            |
-| `repoServer.metrics.service.loadBalancerIP`              | Argo CD repo server service Load Balancer IP                                                         | `""`            |
-| `repoServer.metrics.service.loadBalancerSourceRanges`    | Argo CD repo server service Load Balancer sources                                                    | `[]`            |
-| `repoServer.metrics.service.externalTrafficPolicy`       | Argo CD repo server service external traffic policy                                                  | `Cluster`       |
-| `repoServer.metrics.service.annotations`                 | Additional custom annotations for Argo CD repo server service                                        | `{}`            |
-| `repoServer.metrics.service.sessionAffinity`             | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                 | `None`          |
-| `repoServer.metrics.service.sessionAffinityConfig`       | Additional settings for the sessionAffinity                                                          | `{}`            |
-| `repoServer.metrics.serviceMonitor.enabled`              | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                         | `false`         |
-| `repoServer.metrics.serviceMonitor.namespace`            | Namespace which Prometheus is running in                                                             | `""`            |
-| `repoServer.metrics.serviceMonitor.jobLabel`             | The name of the label on the target service to use as the job name in prometheus.                    | `""`            |
-| `repoServer.metrics.serviceMonitor.interval`             | Interval at which metrics should be scraped                                                          | `30s`           |
-| `repoServer.metrics.serviceMonitor.scrapeTimeout`        | Timeout after which the scrape is ended                                                              | `10s`           |
-| `repoServer.metrics.serviceMonitor.relabelings`          | RelabelConfigs to apply to samples before scraping                                                   | `[]`            |
-| `repoServer.metrics.serviceMonitor.metricRelabelings`    | MetricRelabelConfigs to apply to samples before ingestion                                            | `[]`            |
-| `repoServer.metrics.serviceMonitor.selector`             | ServiceMonitor selector labels                                                                       | `{}`            |
-| `repoServer.metrics.serviceMonitor.honorLabels`          | honorLabels chooses the metric's labels on collisions with target labels                             | `false`         |
-| `repoServer.autoscaling.enabled`                         | Enable Argo CD repo server deployment autoscaling                                                    | `false`         |
-| `repoServer.autoscaling.minReplicas`                     | Argo CD repo server deployment autoscaling minimum number of replicas                                | `1`             |
-| `repoServer.autoscaling.maxReplicas`                     | Argo CD repo server deployment autoscaling maximum number of replicas                                | `5`             |
-| `repoServer.autoscaling.targetCPU`                       | Argo CD repo server deployment autoscaling target CPU percentage                                     | `50`            |
-| `repoServer.autoscaling.targetMemory`                    | Argo CD repo server deployment autoscaling target CPU memory                                         | `50`            |
-| `repoServer.serviceAccount.create`                       | Specifies whether a ServiceAccount for repo server should be created                                 | `true`          |
-| `repoServer.serviceAccount.name`                         | The name of the ServiceAccount for repo server to use.                                               | `""`            |
-| `repoServer.serviceAccount.automountServiceAccountToken` | Automount service account token for the repo server service account                                  | `true`          |
-| `repoServer.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.           | `{}`            |
-| `repoServer.command`                                     | Override default container command (useful when using custom images)                                 | `[]`            |
-| `repoServer.args`                                        | Override default container args (useful when using custom images)                                    | `[]`            |
-| `repoServer.extraArgs`                                   | Add extra args to the default repo server args                                                       | `[]`            |
-| `repoServer.hostAliases`                                 | Argo CD repo server pods host aliases                                                                | `[]`            |
-| `repoServer.podLabels`                                   | Extra labels for Argo CD repo server pods                                                            | `{}`            |
-| `repoServer.podAnnotations`                              | Annotations for Argo CD repo server pods                                                             | `{}`            |
-| `repoServer.podAffinityPreset`                           | Pod affinity preset. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
-| `repoServer.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
-| `repoServer.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
-| `repoServer.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `repoServer.affinity` is set                                     | `""`            |
-| `repoServer.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `repoServer.affinity` is set                                  | `[]`            |
-| `repoServer.affinity`                                    | Affinity for Argo CD repo server pods assignment                                                     | `{}`            |
-| `repoServer.nodeSelector`                                | Node labels for Argo CD repo server pods assignment                                                  | `{}`            |
-| `repoServer.tolerations`                                 | Tolerations for Argo CD repo server pods assignment                                                  | `[]`            |
-| `repoServer.schedulerName`                               | Name of the k8s scheduler (other than default)                                                       | `""`            |
-| `repoServer.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                       | `[]`            |
-| `repoServer.updateStrategy.type`                         | Argo CD repo server statefulset strategy type                                                        | `RollingUpdate` |
-| `repoServer.priorityClassName`                           | Argo CD repo server pods' priorityClassName                                                          | `""`            |
-| `repoServer.lifecycleHooks`                              | for the Argo CD repo server container(s) to automate configuration before or after startup           | `{}`            |
-| `repoServer.extraEnvVars`                                | Array with extra environment variables to add to Argo CD repo server nodes                           | `[]`            |
-| `repoServer.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Argo CD repo server nodes                   | `""`            |
-| `repoServer.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Argo CD repo server nodes                      | `""`            |
-| `repoServer.extraVolumes`                                | Optionally specify extra list of additional volumes for the Argo CD repo server pod(s)               | `[]`            |
-| `repoServer.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Argo CD repo server container(s)    | `[]`            |
-| `repoServer.sidecars`                                    | Add additional sidecar containers to the Argo CD repo server pod(s)                                  | `[]`            |
-| `repoServer.initContainers`                              | Add additional init containers to the Argo CD repo server pod(s)                                     | `[]`            |
+| Name                                                           | Description                                                                                          | Value           |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------- |
+| `repoServer.replicaCount`                                      | Number of Argo CD repo server replicas to deploy                                                     | `1`             |
+| `repoServer.startupProbe.enabled`                              | Enable startupProbe on Argo CD repo server nodes                                                     | `false`         |
+| `repoServer.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                               | `10`            |
+| `repoServer.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                      | `10`            |
+| `repoServer.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                     | `1`             |
+| `repoServer.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                   | `3`             |
+| `repoServer.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                   | `1`             |
+| `repoServer.livenessProbe.enabled`                             | Enable livenessProbe on Argo CD repo server nodes                                                    | `true`          |
+| `repoServer.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                              | `10`            |
+| `repoServer.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                     | `10`            |
+| `repoServer.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                    | `1`             |
+| `repoServer.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                  | `3`             |
+| `repoServer.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                  | `1`             |
+| `repoServer.readinessProbe.enabled`                            | Enable readinessProbe on Argo CD repo server nodes                                                   | `true`          |
+| `repoServer.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                             | `10`            |
+| `repoServer.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                    | `10`            |
+| `repoServer.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                   | `1`             |
+| `repoServer.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                 | `3`             |
+| `repoServer.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                 | `1`             |
+| `repoServer.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                   | `{}`            |
+| `repoServer.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                  | `{}`            |
+| `repoServer.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                                 | `{}`            |
+| `repoServer.resources.limits`                                  | The resources limits for the Argo CD repo server containers                                          | `{}`            |
+| `repoServer.resources.requests`                                | The requested resources for the Argo CD repo server containers                                       | `{}`            |
+| `repoServer.podSecurityContext.enabled`                        | Enabled Argo CD repo server pods' Security Context                                                   | `true`          |
+| `repoServer.podSecurityContext.fsGroup`                        | Set Argo CD repo server pod's Security Context fsGroup                                               | `1001`          |
+| `repoServer.containerSecurityContext.enabled`                  | Enabled Argo CD repo server containers' Security Context                                             | `true`          |
+| `repoServer.containerSecurityContext.runAsUser`                | Set Argo CD repo server containers' Security Context runAsUser                                       | `65534`         |
+| `repoServer.containerSecurityContext.allowPrivilegeEscalation` | Set Argo CD repo server containers' Security Context allowPrivilegeEscalation                        | `false`         |
+| `repoServer.containerSecurityContext.capabilities.drop`        | Set Argo CD containers' repo server Security Context capabilities to be dropped                      | `["all"]`       |
+| `repoServer.containerSecurityContext.readOnlyRootFilesystem`   | Set Argo CD containers' repo server Security Context readOnlyRootFilesystem                          | `true`          |
+| `repoServer.containerSecurityContext.runAsNonRoot`             | Set Argo CD repo server containers' Security Context runAsNonRoot                                    | `true`          |
+| `repoServer.service.type`                                      | Repo server service type                                                                             | `ClusterIP`     |
+| `repoServer.service.port`                                      | Repo server service port                                                                             | `8081`          |
+| `repoServer.service.nodePort`                                  | Node port for the repo server service                                                                | `""`            |
+| `repoServer.service.clusterIP`                                 | Repo server service Cluster IP                                                                       | `""`            |
+| `repoServer.service.loadBalancerIP`                            | Repo server service Load Balancer IP                                                                 | `""`            |
+| `repoServer.service.loadBalancerSourceRanges`                  | Repo server service Load Balancer sources                                                            | `[]`            |
+| `repoServer.service.externalTrafficPolicy`                     | Repo server service external traffic policy                                                          | `Cluster`       |
+| `repoServer.service.annotations`                               | Additional custom annotations for Repo server service                                                | `{}`            |
+| `repoServer.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                       | `[]`            |
+| `repoServer.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                 | `None`          |
+| `repoServer.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                          | `{}`            |
+| `repoServer.logFormat`                                         | Format for the Argo CD repo server logs. Options: [text, json]                                       | `text`          |
+| `repoServer.logLevel`                                          | Log level for the Argo CD repo server                                                                | `info`          |
+| `repoServer.containerPorts.repoServer`                         | Container port for Argo CD repo server                                                               | `8081`          |
+| `repoServer.containerPorts.metrics`                            | Metrics port for Argo CD repo server                                                                 | `8084`          |
+| `repoServer.metrics.enabled`                                   | Enable metrics for the Argo CD repo server                                                           | `false`         |
+| `repoServer.metrics.service.type`                              | Argo CD repo server service type                                                                     | `ClusterIP`     |
+| `repoServer.metrics.service.port`                              | Argo CD repo server metrics service port                                                             | `8084`          |
+| `repoServer.metrics.service.nodePort`                          | Node port for the repo server metrics service                                                        | `""`            |
+| `repoServer.metrics.service.clusterIP`                         | Argo CD repo server metrics service Cluster IP                                                       | `""`            |
+| `repoServer.metrics.service.loadBalancerIP`                    | Argo CD repo server service Load Balancer IP                                                         | `""`            |
+| `repoServer.metrics.service.loadBalancerSourceRanges`          | Argo CD repo server service Load Balancer sources                                                    | `[]`            |
+| `repoServer.metrics.service.externalTrafficPolicy`             | Argo CD repo server service external traffic policy                                                  | `Cluster`       |
+| `repoServer.metrics.service.annotations`                       | Additional custom annotations for Argo CD repo server service                                        | `{}`            |
+| `repoServer.metrics.service.sessionAffinity`                   | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                 | `None`          |
+| `repoServer.metrics.service.sessionAffinityConfig`             | Additional settings for the sessionAffinity                                                          | `{}`            |
+| `repoServer.metrics.serviceMonitor.enabled`                    | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                         | `false`         |
+| `repoServer.metrics.serviceMonitor.namespace`                  | Namespace which Prometheus is running in                                                             | `""`            |
+| `repoServer.metrics.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in prometheus.                    | `""`            |
+| `repoServer.metrics.serviceMonitor.interval`                   | Interval at which metrics should be scraped                                                          | `30s`           |
+| `repoServer.metrics.serviceMonitor.scrapeTimeout`              | Timeout after which the scrape is ended                                                              | `10s`           |
+| `repoServer.metrics.serviceMonitor.relabelings`                | RelabelConfigs to apply to samples before scraping                                                   | `[]`            |
+| `repoServer.metrics.serviceMonitor.metricRelabelings`          | MetricRelabelConfigs to apply to samples before ingestion                                            | `[]`            |
+| `repoServer.metrics.serviceMonitor.selector`                   | ServiceMonitor selector labels                                                                       | `{}`            |
+| `repoServer.metrics.serviceMonitor.honorLabels`                | honorLabels chooses the metric's labels on collisions with target labels                             | `false`         |
+| `repoServer.autoscaling.enabled`                               | Enable Argo CD repo server deployment autoscaling                                                    | `false`         |
+| `repoServer.autoscaling.minReplicas`                           | Argo CD repo server deployment autoscaling minimum number of replicas                                | `1`             |
+| `repoServer.autoscaling.maxReplicas`                           | Argo CD repo server deployment autoscaling maximum number of replicas                                | `5`             |
+| `repoServer.autoscaling.targetCPU`                             | Argo CD repo server deployment autoscaling target CPU percentage                                     | `50`            |
+| `repoServer.autoscaling.targetMemory`                          | Argo CD repo server deployment autoscaling target CPU memory                                         | `50`            |
+| `repoServer.serviceAccount.create`                             | Specifies whether a ServiceAccount for repo server should be created                                 | `true`          |
+| `repoServer.serviceAccount.name`                               | The name of the ServiceAccount for repo server to use.                                               | `""`            |
+| `repoServer.serviceAccount.automountServiceAccountToken`       | Automount service account token for the repo server service account                                  | `true`          |
+| `repoServer.serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.           | `{}`            |
+| `repoServer.command`                                           | Override default container command (useful when using custom images)                                 | `[]`            |
+| `repoServer.args`                                              | Override default container args (useful when using custom images)                                    | `[]`            |
+| `repoServer.extraArgs`                                         | Add extra args to the default repo server args                                                       | `[]`            |
+| `repoServer.hostAliases`                                       | Argo CD repo server pods host aliases                                                                | `[]`            |
+| `repoServer.podLabels`                                         | Extra labels for Argo CD repo server pods                                                            | `{}`            |
+| `repoServer.podAnnotations`                                    | Annotations for Argo CD repo server pods                                                             | `{}`            |
+| `repoServer.podAffinityPreset`                                 | Pod affinity preset. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`       | `""`            |
+| `repoServer.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard`  | `soft`          |
+| `repoServer.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `repoServer.affinity` is set. Allowed values: `soft` or `hard` | `""`            |
+| `repoServer.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `repoServer.affinity` is set                                     | `""`            |
+| `repoServer.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `repoServer.affinity` is set                                  | `[]`            |
+| `repoServer.affinity`                                          | Affinity for Argo CD repo server pods assignment                                                     | `{}`            |
+| `repoServer.nodeSelector`                                      | Node labels for Argo CD repo server pods assignment                                                  | `{}`            |
+| `repoServer.tolerations`                                       | Tolerations for Argo CD repo server pods assignment                                                  | `[]`            |
+| `repoServer.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                       | `""`            |
+| `repoServer.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                       | `[]`            |
+| `repoServer.updateStrategy.type`                               | Argo CD repo server statefulset strategy type                                                        | `RollingUpdate` |
+| `repoServer.priorityClassName`                                 | Argo CD repo server pods' priorityClassName                                                          | `""`            |
+| `repoServer.lifecycleHooks`                                    | for the Argo CD repo server container(s) to automate configuration before or after startup           | `{}`            |
+| `repoServer.extraEnvVars`                                      | Array with extra environment variables to add to Argo CD repo server nodes                           | `[]`            |
+| `repoServer.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Argo CD repo server nodes                   | `""`            |
+| `repoServer.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Argo CD repo server nodes                      | `""`            |
+| `repoServer.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Argo CD repo server pod(s)               | `[]`            |
+| `repoServer.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Argo CD repo server container(s)    | `[]`            |
+| `repoServer.sidecars`                                          | Add additional sidecar containers to the Argo CD repo server pod(s)                                  | `[]`            |
+| `repoServer.initContainers`                                    | Add additional init containers to the Argo CD repo server pod(s)                                     | `[]`            |
 
 
 ### Dex Parameters
 
-| Name                                              | Description                                                                                   | Value                 |
-| ------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------- |
-| `dex.image.registry`                              | Dex image registry                                                                            | `docker.io`           |
-| `dex.image.repository`                            | Dex image repository                                                                          | `bitnami/dex`         |
-| `dex.image.tag`                                   | Dex image tag (immutable tags are recommended)                                                | `2.31.1-debian-10-r7` |
-| `dex.image.pullPolicy`                            | Dex image pull policy                                                                         | `IfNotPresent`        |
-| `dex.image.pullSecrets`                           | Dex image pull secrets                                                                        | `[]`                  |
-| `dex.image.debug`                                 | Enable Dex image debug mode                                                                   | `false`               |
-| `dex.enabled`                                     | Enable the creation of a Dex deployment for SSO                                               | `false`               |
-| `dex.replicaCount`                                | Number of Dex replicas to deploy                                                              | `1`                   |
-| `dex.startupProbe.enabled`                        | Enable startupProbe on Dex nodes                                                              | `false`               |
-| `dex.startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                        | `10`                  |
-| `dex.startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                               | `10`                  |
-| `dex.startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                              | `1`                   |
-| `dex.startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                            | `3`                   |
-| `dex.startupProbe.successThreshold`               | Success threshold for startupProbe                                                            | `1`                   |
-| `dex.livenessProbe.enabled`                       | Enable livenessProbe on Dex nodes                                                             | `true`                |
-| `dex.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                       | `10`                  |
-| `dex.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                              | `10`                  |
-| `dex.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                             | `1`                   |
-| `dex.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                           | `3`                   |
-| `dex.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                           | `1`                   |
-| `dex.readinessProbe.enabled`                      | Enable readinessProbe on Dex nodes                                                            | `true`                |
-| `dex.readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                      | `10`                  |
-| `dex.readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                             | `10`                  |
-| `dex.readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                            | `1`                   |
-| `dex.readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                          | `3`                   |
-| `dex.readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                          | `1`                   |
-| `dex.customStartupProbe`                          | Custom startupProbe that overrides the default one                                            | `{}`                  |
-| `dex.customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                           | `{}`                  |
-| `dex.customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                          | `{}`                  |
-| `dex.resources.limits`                            | The resources limits for the Dex containers                                                   | `{}`                  |
-| `dex.resources.requests`                          | The requested resources for the Dex containers                                                | `{}`                  |
-| `dex.podSecurityContext.enabled`                  | Enabled Dex pods' Security Context                                                            | `true`                |
-| `dex.podSecurityContext.fsGroup`                  | Set Dex pod's Security Context fsGroup                                                        | `1001`                |
-| `dex.containerSecurityContext.enabled`            | Enabled Dex containers' Security Context                                                      | `true`                |
-| `dex.containerSecurityContext.runAsUser`          | Set Dex containers' Security Context runAsUser                                                | `1001`                |
-| `dex.containerSecurityContext.runAsNonRoot`       | Set Dex containers' Security Context runAsNonRoot                                             | `true`                |
-| `dex.service.type`                                | Dex service type                                                                              | `ClusterIP`           |
-| `dex.service.ports.http`                          | Dex HTTP service port                                                                         | `5556`                |
-| `dex.service.ports.grpc`                          | Dex grpc service port                                                                         | `5557`                |
-| `dex.service.nodePorts.http`                      | HTTP node port for the Dex service                                                            | `""`                  |
-| `dex.service.nodePorts.grpc`                      | gRPC node port for the Dex service                                                            | `""`                  |
-| `dex.service.clusterIP`                           | Dex service Cluster IP                                                                        | `""`                  |
-| `dex.service.loadBalancerIP`                      | Dex service Load Balancer IP                                                                  | `""`                  |
-| `dex.service.loadBalancerSourceRanges`            | Dex service Load Balancer sources                                                             | `[]`                  |
-| `dex.service.externalTrafficPolicy`               | Dex service external traffic policy                                                           | `Cluster`             |
-| `dex.service.annotations`                         | Additional custom annotations for Dex service                                                 | `{}`                  |
-| `dex.service.extraPorts`                          | Extra ports to expose (normally used with the `sidecar` value)                                | `[]`                  |
-| `dex.service.sessionAffinity`                     | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                          | `None`                |
-| `dex.service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                   | `{}`                  |
-| `dex.containerPorts.http`                         | Dex container HTTP port                                                                       | `5556`                |
-| `dex.containerPorts.grpc`                         | Dex gRPC port                                                                                 | `5557`                |
-| `dex.containerPorts.metrics`                      | Dex metrics port                                                                              | `5558`                |
-| `dex.metrics.enabled`                             | Enable metrics for Dex                                                                        | `false`               |
-| `dex.metrics.service.type`                        | Dex service type                                                                              | `ClusterIP`           |
-| `dex.metrics.service.port`                        | Dex metrics service port                                                                      | `5558`                |
-| `dex.metrics.service.nodePort`                    | Node port for the Dex service                                                                 | `""`                  |
-| `dex.metrics.service.clusterIP`                   | Dex service metrics service Cluster IP                                                        | `""`                  |
-| `dex.metrics.service.loadBalancerIP`              | Dex service Load Balancer IP                                                                  | `""`                  |
-| `dex.metrics.service.loadBalancerSourceRanges`    | Dex service Load Balancer sources                                                             | `[]`                  |
-| `dex.metrics.service.externalTrafficPolicy`       | Dex service external traffic policy                                                           | `Cluster`             |
-| `dex.metrics.service.annotations`                 | Additional custom annotations for Dex service                                                 | `{}`                  |
-| `dex.metrics.service.sessionAffinity`             | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                          | `None`                |
-| `dex.metrics.service.sessionAffinityConfig`       | Additional settings for the sessionAffinity                                                   | `{}`                  |
-| `dex.metrics.serviceMonitor.enabled`              | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                  | `false`               |
-| `dex.metrics.serviceMonitor.namespace`            | Namespace which Prometheus is running in                                                      | `""`                  |
-| `dex.metrics.serviceMonitor.jobLabel`             | The name of the label on the target service to use as the job name in prometheus.             | `""`                  |
-| `dex.metrics.serviceMonitor.interval`             | Interval at which metrics should be scraped                                                   | `30s`                 |
-| `dex.metrics.serviceMonitor.scrapeTimeout`        | Timeout after which the scrape is ended                                                       | `10s`                 |
-| `dex.metrics.serviceMonitor.relabelings`          | RelabelConfigs to apply to samples before scraping                                            | `[]`                  |
-| `dex.metrics.serviceMonitor.metricRelabelings`    | MetricRelabelConfigs to apply to samples before ingestion                                     | `[]`                  |
-| `dex.metrics.serviceMonitor.selector`             | ServiceMonitor selector labels                                                                | `{}`                  |
-| `dex.metrics.serviceMonitor.honorLabels`          | honorLabels chooses the metric's labels on collisions with target labels                      | `false`               |
-| `dex.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created for Dex                                  | `true`                |
-| `dex.serviceAccount.name`                         | The name of the ServiceAccount to use.                                                        | `""`                  |
-| `dex.serviceAccount.automountServiceAccountToken` | Automount service account token for the Dex service account                                   | `true`                |
-| `dex.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.    | `{}`                  |
-| `dex.command`                                     | Override default container command (useful when using custom images)                          | `[]`                  |
-| `dex.args`                                        | Override default container args (useful when using custom images)                             | `[]`                  |
-| `dex.extraArgs`                                   | Add extra args to the default args for Dex                                                    | `[]`                  |
-| `dex.hostAliases`                                 | Dex pods host aliases                                                                         | `[]`                  |
-| `dex.podLabels`                                   | Extra labels for Dex pods                                                                     | `{}`                  |
-| `dex.podAnnotations`                              | Annotations for Dex pods                                                                      | `{}`                  |
-| `dex.podAffinityPreset`                           | Pod affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`       | `""`                  |
-| `dex.podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                |
-| `dex.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard` | `""`                  |
-| `dex.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `dex.affinity` is set                                     | `""`                  |
-| `dex.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `dex.affinity` is set                                  | `[]`                  |
-| `dex.affinity`                                    | Affinity for Dex pods assignment                                                              | `{}`                  |
-| `dex.nodeSelector`                                | Node labels for Dex pods assignment                                                           | `{}`                  |
-| `dex.tolerations`                                 | Tolerations for Dex pods assignment                                                           | `[]`                  |
-| `dex.schedulerName`                               | Name of the k8s scheduler (other than default)                                                | `""`                  |
-| `dex.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                | `[]`                  |
-| `dex.updateStrategy.type`                         | Dex statefulset strategy type                                                                 | `RollingUpdate`       |
-| `dex.priorityClassName`                           | Dex pods' priorityClassName                                                                   | `""`                  |
-| `dex.lifecycleHooks`                              | for the Dex container(s) to automate configuration before or after startup                    | `{}`                  |
-| `dex.extraEnvVars`                                | Array with extra environment variables to add to Dex nodes                                    | `[]`                  |
-| `dex.extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for Dex nodes                            | `""`                  |
-| `dex.extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for Dex nodes                               | `""`                  |
-| `dex.extraVolumes`                                | Optionally specify extra list of additional volumes for the Dex pod(s)                        | `[]`                  |
-| `dex.extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the Dex container(s)             | `[]`                  |
-| `dex.sidecars`                                    | Add additional sidecar containers to the Dex pod(s)                                           | `[]`                  |
-| `dex.initContainers`                              | Add additional init containers to the Dex pod(s)                                              | `[]`                  |
+| Name                                                    | Description                                                                                   | Value                  |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------- |
+| `dex.image.registry`                                    | Dex image registry                                                                            | `docker.io`            |
+| `dex.image.repository`                                  | Dex image repository                                                                          | `bitnami/dex`          |
+| `dex.image.tag`                                         | Dex image tag (immutable tags are recommended)                                                | `2.31.1-debian-10-r33` |
+| `dex.image.pullPolicy`                                  | Dex image pull policy                                                                         | `IfNotPresent`         |
+| `dex.image.pullSecrets`                                 | Dex image pull secrets                                                                        | `[]`                   |
+| `dex.image.debug`                                       | Enable Dex image debug mode                                                                   | `false`                |
+| `dex.enabled`                                           | Enable the creation of a Dex deployment for SSO                                               | `false`                |
+| `dex.replicaCount`                                      | Number of Dex replicas to deploy                                                              | `1`                    |
+| `dex.startupProbe.enabled`                              | Enable startupProbe on Dex nodes                                                              | `false`                |
+| `dex.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                        | `10`                   |
+| `dex.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                               | `10`                   |
+| `dex.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                              | `1`                    |
+| `dex.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                            | `3`                    |
+| `dex.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                            | `1`                    |
+| `dex.livenessProbe.enabled`                             | Enable livenessProbe on Dex nodes                                                             | `true`                 |
+| `dex.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                       | `10`                   |
+| `dex.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                              | `10`                   |
+| `dex.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                             | `1`                    |
+| `dex.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                           | `3`                    |
+| `dex.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                           | `1`                    |
+| `dex.readinessProbe.enabled`                            | Enable readinessProbe on Dex nodes                                                            | `true`                 |
+| `dex.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                      | `10`                   |
+| `dex.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                             | `10`                   |
+| `dex.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                            | `1`                    |
+| `dex.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                          | `3`                    |
+| `dex.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                          | `1`                    |
+| `dex.customStartupProbe`                                | Custom startupProbe that overrides the default one                                            | `{}`                   |
+| `dex.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                           | `{}`                   |
+| `dex.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                          | `{}`                   |
+| `dex.resources.limits`                                  | The resources limits for the Dex containers                                                   | `{}`                   |
+| `dex.resources.requests`                                | The requested resources for the Dex containers                                                | `{}`                   |
+| `dex.podSecurityContext.enabled`                        | Enabled Dex pods' Security Context                                                            | `true`                 |
+| `dex.podSecurityContext.fsGroup`                        | Set Dex pod's Security Context fsGroup                                                        | `1001`                 |
+| `dex.containerSecurityContext.enabled`                  | Enabled Dex containers' Security Context                                                      | `true`                 |
+| `dex.containerSecurityContext.runAsUser`                | Set Dex containers' Security Context runAsUser                                                | `1001`                 |
+| `dex.containerSecurityContext.allowPrivilegeEscalation` | Set Dex containers' Security Context allowPrivilegeEscalation                                 | `false`                |
+| `dex.containerSecurityContext.readOnlyRootFilesystem`   | Set Dex containers' server Security Context readOnlyRootFilesystem                            | `true`                 |
+| `dex.containerSecurityContext.runAsNonRoot`             | Set Dex containers' Security Context runAsNonRoot                                             | `true`                 |
+| `dex.service.type`                                      | Dex service type                                                                              | `ClusterIP`            |
+| `dex.service.ports.http`                                | Dex HTTP service port                                                                         | `5556`                 |
+| `dex.service.ports.grpc`                                | Dex grpc service port                                                                         | `5557`                 |
+| `dex.service.nodePorts.http`                            | HTTP node port for the Dex service                                                            | `""`                   |
+| `dex.service.nodePorts.grpc`                            | gRPC node port for the Dex service                                                            | `""`                   |
+| `dex.service.clusterIP`                                 | Dex service Cluster IP                                                                        | `""`                   |
+| `dex.service.loadBalancerIP`                            | Dex service Load Balancer IP                                                                  | `""`                   |
+| `dex.service.loadBalancerSourceRanges`                  | Dex service Load Balancer sources                                                             | `[]`                   |
+| `dex.service.externalTrafficPolicy`                     | Dex service external traffic policy                                                           | `Cluster`              |
+| `dex.service.annotations`                               | Additional custom annotations for Dex service                                                 | `{}`                   |
+| `dex.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                | `[]`                   |
+| `dex.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                          | `None`                 |
+| `dex.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                   | `{}`                   |
+| `dex.containerPorts.http`                               | Dex container HTTP port                                                                       | `5556`                 |
+| `dex.containerPorts.grpc`                               | Dex gRPC port                                                                                 | `5557`                 |
+| `dex.containerPorts.metrics`                            | Dex metrics port                                                                              | `5558`                 |
+| `dex.metrics.enabled`                                   | Enable metrics for Dex                                                                        | `false`                |
+| `dex.metrics.service.type`                              | Dex service type                                                                              | `ClusterIP`            |
+| `dex.metrics.service.port`                              | Dex metrics service port                                                                      | `5558`                 |
+| `dex.metrics.service.nodePort`                          | Node port for the Dex service                                                                 | `""`                   |
+| `dex.metrics.service.clusterIP`                         | Dex service metrics service Cluster IP                                                        | `""`                   |
+| `dex.metrics.service.loadBalancerIP`                    | Dex service Load Balancer IP                                                                  | `""`                   |
+| `dex.metrics.service.loadBalancerSourceRanges`          | Dex service Load Balancer sources                                                             | `[]`                   |
+| `dex.metrics.service.externalTrafficPolicy`             | Dex service external traffic policy                                                           | `Cluster`              |
+| `dex.metrics.service.annotations`                       | Additional custom annotations for Dex service                                                 | `{}`                   |
+| `dex.metrics.service.sessionAffinity`                   | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                          | `None`                 |
+| `dex.metrics.service.sessionAffinityConfig`             | Additional settings for the sessionAffinity                                                   | `{}`                   |
+| `dex.metrics.serviceMonitor.enabled`                    | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                  | `false`                |
+| `dex.metrics.serviceMonitor.namespace`                  | Namespace which Prometheus is running in                                                      | `""`                   |
+| `dex.metrics.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in prometheus.             | `""`                   |
+| `dex.metrics.serviceMonitor.interval`                   | Interval at which metrics should be scraped                                                   | `30s`                  |
+| `dex.metrics.serviceMonitor.scrapeTimeout`              | Timeout after which the scrape is ended                                                       | `10s`                  |
+| `dex.metrics.serviceMonitor.relabelings`                | RelabelConfigs to apply to samples before scraping                                            | `[]`                   |
+| `dex.metrics.serviceMonitor.metricRelabelings`          | MetricRelabelConfigs to apply to samples before ingestion                                     | `[]`                   |
+| `dex.metrics.serviceMonitor.selector`                   | ServiceMonitor selector labels                                                                | `{}`                   |
+| `dex.metrics.serviceMonitor.honorLabels`                | honorLabels chooses the metric's labels on collisions with target labels                      | `false`                |
+| `dex.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created for Dex                                  | `true`                 |
+| `dex.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                        | `""`                   |
+| `dex.serviceAccount.automountServiceAccountToken`       | Automount service account token for the Dex service account                                   | `true`                 |
+| `dex.serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.    | `{}`                   |
+| `dex.command`                                           | Override default container command (useful when using custom images)                          | `[]`                   |
+| `dex.args`                                              | Override default container args (useful when using custom images)                             | `[]`                   |
+| `dex.extraArgs`                                         | Add extra args to the default args for Dex                                                    | `[]`                   |
+| `dex.hostAliases`                                       | Dex pods host aliases                                                                         | `[]`                   |
+| `dex.podLabels`                                         | Extra labels for Dex pods                                                                     | `{}`                   |
+| `dex.podAnnotations`                                    | Annotations for Dex pods                                                                      | `{}`                   |
+| `dex.podAffinityPreset`                                 | Pod affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`       | `""`                   |
+| `dex.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                 |
+| `dex.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard` | `""`                   |
+| `dex.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `dex.affinity` is set                                     | `""`                   |
+| `dex.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `dex.affinity` is set                                  | `[]`                   |
+| `dex.affinity`                                          | Affinity for Dex pods assignment                                                              | `{}`                   |
+| `dex.nodeSelector`                                      | Node labels for Dex pods assignment                                                           | `{}`                   |
+| `dex.tolerations`                                       | Tolerations for Dex pods assignment                                                           | `[]`                   |
+| `dex.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                | `""`                   |
+| `dex.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                | `[]`                   |
+| `dex.updateStrategy.type`                               | Dex statefulset strategy type                                                                 | `RollingUpdate`        |
+| `dex.priorityClassName`                                 | Dex pods' priorityClassName                                                                   | `""`                   |
+| `dex.lifecycleHooks`                                    | for the Dex container(s) to automate configuration before or after startup                    | `{}`                   |
+| `dex.extraEnvVars`                                      | Array with extra environment variables to add to Dex nodes                                    | `[]`                   |
+| `dex.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Dex nodes                            | `""`                   |
+| `dex.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Dex nodes                               | `""`                   |
+| `dex.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Dex pod(s)                        | `[]`                   |
+| `dex.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Dex container(s)             | `[]`                   |
+| `dex.sidecars`                                          | Add additional sidecar containers to the Dex pod(s)                                           | `[]`                   |
+| `dex.initContainers`                                    | Add additional init containers to the Dex pod(s)                                              | `[]`                   |
 
 
 ### Shared config for Argo CD components
@@ -581,7 +592,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                    | `docker.io`             |
 | `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r383`     |
+| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r409`     |
 | `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                | `[]`                    |
 | `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                    |
@@ -591,26 +602,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Other Parameters
 
-| Name                                      | Description                                                                 | Value                  |
-| ----------------------------------------- | --------------------------------------------------------------------------- | ---------------------- |
-| `rbac.create`                             | Specifies whether RBAC resources should be created                          | `true`                 |
-| `redis.image.registry`                    | Argo CD controller image registry                                           | `docker.io`            |
-| `redis.image.repository`                  | Argo CD controller image repository                                         | `bitnami/redis`        |
-| `redis.image.tag`                         | Argo CD controller image tag (immutable tags are recommended)               | `6.2.6-debian-10-r174` |
-| `redis.image.pullPolicy`                  | Argo CD controller image pull policy                                        | `IfNotPresent`         |
-| `redis.image.pullSecrets`                 | Argo CD controller image pull secrets                                       | `[]`                   |
-| `redis.enabled`                           | Enable Redis dependency                                                     | `true`                 |
-| `redis.nameOverride`                      | Name override for the Redis dependency                                      | `""`                   |
-| `redis.service.port`                      | Service port for Redis dependency                                           | `6379`                 |
-| `redis.auth.enabled`                      | Enable Redis dependency authentication                                      | `true`                 |
-| `redis.auth.existingSecret`               | Existing secret to load redis dependency password                           | `""`                   |
-| `redis.auth.existingSecretPasswordKey`    | Pasword key name inside the existing secret                                 | `redis-password`       |
-| `redis.architecture`                      | Redis&trade; architecture. Allowed values: `standalone` or `replication`    | `standalone`           |
-| `externalRedis.host`                      | External Redis host                                                         | `""`                   |
-| `externalRedis.port`                      | External Redis port                                                         | `6379`                 |
-| `externalRedis.password`                  | External Redis password                                                     | `""`                   |
-| `externalRedis.existingSecret`            | Existing secret for the external redis                                      | `""`                   |
-| `externalRedis.existingSecretPasswordKey` | Password key for the existing secret containing the external redis password | `redis-password`       |
+| Name                                      | Description                                                                 | Value                |
+| ----------------------------------------- | --------------------------------------------------------------------------- | -------------------- |
+| `rbac.create`                             | Specifies whether RBAC resources should be created                          | `true`               |
+| `redis.image.registry`                    | Argo CD controller image registry                                           | `docker.io`          |
+| `redis.image.repository`                  | Argo CD controller image repository                                         | `bitnami/redis`      |
+| `redis.image.tag`                         | Argo CD controller image tag (immutable tags are recommended)               | `6.2.7-debian-10-r0` |
+| `redis.image.pullPolicy`                  | Argo CD controller image pull policy                                        | `IfNotPresent`       |
+| `redis.image.pullSecrets`                 | Argo CD controller image pull secrets                                       | `[]`                 |
+| `redis.enabled`                           | Enable Redis dependency                                                     | `true`               |
+| `redis.nameOverride`                      | Name override for the Redis dependency                                      | `""`                 |
+| `redis.service.port`                      | Service port for Redis dependency                                           | `6379`               |
+| `redis.auth.enabled`                      | Enable Redis dependency authentication                                      | `true`               |
+| `redis.auth.existingSecret`               | Existing secret to load redis dependency password                           | `""`                 |
+| `redis.auth.existingSecretPasswordKey`    | Pasword key name inside the existing secret                                 | `redis-password`     |
+| `redis.architecture`                      | Redis&trade; architecture. Allowed values: `standalone` or `replication`    | `standalone`         |
+| `externalRedis.host`                      | External Redis host                                                         | `""`                 |
+| `externalRedis.port`                      | External Redis port                                                         | `6379`               |
+| `externalRedis.password`                  | External Redis password                                                     | `""`                 |
+| `externalRedis.existingSecret`            | Existing secret for the external redis                                      | `""`                 |
+| `externalRedis.existingSecretPasswordKey` | Password key for the existing secret containing the external redis password | `redis-password`     |
 
 
 The above parameters map to the env variables defined in [bitnami/argo-cd](https://github.com/bitnami/bitnami-docker-argo-cd). For more information please refer to the [bitnami/argo-cd](https://github.com/bitnami/bitnami-docker-argo-cd) image documentation.

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -158,6 +158,11 @@ controller:
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - all
+    readOnlyRootFilesystem: true
     runAsNonRoot: true
 
   ## ServiceAccount configuration for the Argo CD application controller
@@ -619,6 +624,11 @@ server:
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - all
+    readOnlyRootFilesystem: true
     runAsNonRoot: true
 
   ## Argo CD server deployment autoscaling
@@ -1317,7 +1327,12 @@ repoServer:
   ##
   containerSecurityContext:
     enabled: true
-    runAsUser: 1001
+    runAsUser: 65534
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+      - all
+    readOnlyRootFilesystem: true
     runAsNonRoot: true
 
   ## Repo server service parameters
@@ -1759,6 +1774,8 @@ dex:
   containerSecurityContext:
     enabled: true
     runAsUser: 1001
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
     runAsNonRoot: true
 
   ## Dex service parameters

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -153,6 +153,9 @@ controller:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param controller.containerSecurityContext.enabled Enabled Argo CD containers' Security Context
   ## @param controller.containerSecurityContext.runAsUser Set Argo CD containers' Security Context runAsUser
+  ## @param controller.containerSecurityContext.allowPrivilegeEscalation Set Argo CD containers' Security Context allowPrivilegeEscalation
+  ## @param controller.containerSecurityContext.capabilities.drop Set Argo CD containers' Security Context capabilities to be dropped
+  ## @param controller.containerSecurityContext.readOnlyRootFilesystem Set Argo CD containers' Security Context readOnlyRootFilesystem
   ## @param controller.containerSecurityContext.runAsNonRoot Set Argo CD container's Security Context runAsNonRoot
   ##
   containerSecurityContext:
@@ -619,6 +622,9 @@ server:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param server.containerSecurityContext.enabled Enabled Argo CD server containers' Security Context
   ## @param server.containerSecurityContext.runAsUser Set Argo CD server containers' Security Context runAsUser
+  ## @param server.containerSecurityContext.allowPrivilegeEscalation Set Argo CD server containers' Security Context allowPrivilegeEscalation
+  ## @param server.containerSecurityContext.capabilities.drop Set Argo CD containers' server Security Context capabilities to be dropped
+  ## @param server.containerSecurityContext.readOnlyRootFilesystem Set Argo CD containers' server Security Context readOnlyRootFilesystem
   ## @param server.containerSecurityContext.runAsNonRoot Set Argo CD server containers' Security Context runAsNonRoot
   ##
   containerSecurityContext:
@@ -1323,6 +1329,9 @@ repoServer:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param repoServer.containerSecurityContext.enabled Enabled Argo CD repo server containers' Security Context
   ## @param repoServer.containerSecurityContext.runAsUser Set Argo CD repo server containers' Security Context runAsUser
+  ## @param reposerver.containerSecurityContext.allowPrivilegeEscalation Set Argo CD repo server containers' Security Context allowPrivilegeEscalation
+  ## @param reposerver.containerSecurityContext.capabilities.drop Set Argo CD containers' repo server Security Context capabilities to be dropped
+  ## @param reposerver.containerSecurityContext.readOnlyRootFilesystem Set Argo CD containers' repo server Security Context readOnlyRootFilesystem
   ## @param repoServer.containerSecurityContext.runAsNonRoot Set Argo CD repo server containers' Security Context runAsNonRoot
   ##
   containerSecurityContext:
@@ -1769,6 +1778,8 @@ dex:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param dex.containerSecurityContext.enabled Enabled Dex containers' Security Context
   ## @param dex.containerSecurityContext.runAsUser Set Dex containers' Security Context runAsUser
+  ## @param dex.containerSecurityContext.allowPrivilegeEscalation Set Dex containers' Security Context allowPrivilegeEscalation
+  ## @param dex.containerSecurityContext.readOnlyRootFilesystem Set Dex containers' server Security Context readOnlyRootFilesystem
   ## @param dex.containerSecurityContext.runAsNonRoot Set Dex containers' Security Context runAsNonRoot
   ##
   containerSecurityContext:

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -1329,9 +1329,9 @@ repoServer:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
   ## @param repoServer.containerSecurityContext.enabled Enabled Argo CD repo server containers' Security Context
   ## @param repoServer.containerSecurityContext.runAsUser Set Argo CD repo server containers' Security Context runAsUser
-  ## @param reposerver.containerSecurityContext.allowPrivilegeEscalation Set Argo CD repo server containers' Security Context allowPrivilegeEscalation
-  ## @param reposerver.containerSecurityContext.capabilities.drop Set Argo CD containers' repo server Security Context capabilities to be dropped
-  ## @param reposerver.containerSecurityContext.readOnlyRootFilesystem Set Argo CD containers' repo server Security Context readOnlyRootFilesystem
+  ## @param repoServer.containerSecurityContext.allowPrivilegeEscalation Set Argo CD repo server containers' Security Context allowPrivilegeEscalation
+  ## @param repoServer.containerSecurityContext.capabilities.drop Set Argo CD containers' repo server Security Context capabilities to be dropped
+  ## @param repoServer.containerSecurityContext.readOnlyRootFilesystem Set Argo CD containers' repo server Security Context readOnlyRootFilesystem
   ## @param repoServer.containerSecurityContext.runAsNonRoot Set Argo CD repo server containers' Security Context runAsNonRoot
   ##
   containerSecurityContext:


### PR DESCRIPTION
### Description of the change

Changes the `runAsUser` parameter to 65534 for the repoServer, fixing a problem with SSH based repos not being able to add applications and throwing a `No user exists for uid 1001` error. This is caused due to user 1001 not existing on the repoServer pod. By changing the userID to a user that does exist on the pod, the issue no longer occurs.

Also updates the containerSecurityContext on the controller, repo, server and dex deploys to be in line with Argo CD's own defaults as can be seen [here](https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml).

### Benefits

Fixes the `No user exists for uid 1001` error when tried to add applications from SSH based private repos

### Possible drawbacks

None

### Applicable issues

  - fixes https://github.com/argoproj/argo-cd/issues/2890

### Additional information

None

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
