### PR TITLE
[bitnami/kafka] Fix label selector in jmx service monitor

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 16.2.9
+version: 16.2.10

--- a/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
@@ -28,7 +28,7 @@ spec:
       {{- if .Values.metrics.serviceMonitor.selector }}
       {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}
-      app.kubernetes.io/component: kafka
+      app.kubernetes.io/component: metrics
   endpoints:
     - port: http-metrics
       path: "/"


### PR DESCRIPTION
### Description of the change

Change the JMX service monitor selector to target services labeled as `metrics` instead of `kafka`. Makes the JMX service monitor consistent with the [exporter service monitor](https://github.com/bitnami/charts/blob/master/bitnami/kafka/templates/servicemonitor-metrics.yaml#L31). The label is already correctly set on the [JMX service](https://github.com/bitnami/charts/blob/master/bitnami/kafka/templates/jmx-metrics-svc.yaml#L8).
### Benefits

JMX service monitor points to the correct service. This will allow prometheus to properly retrieve JMX metrics.

### Applicable issues

  - fixes #9936 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
