### PR TITLE
[bitnami/mongodb] Use deepCopy in "common.secrets.passwords.manage" call 

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 12.1.8
+version: 12.1.9

--- a/bitnami/mongodb/templates/secrets.yaml
+++ b/bitnami/mongodb/templates/secrets.yaml
@@ -30,7 +30,7 @@ data:
   {{- end -}}
   {{- $passwordList = (join "," $customPasswordsList) -}}
   {{- end }}
-  mongodb-passwords: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mongodb.fullname" .) "key" "mongodb-passwords" "providedValues" (list "mongodbPasswords") "context" (dict "Values" (dict "mongodbPasswords" $passwordList))) }}
+  mongodb-passwords: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mongodb.fullname" .) "key" "mongodb-passwords" "providedValues" (list "mongodbPasswords") "context" (merge (deepCopy $) (dict "Values" (dict "mongodbPasswords" $passwordList)))) }}
   {{- end }}
   {{- if .Values.metrics.username }}
   mongodb-metrics-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mongodb.fullname" .) "key" "mongodb-metrics-password" "providedValues" (list "metrics.password" ) "context" $) }}

--- a/bitnami/mongodb/templates/secrets.yaml
+++ b/bitnami/mongodb/templates/secrets.yaml
@@ -30,7 +30,7 @@ data:
   {{- end -}}
   {{- $passwordList = (join "," $customPasswordsList) -}}
   {{- end }}
-  mongodb-passwords: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mongodb.fullname" .) "key" "mongodb-passwords" "providedValues" (list "mongodbPasswords") "context" (merge (deepCopy $) (dict "Values" (dict "mongodbPasswords" $passwordList)))) }}
+  mongodb-passwords: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mongodb.fullname" .) "key" "mongodb-passwords" "providedValues" (list "mongodbPasswords") "context" (set (deepCopy $) "Values" (dict "mongodbPasswords" $passwordList))) }}
   {{- end }}
   {{- if .Values.metrics.username }}
   mongodb-metrics-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "mongodb.fullname" .) "key" "mongodb-metrics-password" "providedValues" (list "metrics.password" ) "context" $) }}

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -105,7 +105,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/mongodb
-  tag: 5.0.8-debian-10-r21
+  tag: 5.0.8-debian-10-r23
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -196,7 +196,7 @@ tls:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.21.6-debian-10-r111
+    tag: 1.21.6-debian-10-r113
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -734,7 +734,7 @@ externalAccess:
     image:
       registry: docker.io
       repository: bitnami/kubectl
-      tag: 1.24.0-debian-10-r0
+      tag: 1.24.0-debian-10-r1
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1081,7 +1081,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r429
+    tag: 10-debian-10-r430
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1825,7 +1825,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/mongodb-exporter
-    tag: 0.32.0-debian-10-r22
+    tag: 0.32.0-debian-10-r23
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

### Description of the change

Use a deepCopy of the context with custom Values in `common.secrets.passwords.manage` call. Some context information (from .Release object) is required by `common.secrets.passwords.manage` helper


### Applicable issues

Not reported. 

### Additional information

`bitnami/parse` or `bitnami/node` charts couldn't be upgraded if they used version 12.1.8 of this chart

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
