### PR TITLE
[bitnami/argo-workflows] Bump mysql subchart version

### DIFF
--- a/bitnami/argo-workflows/Chart.lock
+++ b/bitnami/argo-workflows/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.26
+  version: 11.1.28
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
-  version: 8.9.6
+  version: 9.0.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.13.1
-digest: sha256:60417596aecfc748fb902c039eed07e850f35010c176476951bfd1352f869921
-generated: "2022-05-04T03:46:47.328545544Z"
+digest: sha256:f69fa838e8e8cfec36af28b19c0573e63908c01e90b2671b1de45e94fa49f125
+generated: "2022-05-12T17:02:59.592473+02:00"

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
   - condition: mysql.enabled
     name: mysql
     repository: https://charts.bitnami.com/bitnami
-    version: 8.x.x
+    version: 9.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-argo-workflow-controller
   - https://github.com/bitnami/bitnami-docker-argo-workflow-exec
   - https://argoproj.github.io/workflows/
-version: 1.1.14
+version: 2.0.0

--- a/bitnami/argo-workflows/README.md
+++ b/bitnami/argo-workflows/README.md
@@ -341,13 +341,13 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### MySQL subchart
 
-| Name                  | Description                                                  | Value               |
-| --------------------- | ------------------------------------------------------------ | ------------------- |
-| `mysql.enabled`       | Enable MySQL subchart and controller persistence using MySQL | `false`             |
-| `mysql.service.port`  | MySQL port                                                   | `3306`              |
-| `mysql.auth.username` | MySQL username                                               | `mysql`             |
-| `mysql.auth.database` | MySQL database name                                          | `bn_argo_workflows` |
-| `mysql.auth.password` | MySQL database password                                      | `""`                |
+| Name                        | Description                                                  | Value               |
+| --------------------------- | ------------------------------------------------------------ | ------------------- |
+| `mysql.enabled`             | Enable MySQL subchart and controller persistence using MySQL | `false`             |
+| `mysql.service.ports.mysql` | MySQL port                                                   | `3306`              |
+| `mysql.auth.username`       | MySQL username                                               | `mysql`             |
+| `mysql.auth.database`       | MySQL database name                                          | `bn_argo_workflows` |
+| `mysql.auth.password`       | MySQL database password                                      | `""`                |
 
 
 ### External Database configuration

--- a/bitnami/argo-workflows/values.yaml
+++ b/bitnami/argo-workflows/values.yaml
@@ -1142,7 +1142,7 @@ postgresql:
 
 ## Mysql subchart configuration
 ## @param mysql.enabled Enable MySQL subchart and controller persistence using MySQL
-## @param mysql.service.port MySQL port
+## @param mysql.service.ports.mysql MySQL port
 ## @param mysql.auth.username MySQL username
 ## @param mysql.auth.database MySQL database name
 ## @param mysql.auth.password MySQL database password
@@ -1150,7 +1150,8 @@ postgresql:
 mysql:
   enabled: false
   service:
-    port: 3306
+    ports:
+      mysql: 3306
   auth:
     username: mysql
     database: bn_argo_workflows


### PR DESCRIPTION
### Description of the change

Bumps the MySQL subchart to its latest major 9.0.0.

Documentation PR:  https://github.com/bitnami/charts-docs/pull/108

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
