### PR TITLE
[bitnami/thanos] Use the new helper for HPA API version

### DIFF
--- a/bitnami/thanos/Chart.lock
+++ b/bitnami/thanos/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: minio
   repository: https://charts.bitnami.com/bitnami
-  version: 11.3.2
+  version: 11.3.5
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.13.1
-digest: sha256:1913b859d9b836a3b93338798aaa7de959c4727162ce86830afd61f0c4e98f55
-generated: "2022-05-05T15:58:03.565766438Z"
+  version: 1.14.0
+digest: sha256:64aed0774281181ac96de470a48f9dcdf2bb7937a08777da4ea493c44370fa7e
+generated: "2022-05-13T15:16:12.039008+02:00"

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 10.3.9
+version: 10.3.10

--- a/bitnami/thanos/templates/bucketweb/hpa.yaml
+++ b/bitnami/thanos/templates/bucketweb/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.bucketweb.enabled .Values.bucketweb.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" . }}-bucketweb

--- a/bitnami/thanos/templates/bucketweb/hpa.yaml
+++ b/bitnami/thanos/templates/bucketweb/hpa.yaml
@@ -24,12 +24,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.bucketweb.autoscaling.targetMemory  }}
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.bucketweb.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.bucketweb.autoscaling.targetMemory }}
+        {{- end }}
     {{- end }}
     {{- if .Values.bucketweb.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.bucketweb.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.bucketweb.autoscaling.targetCPU }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/query-frontend/hpa.yaml
+++ b/bitnami/thanos/templates/query-frontend/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.queryFrontend.enabled .Values.queryFrontend.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" . }}-query-frontend

--- a/bitnami/thanos/templates/query-frontend/hpa.yaml
+++ b/bitnami/thanos/templates/query-frontend/hpa.yaml
@@ -24,12 +24,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.queryFrontend.autoscaling.targetMemory  }}
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.queryFrontend.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.queryFrontend.autoscaling.targetMemory }}
+        {{- end }}
     {{- end }}
     {{- if .Values.queryFrontend.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.queryFrontend.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.queryFrontend.autoscaling.targetCPU }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/query/hpa.yaml
+++ b/bitnami/thanos/templates/query/hpa.yaml
@@ -1,6 +1,6 @@
 {{- $query := (include "thanos.query.values" . | fromYaml) -}}
 {{- if and $query.enabled $query.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" . }}-query

--- a/bitnami/thanos/templates/query/hpa.yaml
+++ b/bitnami/thanos/templates/query/hpa.yaml
@@ -42,7 +42,7 @@ spec:
         {{- else }}
         target:
           type: Utilization
-          averageUtilization: {{ $query..autoscaling.targetCPU }}
+          averageUtilization: {{ $query.autoscaling.targetCPU }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/query/hpa.yaml
+++ b/bitnami/thanos/templates/query/hpa.yaml
@@ -25,12 +25,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ $query.autoscaling.targetMemory  }}
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ $query.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ $query.autoscaling.targetMemory }}
+        {{- end }}
     {{- end }}
     {{- if $query.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ $query.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ $query..autoscaling.targetCPU }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/receive-distributor/hpa.yaml
+++ b/bitnami/thanos/templates/receive-distributor/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.receiveDistributor.enabled .Values.receiveDistributor.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" . }}-receive-distributor

--- a/bitnami/thanos/templates/receive-distributor/hpa.yaml
+++ b/bitnami/thanos/templates/receive-distributor/hpa.yaml
@@ -24,12 +24,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.receiveDistributor.autoscaling.targetMemory  }}
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.receiveDistributor.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.receiveDistributor.autoscaling.targetMemory }}
+        {{- end }}
     {{- end }}
     {{- if .Values.receiveDistributor.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.receiveDistributor.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.receiveDistributor.autoscaling.targetCPU }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/receive/hpa.yaml
+++ b/bitnami/thanos/templates/receive/hpa.yaml
@@ -24,12 +24,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.receive.autoscaling.targetMemory  }}
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.receive.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.receive.autoscaling.targetMemory }}
+        {{- end }}
     {{- end }}
     {{- if .Values.receive.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.receive.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.receive.autoscaling.targetCPU }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/receive/hpa.yaml
+++ b/bitnami/thanos/templates/receive/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.receive.enabled .Values.receive.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" . }}-receive

--- a/bitnami/thanos/templates/ruler/hpa.yaml
+++ b/bitnami/thanos/templates/ruler/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.ruler.enabled .Values.ruler.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" . }}-ruler

--- a/bitnami/thanos/templates/ruler/hpa.yaml
+++ b/bitnami/thanos/templates/ruler/hpa.yaml
@@ -24,12 +24,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.ruler.autoscaling.targetMemory  }}
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.ruler.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.ruler.autoscaling.targetMemory }}
+        {{- end }}
     {{- end }}
     {{- if .Values.ruler.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.ruler.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.ruler.autoscaling.targetCPU }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/storegateway/hpa.yaml
+++ b/bitnami/thanos/templates/storegateway/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.storegateway.enabled .Values.storegateway.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "common.names.fullname" . }}-storegateway

--- a/bitnami/thanos/templates/storegateway/hpa.yaml
+++ b/bitnami/thanos/templates/storegateway/hpa.yaml
@@ -24,12 +24,24 @@ spec:
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.storegateway.autoscaling.targetMemory  }}
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.storegateway.autoscaling.targetMemory }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.storegateway.autoscaling.targetMemory }}
+        {{- end }}
     {{- end }}
     {{- if .Values.storegateway.autoscaling.targetCPU }}
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
         targetAverageUtilization: {{ .Values.storegateway.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.storegateway.autoscaling.targetCPU }}
+        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use the new helper in `common` and adapt HPA to be compatible with `autoscaling/v2`
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

Up-to-date components.

### Possible drawbacks

None, it is backwards compatible.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
NA

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)