### PR TITLE
[bitnami/mongodb] Fix incorrect SAN field in TLS certs

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 12.1.4
+version: 12.1.5

--- a/bitnami/mongodb/templates/common-scripts-cm.yaml
+++ b/bitnami/mongodb/templates/common-scripts-cm.yaml
@@ -71,8 +71,8 @@ data:
     DNS.2 = $my_hostname
     DNS.3 = $my_hostname.$svc.$MY_POD_NAMESPACE.svc.cluster.local
     DNS.4 = localhost
-    DNS.5 = 127.0.0.1
     IP.0 = ${MY_POD_HOST_IP}
+    IP.1 = 127.0.0.1
     EOL
     index=1
     for ip in "${additional_ips[@]}"; do


### PR DESCRIPTION
### Description of the change

The autogenerated TLS certificates declared the loopback IP address as a DNS entry, which is incorrect. This diff declares it as an `IP Address` instead of a `DNS` entry.

### Benefits

The loopback IP address is declared correctly in the autogenerated TLS certificate, which prevents probes from failing.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #10104

### Additional information

```diff
        X509v3 extensions:
            X509v3 Subject Alternative Name:
-               DNS:beta-mongodb-headless, DNS:beta-mongodb-0, DNS:beta-mongodb-0.beta-mongodb-headless.default.svc.cluster.local, DNS:localhost, DNS:127.0.0.1, IP Address:10.99.24.3
+               DNS:beta-mongodb-headless, DNS:beta-mongodb-0, DNS:beta-mongodb-0.beta-mongodb-headless.default.svc.cluster.local, DNS:localhost, IP Address:10.99.24.3, IP Address:127.0.0.1
```


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
