### PR TITLE
[bitnami/drupal] Add missing namespace metadata

### DIFF
--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -31,4 +31,4 @@ name: drupal
 sources:
   - https://github.com/bitnami/bitnami-docker-drupal
   - https://www.drupal.org/
-version: 12.0.1
+version: 12.1.0

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -62,6 +62,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
+
 ### Common parameters
 
 | Name                | Description                                                                                                | Value |
@@ -69,98 +70,101 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                                       | `""`  |
 | `nameOverride`      | String to partially override drupal.fullname template (will maintain the release name)                     | `""`  |
 | `fullnameOverride`  | String to fully override drupal.fullname template                                                          | `""`  |
+| `namespaceOverride` | String to fully override common.names.namespace                                                            | `""`  |
 | `commonAnnotations` | Common annotations to add to all Drupal resources (sub-charts are not considered). Evaluated as a template | `{}`  |
 | `commonLabels`      | Common labels to add to all Drupal resources (sub-charts are not considered). Evaluated as a template      | `{}`  |
 | `extraDeploy`       | Array of extra objects to deploy with the release (evaluated as a template).                               | `[]`  |
 
+
 ### Drupal parameters
 
-| Name                                    | Description                                                                                                           | Value                |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| `image.registry`                        | Drupal image registry                                                                                                 | `docker.io`          |
-| `image.repository`                      | Drupal Image name                                                                                                     | `bitnami/drupal`     |
-| `image.tag`                             | Drupal Image tag                                                                                                      | `9.3.2-debian-10-r6` |
-| `image.pullPolicy`                      | Drupal image pull policy                                                                                              | `IfNotPresent`       |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                      | `[]`                 |
-| `image.debug`                           | Specify if debug logs should be enabled                                                                               | `false`              |
-| `replicaCount`                          | Number of Drupal Pods to run (requires ReadWriteMany PVC support)                                                     | `1`                  |
-| `drupalProfile`                         | Drupal installation profile                                                                                           | `standard`           |
-| `drupalSkipInstall`                     | Skip Drupal installation wizard. Useful for migrations and restoring from SQL dump                                    | `false`              |
-| `drupalUsername`                        | User of the application                                                                                               | `user`               |
-| `drupalPassword`                        | Application password                                                                                                  | `""`                 |
-| `drupalEmail`                           | Admin email                                                                                                           | `user@example.com`   |
-| `allowEmptyPassword`                    | Allow DB blank passwords                                                                                              | `true`               |
-| `command`                               | Override default container command (useful when using custom images)                                                  | `[]`                 |
-| `args`                                  | Override default container args (useful when using custom images)                                                     | `[]`                 |
-| `updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                        | `RollingUpdate`      |
-| `priorityClassName`                     | Drupal pods' priorityClassName                                                                                        | `""`                 |
-| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                                        | `""`                 |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                        | `[]`                 |
-| `hostAliases`                           | Add deployment host aliases                                                                                           | `[]`                 |
-| `extraEnvVars`                          | Extra environment variables                                                                                           | `[]`                 |
-| `extraEnvVarsCM`                        | ConfigMap containing extra env vars                                                                                   | `""`                 |
-| `extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)                                                          | `""`                 |
-| `extraVolumes`                          | Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`    | `[]`                 |
-| `extraVolumeMounts`                     | Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`. | `[]`                 |
-| `initContainers`                        | Add additional init containers to the pod (evaluated as a template)                                                   | `[]`                 |
-| `sidecars`                              | Attach additional containers to the pod (evaluated as a template)                                                     | `[]`                 |
-| `tolerations`                           | Tolerations for pod assignment                                                                                        | `[]`                 |
-| `existingSecret`                        | Name of a secret with the application password                                                                        | `""`                 |
-| `smtpHost`                              | SMTP host                                                                                                             | `""`                 |
-| `smtpPort`                              | SMTP port                                                                                                             | `""`                 |
-| `smtpUser`                              | SMTP user                                                                                                             | `""`                 |
-| `smtpPassword`                          | SMTP password                                                                                                         | `""`                 |
-| `smtpProtocol`                          | SMTP Protocol (options: ssl,tls, nil)                                                                                 | `""`                 |
-| `containerPorts`                        | Container ports                                                                                                       | `{}`                 |
-| `sessionAffinity`                       | Control where client requests go, to the same pod or round-robin. Values: ClientIP or None                            | `None`               |
-| `persistence.enabled`                   | Enable persistence using PVC                                                                                          | `true`               |
-| `persistence.storageClass`              | PVC Storage Class for Drupal volume                                                                                   | `""`                 |
-| `persistence.accessModes`               | PVC Access Mode for Drupal volume                                                                                     | `["ReadWriteOnce"]`  |
-| `persistence.size`                      | PVC Storage Request for Drupal volume                                                                                 | `8Gi`                |
-| `persistence.existingClaim`             | A manually managed Persistent Volume Claim                                                                            | `""`                 |
-| `persistence.hostPath`                  | If defined, the drupal-data volume will mount to the specified hostPath.                                              | `""`                 |
-| `persistence.annotations`               | Persistent Volume Claim annotations                                                                                   | `{}`                 |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                   | `""`                 |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `soft`               |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                 |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                                 | `""`                 |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                             | `[]`                 |
-| `affinity`                              | Affinity for pod assignment                                                                                           | `{}`                 |
-| `nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                                              | `{}`                 |
-| `resources.requests`                    | The requested resources for the init container                                                                        | `{}`                 |
-| `resources.limits`                      | The resources limits for the init container                                                                           | `{}`                 |
-| `podSecurityContext.enabled`            | Enable Drupal pods' Security Context                                                                                  | `true`               |
-| `podSecurityContext.fsGroup`            | Drupal pods' group ID                                                                                                 | `1001`               |
-| `containerSecurityContext.enabled`      | Enable Drupal containers' Security Context                                                                            | `true`               |
-| `containerSecurityContext.runAsUser`    | Drupal containers' Security Context                                                                                   | `1001`               |
-| `containerSecurityContext.runAsNonRoot` | Set Controller container's Security Context runAsNonRoot                                                              | `true`               |
-| `startupProbe.enabled`                  | Enable startupProbe                                                                                                   | `false`              |
-| `startupProbe.path`                     | Request path for startupProbe                                                                                         | `/user/login`        |
-| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                | `600`                |
-| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                       | `10`                 |
-| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                      | `5`                  |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                    | `5`                  |
-| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                    | `1`                  |
-| `livenessProbe.enabled`                 | Enable livenessProbe                                                                                                  | `true`               |
-| `livenessProbe.path`                    | Request path for livenessProbe                                                                                        | `/user/login`        |
-| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                               | `600`                |
-| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                      | `10`                 |
-| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                     | `5`                  |
-| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                   | `5`                  |
-| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                   | `1`                  |
-| `readinessProbe.enabled`                | Enable readinessProbe                                                                                                 | `true`               |
-| `readinessProbe.path`                   | Request path for readinessProbe                                                                                       | `/user/login`        |
-| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                              | `30`                 |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                     | `5`                  |
-| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                    | `1`                  |
-| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                  | `5`                  |
-| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                  | `1`                  |
-| `customStartupProbe`                    | Override default startup probe                                                                                        | `{}`                 |
-| `customLivenessProbe`                   | Override default liveness probe                                                                                       | `{}`                 |
-| `customReadinessProbe`                  | Override default readiness probe                                                                                      | `{}`                 |
-| `lifecycleHooks`                        | LifecycleHook to set additional configuration at startup Evaluated as a template                                      | `{}`                 |
-| `podAnnotations`                        | Pod annotations                                                                                                       | `{}`                 |
-| `podLabels`                             | Add additional labels to the pod (evaluated as a template)                                                            | `{}`                 |
+| Name                                    | Description                                                                                                           | Value                 |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`                        | Drupal image registry                                                                                                 | `docker.io`           |
+| `image.repository`                      | Drupal Image name                                                                                                     | `bitnami/drupal`      |
+| `image.tag`                             | Drupal Image tag                                                                                                      | `9.3.12-debian-10-r1` |
+| `image.pullPolicy`                      | Drupal image pull policy                                                                                              | `IfNotPresent`        |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                      | `[]`                  |
+| `image.debug`                           | Specify if debug logs should be enabled                                                                               | `false`               |
+| `replicaCount`                          | Number of Drupal Pods to run (requires ReadWriteMany PVC support)                                                     | `1`                   |
+| `drupalProfile`                         | Drupal installation profile                                                                                           | `standard`            |
+| `drupalSkipInstall`                     | Skip Drupal installation wizard. Useful for migrations and restoring from SQL dump                                    | `false`               |
+| `drupalUsername`                        | User of the application                                                                                               | `user`                |
+| `drupalPassword`                        | Application password                                                                                                  | `""`                  |
+| `drupalEmail`                           | Admin email                                                                                                           | `user@example.com`    |
+| `allowEmptyPassword`                    | Allow DB blank passwords                                                                                              | `true`                |
+| `command`                               | Override default container command (useful when using custom images)                                                  | `[]`                  |
+| `args`                                  | Override default container args (useful when using custom images)                                                     | `[]`                  |
+| `updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                        | `RollingUpdate`       |
+| `priorityClassName`                     | Drupal pods' priorityClassName                                                                                        | `""`                  |
+| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                                        | `""`                  |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                        | `[]`                  |
+| `hostAliases`                           | Add deployment host aliases                                                                                           | `[]`                  |
+| `extraEnvVars`                          | Extra environment variables                                                                                           | `[]`                  |
+| `extraEnvVarsCM`                        | ConfigMap containing extra env vars                                                                                   | `""`                  |
+| `extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)                                                          | `""`                  |
+| `extraVolumes`                          | Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`    | `[]`                  |
+| `extraVolumeMounts`                     | Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`. | `[]`                  |
+| `initContainers`                        | Add additional init containers to the pod (evaluated as a template)                                                   | `[]`                  |
+| `sidecars`                              | Attach additional containers to the pod (evaluated as a template)                                                     | `[]`                  |
+| `tolerations`                           | Tolerations for pod assignment                                                                                        | `[]`                  |
+| `existingSecret`                        | Name of a secret with the application password                                                                        | `""`                  |
+| `smtpHost`                              | SMTP host                                                                                                             | `""`                  |
+| `smtpPort`                              | SMTP port                                                                                                             | `""`                  |
+| `smtpUser`                              | SMTP user                                                                                                             | `""`                  |
+| `smtpPassword`                          | SMTP password                                                                                                         | `""`                  |
+| `smtpProtocol`                          | SMTP Protocol (options: ssl,tls, nil)                                                                                 | `""`                  |
+| `containerPorts`                        | Container ports                                                                                                       | `{}`                  |
+| `sessionAffinity`                       | Control where client requests go, to the same pod or round-robin. Values: ClientIP or None                            | `None`                |
+| `persistence.enabled`                   | Enable persistence using PVC                                                                                          | `true`                |
+| `persistence.storageClass`              | PVC Storage Class for Drupal volume                                                                                   | `""`                  |
+| `persistence.accessModes`               | PVC Access Mode for Drupal volume                                                                                     | `["ReadWriteOnce"]`   |
+| `persistence.size`                      | PVC Storage Request for Drupal volume                                                                                 | `8Gi`                 |
+| `persistence.existingClaim`             | A manually managed Persistent Volume Claim                                                                            | `""`                  |
+| `persistence.hostPath`                  | If defined, the drupal-data volume will mount to the specified hostPath.                                              | `""`                  |
+| `persistence.annotations`               | Persistent Volume Claim annotations                                                                                   | `{}`                  |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                   | `""`                  |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `soft`                |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                  |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                                 | `""`                  |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                             | `[]`                  |
+| `affinity`                              | Affinity for pod assignment                                                                                           | `{}`                  |
+| `nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                                              | `{}`                  |
+| `resources.requests`                    | The requested resources for the init container                                                                        | `{}`                  |
+| `resources.limits`                      | The resources limits for the init container                                                                           | `{}`                  |
+| `podSecurityContext.enabled`            | Enable Drupal pods' Security Context                                                                                  | `true`                |
+| `podSecurityContext.fsGroup`            | Drupal pods' group ID                                                                                                 | `1001`                |
+| `containerSecurityContext.enabled`      | Enable Drupal containers' Security Context                                                                            | `true`                |
+| `containerSecurityContext.runAsUser`    | Drupal containers' Security Context                                                                                   | `1001`                |
+| `containerSecurityContext.runAsNonRoot` | Set Controller container's Security Context runAsNonRoot                                                              | `true`                |
+| `startupProbe.enabled`                  | Enable startupProbe                                                                                                   | `false`               |
+| `startupProbe.path`                     | Request path for startupProbe                                                                                         | `/user/login`         |
+| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                | `600`                 |
+| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                       | `10`                  |
+| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                      | `5`                   |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                    | `5`                   |
+| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                    | `1`                   |
+| `livenessProbe.enabled`                 | Enable livenessProbe                                                                                                  | `true`                |
+| `livenessProbe.path`                    | Request path for livenessProbe                                                                                        | `/user/login`         |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                               | `600`                 |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                      | `10`                  |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                     | `5`                   |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                   | `5`                   |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                   | `1`                   |
+| `readinessProbe.enabled`                | Enable readinessProbe                                                                                                 | `true`                |
+| `readinessProbe.path`                   | Request path for readinessProbe                                                                                       | `/user/login`         |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                              | `30`                  |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                     | `5`                   |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                    | `1`                   |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                  | `5`                   |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                  | `1`                   |
+| `customStartupProbe`                    | Override default startup probe                                                                                        | `{}`                  |
+| `customLivenessProbe`                   | Override default liveness probe                                                                                       | `{}`                  |
+| `customReadinessProbe`                  | Override default readiness probe                                                                                      | `{}`                  |
+| `lifecycleHooks`                        | LifecycleHook to set additional configuration at startup Evaluated as a template                                      | `{}`                  |
+| `podAnnotations`                        | Pod annotations                                                                                                       | `{}`                  |
+| `podLabels`                             | Add additional labels to the pod (evaluated as a template)                                                            | `{}`                  |
+
 
 ### Traffic Exposure Parameters
 
@@ -191,6 +195,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.extraTls`                 | The tls configuration for additional hostnames to be covered with this ingress record.                                           | `[]`                     |
 | `ingress.secrets`                  | If you're providing your own certificates, please use this to add the certificates as secrets                                    | `[]`                     |
 
+
 ### Database parameters
 
 | Name                                        | Description                                                                              | Value               |
@@ -213,6 +218,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalDatabase.password`                 | Password for the above username                                                          | `""`                |
 | `externalDatabase.database`                 | Name of the existing database                                                            | `bitnami_drupal`    |
 
+
 ### Volume Permissions parameters
 
 | Name                                   | Description                                                                                                                                               | Value                   |
@@ -220,11 +226,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                 |
 | `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                                          | `docker.io`             |
 | `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                                                              | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `10-debian-10-r305`     |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `10-debian-10-r403`     |
 | `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                                                       | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                                          | `[]`                    |
 | `volumePermissions.resources.limits`   | The resources limits for the container                                                                                                                    | `{}`                    |
 | `volumePermissions.resources.requests` | The requested resources for the container                                                                                                                 | `{}`                    |
+
 
 ### Metrics parameters
 
@@ -233,11 +240,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`           | Start a exporter side-car                        | `false`                   |
 | `metrics.image.registry`    | Apache exporter image registry                   | `docker.io`               |
 | `metrics.image.repository`  | Apache exporter image repository                 | `bitnami/apache-exporter` |
-| `metrics.image.tag`         | Apache exporter image tag                        | `0.11.0-debian-10-r23`    |
+| `metrics.image.tag`         | Apache exporter image tag                        | `0.11.0-debian-10-r122`   |
 | `metrics.image.pullPolicy`  | Image pull policy                                | `IfNotPresent`            |
 | `metrics.image.pullSecrets` | Specify docker-registry secret names as an array | `[]`                      |
 | `metrics.resources`         | Metrics exporter resource requests and limits    | `{}`                      |
 | `metrics.podAnnotations`    | Additional annotations for Metrics exporter pod  | `{}`                      |
+
 
 ### Certificate injection parameters
 
@@ -257,9 +265,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `certificates.extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)         | `""`                                     |
 | `certificates.image.registry`                        | Container sidecar registry                                           | `docker.io`                              |
 | `certificates.image.repository`                      | Container sidecar image                                              | `bitnami/bitnami-shell`                  |
-| `certificates.image.tag`                             | Container sidecar image tag                                          | `10-debian-10-r305`                      |
+| `certificates.image.tag`                             | Container sidecar image tag                                          | `10-debian-10-r403`                      |
 | `certificates.image.pullPolicy`                      | Container sidecar image pull policy                                  | `IfNotPresent`                           |
 | `certificates.image.pullSecrets`                     | Container sidecar image pull secrets                                 | `[]`                                     |
+
 
 ### NetworkPolicy parameters
 
@@ -280,6 +289,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.ingressRules.customRules`                      | Custom network policy ingress rule                                                                                         | `{}`    |
 | `networkPolicy.egressRules.denyConnectionsToExternal`         | Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).                             | `false` |
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                 | `{}`    |
+
 
 The above parameters map to the env variables defined in [bitnami/drupal](https://github.com/bitnami/bitnami-docker-drupal). For more information please refer to the [bitnami/drupal](https://github.com/bitnami/bitnami-docker-drupal) image documentation.
 

--- a/bitnami/drupal/templates/NOTES.txt
+++ b/bitnami/drupal/templates/NOTES.txt
@@ -17,9 +17,9 @@ APP VERSION: {{ .Chart.AppVersion }}
 {{- else if eq .Values.service.type "LoadBalancer" }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "common.names.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ include "common.names.namespace" . }} -w {{ include "common.names.fullname" . }}'
 
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  export SERVICE_IP=$(kubectl get svc --namespace {{ include "common.names.namespace" . }} {{ include "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
 
 {{- $port:=(coalesce .Values.service.ports.http .Values.service.port) | toString }}
   echo "Drupal URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ coalesce .Values.service.ports.http .Values.service.port }}{{ end }}/"
@@ -27,7 +27,7 @@ APP VERSION: {{ .Chart.AppVersion }}
 {{- else if eq .Values.service.type "ClusterIP" }}
 
   echo "Drupal URL: http://127.0.0.1:8080/"
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} 8080:{{ coalesce .Values.service.ports.http .Values.service.port }}
+  kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ include "common.names.fullname" . }} 8080:{{ coalesce .Values.service.ports.http .Values.service.port }}
 
 {{- end }}
 
@@ -35,8 +35,8 @@ APP VERSION: {{ .Chart.AppVersion }}
 
   Or running:
 
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo "Drupal URL: http://$NODE_IP:$NODE_PORT/"
 
 {{- end }}
@@ -44,7 +44,7 @@ APP VERSION: {{ .Chart.AppVersion }}
 2. Get your Drupal login credentials by running:
 
   echo Username: {{ .Values.drupalUsername }}
-  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "drupal.secretName" . }} -o jsonpath="{.data.drupal-password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ template "drupal.secretName" . }} -o jsonpath="{.data.drupal-password}" | base64 --decode)
 
 {{- else -}}
 
@@ -57,11 +57,11 @@ host. To configure Drupal to use and external database host:
 
 1. Complete your Drupal deployment by running:
 
-  export APP_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "drupal.secretName" . }} -o jsonpath="{.data.drupal-password}" | base64 --decode)
+  export APP_PASSWORD=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ template "drupal.secretName" . }} -o jsonpath="{.data.drupal-password}" | base64 --decode)
 
   ## PLEASE UPDATE THE EXTERNAL DATABASE CONNECTION PARAMETERS IN THE FOLLOWING COMMAND AS NEEDED ##
 
-  helm upgrade --namespace {{ .Release.Namespace }} {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
+  helm upgrade --namespace {{ include "common.names.namespace" . }} {{ .Release.Name }} bitnami/{{ .Chart.Name }} \
     --set drupalPassword=$APP_PASSWORD,service.type={{ .Values.service.type }},mariadb.enabled=false{{- if not (empty .Values.externalDatabase.user) }},externalDatabase.user={{ .Values.externalDatabase.user }}{{- end }}{{- if not (empty .Values.externalDatabase.password) }},externalDatabase.password={{ .Values.externalDatabase.password }}{{- end }}{{- if not (empty .Values.externalDatabase.database) }},externalDatabase.database={{ .Values.externalDatabase.database }}{{- end }},externalDatabase.host=YOUR_EXTERNAL_DATABASE_HOST{{- if .Values.global }}{{- if .Values.global.imagePullSecrets }},global.imagePullSecrets={{ .Values.global.imagePullSecrets }}{{- end }}{{- end }}
 
 {{- end }}

--- a/bitnami/drupal/templates/deployment.yaml
+++ b/bitnami/drupal/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/drupal/templates/externaldb-secrets.yaml
+++ b/bitnami/drupal/templates/externaldb-secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ include "common.names.fullname" . }}-externaldb"
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 type: Opaque
 data:

--- a/bitnami/drupal/templates/ingress.yaml
+++ b/bitnami/drupal/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/drupal/templates/networkpolicy-backend-ingress.yaml
+++ b/bitnami/drupal/templates/networkpolicy-backend-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-backend" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/drupal/templates/networkpolicy-egress.yaml
+++ b/bitnami/drupal/templates/networkpolicy-egress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-egress" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/drupal/templates/networkpolicy-ingress.yaml
+++ b/bitnami/drupal/templates/networkpolicy-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-ingress" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/drupal/templates/pv.yaml
+++ b/bitnami/drupal/templates/pv.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ include "common.names.fullname" . }}-drupal
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/drupal/templates/pvc.yaml
+++ b/bitnami/drupal/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "common.names.fullname" . }}-drupal
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/drupal/templates/secrets.yaml
+++ b/bitnami/drupal/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/drupal/templates/svc.yaml
+++ b/bitnami/drupal/templates/svc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/drupal/templates/tls-secrets.yaml
+++ b/bitnami/drupal/templates/tls-secrets.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
+  namespace: {{ include "common.names.namespace" $ | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     {{- if $.Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/drupal/values.yaml
+++ b/bitnami/drupal/values.yaml
@@ -27,6 +27,9 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override drupal.fullname template
 ##
 fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
 ## @param commonAnnotations Common annotations to add to all Drupal resources (sub-charts are not considered). Evaluated as a template
 ##
 commonAnnotations: {}


### PR DESCRIPTION
**Description of the change**

This PR adds the `namespace` metadata to templates missing it.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
