### PR TITLE
[bitnami/mariadb-galera] Add missing namespace metadata

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 7.1.8
+version: 7.2.0

--- a/bitnami/mariadb-galera/templates/NOTES.txt
+++ b/bitnami/mariadb-galera/templates/NOTES.txt
@@ -12,11 +12,11 @@ The chart has been deployed in diagnostic mode. All probes have been disabled an
 
 Get the list of pods by executing:
 
-  kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl get pods --namespace {{ include "common.names.namespace" . }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
 Access the pod you want to debug by executing
 
-  kubectl exec --namespace {{ .Release.Namespace }} -ti <NAME OF THE POD> -- bash
+  kubectl exec --namespace {{ include "common.names.namespace" . }} -ti <NAME OF THE POD> -- bash
 
 In order to replicate the container startup scripts execute this command:
 
@@ -27,41 +27,41 @@ Tip:
 
   Watch the deployment status using the command:
 
-    kubectl get sts -w --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+    kubectl get sts -w --namespace {{ include "common.names.namespace" . }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
 MariaDB can be accessed via port "{{ .Values.service.port }}" on the following DNS name from within your cluster:
 
-    {{ template "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+    {{ template "common.names.fullname" . }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}
 
 To obtain the password for the MariaDB admin user run the following command:
 
-    echo "$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)"
+    echo "$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode)"
 
 To connect to your database run the following command:
 
-    kubectl run {{ template "common.names.fullname" . }}-client --rm --tty -i --restart='Never' --namespace {{ .Release.Namespace }} --image {{ template "mariadb-galera.image" . }} --command \
-      -- mysql -h {{ template "common.names.fullname" . }} -P {{ .Values.service.port }} -u{{ if .Values.db.user }}{{ .Values.db.user }}{{ else }}{{ .Values.rootUser.user }}{{ end }} -p{{ if .Values.db.user }}$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 --decode){{ else }}$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode){{ end }} {{ .Values.db.name }}
+    kubectl run {{ template "common.names.fullname" . }}-client --rm --tty -i --restart='Never' --namespace {{ include "common.names.namespace" . }} --image {{ template "mariadb-galera.image" . }} --command \
+      -- mysql -h {{ template "common.names.fullname" . }} -P {{ .Values.service.port }} -u{{ if .Values.db.user }}{{ .Values.db.user }}{{ else }}{{ .Values.rootUser.user }}{{ end }} -p{{ if .Values.db.user }}$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 --decode){{ else }}$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode){{ end }} {{ .Values.db.name }}
 
 To connect to your database from outside the cluster execute the following commands:
 
 {{- if contains "NodePort" .Values.service.type }}
 
-    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
-    mysql -h $NODE_IP -P $NODE_PORT -u{{ if .Values.db.user }}{{ .Values.db.user }}{{ else }}{{ .Values.rootUser.user }}{{ end }} -p{{ if .Values.db.user }}$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 --decode){{ else }}$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode){{ end }} {{ .Values.db.name }}
+    export NODE_IP=$(kubectl get nodes --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    export NODE_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
+    mysql -h $NODE_IP -P $NODE_PORT -u{{ if .Values.db.user }}{{ .Values.db.user }}{{ else }}{{ .Values.rootUser.user }}{{ end }} -p{{ if .Values.db.user }}$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 --decode){{ else }}$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode){{ end }} {{ .Values.db.name }}
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ template "common.names.fullname" . }}'
+        Watch the status with: 'kubectl get svc --namespace {{ include "common.names.namespace" . }} -w {{ template "common.names.fullname" . }}'
 
-    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
-    mysql -h $SERVICE_IP -P {{ .Values.service.port }} -u{{ if .Values.db.user }}{{ .Values.db.user }}{{ else }}{{ .Values.rootUser.user }}{{ end }} -p{{ if .Values.db.user }}$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 --decode){{ else }}$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode){{ end }} {{ .Values.db.name }}
+    export SERVICE_IP=$(kubectl get svc --namespace {{ include "common.names.namespace" . }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+    mysql -h $SERVICE_IP -P {{ .Values.service.port }} -u{{ if .Values.db.user }}{{ .Values.db.user }}{{ else }}{{ .Values.rootUser.user }}{{ end }} -p{{ if .Values.db.user }}$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 --decode){{ else }}$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode){{ end }} {{ .Values.db.name }}
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} &
-    mysql -h 127.0.0.1 -P {{ .Values.service.port }} -u{{ if .Values.db.user }}{{ .Values.db.user }}{{ else }}{{ .Values.rootUser.user }}{{ end }} -p{{ if .Values.db.user }}$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 --decode){{ else }}$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode){{ end }} {{ .Values.db.name }}
+    kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ template "common.names.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} &
+    mysql -h 127.0.0.1 -P {{ .Values.service.port }} -u{{ if .Values.db.user }}{{ .Values.db.user }}{{ else }}{{ .Values.rootUser.user }}{{ end }} -p{{ if .Values.db.user }}$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 --decode){{ else }}$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode){{ end }} {{ .Values.db.name }}
 
 {{- end }}
 
@@ -69,17 +69,17 @@ To connect to your database from outside the cluster execute the following comma
 
 To access the MariaDB Prometheus metrics from outside the cluster execute the following commands:
 
-    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "common.names.fullname" . }}-metrics {{ .Values.metrics.service.port }}:{{ .Values.metrics.service.port }} &
+    kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ template "common.names.fullname" . }}-metrics {{ .Values.metrics.service.port }}:{{ .Values.metrics.service.port }} &
     curl 127.0.0.1:{{ .Values.metrics.service.port }}/metrics
 
 {{- end }}
 
 To upgrade this helm chart:
 
-    helm upgrade --namespace {{ .Release.Namespace }} {{ .Release.Name }} bitnami/mariadb-galera \
-      --set rootUser.password=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode) \
-      {{ if .Values.db.user }}--set db.user={{ .Values.db.user }} --set db.password=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 --decode) {{ end }}--set db.name={{ .Values.db.name }} \
-      --set galera.mariabackup.password=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-galera-mariabackup-password}" | base64 --decode)
+    helm upgrade --namespace {{ include "common.names.namespace" . }} {{ .Release.Name }} bitnami/mariadb-galera \
+      --set rootUser.password=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 --decode) \
+      {{ if .Values.db.user }}--set db.user={{ .Values.db.user }} --set db.password=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 --decode) {{ end }}--set db.name={{ .Values.db.name }} \
+      --set galera.mariabackup.password=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-galera-mariabackup-password}" | base64 --decode)
 
 {{- end }}
 

--- a/bitnami/mariadb-galera/templates/configmap.yaml
+++ b/bitnami/mariadb-galera/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-configuration" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/headless-svc.yaml
+++ b/bitnami/mariadb-galera/templates/headless-svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-headless" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/initialization-configmap.yaml
+++ b/bitnami/mariadb-galera/templates/initialization-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ printf "%s-init-scripts" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/metrics-svc.yaml
+++ b/bitnami/mariadb-galera/templates/metrics-svc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-metrics" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/pdb.yaml
+++ b/bitnami/mariadb-galera/templates/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/prometheusrules.yaml
+++ b/bitnami/mariadb-galera/templates/prometheusrules.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/role.yaml
+++ b/bitnami/mariadb-galera/templates/role.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/rolebinding.yaml
+++ b/bitnami/mariadb-galera/templates/rolebinding.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/secrets.yaml
+++ b/bitnami/mariadb-galera/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
   {{- if .Values.commonLabels }}
   {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/serviceaccount.yaml
+++ b/bitnami/mariadb-galera/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "mariadb-galera.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/servicemonitor.yaml
+++ b/bitnami/mariadb-galera/templates/servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   {{- if .Values.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -42,5 +44,5 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
@@ -117,7 +118,7 @@ spec:
             - name: MARIADB_GALERA_CLUSTER_NAME
               value: {{ .Values.galera.name | quote }}
             {{- $fullName := include "common.names.fullname" . }}
-            {{- $releaseName := .Release.Namespace }}
+            {{- $releaseName := include "common.names.namespace" . }}
             {{- $clusterDomain := .Values.clusterDomain }}
             {{- $initialCluster := list }}
             {{- range $e, $i := until (int .Values.replicaCount) }}

--- a/bitnami/mariadb-galera/templates/svc.yaml
+++ b/bitnami/mariadb-galera/templates/svc.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/tls-secrets.yaml
+++ b/bitnami/mariadb-galera/templates/tls-secrets.yaml
@@ -1,6 +1,6 @@
 {{- if (include "mariadb-galera.createTlsSecret" . ) }}
 {{- $ca := genCA "mariadb-galera-internal-ca" 365 }}
-{{- $releaseNamespace := .Release.Namespace }}
+{{- $releaseNamespace := include "common.names.namespace" . }}
 {{- $clusterDomain := .Values.clusterDomain }}
 {{- $fullname := include "common.names.fullname" . }}
 {{- $serviceName := include "common.names.fullname" . }}
@@ -11,6 +11,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "common.names.fullname" . }}-crt
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -27,6 +27,9 @@ nameOverride: ""
 ## @param fullnameOverride String to fully override common.names.fullname template with a string
 ##
 fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
 ## @param commonAnnotations Annotations to add to all deployed objects
 ##
 commonAnnotations: {}


### PR DESCRIPTION
**Description of the change**

This PR adds the `namespace` metadata to templates missing it.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
