### PR TITLE
[bitnami/mediawiki] support existing Secret parameter for mediawiki admin

### DIFF
--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -32,4 +32,4 @@ name: mediawiki
 sources:
   - https://github.com/bitnami/bitnami-docker-mediawiki
   - https://www.mediawiki.org/
-version: 14.0.1
+version: 14.1.0

--- a/bitnami/mediawiki/README.md
+++ b/bitnami/mediawiki/README.md
@@ -62,6 +62,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
+
 ### Common parameters
 
 | Name                | Description                                                                                  | Value           |
@@ -74,34 +75,37 @@ The command removes all the Kubernetes components associated with the chart and 
 | `clusterDomain`     | Default Kubernetes cluster domain                                                            | `cluster.local` |
 | `extraDeploy`       | Array of extra objects to deploy with the release                                            | `[]`            |
 
+
 ### Mediawiki parameters
 
-| Name                 | Description                                                                      | Value                  |
-| -------------------- | -------------------------------------------------------------------------------- | ---------------------- |
-| `image.registry`     | MediaWiki image registry                                                         | `docker.io`            |
-| `image.repository`   | MediaWiki image repository                                                       | `bitnami/mediawiki`    |
-| `image.tag`          | MediaWiki image tag (immutable tags are recommended)                             | `1.37.1-debian-10-r20` |
-| `image.pullPolicy`   | Image pull policy                                                                | `IfNotPresent`         |
-| `image.pullSecrets`  | Specify docker-registry secret names as an array                                 | `[]`                   |
-| `image.debug`        | Enable MediaWiki image debug mode                                                | `false`                |
-| `hostAliases`        | Deployment pod host aliases                                                      | `[]`                   |
-| `mediawikiUser`      | User of the application                                                          | `user`                 |
-| `mediawikiPassword`  | Application password                                                             | `""`                   |
-| `mediawikiEmail`     | Admin email                                                                      | `user@example.com`     |
-| `mediawikiName`      | Name for the wiki                                                                | `My Wiki`              |
-| `mediawikiHost`      | Mediawiki host to create application URLs                                        | `""`                   |
-| `allowEmptyPassword` | Allow DB blank passwords                                                         | `yes`                  |
-| `smtpHost`           | SMTP host                                                                        | `""`                   |
-| `smtpPort`           | SMTP port                                                                        | `""`                   |
-| `smtpHostID`         | SMTP host ID                                                                     | `""`                   |
-| `smtpUser`           | SMTP user                                                                        | `""`                   |
-| `smtpPassword`       | SMTP password                                                                    | `""`                   |
-| `command`            | Override default container command (useful when using custom images)             | `[]`                   |
-| `args`               | Override default container args (useful when using custom images)                | `[]`                   |
-| `lifecycleHooks`     | for the Mediawiki container(s) to automate configuration before or after startup | `{}`                   |
-| `extraEnvVars`       | Extra environment variables to be set on Mediawki container                      | `[]`                   |
-| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars                             | `""`                   |
-| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars                                | `""`                   |
+| Name                 | Description                                                                                                                                        | Value                  |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `image.registry`     | MediaWiki image registry                                                                                                                           | `docker.io`            |
+| `image.repository`   | MediaWiki image repository                                                                                                                         | `bitnami/mediawiki`    |
+| `image.tag`          | MediaWiki image tag (immutable tags are recommended)                                                                                               | `1.37.2-debian-10-r21` |
+| `image.pullPolicy`   | Image pull policy                                                                                                                                  | `IfNotPresent`         |
+| `image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                                   | `[]`                   |
+| `image.debug`        | Enable MediaWiki image debug mode                                                                                                                  | `false`                |
+| `hostAliases`        | Deployment pod host aliases                                                                                                                        | `[]`                   |
+| `mediawikiUser`      | User of the application                                                                                                                            | `user`                 |
+| `mediawikiPassword`  | Application password                                                                                                                               | `""`                   |
+| `mediawikiSecret`    | Existing `Secret` containing the password for the `mediawikiUser` user; must contain the key `mediawiki-password` and optional key `smtp-password` | `""`                   |
+| `mediawikiEmail`     | Admin email                                                                                                                                        | `user@example.com`     |
+| `mediawikiName`      | Name for the wiki                                                                                                                                  | `My Wiki`              |
+| `mediawikiHost`      | Mediawiki host to create application URLs                                                                                                          | `""`                   |
+| `allowEmptyPassword` | Allow DB blank passwords                                                                                                                           | `yes`                  |
+| `smtpHost`           | SMTP host                                                                                                                                          | `""`                   |
+| `smtpPort`           | SMTP port                                                                                                                                          | `""`                   |
+| `smtpHostID`         | SMTP host ID                                                                                                                                       | `""`                   |
+| `smtpUser`           | SMTP user                                                                                                                                          | `""`                   |
+| `smtpPassword`       | SMTP password                                                                                                                                      | `""`                   |
+| `command`            | Override default container command (useful when using custom images)                                                                               | `[]`                   |
+| `args`               | Override default container args (useful when using custom images)                                                                                  | `[]`                   |
+| `lifecycleHooks`     | for the Mediawiki container(s) to automate configuration before or after startup                                                                   | `{}`                   |
+| `extraEnvVars`       | Extra environment variables to be set on Mediawki container                                                                                        | `[]`                   |
+| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars                                                                                               | `""`                   |
+| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars                                                                                                  | `""`                   |
+
 
 ### Mediawiki deployment parameters
 
@@ -169,6 +173,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `persistence.size`                      | PVC Storage Request for MediaWiki volume                                                  | `8Gi`                                             |
 | `persistence.annotations`               | Persistent Volume Claim annotations                                                       | `{}`                                              |
 
+
 ### Traffic Exposure parameters
 
 | Name                               | Description                                                                                                                      | Value                    |
@@ -199,6 +204,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.secrets`                  | If you're providing your own certificates, please use this to add the certificates as secrets                                    | `[]`                     |
 | `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 
+
 ### Database parameters
 
 | Name                                        | Description                                                                           | Value               |
@@ -222,6 +228,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalDatabase.password`                 | Password for the above username                                                       | `""`                |
 | `externalDatabase.database`                 | Name of the existing database                                                         | `bitnami_mediawiki` |
 
+
 ### Metrics parameters
 
 | Name                                       | Description                                                                  | Value                     |
@@ -229,7 +236,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                          | Start a side-car prometheus exporter                                         | `false`                   |
 | `metrics.image.registry`                   | Apache exporter image registry                                               | `docker.io`               |
 | `metrics.image.repository`                 | Apache exporter image repository                                             | `bitnami/apache-exporter` |
-| `metrics.image.tag`                        | Apache exporter image tag (immutable tags are recommended)                   | `0.11.0-debian-10-r18`    |
+| `metrics.image.tag`                        | Apache exporter image tag (immutable tags are recommended)                   | `0.11.0-debian-10-r122`   |
 | `metrics.image.pullPolicy`                 | Image pull policy                                                            | `IfNotPresent`            |
 | `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                             | `[]`                      |
 | `metrics.resources`                        | Exporter resource requests/limit                                             | `{}`                      |
@@ -244,6 +251,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                               | `{}`                      |
 | `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                          | `{}`                      |
 | `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels     | `false`                   |
+
 
 ### NetworkPolicy parameters
 
@@ -264,6 +272,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.ingressRules.customRules`                      | Custom network policy ingress rule                                                                                            | `{}`    |
 | `networkPolicy.egressRules.denyConnectionsToExternal`         | Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).                                | `false` |
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                    | `{}`    |
+
 
 The above parameters map to the env variables defined in [bitnami/mediawiki](https://github.com/bitnami/bitnami-docker-mediawiki). For more information please refer to the [bitnami/mediawiki](https://github.com/bitnami/bitnami-docker-mediawiki) image documentation.
 

--- a/bitnami/mediawiki/templates/NOTES.txt
+++ b/bitnami/mediawiki/templates/NOTES.txt
@@ -116,3 +116,5 @@ host. To configure MediaWiki to use and external database host:
     {{- $passwordValidationErrors = append $passwordValidationErrors $mariadbPasswordValidationErrors -}}
 {{- end }}
 {{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}
+
+{{ include "mediawiki.validateValues" . }}

--- a/bitnami/mediawiki/templates/_helpers.tpl
+++ b/bitnami/mediawiki/templates/_helpers.tpl
@@ -122,3 +122,48 @@ Check if there are rolling tags in the images
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.rollingTag" .Values.metrics.image }}
 {{- end -}}
+
+{{/*
+Get the credentials Secret
+*/}}
+{{- define "mediawiki.secretName" -}}
+{{- if .Values.mediawikiSecret -}}
+    {{- printf "%s" (tpl .Values.mediawikiSecret $) -}}
+{{- else -}}
+    {{- printf "%s" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a Secret object should be created
+*/}}
+{{- define "mediawiki.createSecret" -}}
+{{- if .Values.mediawikiSecret -}}
+{{- else -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate values of password and existing Secret mutually exclusive
+*/}}
+{{- define "mediawiki.validateValues.passwordSecretMutExclusive" -}}
+{{- if and .Values.mediawikiPassword .Values.mediawikiSecret -}}
+mediawiki: mediawikiSecret
+    You cannot provide both mediawikiPassword and mediawikiSecret
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "mediawiki.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "mediawiki.validateValues.passwordSecretMutExclusive" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}

--- a/bitnami/mediawiki/templates/deployment.yaml
+++ b/bitnami/mediawiki/templates/deployment.yaml
@@ -105,7 +105,7 @@ spec:
             - name: MEDIAWIKI_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "common.names.fullname" . }}
+                  name: {{ include "mediawiki.secretName" . }}
                   key: mediawiki-password
             - name: MEDIAWIKI_EMAIL
               value: {{ .Values.mediawikiEmail | quote }}
@@ -131,7 +131,7 @@ spec:
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "common.names.fullname" . }}
+                  name: {{ include "mediawiki.secretName" . }}
                   key: smtp-password
             {{- end }}
             {{- if .Values.extraEnvVars }}

--- a/bitnami/mediawiki/templates/secrets.yaml
+++ b/bitnami/mediawiki/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if (include "mediawiki.createSecret" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,3 +20,4 @@ data:
   {{- if .Values.smtpPassword }}
   smtp-password: {{ .Values.smtpPassword | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/bitnami/mediawiki/values.yaml
+++ b/bitnami/mediawiki/values.yaml
@@ -89,6 +89,10 @@ mediawikiUser: user
 ## ref: https://github.com/bitnami/bitnami-docker-mediawiki#environment-variables
 ##
 mediawikiPassword: ""
+## @param mediawikiSecret Existing `Secret` containing the password for the `mediawikiUser` user; must contain the key `mediawiki-password` and optional key `smtp-password`
+## Mutually exclusive with `mediawikiPassword`
+##
+mediawikiSecret: ""
 ## @param mediawikiEmail Admin email
 ## ref: https://github.com/bitnami/bitnami-docker-mediawiki#environment-variables
 ##


### PR DESCRIPTION
### Description of the change

Support existing Secret parameter for mediawiki password.

- Add parameter: mediawikiSecret to point to existing admin Secret
- Add some validation of mutual exclusivity
- Add helper functions
- Bump chart version

### Benefits

Allow passing an existing `Secret` rather than hardcoding and passing the password directly.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
