### PR TITLE
[bitnami/kubeapps] Restore PG persistence disabling in Kubeapps chart.

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 8.0.19
+version: 8.0.20

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -582,19 +582,17 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 
 ### Database Parameters
 
-| Name                                   | Description                                                                  | Value         |
-| -------------------------------------- | ---------------------------------------------------------------------------- | ------------- |
-| `postgresql.enabled`                   | Deploy a PostgreSQL server to satisfy the applications database requirements | `true`        |
-| `postgresql.architecture`              | PostgreSQL architecture (`standalone` or `replication`)                      | `replication` |
-| `postgresql.auth.postgresPassword`     | Password for 'postgres' user                                                 | `""`          |
-| `postgresql.auth.database`             | Name for a custom database to create                                         | `assets`      |
-| `postgresql.auth.existingSecret`       | Name of existing secret to use for PostgreSQL credentials                    | `""`          |
-| `postgresql.persistence.enabled`       | Enable persistence on PostgreSQL using PVC(s)                                | `false`       |
-| `postgresql.persistence.size`          | Persistent Volume size                                                       | `8Gi`         |
-| `postgresql.securityContext.enabled`   | Enabled PostgreSQL replicas pods' Security Context                           | `false`       |
-| `postgresql.resources.limits`          | The resources limits for the PostreSQL container                             | `{}`          |
-| `postgresql.resources.requests.cpu`    | The requested CPU for the PostreSQL container                                | `250m`        |
-| `postgresql.resources.requests.memory` | The requested memory for the PostreSQL container                             | `256Mi`       |
+| Name                                     | Description                                                                  | Value    |
+| ---------------------------------------- | ---------------------------------------------------------------------------- | -------- |
+| `postgresql.enabled`                     | Deploy a PostgreSQL server to satisfy the applications database requirements | `true`   |
+| `postgresql.auth.postgresPassword`       | Password for 'postgres' user                                                 | `""`     |
+| `postgresql.auth.database`               | Name for a custom database to create                                         | `assets` |
+| `postgresql.auth.existingSecret`         | Name of existing secret to use for PostgreSQL credentials                    | `""`     |
+| `postgresql.primary.persistence.enabled` | Enable PostgreSQL Primary data persistence using PVC                         | `false`  |
+| `postgresql.securityContext.enabled`     | Enabled PostgreSQL replicas pods' Security Context                           | `false`  |
+| `postgresql.resources.limits`            | The resources limits for the PostreSQL container                             | `{}`     |
+| `postgresql.resources.requests.cpu`      | The requested CPU for the PostreSQL container                                | `250m`   |
+| `postgresql.resources.requests.memory`   | The requested memory for the PostreSQL container                             | `256Mi`  |
 
 
 ### kubeappsapis parameters

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1974,7 +1974,6 @@ testImage:
 ## PostgreSQL chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 ## @param postgresql.enabled Deploy a PostgreSQL server to satisfy the applications database requirements
-## @param postgresql.architecture PostgreSQL architecture (`standalone` or `replication`)
 ## @param postgresql.auth.postgresPassword Password for 'postgres' user
 ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
 ## @param postgresql.auth.database Name for a custom database to create

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1982,19 +1982,15 @@ testImage:
 ##
 postgresql:
   enabled: true
-  architecture: "replication"
   auth:
     postgresPassword: ""
     database: assets
     existingSecret: ""
-  ## PostgreSQL Persistence parameters
-  ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
-  ## @param postgresql.persistence.enabled Enable persistence on PostgreSQL using PVC(s)
-  ## @param postgresql.persistence.size Persistent Volume size
-  ##
-  persistence:
-    enabled: false
-    size: 8Gi
+  primary:
+    ## PostgreSQL Primary persistence configuration
+    persistence:
+      ## @param primary.persistence.enabled Enable PostgreSQL Primary data persistence using PVC
+      enabled: false
   ## @param postgresql.securityContext.enabled Enabled PostgreSQL replicas pods' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1986,10 +1986,10 @@ postgresql:
     postgresPassword: ""
     database: assets
     existingSecret: ""
+  ## PostgreSQL Primary persistence configuration
+  ## @param postgresql.primary.persistence.enabled Enable PostgreSQL Primary data persistence using PVC
   primary:
-    ## PostgreSQL Primary persistence configuration
     persistence:
-      ## @param primary.persistence.enabled Enable PostgreSQL Primary data persistence using PVC
       enabled: false
   ## @param postgresql.securityContext.enabled Enabled PostgreSQL replicas pods' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This change restores the Kubeapps configuration for Postgresql to disable persistence. Kubeapps uses postgres as a cache only, so persistence is not necessary. We've recently had a number of users having postgres auth issues due to the persistence (latest in https://github.com/vmware-tanzu/kubeapps/issues/4689), but what we didn't realise is that this is another setting which had accidentally changed when upgrading postgres from 10->11. As you can see in the diff here, we still had intended to disable persistence, but it's still using the location of that knob for the postgres 10 chart (postgresql.persistence.enabled) rather than the 11 location (postgresql.primary.persistence.enabled).

### Benefits

<!-- What benefits will be realized by the code change? -->
No auth issues when upgrading kubeapps with the default settings.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/vmware-tanzu/kubeapps/issues/4689

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
