### PR TITLE
[bitnami/spark] Add missing namespace metadata

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -22,4 +22,4 @@ name: spark
 sources:
   - https://github.com/bitnami/bitnami-docker-spark
   - https://spark.apache.org/
-version: 6.0.0
+version: 6.0.1

--- a/bitnami/spark/templates/NOTES.txt
+++ b/bitnami/spark/templates/NOTES.txt
@@ -12,11 +12,11 @@ The chart has been deployed in diagnostic mode. All probes have been disabled an
 
 Get the list of pods by executing:
 
-  kubectl get pods --namespace {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+  kubectl get pods --namespace {{ include "common.names.namespace" . }} -l app.kubernetes.io/instance={{ .Release.Name }}
 
 Access the pod you want to debug by executing
 
-  kubectl exec --namespace {{ .Release.Namespace }} -ti <NAME OF THE POD> -- bash
+  kubectl exec --namespace {{ include "common.names.namespace" . }} -ti <NAME OF THE POD> -- bash
 
 In order to replicate the container startup scripts execute this command:
 
@@ -27,27 +27,27 @@ In order to replicate the container startup scripts execute this command:
 1. Get the Spark master WebUI URL by running these commands:
 {{- if .Values.ingress.enabled }}
 
-  export HOSTNAME=$(kubectl get ingress --namespace {{ .Release.Namespace }} {{ printf "%s-ingress" (include "common.names.fullname" .) }} -o jsonpath='{.spec.rules[0].host}')
+  export HOSTNAME=$(kubectl get ingress --namespace {{ include "common.names.namespace" . }} {{ printf "%s-ingress" (include "common.names.fullname" .) }} -o jsonpath='{.spec.rules[0].host}')
   echo "Spark-master URL: http://$HOSTNAME/"
 
 {{- else -}}
 {{- if contains "NodePort" .Values.service.type }}
 
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[?(@.name=='http')].nodePort}" services {{ printf "%s-master-svc" (include "common.names.fullname" .) }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[?(@.name=='http')].nodePort}" services {{ printf "%s-master-svc" (include "common.names.fullname" .) }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 
 {{- else if contains "LoadBalancer" .Values.service.type }}
 
     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-    You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ printf "%s-master-svc" (include "common.names.fullname" .) }}'
+    You can watch the status of by running 'kubectl get --namespace {{ include "common.names.namespace" . }} svc -w {{ printf "%s-master-svc" (include "common.names.fullname" .) }}'
 
-  export SERVICE_IP=$(kubectl get --namespace {{ .Release.Namespace }} svc {{ printf "%s-master-svc" (include "common.names.fullname" .) }} -o jsonpath="{.status.loadBalancer.ingress[0]['ip', 'hostname'] }")
+  export SERVICE_IP=$(kubectl get --namespace {{ include "common.names.namespace" . }} svc {{ printf "%s-master-svc" (include "common.names.fullname" .) }} -o jsonpath="{.status.loadBalancer.ingress[0]['ip', 'hostname'] }")
   echo http://$SERVICE_IP:{{ .Values.service.ports.http }}
 
 {{- else if contains "ClusterIP" .Values.service.type }}
 
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ printf "%s-master-svc" (include "common.names.fullname" .) }} {{ default "80" .Values.service.ports.http }}:{{ default "80" .Values.service.ports.http }}
+  kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ printf "%s-master-svc" (include "common.names.fullname" .) }} {{ default "80" .Values.service.ports.http }}:{{ default "80" .Values.service.ports.http }}
   echo "Visit http://127.0.0.1:{{ .Values.service.ports.http }} to use your application"
 
 {{- end }}
@@ -63,12 +63,12 @@ In order to replicate the container startup scripts execute this command:
   Run the commands below to obtain the master IP and submit your application.
 {{- end }}
 
-  export EXAMPLE_JAR=$(kubectl exec -ti --namespace {{ .Release.Namespace }} {{ printf "%s-worker-0" (include "common.names.fullname" .) }} -- find examples/jars/ -name 'spark-example*\.jar' | tr -d '\r')
+  export EXAMPLE_JAR=$(kubectl exec -ti --namespace {{ include "common.names.namespace" . }} {{ printf "%s-worker-0" (include "common.names.fullname" .) }} -- find examples/jars/ -name 'spark-example*\.jar' | tr -d '\r')
 {{- if eq "NodePort" .Values.service.type }}
-  export SUBMIT_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[?(@.name=='cluster')].nodePort}" services {{ printf "%s-master-svc" (include "common.names.fullname" .) }})
-  export SUBMIT_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export SUBMIT_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[?(@.name=='cluster')].nodePort}" services {{ printf "%s-master-svc" (include "common.names.fullname" .) }})
+  export SUBMIT_IP=$(kubectl get nodes --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
 
-  kubectl run --namespace {{ .Release.Namespace }} {{ printf "%s-client" (include "common.names.fullname" .) }} --rm --tty -i --restart='Never' \
+  kubectl run --namespace {{ include "common.names.namespace" . }} {{ printf "%s-client" (include "common.names.fullname" .) }} --rm --tty -i --restart='Never' \
     --image {{ template "spark.image" . }} \
     -- spark-submit --master spark://$SUBMIT_IP:$SUBMIT_PORT \
     --class org.apache.spark.examples.SparkPi \
@@ -76,9 +76,9 @@ In order to replicate the container startup scripts execute this command:
     $EXAMPLE_JAR 1000
 
 {{- else if eq "LoadBalancer" .Values.service.type }}
-  export SUBMIT_IP=$(kubectl get --namespace {{ .Release.Namespace }} svc {{ printf "%s-master-svc" (include "common.names.fullname" .) }} -o jsonpath="{.status.loadBalancer.ingress[0]['ip', 'hostname'] }")
+  export SUBMIT_IP=$(kubectl get --namespace {{ include "common.names.namespace" . }} svc {{ printf "%s-master-svc" (include "common.names.fullname" .) }} -o jsonpath="{.status.loadBalancer.ingress[0]['ip', 'hostname'] }")
 
-  kubectl run --namespace {{ .Release.Namespace }} {{ printf "%s-client" (include "common.names.fullname" .) }} --rm --tty -i --restart='Never' \
+  kubectl run --namespace {{ include "common.names.namespace" . }} {{ printf "%s-client" (include "common.names.fullname" .) }} --rm --tty -i --restart='Never' \
     --image {{ template "spark.image" . }} \
     -- spark-submit --master spark://$SUBMIT_IP:{{ .Values.service.ports.cluster }} \
     --deploy-mode cluster \
@@ -87,7 +87,7 @@ In order to replicate the container startup scripts execute this command:
 
 {{- else }}
 
-  kubectl exec -ti --namespace {{ .Release.Namespace }} {{ printf "%s-worker-0" (include "common.names.fullname" .) }} -- spark-submit --master spark://{{ printf "%s-master-svc" (include "common.names.fullname" .) }}:{{ .Values.service.ports.cluster }} \
+  kubectl exec -ti --namespace {{ include "common.names.namespace" . }} {{ printf "%s-worker-0" (include "common.names.fullname" .) }} -- spark-submit --master spark://{{ printf "%s-master-svc" (include "common.names.fullname" .) }}:{{ .Values.service.ports.cluster }} \
     --class org.apache.spark.examples.SparkPi \
     $EXAMPLE_JAR 5
 

--- a/bitnami/spark/templates/hpa-worker.yaml
+++ b/bitnami/spark/templates/hpa-worker.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ printf "%s-autoscaler" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: worker-autoscaler
     {{- if .Values.commonLabels }}

--- a/bitnami/spark/templates/podmonitor.yaml
+++ b/bitnami/spark/templates/podmonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   {{- if .Values.metrics.podMonitor.namespace }}
   namespace: {{ .Values.metrics.podMonitor.namespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   {{- end }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
@@ -42,7 +42,7 @@ spec:
   {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "common.names.namespace" . | quote }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
 {{- end }}

--- a/bitnami/spark/templates/tls-secrets.yaml
+++ b/bitnami/spark/templates/tls-secrets.yaml
@@ -45,7 +45,7 @@ data:
 {{- end }}
 {{- if (include "spark.createTlsSecret" . ) }}
 {{- $ca := genCA "spark-internal-ca" 365 }}
-{{- $releaseNamespace := .Release.Namespace }}
+{{- $releaseNamespace := include "common.names.namespace" . }}
 {{- $clusterDomain := .Values.clusterDomain }}
 {{- $fullname := include "common.names.fullname" . }}
 {{- $headlessServiceName := printf "%s-headless" ( include "common.names.fullname" . ) }}


### PR DESCRIPTION
**Description of the change**

This PR adds the `namespace` metadata to templates missing it.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
