### PR TITLE
[bitnami/kube-prometheus] Add missing namespace metadata

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 6.10.3
+version: 6.10.4

--- a/bitnami/kube-prometheus/templates/alertmanager/alertmanager.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/alertmanager.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.alertmanager.replicaCount }}

--- a/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.alertmanager.ingress.certManager }}

--- a/bitnami/kube-prometheus/templates/alertmanager/pdb.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrole.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}-psp
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
 rules:
   - apiGroups: ['extensions']

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}-psp
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12,5 +13,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.alertmanager.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/alertmanager/psp.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
 spec:
   privileged: false

--- a/bitnami/kube-prometheus/templates/alertmanager/secrets.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/secrets.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: alertmanager-{{ template "kube-prometheus.alertmanager.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
 data:
   alertmanager.yaml: {{ toYaml .Values.alertmanager.config | b64enc | quote }}

--- a/bitnami/kube-prometheus/templates/alertmanager/service.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
   {{- with .Values.alertmanager.service.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/alertmanager/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kube-prometheus.alertmanager.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
   {{- if index .Values.alertmanager.serviceAccount "annotations" }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.alertmanager.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/alertmanager/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.alertmanager.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/kube-prometheus/templates/alertmanager/tls-secrets.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/tls-secrets.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.alertmanager.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:

--- a/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/core-dns/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-coredns
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-coredns
 spec:

--- a/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-apiserver/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-apiserver
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: apiserver
 spec:

--- a/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-controller-manager
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-kube-controller-manager
 spec:

--- a/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-proxy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: kube-proxy
 spec:

--- a/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kube-scheduler
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ template "kube-prometheus.fullname" . }}-kube-scheduler
 spec:

--- a/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/exporters/kubelet/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.fullname" . }}-kubelet
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/component: kubelet
 spec:

--- a/bitnami/kube-prometheus/templates/prometheus-operator/clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/clusterrole.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:

--- a/bitnami/kube-prometheus/templates/prometheus-operator/clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/clusterrolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.operator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/configmap.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
 data:
   prometheus-config-reloader: {{ template "kube-prometheus.prometheusConfigReloader.image" . }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
 spec:
   replicas: 1

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrole.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}-psp
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
 rules:
   - apiGroups: ['extensions']

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp-clusterrolebinding.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}-psp
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12,5 +13,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.operator.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/psp.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/psp.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
 spec:
   privileged: false

--- a/bitnami/kube-prometheus/templates/prometheus-operator/service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
   {{- with .Values.operator.service.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kube-prometheus.operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
 {{- include "kube-prometheus.imagePullSecrets" . }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.operator.labels" . | nindent 4 }}
 spec:
   endpoints:

--- a/bitnami/kube-prometheus/templates/prometheus/additionalScrapeJobs.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/additionalScrapeJobs.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: additional-scrape-jobs-{{ template "kube-prometheus.prometheus.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
 data:
   scrape-jobs.yaml: {{ include "common.tplvalues.render" ( dict "value" .Values.prometheus.additionalScrapeConfigs.internal.jobList "context" $ ) | b64enc | quote }}

--- a/bitnami/kube-prometheus/templates/prometheus/clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/clusterrole.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
 rules:
   - apiGroups:

--- a/bitnami/kube-prometheus/templates/prometheus/clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/clusterrolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.prometheus.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.prometheus.ingress.certManager }}

--- a/bitnami/kube-prometheus/templates/prometheus/pdb.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.prometheus.replicaCount }}
@@ -28,7 +28,7 @@ spec:
     {{- if .Values.prometheus.alertingEndpoints }}
     {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.alertingEndpoints "context" $) | nindent 6 }}
     {{- else if .Values.alertmanager.enabled }}
-      - namespace: {{ .Release.Namespace }}
+      - namespace: {{ .Release.Namespace | quote }}
         name: {{ template "kube-prometheus.alertmanager.fullname" . }}
         port: http
         pathPrefix: "{{ .Values.alertmanager.routePrefix }}"

--- a/bitnami/kube-prometheus/templates/prometheus/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp-clusterrole.yaml
@@ -4,6 +4,7 @@ kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}-psp
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
 rules:
   - apiGroups: ['extensions']

--- a/bitnami/kube-prometheus/templates/prometheus/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp-clusterrolebinding.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}-psp
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -12,5 +13,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-prometheus.prometheus.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus/psp.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/psp.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
 spec:
   privileged: false

--- a/bitnami/kube-prometheus/templates/prometheus/service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
   {{- if .Values.prometheus.service.annotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.service.annotations "context" $) | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/prometheus/serviceaccount.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "kube-prometheus.prometheus.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
   {{- if index .Values.prometheus.serviceAccount "annotations" }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.serviceAccount.annotations "context" $) | nindent 4 }}

--- a/bitnami/kube-prometheus/templates/prometheus/servicemonitor.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
 spec:
   selector:

--- a/bitnami/kube-prometheus/templates/prometheus/thanos-ingress.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ template "kube-prometheus.thanos.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/subcomponent: thanos
   annotations:

--- a/bitnami/kube-prometheus/templates/prometheus/thanos-service.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/thanos-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "kube-prometheus.prometheus.fullname" . }}-thanos
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
     app.kubernetes.io/subcomponent: thanos
   {{- if .Values.prometheus.thanos.service.annotations }}

--- a/bitnami/kube-prometheus/templates/prometheus/tls-secrets.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/tls-secrets.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.prometheus.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "kube-prometheus.prometheus.labels" . | nindent 4 }}
 type: kubernetes.io/tls
 data:


### PR DESCRIPTION
**Description of the change**

This PR adds the `namespace` metadata to templates missing it.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
