### PR TITLE
[bitnami/nginx] fixed tpl error in server-block configmap

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 11.0.0
+version: 11.0.1

--- a/bitnami/nginx/templates/server-block-configmap.yaml
+++ b/bitnami/nginx/templates/server-block-configmap.yaml
@@ -10,7 +10,8 @@ metadata:
     {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}data:
+  {{- end }}
+data:
   server-block.conf: |-
     {{- include "common.tplvalues.render" ( dict "value" .Values.serverBlock "context" $ ) | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Fixes `Error: YAML parse error on nginx/templates/server-block-configmap.yaml: error converting YAML to JSON: yaml: line 12: mapping values are not allowed in this context`when deploying nginx helm chart with server block enabled 

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
