### PR TITLE
[bitnami/rabbitmq] Fix metrics service port value

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 9.0.0
+version: 9.0.1

--- a/bitnami/rabbitmq/templates/svc.yaml
+++ b/bitnami/rabbitmq/templates/svc.yaml
@@ -97,7 +97,7 @@ spec:
     {{- end }}
     {{- if .Values.metrics.enabled }}
     - name: {{ .Values.service.portNames.metrics }}
-      port: {{ .Values.service.ports.metrics.metrics }}
+      port: {{ .Values.service.ports.metrics }}
       targetPort: metrics
       {{- if eq .Values.service.type "ClusterIP" }}
       nodePort: null


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

### Description of the change

Fixes typo in service template.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #9979

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
