### PR TITLE
Add ability change name port for metrics service

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.9.5
+version: 16.9.6

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.9.6
+version: 16.10.0

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -442,7 +442,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.podAnnotations`                     | Annotations for Redis&trade; exporter pods                                                       | `{}`                     |
 | `metrics.service.type`                       | Redis&trade; exporter service type                                                               | `ClusterIP`              |
 | `metrics.service.port`                       | Redis&trade; exporter service port                                                               | `9121`                   |
-| `metrics.service.portName`                       | Redis&trade; exporter service name                                                               | `http-metrics`                   |
+| `metrics.service.portName`                   | Redis&trade; exporter service port name                                                          | `http-metrics`           |
 | `metrics.service.externalTrafficPolicy`      | Redis&trade; exporter service external traffic policy                                            | `Cluster`                |
 | `metrics.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                   | `[]`                     |
 | `metrics.service.loadBalancerIP`             | Redis&trade; exporter service Load Balancer IP                                                   | `""`                     |

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -442,7 +442,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.podAnnotations`                     | Annotations for Redis&trade; exporter pods                                                       | `{}`                     |
 | `metrics.service.type`                       | Redis&trade; exporter service type                                                               | `ClusterIP`              |
 | `metrics.service.port`                       | Redis&trade; exporter service port                                                               | `9121`                   |
-| `metrics.service.name`                       | Redis&trade; exporter service name                                                               | `http-metrics`                   |
+| `metrics.service.portName`                       | Redis&trade; exporter service name                                                               | `http-metrics`                   |
 | `metrics.service.externalTrafficPolicy`      | Redis&trade; exporter service external traffic policy                                            | `Cluster`                |
 | `metrics.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                   | `[]`                     |
 | `metrics.service.loadBalancerIP`             | Redis&trade; exporter service Load Balancer IP                                                   | `""`                     |

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -442,6 +442,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.podAnnotations`                     | Annotations for Redis&trade; exporter pods                                                       | `{}`                     |
 | `metrics.service.type`                       | Redis&trade; exporter service type                                                               | `ClusterIP`              |
 | `metrics.service.port`                       | Redis&trade; exporter service port                                                               | `9121`                   |
+| `metrics.service.name`                       | Redis&trade; exporter service name                                                               | `http-metrics`                   |
 | `metrics.service.externalTrafficPolicy`      | Redis&trade; exporter service external traffic policy                                            | `Cluster`                |
 | `metrics.service.extraPorts`                 | Extra ports to expose (normally used with the `sidecar` value)                                   | `[]`                     |
 | `metrics.service.loadBalancerIP`             | Redis&trade; exporter service Load Balancer IP                                                   | `""`                     |

--- a/bitnami/redis/templates/metrics-svc.yaml
+++ b/bitnami/redis/templates/metrics-svc.yaml
@@ -30,7 +30,7 @@ spec:
   loadBalancerSourceRanges: {{- toYaml .Values.metrics.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   ports:
-    - name: {{ .Values.metrics.service.name }}
+    - name: {{ .Values.metrics.service.portName }}
       port: {{ .Values.metrics.service.port }}
       protocol: TCP
       targetPort: metrics

--- a/bitnami/redis/templates/metrics-svc.yaml
+++ b/bitnami/redis/templates/metrics-svc.yaml
@@ -30,7 +30,7 @@ spec:
   loadBalancerSourceRanges: {{- toYaml .Values.metrics.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   ports:
-    - name: http-metrics
+    - name: {{ .Values.metrics.service.name }}
       port: {{ .Values.metrics.service.port }}
       protocol: TCP
       targetPort: metrics

--- a/bitnami/redis/templates/servicemonitor.yaml
+++ b/bitnami/redis/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: {{ .Values.metrics.service.name }}
+    - port: {{ .Values.metrics.service.portName }}
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}

--- a/bitnami/redis/templates/servicemonitor.yaml
+++ b/bitnami/redis/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   endpoints:
-    - port: http-metrics
+    - port: {{ .Values.metrics.service.name }}
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1371,6 +1371,9 @@ metrics:
     ## @param metrics.service.port Redis&trade; exporter service port
     ##
     port: 9121
+    ## @param metrics.service.name Redis&trade; exporter service port name
+    ##
+    name: http-metrics
     ## @param metrics.service.externalTrafficPolicy Redis&trade; exporter service external traffic policy
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -1371,9 +1371,9 @@ metrics:
     ## @param metrics.service.port Redis&trade; exporter service port
     ##
     port: 9121
-    ## @param metrics.service.name Redis&trade; exporter service port name
+    ## @param metrics.service.portName Redis&trade; exporter service port name
     ##
-    name: http-metrics
+    portName: http-metrics
     ## @param metrics.service.externalTrafficPolicy Redis&trade; exporter service external traffic policy
     ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
     ##


### PR DESCRIPTION
Signed-off-by: hontarenko <serhii.hontarenko@amomedia.com>
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Changed name port for metrics service via values

### Benefits

It will be possible to connect two Redis services with exporters without any problems

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #10232 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
