### PR TITLE
[bitnami/*] chore 🔨: Prevent automated README updates from triggering the CI

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -61,5 +61,5 @@ jobs:
           if git status -s | grep bitnami; then
             git config user.name "Bitnami Containers"
             git config user.email "containers@bitnami.com"
-            git add . && git commit -am "Update README.md with readme-generator-for-helm" --signoff && git push
+            git add . && git commit -am "[skip ci] Update README.md with readme-generator-for-helm" --signoff && git push
           fi


### PR DESCRIPTION
Signed-off-by: Alejandro Ruiz <alejandroruiz@vmware.com>

### Description of the change

The automation for automatically updating the README files is producing a new commit, which retriggers again the complete CI. This PR uses [this functionality](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/) to prevent that.

### Benefits

Expensive verify actions are only executed once.

### Possible drawbacks

A wrong README generation wouldn't be caught by the verify actions, but this is not being checked AFAIK.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
