### PR TITLE
[bitnami/thanos] Add missing namespace metadata

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 10.3.7
+version: 10.3.8

--- a/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
+++ b/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.bucketweb.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/compactor/tls-secrets.yaml
+++ b/bitnami/thanos/templates/compactor/tls-secrets.yaml
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.compactor.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: compactor
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/networkpolicy.yaml
+++ b/bitnami/thanos/templates/networkpolicy.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   podSelector:
     matchLabels:

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrole.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrole.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
     {{- if .Values.commonLabels }}
@@ -19,5 +20,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "thanos.serviceAccount.name" (dict "component" "query-frontend" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/thanos/templates/query-frontend/psp.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp.yaml
@@ -4,6 +4,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
+++ b/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.queryFrontend.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/query/psp-clusterrole.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrole.yaml
@@ -5,6 +5,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
   name: {{ include "common.names.fullname" . }}-query
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
@@ -5,6 +5,7 @@ apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "common.names.fullname" . }}-query
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
     {{- if .Values.commonLabels }}
@@ -20,5 +21,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "thanos.serviceAccount.name" (dict "component" "query" "context" $) }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/thanos/templates/query/psp.yaml
+++ b/bitnami/thanos/templates/query/psp.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "common.names.fullname" . }}-query
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/query/tls-secrets-grpc.yaml
+++ b/bitnami/thanos/templates/query/tls-secrets-grpc.yaml
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.query.ingress.grpc.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/query/tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/tls-secrets.yaml
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.query.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/receive/tls-secrets.yaml
+++ b/bitnami/thanos/templates/receive/tls-secrets.yaml
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.receive.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/ruler/tls-secrets.yaml
+++ b/bitnami/thanos/templates/ruler/tls-secrets.yaml
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.ruler.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler
     {{- if .Values.commonLabels }}

--- a/bitnami/thanos/templates/storegateway/tls-secrets.yaml
+++ b/bitnami/thanos/templates/storegateway/tls-secrets.yaml
@@ -28,7 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-tls" .Values.storegateway.ingress.hostname }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
     {{- if .Values.commonLabels }}


### PR DESCRIPTION
**Description of the change**

This PR adds the `namespace` metadata to templates missing it.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
