### PR TITLE
[bitnami/discourse] Add goss/cypress tests

### DIFF
--- a/.vib/discourse/cypress/cypress.json
+++ b/.vib/discourse/cypress/cypress.json
@@ -1,0 +1,10 @@
+{
+  "env": {
+    "username": "user",
+    "password": "ComplicatedPassword123!4"
+  },
+  "hosts": {
+    "bitnami-discourse.my": "{{ TARGET_IP }}"
+  },
+  "defaultCommandTimeout": 30000
+}

--- a/.vib/discourse/cypress/cypress/fixtures/topics.json
+++ b/.vib/discourse/cypress/cypress/fixtures/topics.json
@@ -1,0 +1,6 @@
+{
+  "newTopic": {
+    "title": "Super Topic",
+    "content": "Inventive Lorem ipsum content v2"
+  }
+}

--- a/.vib/discourse/cypress/cypress/fixtures/user-settings.json
+++ b/.vib/discourse/cypress/cypress/fixtures/user-settings.json
@@ -1,0 +1,5 @@
+{
+  "user": {
+    "name": "Jeff Developer"
+  }
+}

--- a/.vib/discourse/cypress/cypress/fixtures/users.json
+++ b/.vib/discourse/cypress/cypress/fixtures/users.json
@@ -1,0 +1,8 @@
+{
+  "newUser": {
+    "username": "NonTrivialUser",
+    "password": "N0ntR1Vi@lPaS$wOrD",
+    "email": "nontrivial@email.com",
+    "name": "Trivial Name"
+  }
+}

--- a/.vib/discourse/cypress/cypress/integration/discourse_spec.js
+++ b/.vib/discourse/cypress/cypress/integration/discourse_spec.js
@@ -1,0 +1,64 @@
+/// <reference types="cypress" />
+import { random } from './utils';
+
+it('allows to log in and out', () => {
+  cy.login();
+  cy.contains('a', 'Unread');
+  cy.get('#current-user').click();
+  cy.get('[title="Preferences"]').click();
+  cy.contains('Log Out').click();
+  cy.contains('button', 'Log In');
+});
+
+it('allows to sign in', () => {
+  cy.contains('button', 'Sign Up').click();
+  cy.fixture('users').then((user) => {
+    cy.get('#new-account-email').type(`${random}.${user.newUser.email}`);
+    cy.get('#new-account-username').type(`${random}.${user.newUser.username}`);
+    cy.get('#new-account-name').type(`${user.newUser.name} ${random}`);
+    cy.get('#new-account-password').type(`${random}.${user.newUser.password}`);
+  });
+  cy.contains('Checking username').should('not.exist');
+  cy.contains('button', 'Create your account').click();
+  cy.contains('button', 'Resend Activation Email');
+});
+
+it('allows to create a topic', () => {
+  cy.login();
+  cy.contains('button', 'New Topic').click();
+  cy.fixture('topics').then((topic) => {
+    cy.get('[id="reply-title"]').type(`${topic.newTopic.title}-${random}`);
+    cy.get('textarea').type(`${topic.newTopic.content} ${random}`);
+    cy.contains('button', 'Create Topic').click();
+    cy.contains('Saving').should('not.exist');
+    cy.reload();
+    cy.get('[class*="topic-list"]').within(() => {
+      cy.contains('td', `${topic.newTopic.title}-${random}`);
+    });
+  });
+});
+
+it('allows to modify user settings', () => {
+  cy.login();
+  cy.visit('/u/user/preferences/account');
+  cy.fixture('user-settings').then((userSettings) => {
+    cy.get('[class*="pref-name"]').within(() => {
+      cy.get('input')
+        .clear({ force: true })
+        .type(`${userSettings.user.realName} ${random}`);
+    });
+    cy.contains('button', 'Save Changes').click();
+    cy.contains('Saved').click();
+    cy.contains('h2', `${userSettings.user.realName} ${random}`);
+  });
+});
+
+it('checks sideqik and discourse status', () => {
+  const PROCESS_NAME = 'discourse';
+
+  cy.login();
+  cy.visit('/sidekiq/busy');
+  cy.get('[class*="processes"]').within(() => {
+    cy.contains('td', PROCESS_NAME);
+  });
+});

--- a/.vib/discourse/cypress/cypress/integration/utils.js
+++ b/.vib/discourse/cypress/cypress/integration/utils.js
@@ -1,0 +1,3 @@
+/// <reference types="cypress" />
+
+export let random = (Math.random() + 1).toString(36).substring(7);

--- a/.vib/discourse/cypress/cypress/support/commands.js
+++ b/.vib/discourse/cypress/cypress/support/commands.js
@@ -1,0 +1,36 @@
+const CLICK_DELAY = 500;
+const BASE_URL = 'http://bitnami-discourse.my';
+
+for (const command of ['click']) {
+  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
+    const origVal = originalFn(...args);
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(origVal);
+      }, CLICK_DELAY);
+    });
+  });
+}
+
+Cypress.Commands.overwrite('visit', (originalFn, url, options) => {
+  return originalFn(`${BASE_URL}${url}`, options);
+});
+
+Cypress.Commands.add(
+  'login',
+  (username = Cypress.env('username'), password = Cypress.env('password')) => {
+    cy.visit('/');
+    cy.contains('button', 'Log In').click();
+    cy.get('#login-account-name').type(username);
+    cy.get('#login-account-password').type(`${password}{enter}`);
+    cy.get('body').then(($body) => {
+      if ($body.text().includes('Skip these tips')) {
+        cy.contains('Skip these tips').click();
+      }
+    });
+    // In Discourse, logging is not considered as completed until the home page is visible.
+    // Navigating to any other site before that will lead to a 404 error
+    cy.contains('Admin Quick Start Guide');
+  }
+);

--- a/.vib/discourse/cypress/cypress/support/index.js
+++ b/.vib/discourse/cypress/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/.vib/discourse/goss/goss.yaml
+++ b/.vib/discourse/goss/goss.yaml
@@ -1,0 +1,30 @@
+file:
+  /opt/bitnami/discourse/tmp:
+    exists: true
+    filetype: directory
+    mode: "0775"
+    owner: discourse
+    group: root
+  /opt/bitnami/discourse/plugins:
+    filetype: symlink
+    linked-to: /bitnami/discourse/plugins
+    exists: true
+  /opt/bitnami/discourse/config/discourse.conf:
+    exists: true
+    filetype: file
+    mode: "0644"
+    owner: root
+    group: root
+    contains:
+      - hostname = bitnami-discourse.my
+command:
+  discourse-cli:
+    exec: cd /opt/bitnami/discourse/ && RAILS_ENV=production bundle exec rake -T
+    exit-status: 0
+    stdout:
+      - rake about
+      - rake plugin:versions
+    stderr: []
+user:
+  discourse:
+    exists: true

--- a/.vib/discourse/vib-verify.json
+++ b/.vib/discourse/vib-verify.json
@@ -17,12 +17,59 @@
       ]
     },
     "verify": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/discourse"
+        },
+        "runtime_parameters": "YXV0aDoKICBlbWFpbDogdXNlckBleGFtcGxlLmNvbQogIHVzZXI6IHVzZXIKICBwYXNzd29yZDogQ29tcGxpY2F0ZWRQYXNzd29yZDEyMyE0Cmhvc3Q6IGJpdG5hbWktZGlzY291cnNlLm15CnNlcnZpY2U6CiAgdHlwZTogTG9hZEJhbGFuY2VyCiAgcG9ydHM6CiAgICBodHRwOiA4MA==",
+        "target_platform": {
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
+          "size": {
+            "name": "M4"
+          }
+        }
+      },
       "actions": [
         {
           "action_id": "trivy",
           "params": {
             "threshold": "CRITICAL",
-            "vuln_type": ["OS"]
+            "vuln_type": [
+              "OS"
+            ]
+          }
+        },
+        {
+          "action_id": "health-check",
+          "params": {
+            "endpoint": "lb-discourse-http",
+            "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/discourse/goss"
+            },
+            "remote": {
+              "workload": "deploy-discourse"
+            }
+          }
+        },
+        {
+          "action_id": "cypress",
+          "params": {
+            "resources": {
+              "path": "/.vib/discourse/cypress"
+            },
+            "endpoint": "lb-discourse-http",
+            "app_protocol": "HTTP",
+            "env": {
+              "username": "user",
+              "password": "ComplicatedPassword123!4"
+            }
           }
         }
       ]


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also, don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open-source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
Adds Cypress and Goss tests to the `bitnami/discourse` chart.

**Benefits**

Ensuring higher quality of the Helm chart.

**Possible drawbacks**

Automated tests could show to be potentially flaky. 

**Test results** - PASS

[Please see them in the history here](https://github.com/FraPazGal/charts/pull/9)

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
