### PR TITLE
[bitnami/nginx-ingress-controller] Solve issues 10059 (HPA/v2) and 10060 (PDB)

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -27,4 +27,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 9.1.27
+version: 9.1.28

--- a/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
+++ b/bitnami/nginx-ingress-controller/templates/controller-hpa.yaml
@@ -28,12 +28,24 @@ spec:
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemory }}
+        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPU }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/nginx-ingress-controller/templates/default-backend-poddisruptionbudget.yaml
+++ b/bitnami/nginx-ingress-controller/templates/default-backend-poddisruptionbudget.yaml
@@ -20,6 +20,6 @@ spec:
   maxUnavailable: {{ .Values.defaultBackend.pdb.maxUnavailable }}
   {{- end }}
   selector:
-    matchLabels: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: default-backend
 {{- end }}


### PR DESCRIPTION
### Description of the change
* Solve the issue 10059: Unable to deploy HorizontalPodAutoscaler on cluster >= 1.23.0.. The format of the HPA resource v2 was not correct.
* Solve the issue 10060: Error in PodDisruptionBudget. Missing tabulation for included match labels.

### Applicable issues

  - fixes #10059
  - fixes #10060

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

Signed-off-by: Renaud Demarneffe <renaud.demarneffe@gmail.com>