### PR TITLE
[bitnami/redis] Support allocateLoadBalancerNodePorts setting

### DIFF
--- a/bitnami/redis-cluster/templates/redis-svc.yaml
+++ b/bitnami/redis-cluster/templates/redis-svc.yaml
@@ -31,6 +31,9 @@ spec:
   {{- if and (eq "LoadBalancer" .Values.service.type) .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  {{- if and (eq "LoadBalancer" .Values.service.type) .Values.service.loadBalancerIP }}
+  allocateLoadBalancerNodePorts: {{ .Values.service.allocateLoadBalancerNodePorts }}
+  {{- end }}
   ports:
     - name: tcp-redis
       port: {{ .Values.service.ports.redis }}

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -271,6 +271,8 @@ service:
   ## ref https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
   ##
   externalTrafficPolicy: Cluster
+
+  allocateLoadBalancerNodePorts: true
 ## Enable persistence using Persistent Volume Claims
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
 ##


### PR DESCRIPTION
### Description of the change
I noticed that `allocateLoadBalancerNodePorts` looks to be supported by some Bitnami charts but not all of them and we prefer to be able to skip node port allocation on services which use service type `LoadBalancer`
