### PR TITLE
[bitnami/mongodb] Allow custom command and args in the metrics container

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Database
 apiVersion: v2
-appVersion: 5.1.0
+appVersion: 5.0.8
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 12.0.2
+version: 12.1.0

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Database
 apiVersion: v2
-appVersion: 5.0.8
+appVersion: 5.1.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -158,65 +158,65 @@ Refer to the [chart documentation for more information on each of these architec
 
 ### MongoDB(&reg;) statefulset parameters
 
-| Name                                    | Description                                                                                                      | Value           |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | --------------- |
-| `annotations`                           | Additional labels to be added to the MongoDB(&reg;) statefulset. Evaluated as a template                         | `{}`            |
-| `labels`                                | Annotations to be added to the MongoDB(&reg;) statefulset. Evaluated as a template                               | `{}`            |
-| `replicaCount`                          | Number of MongoDB(&reg;) nodes (only when `architecture=replicaset`)                                             | `2`             |
-| `updateStrategy.type`                   | Strategy to use to replace existing MongoDB(&reg;) pods. When architecture=standalone and useStatefulSet=false,  | `RollingUpdate` |
-| `podManagementPolicy`                   | Pod management policy for MongoDB(&reg;)                                                                         | `OrderedReady`  |
-| `podAffinityPreset`                     | MongoDB(&reg;) Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`            |
-| `podAntiAffinityPreset`                 | MongoDB(&reg;) Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`          | `soft`          |
-| `nodeAffinityPreset.type`               | MongoDB(&reg;) Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`         | `""`            |
-| `nodeAffinityPreset.key`                | MongoDB(&reg;) Node label key to match Ignored if `affinity` is set.                                             | `""`            |
-| `nodeAffinityPreset.values`             | MongoDB(&reg;) Node label values to match. Ignored if `affinity` is set.                                         | `[]`            |
-| `affinity`                              | MongoDB(&reg;) Affinity for pod assignment                                                                       | `{}`            |
-| `nodeSelector`                          | MongoDB(&reg;) Node labels for pod assignment                                                                    | `{}`            |
-| `tolerations`                           | MongoDB(&reg;) Tolerations for pod assignment                                                                    | `[]`            |
-| `topologySpreadConstraints`             | MongoDB(&reg;) Spread Constraints for Pods                                                                       | `[]`            |
-| `lifecycleHooks`                        | LifecycleHook for the MongoDB(&reg;) container(s) to automate configuration before or after startup              | `{}`            |
-| `terminationGracePeriodSeconds`         | MongoDB(&reg;) Termination Grace Period                                                                          | `""`            |
-| `podLabels`                             | MongoDB(&reg;) pod labels                                                                                        | `{}`            |
-| `podAnnotations`                        | MongoDB(&reg;) Pod annotations                                                                                   | `{}`            |
-| `priorityClassName`                     | Name of the existing priority class to be used by MongoDB(&reg;) pod(s)                                          | `""`            |
-| `runtimeClassName`                      | Name of the runtime class to be used by MongoDB(&reg;) pod(s)                                                    | `""`            |
-| `podSecurityContext.enabled`            | Enable MongoDB(&reg;) pod(s)' Security Context                                                                   | `true`          |
-| `podSecurityContext.fsGroup`            | Group ID for the volumes of the MongoDB(&reg;) pod(s)                                                            | `1001`          |
-| `podSecurityContext.sysctls`            | sysctl settings of the MongoDB(&reg;) pod(s)'                                                                    | `[]`            |
-| `containerSecurityContext.enabled`      | Enable MongoDB(&reg;) container(s)' Security Context                                                             | `true`          |
-| `containerSecurityContext.runAsUser`    | User ID for the MongoDB(&reg;) container                                                                         | `1001`          |
-| `containerSecurityContext.runAsNonRoot` | Set MongoDB(&reg;) container's Security Context runAsNonRoot                                                     | `true`          |
-| `resources.limits`                      | The resources limits for MongoDB(&reg;) containers                                                               | `{}`            |
-| `resources.requests`                    | The requested resources for MongoDB(&reg;) containers                                                            | `{}`            |
-| `containerPorts.mongodb`                | MongoDB(&reg;) container port                                                                                    | `27017`         |
-| `livenessProbe.enabled`                 | Enable livenessProbe                                                                                             | `true`          |
-| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                          | `30`            |
-| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                 | `20`            |
-| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                | `10`            |
-| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                              | `6`             |
-| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                              | `1`             |
-| `readinessProbe.enabled`                | Enable readinessProbe                                                                                            | `true`          |
-| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                         | `5`             |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                | `10`            |
-| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                               | `5`             |
-| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                             | `6`             |
-| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                             | `1`             |
-| `startupProbe.enabled`                  | Enable startupProbe                                                                                              | `false`         |
-| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                           | `5`             |
-| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                  | `20`            |
-| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                 | `10`            |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                               | `30`            |
-| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                               | `1`             |
-| `customLivenessProbe`                   | Override default liveness probe for MongoDB(&reg;) containers                                                    | `{}`            |
-| `customReadinessProbe`                  | Override default readiness probe for MongoDB(&reg;) containers                                                   | `{}`            |
-| `customStartupProbe`                    | Override default startup probe for MongoDB(&reg;) containers                                                     | `{}`            |
-| `initContainers`                        | Add additional init containers for the hidden node pod(s)                                                        | `[]`            |
-| `sidecars`                              | Add additional sidecar containers for the MongoDB(&reg;) pod(s)                                                  | `[]`            |
-| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the MongoDB(&reg;) container(s)                     | `[]`            |
-| `extraVolumes`                          | Optionally specify extra list of additional volumes to the MongoDB(&reg;) statefulset                            | `[]`            |
-| `pdb.create`                            | Enable/disable a Pod Disruption Budget creation for MongoDB(&reg;) pod(s)                                        | `false`         |
-| `pdb.minAvailable`                      | Minimum number/percentage of MongoDB(&reg;) pods that must still be available after the eviction                 | `1`             |
-| `pdb.maxUnavailable`                    | Maximum number/percentage of MongoDB(&reg;) pods that may be made unavailable after the eviction                 | `""`            |
+| Name                                    | Description                                                                                                     | Value           |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------- |
+| `annotations`                           | Additional labels to be added to the MongoDB(&reg;) statefulset. Evaluated as a template                        | `{}`            |
+| `labels`                                | Annotations to be added to the MongoDB(&reg;) statefulset. Evaluated as a template                              | `{}`            |
+| `replicaCount`                          | Number of MongoDB(&reg;) nodes (only when `architecture=replicaset`)                                            | `2`             |
+| `updateStrategy.type`                   | Strategy to use to replace existing MongoDB(&reg;) pods. When architecture=standalone and useStatefulSet=false, | `RollingUpdate` |
+| `podManagementPolicy`                   | Pod management policy for MongoDB(&reg;)                                                                        | `OrderedReady`  |
+| `podAffinityPreset`                     | MongoDB(&reg;) Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`              | `""`            |
+| `podAntiAffinityPreset`                 | MongoDB(&reg;) Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`         | `soft`          |
+| `nodeAffinityPreset.type`               | MongoDB(&reg;) Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`        | `""`            |
+| `nodeAffinityPreset.key`                | MongoDB(&reg;) Node label key to match Ignored if `affinity` is set.                                            | `""`            |
+| `nodeAffinityPreset.values`             | MongoDB(&reg;) Node label values to match. Ignored if `affinity` is set.                                        | `[]`            |
+| `affinity`                              | MongoDB(&reg;) Affinity for pod assignment                                                                      | `{}`            |
+| `nodeSelector`                          | MongoDB(&reg;) Node labels for pod assignment                                                                   | `{}`            |
+| `tolerations`                           | MongoDB(&reg;) Tolerations for pod assignment                                                                   | `[]`            |
+| `topologySpreadConstraints`             | MongoDB(&reg;) Spread Constraints for Pods                                                                      | `[]`            |
+| `lifecycleHooks`                        | LifecycleHook for the MongoDB(&reg;) container(s) to automate configuration before or after startup             | `{}`            |
+| `terminationGracePeriodSeconds`         | MongoDB(&reg;) Termination Grace Period                                                                         | `""`            |
+| `podLabels`                             | MongoDB(&reg;) pod labels                                                                                       | `{}`            |
+| `podAnnotations`                        | MongoDB(&reg;) Pod annotations                                                                                  | `{}`            |
+| `priorityClassName`                     | Name of the existing priority class to be used by MongoDB(&reg;) pod(s)                                         | `""`            |
+| `runtimeClassName`                      | Name of the runtime class to be used by MongoDB(&reg;) pod(s)                                                   | `""`            |
+| `podSecurityContext.enabled`            | Enable MongoDB(&reg;) pod(s)' Security Context                                                                  | `true`          |
+| `podSecurityContext.fsGroup`            | Group ID for the volumes of the MongoDB(&reg;) pod(s)                                                           | `1001`          |
+| `podSecurityContext.sysctls`            | sysctl settings of the MongoDB(&reg;) pod(s)'                                                                   | `[]`            |
+| `containerSecurityContext.enabled`      | Enable MongoDB(&reg;) container(s)' Security Context                                                            | `true`          |
+| `containerSecurityContext.runAsUser`    | User ID for the MongoDB(&reg;) container                                                                        | `1001`          |
+| `containerSecurityContext.runAsNonRoot` | Set MongoDB(&reg;) container's Security Context runAsNonRoot                                                    | `true`          |
+| `resources.limits`                      | The resources limits for MongoDB(&reg;) containers                                                              | `{}`            |
+| `resources.requests`                    | The requested resources for MongoDB(&reg;) containers                                                           | `{}`            |
+| `containerPorts.mongodb`                | MongoDB(&reg;) container port                                                                                   | `27017`         |
+| `livenessProbe.enabled`                 | Enable livenessProbe                                                                                            | `true`          |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                         | `30`            |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                | `20`            |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                               | `10`            |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                             | `6`             |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                             | `1`             |
+| `readinessProbe.enabled`                | Enable readinessProbe                                                                                           | `true`          |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                        | `5`             |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                               | `10`            |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                              | `5`             |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                            | `6`             |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                            | `1`             |
+| `startupProbe.enabled`                  | Enable startupProbe                                                                                             | `false`         |
+| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                          | `5`             |
+| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                 | `20`            |
+| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                | `10`            |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                              | `30`            |
+| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                              | `1`             |
+| `customLivenessProbe`                   | Override default liveness probe for MongoDB(&reg;) containers                                                   | `{}`            |
+| `customReadinessProbe`                  | Override default readiness probe for MongoDB(&reg;) containers                                                  | `{}`            |
+| `customStartupProbe`                    | Override default startup probe for MongoDB(&reg;) containers                                                    | `{}`            |
+| `initContainers`                        | Add additional init containers for the hidden node pod(s)                                                       | `[]`            |
+| `sidecars`                              | Add additional sidecar containers for the MongoDB(&reg;) pod(s)                                                 | `[]`            |
+| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the MongoDB(&reg;) container(s)                    | `[]`            |
+| `extraVolumes`                          | Optionally specify extra list of additional volumes to the MongoDB(&reg;) statefulset                           | `[]`            |
+| `pdb.create`                            | Enable/disable a Pod Disruption Budget creation for MongoDB(&reg;) pod(s)                                       | `false`         |
+| `pdb.minAvailable`                      | Minimum number/percentage of MongoDB(&reg;) pods that must still be available after the eviction                | `1`             |
+| `pdb.maxUnavailable`                    | Maximum number/percentage of MongoDB(&reg;) pods that may be made unavailable after the eviction                | `""`            |
 
 
 ### Traffic exposure parameters
@@ -502,6 +502,8 @@ Refer to the [chart documentation for more information on each of these architec
 | `metrics.username`                           | String with username for the metrics exporter                                                                         | `""`                       |
 | `metrics.password`                           | String with password for the metrics exporter                                                                         | `""`                       |
 | `metrics.extraFlags`                         | String with extra flags to the metrics exporter                                                                       | `""`                       |
+| `metrics.command`                            | Override default container command (useful when using custom images)                                                  | `[]`                       |
+| `metrics.args`                               | Override default container args (useful when using custom images)                                                     | `[]`                       |
 | `metrics.resources.limits`                   | The resources limits for Prometheus exporter containers                                                               | `{}`                       |
 | `metrics.resources.requests`                 | The requested resources for Prometheus exporter containers                                                            | `{}`                       |
 | `metrics.containerPort`                      | Port of the Prometheus metrics container                                                                              | `9216`                     |

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -332,7 +332,7 @@ spec:
           {{- if .Values.hidden.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.hidden.startupProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command: 
+              command:
                 - /bitnami/scripts/startup-probe.sh
           {{- else if .Values.hidden.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.hidden.customStartupProbe "context" $) | nindent 12 }}
@@ -379,6 +379,8 @@ spec:
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - /bin/bash
@@ -386,6 +388,8 @@ spec:
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.args "context" $) | nindent 12 }}
           {{- else }}
           args:
             - |

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -318,7 +318,7 @@ spec:
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command: 
+              command:
                 - /bitnami/scripts/ping-mongodb.sh
           {{- else if .Values.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
@@ -326,7 +326,7 @@ spec:
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command: 
+              command:
                 - /bitnami/scripts/readiness-probe.sh
           {{- else if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
@@ -334,7 +334,7 @@ spec:
           {{- if .Values.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
             exec:
-              command: 
+              command:
                 - /bitnami/scripts/startup-probe.sh
           {{- else if .Values.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
@@ -386,6 +386,8 @@ spec:
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.command "context" $) | nindent 12 }}
           {{- else }}
           command:
             - /bin/bash
@@ -393,6 +395,8 @@ spec:
           {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.args "context" $) | nindent 12 }}
           {{- else }}
           args:
             - |

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -325,12 +325,24 @@ spec:
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.command "context" $) | nindent 12 }}
+          {{- else }}
           command:
             - /bin/bash
             - -ec
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.args "context" $) | nindent 12 }}
+          {{- else }}
           args:
             - |
               /bin/mongodb_exporter --web.listen-address ":{{ .Values.metrics.containerPort }}" --mongodb.uri "{{ include "mongodb.mongodb_exporter.uri" . }}" {{ .Values.metrics.extraFlags }}
+          {{- end }}
           env:
             {{- if .Values.auth.enabled }}
             {{- if not .Values.metrics.username }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -386,8 +386,8 @@ labels: {}
 ## Ignored when mongodb.architecture=standalone
 ##
 replicaCount: 2
-## @param updateStrategy.type Strategy to use to replace existing MongoDB(&reg;) pods. When architecture=standalone and useStatefulSet=false, 
-##������this parameter will be applied on a deployment object. In other case it will be applied on a statefulset object
+## @param updateStrategy.type Strategy to use to replace existing MongoDB(&reg;) pods. When architecture=standalone and useStatefulSet=false,
+## this parameter will be applied on a deployment object. In other case it will be applied on a statefulset object
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 ## Example:
@@ -1846,6 +1846,12 @@ metrics:
   ## ref: https://github.com/percona/mongodb_exporter/blob/master/mongodb_exporter.go
   ##
   extraFlags: ""
+  ## Command and args for running the container (set to default if not set). Use array form
+  ## @param metrics.command Override default container command (useful when using custom images)
+  ## @param metrics.args Override default container args (useful when using custom images)
+  ##
+  command: []
+  args: []
   ## Metrics exporter container resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
### Description of the change

Allow using custom command and args to override the default one in the metrics container as we already support it in the regular MongoDB container.

### Benefits

Users can easily customize the command and/or arg used when deploying the metrics container by using the `metrics.command` and `metrics.args` parameters.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #10026

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)