### PR TITLE
[bitnami/ejbca] Add missing namespace metadata

### DIFF
--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -30,4 +30,4 @@ name: ejbca
 sources:
   - https://github.com/bitnami/bitnami-docker-ejbca
   - https://www.ejbca.org/
-version: 6.0.1
+version: 6.1.0

--- a/bitnami/ejbca/README.md
+++ b/bitnami/ejbca/README.md
@@ -61,6 +61,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
+
 ### Common parameters
 
 | Name                     | Description                                                                             | Value          |
@@ -68,6 +69,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                    | `""`           |
 | `nameOverride`           | String to partially override ebjca.fullname template (will maintain the release name)   | `""`           |
 | `fullnameOverride`       | String to fully override ebjca.fullname template                                        | `""`           |
+| `namespaceOverride`      | String to fully override common.names.namespace                                         | `""`           |
 | `commonLabels`           | Add labels to all the deployed resources                                                | `{}`           |
 | `commonAnnotations`      | Annotations to be added to all deployed resources                                       | `{}`           |
 | `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`           |
@@ -75,84 +77,86 @@ The command removes all the Kubernetes components associated with the chart and 
 | `diagnosticMode.command` | Command to override all containers in the deployment                                    | `["sleep"]`    |
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `["infinity"]` |
 
+
 ### EJBCA parameters
 
-| Name                                    | Description                                                                               | Value                   |
-| --------------------------------------- | ----------------------------------------------------------------------------------------- | ----------------------- |
-| `image.registry`                        | EJBCA image registry                                                                      | `docker.io`             |
-| `image.repository`                      | EJBCA image name                                                                          | `bitnami/ejbca`         |
-| `image.tag`                             | EJBCA image tag                                                                           | `7.4.3-2-debian-10-r92` |
-| `image.pullPolicy`                      | EJBCA image pull policy                                                                   | `IfNotPresent`          |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                          | `[]`                    |
-| `image.debug`                           | Enable image debug mode                                                                   | `false`                 |
-| `replicaCount`                          | Number of EJBCA replicas to deploy                                                        | `1`                     |
-| `extraVolumeMounts`                     | Additional volume mounts (used along with `extraVolumes`)                                 | `[]`                    |
-| `extraVolumes`                          | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`       | `[]`                    |
-| `podAnnotations`                        | Additional pod annotations                                                                | `{}`                    |
-| `podLabels`                             | Additional pod labels                                                                     | `{}`                    |
-| `podSecurityContext.enabled`            | Enable security context for EJBCA container                                               | `true`                  |
-| `podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                       | `1001`                  |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                    |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                  |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                    |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                     | `""`                    |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                    |
-| `affinity`                              | Affinity for pod assignment                                                               | `{}`                    |
-| `nodeSelector`                          | Node labels for pod assignment                                                            | `{}`                    |
-| `tolerations`                           | Tolerations for pod assignment                                                            | `[]`                    |
-| `updateStrategy.type`                   | EJBCA deployment strategy type.                                                           | `RollingUpdate`         |
-| `persistence.enabled`                   | Whether to enable persistence based on Persistent Volume Claims                           | `true`                  |
-| `persistence.accessModes`               | Persistent Volume access modes                                                            | `[]`                    |
-| `persistence.size`                      | Size of the PVC to request                                                                | `2Gi`                   |
-| `persistence.storageClass`              | PVC Storage Class                                                                         | `""`                    |
-| `persistence.existingClaim`             | Name of an existing PVC to reuse                                                          | `""`                    |
-| `persistence.annotations`               | Persistent Volume Claim annotations                                                       | `{}`                    |
-| `sidecars`                              | Attach additional sidecar containers to the pod                                           | `[]`                    |
-| `initContainers`                        | Additional init containers to add to the pods                                             | `[]`                    |
-| `hostAliases`                           | Add deployment host aliases                                                               | `[]`                    |
-| `priorityClassName`                     | EJBCA pods' priorityClassName                                                             | `""`                    |
-| `schedulerName`                         | Name of the k8s scheduler (other than default)                                            | `""`                    |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                            | `[]`                    |
-| `ejbcaAdminUsername`                    | EJBCA administrator username                                                              | `bitnami`               |
-| `ejbcaAdminPassword`                    | Password for the administrator account                                                    | `""`                    |
-| `existingSecret`                        | Alternatively, you can provide the name of an existing secret containing                  | `""`                    |
-| `ejbcaJavaOpts`                         | Options used to launch the WildFly server                                                 | `""`                    |
-| `ejbcaCA.name`                          | Name of the CA EJBCA will instantiate by default                                          | `ManagementCA`          |
-| `ejbcaCA.baseDN`                        | Base DomainName of the CA EJBCA will instantiate by default                               | `""`                    |
-| `ejbcaKeystoreExistingSecret`           | Name of an existing Secret containing a Keystore object                                   | `""`                    |
-| `extraEnvVars`                          | Array with extra environment variables to add to EJBCA nodes                              | `[]`                    |
-| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for EJBCA nodes                      | `""`                    |
-| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for EJBCA nodes                         | `""`                    |
-| `command`                               | Custom command to override image cmd                                                      | `[]`                    |
-| `args`                                  | Custom args for the custom command                                                        | `[]`                    |
-| `lifecycleHooks`                        | for the EJBCA container(s) to automate configuration before or after startup              | `{}`                    |
-| `resources.limits`                      | The resources limits for the container                                                    | `{}`                    |
-| `resources.requests`                    | The requested resources for the container                                                 | `{}`                    |
-| `containerSecurityContext.enabled`      | Enabled EJBCA containers' Security Context                                                | `true`                  |
-| `containerSecurityContext.runAsUser`    | Set EJBCA containers' Security Context runAsUser                                          | `1001`                  |
-| `containerSecurityContext.runAsNonRoot` | Set EJBCA container's Security Context runAsNonRoot                                       | `true`                  |
-| `startupProbe.enabled`                  | Enable/disable startupProbe                                                               | `false`                 |
-| `startupProbe.initialDelaySeconds`      | Delay before startup probe is initiated                                                   | `500`                   |
-| `startupProbe.periodSeconds`            | How often to perform the probe                                                            | `10`                    |
-| `startupProbe.timeoutSeconds`           | When the probe times out                                                                  | `5`                     |
-| `startupProbe.failureThreshold`         | Minimum consecutive failures for the probe                                                | `6`                     |
-| `startupProbe.successThreshold`         | Minimum consecutive successes for the probe                                               | `1`                     |
-| `livenessProbe.enabled`                 | Enable/disable livenessProbe                                                              | `true`                  |
-| `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                  | `500`                   |
-| `livenessProbe.periodSeconds`           | How often to perform the probe                                                            | `10`                    |
-| `livenessProbe.timeoutSeconds`          | When the probe times out                                                                  | `5`                     |
-| `livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe                                                | `6`                     |
-| `livenessProbe.successThreshold`        | Minimum consecutive successes for the probe                                               | `1`                     |
-| `readinessProbe.enabled`                | Enable/disable readinessProbe                                                             | `true`                  |
-| `readinessProbe.initialDelaySeconds`    | Delay before readiness probe is initiated                                                 | `500`                   |
-| `readinessProbe.periodSeconds`          | How often to perform the probe                                                            | `10`                    |
-| `readinessProbe.timeoutSeconds`         | When the probe times out                                                                  | `5`                     |
-| `readinessProbe.failureThreshold`       | Minimum consecutive failures for the probe                                                | `6`                     |
-| `readinessProbe.successThreshold`       | Minimum consecutive successes for the probe                                               | `1`                     |
-| `customStartupProbe`                    | Custom startup probe to execute (when the main one is disabled)                           | `{}`                    |
-| `customLivenessProbe`                   | Custom liveness probe to execute (when the main one is disabled)                          | `{}`                    |
-| `customReadinessProbe`                  | Custom readiness probe to execute (when the main one is disabled)                         | `{}`                    |
-| `containerPorts`                        | EJBCA Container ports to open                                                             | `{}`                    |
+| Name                                    | Description                                                                               | Value                    |
+| --------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------ |
+| `image.registry`                        | EJBCA image registry                                                                      | `docker.io`              |
+| `image.repository`                      | EJBCA image name                                                                          | `bitnami/ejbca`          |
+| `image.tag`                             | EJBCA image tag                                                                           | `7.4.3-2-debian-10-r146` |
+| `image.pullPolicy`                      | EJBCA image pull policy                                                                   | `IfNotPresent`           |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                          | `[]`                     |
+| `image.debug`                           | Enable image debug mode                                                                   | `false`                  |
+| `replicaCount`                          | Number of EJBCA replicas to deploy                                                        | `1`                      |
+| `extraVolumeMounts`                     | Additional volume mounts (used along with `extraVolumes`)                                 | `[]`                     |
+| `extraVolumes`                          | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`       | `[]`                     |
+| `podAnnotations`                        | Additional pod annotations                                                                | `{}`                     |
+| `podLabels`                             | Additional pod labels                                                                     | `{}`                     |
+| `podSecurityContext.enabled`            | Enable security context for EJBCA container                                               | `true`                   |
+| `podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                       | `1001`                   |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                     |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                   |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                     |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                     | `""`                     |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                     |
+| `affinity`                              | Affinity for pod assignment                                                               | `{}`                     |
+| `nodeSelector`                          | Node labels for pod assignment                                                            | `{}`                     |
+| `tolerations`                           | Tolerations for pod assignment                                                            | `[]`                     |
+| `updateStrategy.type`                   | EJBCA deployment strategy type.                                                           | `RollingUpdate`          |
+| `persistence.enabled`                   | Whether to enable persistence based on Persistent Volume Claims                           | `true`                   |
+| `persistence.accessModes`               | Persistent Volume access modes                                                            | `[]`                     |
+| `persistence.size`                      | Size of the PVC to request                                                                | `2Gi`                    |
+| `persistence.storageClass`              | PVC Storage Class                                                                         | `""`                     |
+| `persistence.existingClaim`             | Name of an existing PVC to reuse                                                          | `""`                     |
+| `persistence.annotations`               | Persistent Volume Claim annotations                                                       | `{}`                     |
+| `sidecars`                              | Attach additional sidecar containers to the pod                                           | `[]`                     |
+| `initContainers`                        | Additional init containers to add to the pods                                             | `[]`                     |
+| `hostAliases`                           | Add deployment host aliases                                                               | `[]`                     |
+| `priorityClassName`                     | EJBCA pods' priorityClassName                                                             | `""`                     |
+| `schedulerName`                         | Name of the k8s scheduler (other than default)                                            | `""`                     |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                            | `[]`                     |
+| `ejbcaAdminUsername`                    | EJBCA administrator username                                                              | `bitnami`                |
+| `ejbcaAdminPassword`                    | Password for the administrator account                                                    | `""`                     |
+| `existingSecret`                        | Alternatively, you can provide the name of an existing secret containing                  | `""`                     |
+| `ejbcaJavaOpts`                         | Options used to launch the WildFly server                                                 | `""`                     |
+| `ejbcaCA.name`                          | Name of the CA EJBCA will instantiate by default                                          | `ManagementCA`           |
+| `ejbcaCA.baseDN`                        | Base DomainName of the CA EJBCA will instantiate by default                               | `""`                     |
+| `ejbcaKeystoreExistingSecret`           | Name of an existing Secret containing a Keystore object                                   | `""`                     |
+| `extraEnvVars`                          | Array with extra environment variables to add to EJBCA nodes                              | `[]`                     |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for EJBCA nodes                      | `""`                     |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for EJBCA nodes                         | `""`                     |
+| `command`                               | Custom command to override image cmd                                                      | `[]`                     |
+| `args`                                  | Custom args for the custom command                                                        | `[]`                     |
+| `lifecycleHooks`                        | for the EJBCA container(s) to automate configuration before or after startup              | `{}`                     |
+| `resources.limits`                      | The resources limits for the container                                                    | `{}`                     |
+| `resources.requests`                    | The requested resources for the container                                                 | `{}`                     |
+| `containerSecurityContext.enabled`      | Enabled EJBCA containers' Security Context                                                | `true`                   |
+| `containerSecurityContext.runAsUser`    | Set EJBCA containers' Security Context runAsUser                                          | `1001`                   |
+| `containerSecurityContext.runAsNonRoot` | Set EJBCA container's Security Context runAsNonRoot                                       | `true`                   |
+| `startupProbe.enabled`                  | Enable/disable startupProbe                                                               | `false`                  |
+| `startupProbe.initialDelaySeconds`      | Delay before startup probe is initiated                                                   | `500`                    |
+| `startupProbe.periodSeconds`            | How often to perform the probe                                                            | `10`                     |
+| `startupProbe.timeoutSeconds`           | When the probe times out                                                                  | `5`                      |
+| `startupProbe.failureThreshold`         | Minimum consecutive failures for the probe                                                | `6`                      |
+| `startupProbe.successThreshold`         | Minimum consecutive successes for the probe                                               | `1`                      |
+| `livenessProbe.enabled`                 | Enable/disable livenessProbe                                                              | `true`                   |
+| `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                  | `500`                    |
+| `livenessProbe.periodSeconds`           | How often to perform the probe                                                            | `10`                     |
+| `livenessProbe.timeoutSeconds`          | When the probe times out                                                                  | `5`                      |
+| `livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe                                                | `6`                      |
+| `livenessProbe.successThreshold`        | Minimum consecutive successes for the probe                                               | `1`                      |
+| `readinessProbe.enabled`                | Enable/disable readinessProbe                                                             | `true`                   |
+| `readinessProbe.initialDelaySeconds`    | Delay before readiness probe is initiated                                                 | `500`                    |
+| `readinessProbe.periodSeconds`          | How often to perform the probe                                                            | `10`                     |
+| `readinessProbe.timeoutSeconds`         | When the probe times out                                                                  | `5`                      |
+| `readinessProbe.failureThreshold`       | Minimum consecutive failures for the probe                                                | `6`                      |
+| `readinessProbe.successThreshold`       | Minimum consecutive successes for the probe                                               | `1`                      |
+| `customStartupProbe`                    | Custom startup probe to execute (when the main one is disabled)                           | `{}`                     |
+| `customLivenessProbe`                   | Custom liveness probe to execute (when the main one is disabled)                          | `{}`                     |
+| `customReadinessProbe`                  | Custom readiness probe to execute (when the main one is disabled)                         | `{}`                     |
+| `containerPorts`                        | EJBCA Container ports to open                                                             | `{}`                     |
+
 
 ### Service parameters
 
@@ -173,6 +177,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.sessionAffinity`          | Session Affinity for Kubernetes service, can be "None" or "ClientIP"          | `None`         |
 | `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                   | `{}`           |
 
+
 ### Ingress parameters
 
 | Name                       | Description                                                                                                                      | Value                    |
@@ -189,6 +194,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.extraTls`         | The tls configuration for additional hostnames to be covered with this ingress record.                                           | `[]`                     |
 | `ingress.secrets`          | If you're providing your own certificates, please use this to add the certificates as secrets                                    | `[]`                     |
 | `ingress.ingressClassName` | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
+
 
 ### Database parameters
 
@@ -213,6 +219,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalDatabase.database`                 | Name of the existing database                                                              | `bitnami_ejbca` |
 | `externalDatabase.port`                     | Database port number                                                                       | `3306`          |
 
+
 ### NetworkPolicy parameters
 
 | Name                                                          | Description                                                                                                               | Value   |
@@ -229,6 +236,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.ingressRules.customRules`                      | Custom network policy ingress rule                                                                                        | `{}`    |
 | `networkPolicy.egressRules.denyConnectionsToExternal`         | Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).                            | `false` |
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                | `{}`    |
+
 
 The above parameters map to the env variables defined in [bitnami/ejbca](https://github.com/bitnami/bitnami-docker-ejbca). For more information please refer to the [bitnami/ejbca](https://github.com/bitnami/bitnami-docker-ejbca) image documentation.
 

--- a/bitnami/ejbca/templates/NOTES.txt
+++ b/bitnami/ejbca/templates/NOTES.txt
@@ -15,11 +15,11 @@ The chart has been deployed in diagnostic mode. All probes have been disabled an
 
 Get the list of pods by executing:
 
-  kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl get pods --namespace {{ include "common.names.namespace" . }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
 Access the pod you want to debug by executing
 
-  kubectl exec --namespace {{ .Release.Namespace }} -ti <NAME OF THE POD> -- bash
+  kubectl exec --namespace {{ include "common.names.namespace" . }} -ti <NAME OF THE POD> -- bash
 
 In order to replicate the container startup scripts execute this command:
 
@@ -35,8 +35,8 @@ To access your EJBCA site from outside the cluster follow the steps below:
 
 {{- if contains "NodePort" .Values.service.type }}
 
-   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "common.names.fullname" . }})
-   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+   export NODE_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[1].nodePort}" services {{ template "common.names.fullname" . }})
+   export NODE_IP=$(kubectl get nodes --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
    echo "EJBCA Public URL: https://$NODE_IP:$NODE_PORT/ejbca"
    echo "EJBCA Admin URL: https://$NODE_IP:$NODE_PORT/ejbca/adminweb"
    echo "EJBCA Enrol URL: https://$NODE_IP:$NODE_PORT/ejbca/enrol/keystore.jsp"
@@ -44,16 +44,16 @@ To access your EJBCA site from outside the cluster follow the steps below:
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ include "common.names.namespace" . }} -w {{ template "common.names.fullname" . }}'
 
-   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+   export SERVICE_IP=$(kubectl get svc --namespace {{ include "common.names.namespace" . }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
    echo "EJBCA Public URL: https://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.httpsPort }}{{ end }}/ejbca"
    echo "EJBCA Admin URL: https://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.httpsPort }}{{ end }}/ejbca/adminweb"
    echo "EJBCA Enrol URL: https://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.httpsPort }}{{ end }}/ejbca/enrol/keystore.jsp"
 
 {{- else if contains "ClusterIP"  .Values.service.type }}
 
-   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} {{ .Values.service.httpsPort }}:{{ .Values.service.httpsPort }} &
+   kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ template "common.names.fullname" . }} {{ .Values.service.httpsPort }}:{{ .Values.service.httpsPort }} &
    echo "EJBCA Public URL: https://127.0.0.1{{- if ne $port "80" }}:{{ .Values.service.httpsPort }}{{ end }}/ejbca"
    echo "EJBCA Admin URL: https://127.0.0.1{{- if ne $port "80" }}:{{ .Values.service.httpsPort }}{{ end }}/ejbca/adminweb"
    echo "EJBCA Enrol URL: https://127.0.0.1{{- if ne $port "80" }}:{{ .Values.service.httpsPort }}{{ end }}/ejbca/enrol/keystore.jsp"

--- a/bitnami/ejbca/templates/deployment.yaml
+++ b/bitnami/ejbca/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/ejbca/templates/externaldb-secrets.yaml
+++ b/bitnami/ejbca/templates/externaldb-secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-%s" .Release.Name "externaldb"  }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/ejbca/templates/ingress.yaml
+++ b/bitnami/ejbca/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/ejbca/templates/networkpolicy-backend-ingress.yaml
+++ b/bitnami/ejbca/templates/networkpolicy-backend-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-backend" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/ejbca/templates/networkpolicy-egress.yaml
+++ b/bitnami/ejbca/templates/networkpolicy-egress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-egress" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/ejbca/templates/networkpolicy-ingress.yaml
+++ b/bitnami/ejbca/templates/networkpolicy-ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
 kind: NetworkPolicy
 metadata:
   name: {{ printf "%s-ingress" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/ejbca/templates/pvc.yaml
+++ b/bitnami/ejbca/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/ejbca/templates/secrets.yaml
+++ b/bitnami/ejbca/templates/secrets.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/ejbca/templates/svc.yaml
+++ b/bitnami/ejbca/templates/svc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/ejbca/values.yaml
+++ b/bitnami/ejbca/values.yaml
@@ -27,6 +27,9 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override ebjca.fullname template
 ##
 fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
 ## @param commonLabels Add labels to all the deployed resources
 ##
 commonLabels: {}


### PR DESCRIPTION
**Description of the change**

This PR adds the `namespace` metadata to templates missing it.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
