### PR TITLE
[bitnami/fluentd] Add missing namespace metadata

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/bitnami-docker-fluentd
   - https://www.fluentd.org/
-version: 5.0.18
+version: 5.0.19

--- a/bitnami/fluentd/templates/aggregator-configmap.yaml
+++ b/bitnami/fluentd/templates/aggregator-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}-aggregator-cm
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
     {{- if .Values.commonLabels }}

--- a/bitnami/fluentd/templates/aggregator-hpa.yaml
+++ b/bitnami/fluentd/templates/aggregator-hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" . }}-aggregator-hpa
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
     {{- if .Values.commonLabels }}

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/

--- a/bitnami/fluentd/templates/aggregator-svc-headless.yaml
+++ b/bitnami/fluentd/templates/aggregator-svc-headless.yaml
@@ -3,13 +3,14 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}-headless
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
     app: aggregator
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  annotations: 
+  annotations:
     {{- if or .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/fluentd/templates/aggregator-svc.yaml
+++ b/bitnami/fluentd/templates/aggregator-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}-aggregator
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
     app: aggregator

--- a/bitnami/fluentd/templates/forwarder-clusterrole.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrole.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/fluentd/templates/forwarder-clusterrolebinding.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrolebinding.yaml
@@ -3,6 +3,7 @@ kind: ClusterRoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -17,5 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "fluentd.forwarder.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/fluentd/templates/forwarder-configmap.yaml
+++ b/bitnami/fluentd/templates/forwarder-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}-forwarder-cm
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: forwarder
     {{- if .Values.commonLabels }}

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: forwarder
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/

--- a/bitnami/fluentd/templates/forwarder-psp.yaml
+++ b/bitnami/fluentd/templates/forwarder-psp.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "common.names.fullname" . }}-forwarder
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: forwarder
     {{- if .Values.commonLabels }}

--- a/bitnami/fluentd/templates/forwarder-svc.yaml
+++ b/bitnami/fluentd/templates/forwarder-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}-forwarder
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: forwarder
     app: forwarder

--- a/bitnami/fluentd/templates/ingress.yaml
+++ b/bitnami/fluentd/templates/ingress.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "common.names.fullname" . }}-aggregator
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
     app: aggregator

--- a/bitnami/fluentd/templates/metrics-svc.yaml
+++ b/bitnami/fluentd/templates/metrics-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "common.names.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app: metrics
     {{- if .Values.commonLabels }}

--- a/bitnami/fluentd/templates/serviceaccount.yaml
+++ b/bitnami/fluentd/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "fluentd.forwarder.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: forwarder
     {{- if .Values.commonLabels }}
@@ -24,6 +25,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "fluentd.aggregator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: aggregator
     {{- if .Values.commonLabels }}

--- a/bitnami/fluentd/templates/servicemonitor.yaml
+++ b/bitnami/fluentd/templates/servicemonitor.yaml
@@ -3,11 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "common.names.fullname" . }}
-  {{- if .Values.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.metrics.serviceMonitor.namespace | quote }}
-  {{- else }}
-  namespace: {{ .Release.Namespace | quote }}
-  {{- end }}
+  namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}

--- a/bitnami/fluentd/templates/tls-certs.yaml
+++ b/bitnami/fluentd/templates/tls-certs.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .name }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ $.Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     {{- if $.Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
@@ -33,6 +33,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}-agg-crt
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
@@ -55,6 +56,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}-fwd-crt
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}


### PR DESCRIPTION
**Description of the change**

This PR adds the `namespace` metadata to templates missing it.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
