### PR TITLE
[bitnami/redis] fix wrongly placed metrics extra volume mounts

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.9.4
+version: 16.9.5

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -268,9 +268,6 @@ spec:
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
             {{- end }}
-            {{- if .Values.metrics.extraVolumeMounts }}
-            {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.extraVolumeMounts "context" $ ) | nindent 12 }}
-            {{- end }}
             {{- if .Values.replica.extraVolumeMounts }}
             {{- include "common.tplvalues.render" ( dict "value" .Values.replica.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
@@ -506,6 +503,9 @@ spec:
             - name: redis-certificates
               mountPath: /opt/bitnami/redis/certs
               readOnly: true
+            {{- end }}
+            {{- if .Values.metrics.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.extraVolumeMounts "context" $ ) | nindent 12 }}
             {{- end }}
         {{- end }}
         {{- if .Values.replica.sidecars }}


### PR DESCRIPTION
### Description of the change

Metrics related extra volume mounts are placed under redis
container instead of metrics container

Metrics related extra volume mounts shall go under metrics
container

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

### Benefits

Users can define extra volume mounts for metrics container

### Possible drawbacks

N/A

### Applicable issues

  - fixes #10188

### Additional information

It is fix for the regression introduced in https://github.com/bitnami/charts/pull/10085

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
