### PR TITLE
[bitnami/mongodb] Remove unnecessary logic around externalAccess.service.nodePorts

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 12.1.0
+version: 12.1.1

--- a/bitnami/mongodb/templates/hidden/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/hidden/external-access-svc.yaml
@@ -51,8 +51,8 @@ spec:
     - name: {{ $root.Values.externalAccess.hidden.service.portName | quote }}
       port: {{ $root.Values.externalAccess.hidden.service.ports.mongodb }}
       {{- if not (empty $root.Values.externalAccess.hidden.service.nodePorts) }}
-      {{- $nodePort := index $root.Values.externalAccess.hidden.service.nodePorts $i -}}
-      nodePort: {{ ternary (get $nodePort "mongodb") $nodePort (typeIs "dict" $nodePort)}}
+      {{- $nodePort := index $root.Values.externalAccess.hidden.service.nodePorts $i }}
+      nodePort: {{ $nodePort }}
       {{- else }}
       nodePort: null
       {{- end }}

--- a/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/external-access-svc.yaml
@@ -23,7 +23,7 @@ metadata:
     {{- if $root.Values.externalAccess.service.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" $root.Values.externalAccess.service.annotations "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.commonAnnotations }}
+    {{- if $root.Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
@@ -51,8 +51,8 @@ spec:
     - name: {{ $root.Values.externalAccess.service.portName | quote }}
       port: {{ $root.Values.externalAccess.service.ports.mongodb }}
       {{- if not (empty $root.Values.externalAccess.service.nodePorts) }}
-      {{- $nodePort := index $root.Values.externalAccess.service.nodePorts $i -}}
-      nodePort: {{ ternary (get $nodePort "mongodb") $nodePort (typeIs "dict" $nodePort)}}
+      {{- $nodePort := index $root.Values.externalAccess.service.nodePorts $i }}
+      nodePort: {{ $nodePort }}
       {{- else }}
       nodePort: null
       {{- end }}


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

### Description of the change
Remove unnecessary logic around `externalAccess.service.nodePorts`and `externalAccess.hidden.service.nodePorts`. We will use a simple list as mentioned in the original readme file.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #10000

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
