### PR TITLE
[bitnami/kubeapps & solr] Unify icon in Chart.yaml

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     version: 1.x.x
 description: Kubeapps is a web-based UI for launching and managing applications on Kubernetes. It allows users to deploy trusted applications and operators to control users access to the cluster.
 home: https://kubeapps.com
-icon: https://raw.githubusercontent.com/kubeapps/kubeapps/main/docs/img/logo.png
+icon: https://bitnami.com/assets/stacks/kubeapps/img/kubeapps-stack-220x234.png
 keywords:
   - helm
   - dashboard
@@ -30,4 +30,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 8.0.17
+version: 8.0.18

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
 description: Apache Solr is an extremely powerful, open source enterprise search platform built on Apache Lucene. It is highly reliable and flexible, scalable, and designed to add value very quickly after launch.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/solr
-icon: https://bitnami.com/assets/stacks/solr/img/solr-stack-110x117.png
+icon: https://bitnami.com/assets/stacks/solr/img/solr-stack-220x234.png
 keywords:
   - solr
   - zookeeper
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/bitnami-docker-solr
   - https://lucene.apache.org/solr/
-version: 4.0.10
+version: 4.0.11


### PR DESCRIPTION
### Description of the change

Use the same icon used in the rest of the Helm charts, following the unified format:

```
https://bitnami.com/assets/stacks/ASSET/img/ASSET-stack-220x234.png
```