### PR TITLE
[bitnami/{grafana-operator|kube-prometheus}] CRDs should not include unnecessary dashes

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/bitnami-docker-grafana-operator
-version: 2.5.2
+version: 2.5.3

--- a/bitnami/grafana-operator/crds/grafanadashboards.integreatly.org.yaml
+++ b/bitnami/grafana-operator/crds/grafanadashboards.integreatly.org.yaml
@@ -1,5 +1,4 @@
 # !kustomize build https://github.com/grafana-operator/grafana-operator/tree/v4.1.0/config/crd
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/grafana-operator/crds/grafanadatasources.integreatly.org.yaml
+++ b/bitnami/grafana-operator/crds/grafanadatasources.integreatly.org.yaml
@@ -1,5 +1,4 @@
 # !kustomize build https://github.com/grafana-operator/grafana-operator/tree/v4.1.0/config/crd
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/grafana-operator/crds/grafananotificationchannels.integreatly.org.yaml
+++ b/bitnami/grafana-operator/crds/grafananotificationchannels.integreatly.org.yaml
@@ -1,5 +1,4 @@
 # !kustomize build https://github.com/grafana-operator/grafana-operator/tree/v4.1.0/config/crd
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/grafana-operator/crds/grafanas.integreatly.org.yaml
+++ b/bitnami/grafana-operator/crds/grafanas.integreatly.org.yaml
@@ -1,5 +1,4 @@
 # !kustomize build https://github.com/grafana-operator/grafana-operator/tree/v4.1.0/config/crd
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 6.10.4
+version: 6.10.5

--- a/bitnami/kube-prometheus/crds/crd-alertmanager-config.yaml
+++ b/bitnami/kube-prometheus/crds/crd-alertmanager-config.yaml
@@ -1,6 +1,4 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.55.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/kube-prometheus/crds/crd-alertmanager.yaml
+++ b/bitnami/kube-prometheus/crds/crd-alertmanager.yaml
@@ -1,6 +1,4 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.55.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/kube-prometheus/crds/crd-podmonitor.yaml
+++ b/bitnami/kube-prometheus/crds/crd-podmonitor.yaml
@@ -1,6 +1,4 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.55.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/kube-prometheus/crds/crd-probes.yaml
+++ b/bitnami/kube-prometheus/crds/crd-probes.yaml
@@ -1,6 +1,4 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.55.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/kube-prometheus/crds/crd-prometheus.yaml
+++ b/bitnami/kube-prometheus/crds/crd-prometheus.yaml
@@ -1,6 +1,4 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.55.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/kube-prometheus/crds/crd-prometheusrules.yaml
+++ b/bitnami/kube-prometheus/crds/crd-prometheusrules.yaml
@@ -1,6 +1,4 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.55.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/kube-prometheus/crds/crd-servicemonitor.yaml
+++ b/bitnami/kube-prometheus/crds/crd-servicemonitor.yaml
@@ -1,6 +1,4 @@
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.55.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/bitnami/kube-prometheus/crds/crd-thanosrulers.yaml
+++ b/bitnami/kube-prometheus/crds/crd-thanosrulers.yaml
@@ -1,6 +1,4 @@
 # hhttps://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.55.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
-
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Signed-off-by: juan131 <juan.ariza.1311993@gmail.com>

### Description of the change

The Grafana Operator and kube-prometheus charts' CRDs start with 3 dashes that are not necessary since these are only required as a separator when N directives are included in a single YAML file (which is not the case). Indeed, if you render the templates including the CRDs (e.g. running  `helm template kube-prometheus bitnami/kube-prometheus --include-crds > foo.yaml` and inspect the output, you'll find blocks such as the one below:

```
---
# Source: crds/crd-alertmanager-config.yaml
# https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.55.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

---
```

This is interpreted as an empty directive which doesn't make sense.

### Benefits

Charts compatible with `helm template --include-crds ...`.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
