### PR TITLE
[bitnami/dataplatform-bp1] Chart standardised

### DIFF
--- a/bitnami/dataplatform-bp1/Chart.yaml
+++ b/bitnami/dataplatform-bp1/Chart.yaml
@@ -59,4 +59,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 12.0.1
+version: 12.1.0

--- a/bitnami/dataplatform-bp1/README.md
+++ b/bitnami/dataplatform-bp1/README.md
@@ -101,19 +101,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                     | Description                                                                                                     | Value           |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------- | --------------- |
-| `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                                            | `""`            |
-| `nameOverride`           | String to partially override %%COMPONENT_NAME%%.fullname template with a string (will prepend the release name) | `""`            |
-| `fullnameOverride`       | String to fully override %%COMPONENT_NAME%%.fullname template with a string                                     | `""`            |
-| `namespaceOverride`      | String to fully override common.names.namespace                                                                 | `""`            |
-| `commonLabels`           | Labels to add to all deployed objects                                                                           | `{}`            |
-| `commonAnnotations`      | Annotations to add to all deployed objects                                                                      | `{}`            |
-| `extraDeploy`            | Array of extra objects to deploy with the release                                                               | `[]`            |
-| `clusterDomain`          | Kubernetes cluster domain name                                                                                  | `cluster.local` |
-| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                         | `false`         |
-| `diagnosticMode.command` | Command to override all containers in the the deployment(s)/statefulset(s)                                      | `["sleep"]`     |
-| `diagnosticMode.args`    | Args to override all containers in the the deployment(s)/statefulset(s)                                         | `["infinity"]`  |
+| Name                | Description                                                                                                     | Value           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set)                                            | `""`            |
+| `nameOverride`      | String to partially override %%COMPONENT_NAME%%.fullname template with a string (will prepend the release name) | `""`            |
+| `fullnameOverride`  | String to fully override %%COMPONENT_NAME%%.fullname template with a string                                     | `""`            |
+| `namespaceOverride` | String to fully override common.names.namespace                                                                 | `""`            |
+| `commonLabels`      | Labels to add to all deployed objects                                                                           | `{}`            |
+| `commonAnnotations` | Annotations to add to all deployed objects                                                                      | `{}`            |
+| `extraDeploy`       | Array of extra objects to deploy with the release                                                               | `[]`            |
+| `clusterDomain`     | Kubernetes cluster domain name                                                                                  | `cluster.local` |
 
 
 ### Data Platform Chart parameters

--- a/bitnami/dataplatform-bp1/README.md
+++ b/bitnami/dataplatform-bp1/README.md
@@ -101,11 +101,19 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                | Description                                       | Value |
-| ------------------- | ------------------------------------------------- | ----- |
-| `commonLabels`      | Labels to add to all deployed objects             | `{}`  |
-| `commonAnnotations` | Annotations to add to all deployed objects        | `{}`  |
-| `extraDeploy`       | Array of extra objects to deploy with the release | `[]`  |
+| Name                     | Description                                                                                                     | Value           |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                                            | `""`            |
+| `nameOverride`           | String to partially override %%COMPONENT_NAME%%.fullname template with a string (will prepend the release name) | `""`            |
+| `fullnameOverride`       | String to fully override %%COMPONENT_NAME%%.fullname template with a string                                     | `""`            |
+| `namespaceOverride`      | String to fully override common.names.namespace                                                                 | `""`            |
+| `commonLabels`           | Labels to add to all deployed objects                                                                           | `{}`            |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                                                      | `{}`            |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                                               | `[]`            |
+| `clusterDomain`          | Kubernetes cluster domain name                                                                                  | `cluster.local` |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                         | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the the deployment(s)/statefulset(s)                                      | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the the deployment(s)/statefulset(s)                                         | `["infinity"]`  |
 
 
 ### Data Platform Chart parameters
@@ -115,11 +123,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.serviceAccount.create`                          | Specifies whether a ServiceAccount should be created                                                             | `true`                          |
 | `dataplatform.serviceAccount.name`                            | The name of the ServiceAccount to create                                                                         | `""`                            |
 | `dataplatform.serviceAccount.automountServiceAccountToken`    | Allows auto mount of ServiceAccountToken on the serviceAccount created                                           | `true`                          |
+| `dataplatform.serviceAccount.annotations`                     | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                       | `{}`                            |
 | `dataplatform.rbac.create`                                    | Whether to create & use RBAC resources or not                                                                    | `true`                          |
 | `dataplatform.exporter.enabled`                               | Start a prometheus exporter                                                                                      | `true`                          |
 | `dataplatform.exporter.image.registry`                        | dataplatform exporter image registry                                                                             | `docker.io`                     |
 | `dataplatform.exporter.image.repository`                      | dataplatform exporter image repository                                                                           | `bitnami/dataplatform-exporter` |
-| `dataplatform.exporter.image.tag`                             | dataplatform exporter image tag (immutable tags are recommended)                                                 | `1.0.1-scratch-r27`             |
+| `dataplatform.exporter.image.tag`                             | dataplatform exporter image tag (immutable tags are recommended)                                                 | `1.0.1-scratch-r28`             |
 | `dataplatform.exporter.image.pullPolicy`                      | dataplatform exporter image pull policy                                                                          | `IfNotPresent`                  |
 | `dataplatform.exporter.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                 | `[]`                            |
 | `dataplatform.exporter.config`                                | Data Platform Metrics Configuration emitted in Prometheus format                                                 | `""`                            |
@@ -143,6 +152,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.exporter.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                               | `15`                            |
 | `dataplatform.exporter.containerPorts.http`                   | Data Platform Prometheus exporter port                                                                           | `9090`                          |
 | `dataplatform.exporter.priorityClassName`                     | exporter priorityClassName                                                                                       | `""`                            |
+| `dataplatform.exporter.lifecycleHooks`                        | for the Data Platform Exporter container(s) to automate configuration before or after startup                    | `{}`                            |
+| `dataplatform.exporter.schedulerName`                         | Name of the k8s scheduler (other than default)                                                                   | `""`                            |
+| `dataplatform.exporter.terminationGracePeriodSeconds`         | In seconds, time the given to the Data Platform Exporter pod needs to terminate gracefully                       | `""`                            |
+| `dataplatform.exporter.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                   | `[]`                            |
 | `dataplatform.exporter.command`                               | Override Data Platform Exporter entrypoint string.                                                               | `[]`                            |
 | `dataplatform.exporter.args`                                  | Arguments for the provided command if needed                                                                     | `[]`                            |
 | `dataplatform.exporter.resources.limits`                      | The resources limits for the container                                                                           | `{}`                            |
@@ -172,8 +185,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.exporter.extraEnvVarsSecret`                    | Secret with extra environment variables                                                                          | `""`                            |
 | `dataplatform.exporter.extraVolumes`                          | Extra volumes to add to the deployment                                                                           | `[]`                            |
 | `dataplatform.exporter.extraVolumeMounts`                     | Extra volume mounts to add to the container                                                                      | `[]`                            |
-| `dataplatform.exporter.initContainers`                        | Add init containers to the %%MAIN_CONTAINER_NAME%% pods                                                          | `[]`                            |
-| `dataplatform.exporter.sidecars`                              | Add sidecars to the %%MAIN_CONTAINER_NAME%% pods                                                                 | `[]`                            |
+| `dataplatform.exporter.initContainers`                        | Add init containers to the Data Platform exporter pods                                                           | `[]`                            |
+| `dataplatform.exporter.sidecars`                              | Add sidecars to the Data Platform exporter pods                                                                  | `[]`                            |
 | `dataplatform.exporter.service.type`                          | Service type for default Data Platform Prometheus exporter service                                               | `ClusterIP`                     |
 | `dataplatform.exporter.service.annotations`                   | Metrics exporter service annotations                                                                             | `{}`                            |
 | `dataplatform.exporter.service.labels`                        | Additional labels for Data Platform exporter service                                                             | `{}`                            |
@@ -181,11 +194,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.exporter.service.loadBalancerIP`                | Load balancer IP for the Data Platform Exporter Service (optional, cloud specific)                               | `""`                            |
 | `dataplatform.exporter.service.nodePorts.http`                | Node ports for the HTTP exporter service                                                                         | `""`                            |
 | `dataplatform.exporter.service.loadBalancerSourceRanges`      | Exporter Load Balancer Source ranges                                                                             | `[]`                            |
+| `dataplatform.exporter.service.clusterIP`                     | Data Platform exporter service Cluster IP                                                                        | `""`                            |
+| `dataplatform.exporter.service.externalTrafficPolicy`         | Data Platform exporter service external traffic policy                                                           | `Cluster`                       |
+| `dataplatform.exporter.service.extraPorts`                    | Extra ports to expose (normally used with the `sidecar` value)                                                   | `[]`                            |
+| `dataplatform.exporter.service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                             | `None`                          |
+| `dataplatform.exporter.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                      | `{}`                            |
 | `dataplatform.exporter.hostAliases`                           | Deployment pod host aliases                                                                                      | `[]`                            |
 | `dataplatform.emitter.enabled`                                | Start Data Platform metrics emitter                                                                              | `true`                          |
 | `dataplatform.emitter.image.registry`                         | Data Platform emitter image registry                                                                             | `docker.io`                     |
 | `dataplatform.emitter.image.repository`                       | Data Platform emitter image repository                                                                           | `bitnami/dataplatform-emitter`  |
-| `dataplatform.emitter.image.tag`                              | Data Platform emitter image tag (immutable tags are recommended)                                                 | `1.0.1-scratch-r30`             |
+| `dataplatform.emitter.image.tag`                              | Data Platform emitter image tag (immutable tags are recommended)                                                 | `1.0.1-scratch-r32`             |
 | `dataplatform.emitter.image.pullPolicy`                       | Data Platform emitter image pull policy                                                                          | `IfNotPresent`                  |
 | `dataplatform.emitter.image.pullSecrets`                      | Specify docker-registry secret names as an array                                                                 | `[]`                            |
 | `dataplatform.emitter.livenessProbe.enabled`                  | Enable livenessProbe                                                                                             | `true`                          |
@@ -208,6 +226,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.emitter.startupProbe.successThreshold`          | Success threshold for startupProbe                                                                               | `15`                            |
 | `dataplatform.emitter.containerPorts.http`                    | Data Platform emitter port                                                                                       | `8091`                          |
 | `dataplatform.emitter.priorityClassName`                      | exporter priorityClassName                                                                                       | `""`                            |
+| `dataplatform.emitter.lifecycleHooks`                         | for the Data Platform emitter container(s) to automate configuration before or after startup                     | `{}`                            |
+| `dataplatform.emitter.schedulerName`                          | Name of the k8s scheduler (other than default)                                                                   | `""`                            |
+| `dataplatform.emitter.terminationGracePeriodSeconds`          | In seconds, time the given to the Data Platform emitter pod needs to terminate gracefully                        | `""`                            |
+| `dataplatform.emitter.topologySpreadConstraints`              | Topology Spread Constraints for pod assignment                                                                   | `[]`                            |
 | `dataplatform.emitter.command`                                | Override Data Platform entrypoint string.                                                                        | `[]`                            |
 | `dataplatform.emitter.args`                                   | Arguments for the provided command if needed                                                                     | `[]`                            |
 | `dataplatform.emitter.resources.limits`                       | The resources limits for the container                                                                           | `{}`                            |
@@ -227,8 +249,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.emitter.tolerations`                            | Tolerations for emitter pods assignment. Evaluated as a template                                                 | `[]`                            |
 | `dataplatform.emitter.podLabels`                              | Additional labels for Metrics emitter pod                                                                        | `{}`                            |
 | `dataplatform.emitter.podAnnotations`                         | Additional annotations for Metrics emitter pod                                                                   | `{}`                            |
-| `dataplatform.emitter.customLivenessProbe`                    | Override default liveness probe%%MAIN_CONTAINER_NAME%%                                                           | `{}`                            |
-| `dataplatform.emitter.customReadinessProbe`                   | Override default readiness probe%%MAIN_CONTAINER_NAME%%                                                          | `{}`                            |
+| `dataplatform.emitter.customLivenessProbe`                    | Override default liveness probe                                                                                  | `{}`                            |
+| `dataplatform.emitter.customReadinessProbe`                   | Override default readiness probe                                                                                 | `{}`                            |
 | `dataplatform.emitter.customStartupProbe`                     | Override default startup probe                                                                                   | `{}`                            |
 | `dataplatform.emitter.updateStrategy.type`                    | Update strategy - only really applicable for deployments with RWO PVs attached                                   | `RollingUpdate`                 |
 | `dataplatform.emitter.updateStrategy.rollingUpdate`           | Deployment rolling update configuration parameters                                                               | `{}`                            |
@@ -237,8 +259,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.emitter.extraEnvVarsSecret`                     | Secret with extra environment variables                                                                          | `""`                            |
 | `dataplatform.emitter.extraVolumes`                           | Extra volumes to add to the deployment                                                                           | `[]`                            |
 | `dataplatform.emitter.extraVolumeMounts`                      | Extra volume mounts to add to the container                                                                      | `[]`                            |
-| `dataplatform.emitter.initContainers`                         | Add init containers to the %%MAIN_CONTAINER_NAME%% pods                                                          | `[]`                            |
-| `dataplatform.emitter.sidecars`                               | Add sidecars to the %%MAIN_CONTAINER_NAME%% pods                                                                 | `[]`                            |
+| `dataplatform.emitter.initContainers`                         | Add init containers to the Data Platform emitter pods                                                            | `[]`                            |
+| `dataplatform.emitter.sidecars`                               | Add sidecars to the Data Platform emitter pods                                                                   | `[]`                            |
 | `dataplatform.emitter.service.type`                           | Service type for default Data Platform metrics emitter service                                                   | `ClusterIP`                     |
 | `dataplatform.emitter.service.annotations`                    | annotations for Data Platform emitter service                                                                    | `{}`                            |
 | `dataplatform.emitter.service.labels`                         | Additional labels for Data Platform emitter service                                                              | `{}`                            |
@@ -246,6 +268,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dataplatform.emitter.service.loadBalancerIP`                 | Load balancer IP for the dataplatform emitter Service (optional, cloud specific)                                 | `""`                            |
 | `dataplatform.emitter.service.nodePorts.http`                 | Node ports for the HTTP emitter service                                                                          | `""`                            |
 | `dataplatform.emitter.service.loadBalancerSourceRanges`       | Data Platform Emitter Load Balancer Source ranges                                                                | `[]`                            |
+| `dataplatform.emitter.service.clusterIP`                      | Data Platform emitter service Cluster IP                                                                         | `""`                            |
+| `dataplatform.emitter.service.externalTrafficPolicy`          | Data Platform emitter service external traffic policy                                                            | `Cluster`                       |
+| `dataplatform.emitter.service.extraPorts`                     | Extra ports to expose (normally used with the `sidecar` value)                                                   | `[]`                            |
+| `dataplatform.emitter.service.sessionAffinity`                | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                             | `None`                          |
+| `dataplatform.emitter.service.sessionAffinityConfig`          | Additional settings for the sessionAffinity                                                                      | `{}`                            |
 | `dataplatform.emitter.hostAliases`                            | Deployment pod host aliases                                                                                      | `[]`                            |
 
 

--- a/bitnami/dataplatform-bp1/templates/_helpers.tpl
+++ b/bitnami/dataplatform-bp1/templates/_helpers.tpl
@@ -8,26 +8,17 @@ Usage:
 {{- end -}}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "dataplatform.fullname" -}}
-{{- include "common.names.fullname" . -}}
-{{- end -}}
-
-{{/*
 Define the name of the dataplatform exporter
 */}}
 {{- define "dataplatform.exporter-name" -}}
-{{- printf "%s-%s" (include "dataplatform.fullname" .) "exporter" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "exporter" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Define the name of the dataplatform emitter
 */}}
 {{- define "dataplatform.emitter-name" -}}
-{{- printf "%s-%s" (include "dataplatform.fullname" .) "emitter" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" (include "common.names.fullname" .) "emitter" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -35,7 +26,7 @@ Define the name of the dataplatform emitter
  */}}
 {{- define "dataplatform.serviceAccountName" -}}
 {{- if .Values.dataplatform.serviceAccount.create -}}
-    {{- default (include "dataplatform.fullname" .) .Values.dataplatform.serviceAccount.name -}}
+    {{- default (include "common.names.fullname" .) .Values.dataplatform.serviceAccount.name -}}
 {{- else -}}
     {{- default "default" .Values.dataplatform.serviceAccount.name -}}
 {{- end -}}

--- a/bitnami/dataplatform-bp1/templates/configmap.yaml
+++ b/bitnami/dataplatform-bp1/templates/configmap.yaml
@@ -12,4 +12,4 @@ metadata:
   {{- end }}
 data:
   bp.json: |-
-    {{- .Values.dataplatform.exporter.config | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.config "context" $) | nindent 4 }}

--- a/bitnami/dataplatform-bp1/templates/emitter-deployment.yaml
+++ b/bitnami/dataplatform-bp1/templates/emitter-deployment.yaml
@@ -57,12 +57,21 @@ spec:
       {{- if .Values.dataplatform.emitter.priorityClassName }}
       priorityClassName: {{ .Values.dataplatform.emitter.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.dataplatform.emitter.schedulerName }}
+      schedulerName: {{ .Values.dataplatform.emitter.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.dataplatform.emitter.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.dataplatform.emitter.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.dataplatform.emitter.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if .Values.dataplatform.emitter.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.dataplatform.emitter.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       initContainers:
         {{- if .Values.dataplatform.emitter.initContainers }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
         - name: dataplatform-emitter
@@ -71,15 +80,22 @@ spec:
           {{- if .Values.dataplatform.emitter.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.dataplatform.emitter.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.dataplatform.emitter.command }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.dataplatform.emitter.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.command "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.dataplatform.emitter.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.dataplatform.emitter.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.args "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.emitter.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           env:
             - name: BP_NAME
-              value: {{ include "dataplatform.fullname" . }}
+              value: {{ include "common.names.fullname" . }}
             - name: BP_RELEASE_NAME
               value: {{ .Release.Name }}
             - name: BP_NAMESPACE
@@ -101,49 +117,36 @@ spec:
           {{- if .Values.dataplatform.emitter.resources }}
           resources: {{- toYaml .Values.dataplatform.emitter.resources | nindent 12 }}
           {{- end }}
+          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.dataplatform.emitter.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.emitter.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: "/v1/health"
-              port: {{ .Values.dataplatform.emitter.containerPorts.http }}
-            initialDelaySeconds: {{ .Values.dataplatform.emitter.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.dataplatform.emitter.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.dataplatform.emitter.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.dataplatform.emitter.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.dataplatform.emitter.livenessProbe.successThreshold }}
+              port: emitter-port
           {{- else if .Values.dataplatform.emitter.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.dataplatform.emitter.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.emitter.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: "/v1/health"
-              port: {{ .Values.dataplatform.emitter.containerPorts.http }}
-            initialDelaySeconds: {{ .Values.dataplatform.emitter.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.dataplatform.emitter.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.dataplatform.emitter.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.dataplatform.emitter.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.dataplatform.emitter.readinessProbe.successThreshold }}
+              port: emitter-port
           {{- else if .Values.dataplatform.emitter.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.dataplatform.emitter.startupProbe.enabled }}
-          startupProbe:
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.emitter.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: "/v1/health"
-              port: {{ .Values.dataplatform.emitter.containerPorts.http }}
-            initialDelaySeconds: {{ .Values.dataplatform.emitter.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.dataplatform.emitter.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.dataplatform.emitter.startupProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.dataplatform.emitter.startupProbe.failureThreshold }}
-            successThreshold: {{ .Values.dataplatform.emitter.startupProbe.successThreshold }}
+              port: emitter-port
           {{- else if .Values.dataplatform.emitter.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          volumeMounts:
-          {{- if .Values.dataplatform.emitter.extraVolumeMounts }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            {{- if .Values.dataplatform.emitter.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
         {{- if .Values.dataplatform.emitter.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.emitter.sidecars "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/dataplatform-bp1/templates/emitter-deployment.yaml
+++ b/bitnami/dataplatform-bp1/templates/emitter-deployment.yaml
@@ -80,14 +80,10 @@ spec:
           {{- if .Values.dataplatform.emitter.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.dataplatform.emitter.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.diagnosticMode.enabled }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
-          {{- else if .Values.dataplatform.emitter.command }}
+          {{- if .Values.dataplatform.emitter.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.command "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.diagnosticMode.enabled }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
-          {{- else if .Values.dataplatform.emitter.args }}
+          {{- if .Values.dataplatform.emitter.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.args "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.dataplatform.emitter.lifecycleHooks }}
@@ -117,7 +113,6 @@ spec:
           {{- if .Values.dataplatform.emitter.resources }}
           resources: {{- toYaml .Values.dataplatform.emitter.resources | nindent 12 }}
           {{- end }}
-          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.dataplatform.emitter.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.emitter.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
@@ -141,7 +136,6 @@ spec:
               port: emitter-port
           {{- else if .Values.dataplatform.emitter.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.customStartupProbe "context" $) | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             {{- if .Values.dataplatform.emitter.extraVolumeMounts }}

--- a/bitnami/dataplatform-bp1/templates/emitter-svc.yaml
+++ b/bitnami/dataplatform-bp1/templates/emitter-svc.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: "{{ include "dataplatform.emitter-name" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: dataplatform-emitter
     {{- if .Values.commonLabels }}
@@ -10,24 +12,32 @@ metadata:
     {{- if .Values.dataplatform.emitter.service.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.emitter.service.labels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: "{{ include "dataplatform.emitter-name" . }}"
-  {{- if or .Values.dataplatform.emitter.service.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.dataplatform.emitter.service.annotations }}
-    {{ include "common.tplvalues.render" ( dict "value" .Values.dataplatform.emitter.service.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.emitter.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- end }}
-  namespace: {{ .Release.Namespace | quote }}
 spec:
   type: {{ .Values.dataplatform.emitter.service.type }}
-  {{ if eq .Values.dataplatform.emitter.service.type "LoadBalancer" }}
+  {{- if and (eq .Values.dataplatform.emitter.service.type "LoadBalancer") (not (empty .Values.dataplatform.emitter.service.loadBalancerSourceRanges)) }}
   loadBalancerSourceRanges: {{ .Values.dataplatform.emitter.service.loadBalancerSourceRanges }}
-  {{ end }}
-  {{- if (and (eq .Values.dataplatform.emitter.service.type "LoadBalancer") (not (empty .Values.dataplatform.emitter.service.loadBalancerIP))) }}
+  {{- end }}
+  {{- if and (eq .Values.dataplatform.emitter.service.type "LoadBalancer") (not (empty .Values.dataplatform.emitter.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.dataplatform.emitter.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and .Values.dataplatform.emitter.service.clusterIP (eq .Values.dataplatform.emitter.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.dataplatform.emitter.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.dataplatform.emitter.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.dataplatform.emitter.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.dataplatform.emitter.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if or (eq .Values.dataplatform.emitter.service.type "LoadBalancer") (eq .Values.dataplatform.emitter.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.dataplatform.emitter.service.externalTrafficPolicy | quote }}
   {{- end }}
   ports:
     - name: tcp-client
@@ -39,6 +49,9 @@ spec:
       {{- else if eq .Values.dataplatform.emitter.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.dataplatform.emitter.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.emitter.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: dataplatform-emitter
-{{ end }}
+{{- end }}

--- a/bitnami/dataplatform-bp1/templates/exporter-deployment.yaml
+++ b/bitnami/dataplatform-bp1/templates/exporter-deployment.yaml
@@ -57,12 +57,21 @@ spec:
       {{- if .Values.dataplatform.exporter.priorityClassName }}
       priorityClassName: {{ .Values.dataplatform.exporter.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.dataplatform.exporter.schedulerName }}
+      schedulerName: {{ .Values.dataplatform.exporter.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.dataplatform.exporter.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- if .Values.dataplatform.exporter.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.dataplatform.exporter.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.dataplatform.exporter.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.dataplatform.exporter.terminationGracePeriodSeconds }}
+      {{- end }}
       initContainers:
         {{- if .Values.dataplatform.exporter.initContainers }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.initContainers "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.initContainers "context" $) | nindent 8 }}
         {{- end }}
       containers:
         - name: dataplatform-exporter
@@ -71,18 +80,27 @@ spec:
           {{- if .Values.dataplatform.exporter.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.dataplatform.exporter.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.dataplatform.exporter.command }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.dataplatform.exporter.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.command "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.dataplatform.exporter.args }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.dataplatform.exporter.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.args "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.dataplatform.exporter.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
           env:
             - name: METRIC_CONFIG_PATH
               value: "/data/bp.json"
             - name: DP_URI
               value: http://{{ include "dataplatform.emitter-name" . }}:{{ .Values.dataplatform.emitter.service.ports.http }}
-          {{- if or .Values.dataplatform.exporter.extraEnvVarsCM .Values.dataplatform.exporter.extraEnvVarsSecret }}
+            {{- if .Values.dataplatform.exporter.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           envFrom:
             {{- if .Values.dataplatform.exporter.extraEnvVarsCM }}
             - configMapRef:
@@ -92,59 +110,45 @@ spec:
             - secretRef:
                 name: {{ include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.extraEnvVarsSecret "context" $) }}
             {{- end }}
-          {{- end }}
           ports:
             - name: exporter-port
               containerPort: {{ .Values.dataplatform.exporter.containerPorts.http }}
           {{- if .Values.dataplatform.exporter.resources }}
           resources: {{- toYaml .Values.dataplatform.exporter.resources | nindent 12 }}
           {{- end }}
+          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.dataplatform.exporter.livenessProbe.enabled }}
-          livenessProbe:
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.exporter.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: "/metrics"
-              port: {{ .Values.dataplatform.exporter.containerPorts.http }}
-            initialDelaySeconds: {{ .Values.dataplatform.exporter.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.dataplatform.exporter.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.dataplatform.exporter.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.dataplatform.exporter.livenessProbe.failureThreshold }}
-            successThreshold: {{ .Values.dataplatform.exporter.livenessProbe.successThreshold }}
+              port: exporter-port
           {{- else if .Values.dataplatform.exporter.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.dataplatform.exporter.readinessProbe.enabled }}
-          readinessProbe:
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.exporter.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: "/metrics"
-              port: {{ .Values.dataplatform.exporter.containerPorts.http }}
-            initialDelaySeconds: {{ .Values.dataplatform.exporter.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.dataplatform.exporter.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.dataplatform.exporter.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.dataplatform.exporter.readinessProbe.failureThreshold }}
-            successThreshold: {{ .Values.dataplatform.exporter.readinessProbe.successThreshold }}
+              port: exporter-port
           {{- else if .Values.dataplatform.exporter.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.dataplatform.exporter.startupProbe.enabled }}
-          startupProbe:
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.exporter.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: "/v1/health"
-              port: {{ .Values.dataplatform.exporter.containerPorts.http }}
-            initialDelaySeconds: {{ .Values.dataplatform.exporter.startupProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.dataplatform.exporter.startupProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.dataplatform.exporter.startupProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.dataplatform.exporter.startupProbe.failureThreshold }}
-            successThreshold: {{ .Values.dataplatform.exporter.startupProbe.successThreshold }}
+              port: exporter-port
           {{- else if .Values.dataplatform.exporter.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
+          {{- end }}
           volumeMounts:
             - name: exporter-config
-              mountPath: /data/bp.json 
+              mountPath: /data/bp.json
               subPath: bp.json
-          {{- if .Values.dataplatform.exporter.extraVolumeMounts }}
-          {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.extraVolumeMounts "context" $) | nindent 12 }}
-          {{- end }}
+            {{- if .Values.dataplatform.exporter.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
         {{- if .Values.dataplatform.exporter.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.exporter.sidecars "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/dataplatform-bp1/templates/exporter-deployment.yaml
+++ b/bitnami/dataplatform-bp1/templates/exporter-deployment.yaml
@@ -80,14 +80,10 @@ spec:
           {{- if .Values.dataplatform.exporter.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.dataplatform.exporter.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.diagnosticMode.enabled }}
-          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
-          {{- else if .Values.dataplatform.exporter.command }}
+          {{- if .Values.dataplatform.exporter.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.command "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.diagnosticMode.enabled }}
-          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
-          {{- else if .Values.dataplatform.exporter.args }}
+          {{- if .Values.dataplatform.exporter.args }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.args "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.dataplatform.exporter.lifecycleHooks }}
@@ -116,7 +112,6 @@ spec:
           {{- if .Values.dataplatform.exporter.resources }}
           resources: {{- toYaml .Values.dataplatform.exporter.resources | nindent 12 }}
           {{- end }}
-          {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.dataplatform.exporter.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dataplatform.exporter.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
@@ -140,7 +135,6 @@ spec:
               port: exporter-port
           {{- else if .Values.dataplatform.exporter.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.customStartupProbe "context" $) | nindent 12 }}
-          {{- end }}
           {{- end }}
           volumeMounts:
             - name: exporter-config

--- a/bitnami/dataplatform-bp1/templates/exporter-svc.yaml
+++ b/bitnami/dataplatform-bp1/templates/exporter-svc.yaml
@@ -2,6 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: "{{ include "dataplatform.exporter-name" . }}"
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: dataplatform-exporter
     {{- if .Values.commonLabels }}
@@ -10,24 +12,32 @@ metadata:
     {{- if .Values.dataplatform.exporter.service.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.exporter.service.labels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: "{{ include "dataplatform.exporter-name" . }}"
-  {{- if or .Values.dataplatform.exporter.service.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.dataplatform.exporter.service.annotations }}
-    {{ include "common.tplvalues.render" ( dict "value" .Values.dataplatform.exporter.service.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.dataplatform.exporter.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- end }}
-  namespace: {{ .Release.Namespace | quote }}
 spec:
   type: {{ .Values.dataplatform.exporter.service.type }}
-  {{ if eq .Values.dataplatform.exporter.service.type "LoadBalancer" }}
+  {{- if and (eq .Values.dataplatform.exporter.service.type "LoadBalancer") (not (empty .Values.dataplatform.exporter.service.loadBalancerSourceRanges)) }}
   loadBalancerSourceRanges: {{ .Values.dataplatform.exporter.service.loadBalancerSourceRanges }}
-  {{ end }}
-  {{- if (and (eq .Values.dataplatform.exporter.service.type "LoadBalancer") (not (empty .Values.dataplatform.exporter.service.loadBalancerIP))) }}
+  {{- end }}
+  {{- if and (eq .Values.dataplatform.exporter.service.type "LoadBalancer") (not (empty .Values.dataplatform.exporter.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.dataplatform.exporter.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and .Values.dataplatform.exporter.service.clusterIP (eq .Values.dataplatform.exporter.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.dataplatform.exporter.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.dataplatform.exporter.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.dataplatform.exporter.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.dataplatform.exporter.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if or (eq .Values.dataplatform.exporter.service.type "LoadBalancer") (eq .Values.dataplatform.exporter.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.dataplatform.exporter.service.externalTrafficPolicy | quote }}
   {{- end }}
   ports:
     - name: tcp-client
@@ -39,6 +49,9 @@ spec:
       {{- else if eq .Values.dataplatform.exporter.service.type "ClusterIP" }}
       nodePort: null
       {{- end }}
+    {{- if .Values.dataplatform.exporter.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.exporter.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: dataplatform-exporter
 {{ end }}

--- a/bitnami/dataplatform-bp1/templates/role.yaml
+++ b/bitnami/dataplatform-bp1/templates/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
-  name: {{ template "dataplatform.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: dataplatform

--- a/bitnami/dataplatform-bp1/templates/rolebinding.yaml
+++ b/bitnami/dataplatform-bp1/templates/rolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
-  name: {{ template "dataplatform.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: dataplatform
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 roleRef:
   kind: Role
-  name: {{ template "dataplatform.fullname" . }}
+  name: {{ template "common.names.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount

--- a/bitnami/dataplatform-bp1/templates/serviceaccount.yaml
+++ b/bitnami/dataplatform-bp1/templates/serviceaccount.yaml
@@ -9,8 +9,12 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.dataplatform.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.dataplatform.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
 automountServiceAccountToken: {{ .Values.dataplatform.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/bitnami/dataplatform-bp1/values.yaml
+++ b/bitnami/dataplatform-bp1/values.yaml
@@ -43,21 +43,6 @@ extraDeploy: []
 ##
 clusterDomain: cluster.local
 
-## Enable diagnostic mode in the deployment(s)/statefulset(s)
-##
-diagnosticMode:
-  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
-  ##
-  enabled: false
-  ## @param diagnosticMode.command Command to override all containers in the the deployment(s)/statefulset(s)
-  ##
-  command:
-    - sleep
-  ## @param diagnosticMode.args Args to override all containers in the the deployment(s)/statefulset(s)
-  ##
-  args:
-    - infinity
-
 ## @section Data Platform Chart parameters
 ## Configuration for the dataplatform prometheus exporter
 ##

--- a/bitnami/dataplatform-bp1/values.yaml
+++ b/bitnami/dataplatform-bp1/values.yaml
@@ -18,6 +18,18 @@ global:
   storageClass: ""
 
 ## @section Common parameters
+## @param kubeVersion Force target Kubernetes version (using Helm capabilities if not set)
+##
+kubeVersion: ""
+## @param nameOverride String to partially override %%COMPONENT_NAME%%.fullname template with a string (will prepend the release name)
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override %%COMPONENT_NAME%%.fullname template with a string
+##
+fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
 ## @param commonLabels Labels to add to all deployed objects
 ##
 commonLabels: {}
@@ -27,6 +39,24 @@ commonAnnotations: {}
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param clusterDomain Kubernetes cluster domain name
+##
+clusterDomain: cluster.local
+
+## Enable diagnostic mode in the deployment(s)/statefulset(s)
+##
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ##
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the the deployment(s)/statefulset(s)
+  ##
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the the deployment(s)/statefulset(s)
+  ##
+  args:
+    - infinity
 
 ## @section Data Platform Chart parameters
 ## Configuration for the dataplatform prometheus exporter
@@ -44,6 +74,9 @@ dataplatform:
     ## Can be set to false if pods using this serviceAccount do not need to use K8s API
     ##
     automountServiceAccountToken: true
+    ## @param serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
+    ##
+    annotations: {}
   ## Role Based Access
   ## ref: https://kubernetes.io/docs/admin/authorization/rbac/
   ##
@@ -219,6 +252,22 @@ dataplatform:
     ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
     ##
     priorityClassName: ""
+    ## @param dataplatform.exporter.lifecycleHooks for the Data Platform Exporter container(s) to automate configuration before or after startup
+    ##
+    lifecycleHooks: {}
+    ## @param dataplatform.exporter.schedulerName Name of the k8s scheduler (other than default)
+    ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+    ##
+    schedulerName: ""
+    ## @param dataplatform.exporter.terminationGracePeriodSeconds In seconds, time the given to the Data Platform Exporter pod needs to terminate gracefully
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+    ##
+    terminationGracePeriodSeconds: ""
+    ## @param dataplatform.exporter.topologySpreadConstraints Topology Spread Constraints for pod assignment
+    ## https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+    ## The value is evaluated as a template
+    ##
+    topologySpreadConstraints: []
     ## @param dataplatform.exporter.command Override Data Platform Exporter entrypoint string.
     ##
     command: []
@@ -350,7 +399,7 @@ dataplatform:
     ## @param dataplatform.exporter.extraVolumeMounts Extra volume mounts to add to the container
     ##
     extraVolumeMounts: []
-    ## @param dataplatform.exporter.initContainers Add init containers to the %%MAIN_CONTAINER_NAME%% pods
+    ## @param dataplatform.exporter.initContainers Add init containers to the Data Platform exporter pods
     ## Example:
     ## initContainers:
     ##   - name: your-image-name
@@ -361,7 +410,7 @@ dataplatform:
     ##         containerPort: 1234
     ##
     initContainers: []
-    ## @param dataplatform.exporter.sidecars Add sidecars to the %%MAIN_CONTAINER_NAME%% pods
+    ## @param dataplatform.exporter.sidecars Add sidecars to the Data Platform exporter pods
     ## Example:
     ## sidecars:
     ##   - name: your-image-name
@@ -407,6 +456,29 @@ dataplatform:
       ##   - 10.10.10.0/24
       ##
       loadBalancerSourceRanges: []
+      ## @param dataplatform.exporter.service.clusterIP Data Platform exporter service Cluster IP
+      ## e.g.:
+      ## clusterIP: None
+      ##
+      clusterIP: ""
+      ## @param dataplatform.exporter.service.externalTrafficPolicy Data Platform exporter service external traffic policy
+      ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+      ##
+      externalTrafficPolicy: Cluster
+      ## @param dataplatform.exporter.service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
+      ##
+      extraPorts: []
+      ## @param dataplatform.exporter.service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
+      ## If "ClientIP", consecutive client requests will be directed to the same Pod
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+      ##
+      sessionAffinity: None
+      ## @param dataplatform.exporter.service.sessionAffinityConfig Additional settings for the sessionAffinity
+      ## sessionAffinityConfig:
+      ##   clientIP:
+      ##     timeoutSeconds: 300
+      ##
+      sessionAffinityConfig: {}
     ## @param dataplatform.exporter.hostAliases Deployment pod host aliases
     ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
     ##
@@ -496,6 +568,22 @@ dataplatform:
     ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
     ##
     priorityClassName: ""
+    ## @param dataplatform.emitter.lifecycleHooks for the Data Platform emitter container(s) to automate configuration before or after startup
+    ##
+    lifecycleHooks: {}
+    ## @param dataplatform.emitter.schedulerName Name of the k8s scheduler (other than default)
+    ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+    ##
+    schedulerName: ""
+    ## @param dataplatform.emitter.terminationGracePeriodSeconds In seconds, time the given to the Data Platform emitter pod needs to terminate gracefully
+    ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+    ##
+    terminationGracePeriodSeconds: ""
+    ## @param dataplatform.emitter.topologySpreadConstraints Topology Spread Constraints for pod assignment
+    ## https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+    ## The value is evaluated as a template
+    ##
+    topologySpreadConstraints: []
     ## @param dataplatform.emitter.command Override Data Platform entrypoint string.
     ##
     command: []
@@ -589,10 +677,10 @@ dataplatform:
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     ##
     podAnnotations: {}
-    ## @param dataplatform.emitter.customLivenessProbe Override default liveness probe%%MAIN_CONTAINER_NAME%%
+    ## @param dataplatform.emitter.customLivenessProbe Override default liveness probe
     ##
     customLivenessProbe: {}
-    ## @param dataplatform.emitter.customReadinessProbe Override default readiness probe%%MAIN_CONTAINER_NAME%%
+    ## @param dataplatform.emitter.customReadinessProbe Override default readiness probe
     ##
     customReadinessProbe: {}
     ## @param dataplatform.emitter.customStartupProbe Override default startup probe
@@ -627,7 +715,7 @@ dataplatform:
     ## @param dataplatform.emitter.extraVolumeMounts Extra volume mounts to add to the container
     ##
     extraVolumeMounts: []
-    ## @param dataplatform.emitter.initContainers Add init containers to the %%MAIN_CONTAINER_NAME%% pods
+    ## @param dataplatform.emitter.initContainers Add init containers to the Data Platform emitter pods
     ## Example:
     ## initContainers:
     ##   - name: your-image-name
@@ -638,7 +726,7 @@ dataplatform:
     ##         containerPort: 1234
     ##
     initContainers: []
-    ## @param dataplatform.emitter.sidecars Add sidecars to the %%MAIN_CONTAINER_NAME%% pods
+    ## @param dataplatform.emitter.sidecars Add sidecars to the Data Platform emitter pods
     ## Example:
     ## sidecars:
     ##   - name: your-image-name
@@ -681,6 +769,29 @@ dataplatform:
       ##   - 10.10.10.0/24
       ##
       loadBalancerSourceRanges: []
+      ## @param dataplatform.emitter.service.clusterIP Data Platform emitter service Cluster IP
+      ## e.g.:
+      ## clusterIP: None
+      ##
+      clusterIP: ""
+      ## @param dataplatform.emitter.service.externalTrafficPolicy Data Platform emitter service external traffic policy
+      ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+      ##
+      externalTrafficPolicy: Cluster
+      ## @param dataplatform.emitter.service.extraPorts Extra ports to expose (normally used with the `sidecar` value)
+      ##
+      extraPorts: []
+      ## @param dataplatform.emitter.service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
+      ## If "ClientIP", consecutive client requests will be directed to the same Pod
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+      ##
+      sessionAffinity: None
+      ## @param dataplatform.emitter.service.sessionAffinityConfig Additional settings for the sessionAffinity
+      ## sessionAffinityConfig:
+      ##   clientIP:
+      ##     timeoutSeconds: 300
+      ##
+      sessionAffinityConfig: {}
     ## @param dataplatform.emitter.hostAliases Deployment pod host aliases
     ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
     ##

--- a/bitnami/dataplatform-bp1/values.yaml
+++ b/bitnami/dataplatform-bp1/values.yaml
@@ -74,7 +74,7 @@ dataplatform:
     ## Can be set to false if pods using this serviceAccount do not need to use K8s API
     ##
     automountServiceAccountToken: true
-    ## @param serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
+    ## @param dataplatform.serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
     ##
     annotations: {}
   ## Role Based Access


### PR DESCRIPTION
**Description of the change**

This PR standardizes the bitnami/dataplatform-bp1 chart to be in line with the rest of the catalog.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
