### PR TITLE
bitnami/mongodb adding generate-tls-certs resource block

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 12.0.1
+version: 12.0.2

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -92,7 +92,7 @@ Refer to the [chart documentation for more information on each of these architec
 ### MongoDB(&reg;) parameters
 
 | Name                    | Description                                                                                                                     | Value                  |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| ----------------------- |---------------------------------------------------------------------------------------------------------------------------------| ---------------------- |
 | `image.registry`        | MongoDB(&reg;) image registry                                                                                                   | `docker.io`            |
 | `image.repository`      | MongoDB(&reg;) image registry                                                                                                   | `bitnami/mongodb`      |
 | `image.tag`             | MongoDB(&reg;) image tag (immutable tags are recommended)                                                                       | `5.0.8-debian-10-r3`   |
@@ -125,6 +125,8 @@ Refer to the [chart documentation for more information on each of these architec
 | `tls.image.pullSecrets` | Init container TLS certs specify docker-registry secret names as an array                                                       | `[]`                   |
 | `tls.extraDnsNames`     | Add extra dns names to the CA, can solve x509 auth issue for pod clients                                                        | `[]`                   |
 | `tls.mode`              | Allows to set the tls mode which should be used when tls is enabled (options: `allowTLS`, `preferTLS`, `requireTLS`)            | `requireTLS`           |
+| `tls.resources.limits`  | Init container generate-tls-certs resource limits                                                                               | `{}`                   |
+| `tls.resources.requests`| Init container generate-tls-certs resource requests                                                                             | `{}`                   |
 | `hostAliases`           | Add deployment host aliases                                                                                                     | `[]`                   |
 | `replicaSetName`        | Name of the replica set (only when `architecture=replicaset`)                                                                   | `rs0`                  |
 | `replicaSetHostnames`   | Enable DNS hostnames in the replicaset config (only when `architecture=replicaset`)                                             | `true`                 |

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -141,6 +141,9 @@ spec:
             {{- if .Values.tls.extraDnsNames }}
             - -n {{ join "," .Values.tls.extraDnsNames }}
             {{- end }}
+          {{- if .Values.tls.resources }}
+          resources: {{- toYaml .Values.tls.resources | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if and .Values.externalAccess.hidden.enabled .Values.externalAccess.autoDiscovery.enabled (eq .Values.externalAccess.hidden.service.type "LoadBalancer") }}
         - name: auto-discovery

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -147,7 +147,9 @@ spec:
             {{- if .Values.tls.extraDnsNames }}
             - -n {{ join "," .Values.tls.extraDnsNames }}
             {{- end }}
+          {{- if .Values.tls.resources }}
           resources: {{- toYaml .Values.tls.resources | nindent 12 }}
+          {{- end }}
         {{- end }}
         {{- if and .Values.externalAccess.enabled .Values.externalAccess.autoDiscovery.enabled (eq .Values.externalAccess.service.type "LoadBalancer") }}
         - name: auto-discovery

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -147,6 +147,7 @@ spec:
             {{- if .Values.tls.extraDnsNames }}
             - -n {{ join "," .Values.tls.extraDnsNames }}
             {{- end }}
+          resources: {{- toYaml .Values.tls.resources | nindent 12 }}
         {{- end }}
         {{- if and .Values.externalAccess.enabled .Values.externalAccess.autoDiscovery.enabled (eq .Values.externalAccess.service.type "LoadBalancer") }}
         - name: auto-discovery

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -153,6 +153,9 @@ spec:
             {{- if .Values.tls.extraDnsNames }}
             - -n {{ join "," .Values.tls.extraDnsNames }}
             {{- end }}
+          {{- if .Values.tls.resources }}
+          resources: {{- toYaml .Values.tls.resources | nindent 12 }}
+          {{- end }}
         {{- end }}
       {{- end }}
       containers:

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -216,6 +216,28 @@ tls:
   ## @param tls.mode Allows to set the tls mode which should be used when tls is enabled (options: `allowTLS`, `preferTLS`, `requireTLS`)
   ##
   mode: requireTLS
+  ## Init Container resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param volumePermissions.resources.limits Init container generate-tls-certs resource limits
+  ## @param volumePermissions.resources.requests Init container generate-tls-certs resource requests
+  ##
+  resources:
+    ## Example:
+    ## limits:
+    ##   cpu: 100m
+    ##   memory: 128Mi
+    ##
+    limits: {}
+    ## Examples:
+    ## requests:
+    ##   cpu: 100m
+    ##   memory: 128Mi
+    ##
+    requests: {}
 ## @param hostAliases Add deployment host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Adding resources block to the `generate-tls-certs` init container

### Benefits
Add resources to all init containers,
Main motivation is to be able to deploy mongodb to cluster where OPA gatekeeper policy requires resources

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
