### PR TITLE
[bitnami/*] revert: skipping the CI automated README comments

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -61,5 +61,5 @@ jobs:
           if git status -s | grep bitnami; then
             git config user.name "Bitnami Containers"
             git config user.email "containers@bitnami.com"
-            git add . && git commit -am "[skip ci] Update README.md with readme-generator-for-helm" --signoff && git push
+            git add . && git commit -am "Update README.md with readme-generator-for-helm" --signoff && git push
           fi


### PR DESCRIPTION
This functionality is not available for workflows of type: `pull_request_target`.

Signed-off-by: Alejandro Ruiz <alejandroruiz@vmware.com>