### PR TITLE
[bitnami/mongodb-sharded] Fix bug in arbiter statefulset

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 5.0.1
+version: 5.0.2

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -130,7 +130,7 @@ spec:
               value: {{ printf "%s-shard-%d" ( include "common.names.fullname" $ ) $i }}
             {{- if $.Values.common.useHostnames }}
             - name: MONGODB_ADVERTISED_HOSTNAME
-              value: {{ printf "$(MONGODB_POD_NAME).%s-headless.%s.svc.%s" (include "common.names.fullname" $) (include "common.names.namespace" $) .Values.clusterDomain }}
+              value: {{ printf "$(MONGODB_POD_NAME).%s-headless.%s.svc.%s" (include "common.names.fullname" $) (include "common.names.namespace" $) $.Values.clusterDomain }}
             {{- end }}
             - name: MONGODB_ENABLE_IPV6
             {{- if $.Values.common.mongodbEnableIPv6 }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if and  .Values.shards  .Values.shardsvr.arbiter.replicaCount }}
+{{- if and .Values.shards .Values.shardsvr.arbiter.replicaCount }}
 {{- $replicas := $.Values.shards | int }}
 {{- range $i, $e := until $replicas }}
 apiVersion: apps/v1

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if and $.Value.shards $.Value.shardsvr.arbiter.replicaCount }}
+{{- if and  $.Values.shards  $.Values.shardsvr.arbiter.replicaCount }}
 {{- $replicas := $.Values.shards | int }}
 {{- range $i, $e := until $replicas }}
 apiVersion: apps/v1
@@ -27,7 +27,7 @@ spec:
       labels: {{- include "common.labels.standard" $ | nindent 8 }}
         app.kubernetes.io/component: shardsvr-arbiter
         {{- if $.Values.common.podLabels }}
-          {{- include "common.tplvalues.render" ( dict "value" $.Value.common.podLabels "context" $ ) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value"  $.Values.common.podLabels "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.shardsvr.arbiter.podLabels }}
           {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.podLabels "context" $ ) | nindent 8 }}
@@ -208,14 +208,14 @@ spec:
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $.Values.shardsvr.arbiter.livenessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: mongodb
-          {{- else if $.Value.shardsvr.arbiter.customLivenessProbe }}
+          {{- else if  $.Values.shardsvr.arbiter.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if $.Value.shardsvr.arbiter.readinessProbe.enabled }}
+          {{- if  $.Values.shardsvr.arbiter.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $.Values.shardsvr.arbiter.readinessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: mongodb
-          {{- else if $.Value.shardsvr.arbiter.customReadinessProbe }}
+          {{- else if  $.Values.shardsvr.arbiter.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if $.Values.shardsvr.arbiter.startupProbe.enabled }}
@@ -263,7 +263,7 @@ spec:
           env:
           {{- if $.Values.auth.enabled }}
             - name: MONGODB_ROOT_USER
-              value: {{ $.Value.auth.rootUser | quote }}
+              value: {{  $.Values.auth.rootUser | quote }}
           {{- if $.Values.auth.usePasswordFile }}
             - name: MONGODB_ROOT_PASSWORD_FILE
               value: "/bitnami/mongodb/secrets/mongodb-root-password"
@@ -276,8 +276,8 @@ spec:
           {{- end }}
           {{- end }}
           {{- if $.Values.diagnosticMode.enabled }}
-          command: {{- include "common.tplvalues.render" (dict "value" $.Value.diagnosticMode.command "context" $) | nindent 12 }}
-          args: {{- include "common.tplvalues.render" (dict "value" $.Value.diagnosticMode.args "context" $) | nindent 12 }}
+          command: {{- include "common.tplvalues.render" (dict "value"  $.Values.diagnosticMode.command "context" $) | nindent 12 }}
+          args: {{- include "common.tplvalues.render" (dict "value"  $.Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else }}
           command:
             - sh

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.shards .Values.shardsvr.arbiter.replicaCount }}
+{{- if and $.Value.shards $.Value.shardsvr.arbiter.replicaCount }}
 {{- $replicas := $.Values.shards | int }}
 {{- range $i, $e := until $replicas }}
 apiVersion: apps/v1
@@ -27,7 +27,7 @@ spec:
       labels: {{- include "common.labels.standard" $ | nindent 8 }}
         app.kubernetes.io/component: shardsvr-arbiter
         {{- if $.Values.common.podLabels }}
-          {{- include "common.tplvalues.render" ( dict "value" .Values.common.podLabels "context" $ ) | nindent 8 }}
+          {{- include "common.tplvalues.render" ( dict "value" $.Value.common.podLabels "context" $ ) | nindent 8 }}
         {{- end }}
         {{- if $.Values.shardsvr.arbiter.podLabels }}
           {{- include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.podLabels "context" $ ) | nindent 8 }}
@@ -146,7 +146,7 @@ spec:
             {{- end }}
             {{- if $.Values.auth.enabled }}
             - name: MONGODB_INITIAL_PRIMARY_ROOT_USER
-              value: {{ .Values.auth.rootUser | quote }}
+              value: {{ $.Values.auth.rootUser | quote }}
             {{- if $.Values.auth.usePasswordFile }}
             - name: MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD_FILE
               value: "/bitnami/mongodb/secrets/mongodb-root-password"
@@ -211,7 +211,7 @@ spec:
           {{- else if $.Value.shardsvr.arbiter.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" $.Values.shardsvr.arbiter.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.shardsvr.arbiter.readinessProbe.enabled }}
+          {{- if $.Value.shardsvr.arbiter.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $.Values.shardsvr.arbiter.readinessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: mongodb
@@ -263,7 +263,7 @@ spec:
           env:
           {{- if $.Values.auth.enabled }}
             - name: MONGODB_ROOT_USER
-              value: {{ .Values.auth.rootUser | quote }}
+              value: {{ $.Value.auth.rootUser | quote }}
           {{- if $.Values.auth.usePasswordFile }}
             - name: MONGODB_ROOT_PASSWORD_FILE
               value: "/bitnami/mongodb/secrets/mongodb-root-password"
@@ -276,8 +276,8 @@ spec:
           {{- end }}
           {{- end }}
           {{- if $.Values.diagnosticMode.enabled }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          command: {{- include "common.tplvalues.render" (dict "value" $.Value.diagnosticMode.command "context" $) | nindent 12 }}
+          args: {{- include "common.tplvalues.render" (dict "value" $.Value.diagnosticMode.args "context" $) | nindent 12 }}
           {{- else }}
           command:
             - sh

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -1,4 +1,4 @@
-{{- if and  $.Values.shards  $.Values.shardsvr.arbiter.replicaCount }}
+{{- if and  .Values.shards  .Values.shardsvr.arbiter.replicaCount }}
 {{- $replicas := $.Values.shards | int }}
 {{- range $i, $e := until $replicas }}
 apiVersion: apps/v1


### PR DESCRIPTION
Missing "$" causes error on deploying arbiters.

### Description of the change

Fix arbiter statefulset, due to missing `$`

### Benefits

Able to deploy arbiters

### Possible drawbacks

None

### Applicable issues

  - fixes #10062 
### Additional information

None

### Checklist



- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
