### PR TITLE
[bitnami/dataplatform-bp1/2] Deprecate Dataplatform BPs Helm charts

### DIFF
--- a/bitnami/dataplatform-bp1/Chart.yaml
+++ b/bitnami/dataplatform-bp1/Chart.yaml
@@ -28,7 +28,9 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: This Helm chart can be used for the automated deployment of a data platform blueprint containing Kafka, Apache Spark, and Solr. It covers optimized pod sizing and placement diversity rules.
+# This Helm chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED This Helm chart can be used for the automated deployment of a data platform blueprint containing Kafka, Apache Spark, and Solr. It covers optimized pod sizing and placement diversity rules.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/dataplatform-bp1
 icon: https://bitnami.com/assets/stacks/dataplatform-bp1/img/dataplatform-bp1-stack-220x234.png
@@ -42,9 +44,7 @@ keywords:
   - observability
   - apache
   - tanzuobservability
-maintainers:
-  - email: containers@bitnami.com
-    name: Bitnami
+maintainers: []
 name: dataplatform-bp1
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
@@ -59,4 +59,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 12.0.1
+version: 12.0.2

--- a/bitnami/dataplatform-bp1/README.md
+++ b/bitnami/dataplatform-bp1/README.md
@@ -6,8 +6,10 @@ This Helm chart can be used for the automated deployment of a data platform blue
 
 [Overview of Data Platform Blueprint 1](https://github.com/bitnami/dataplatform-exporter)
 
+## This Helm chart is deprecated
 
-                           
+The project behind this solution has been discontinued.
+
 ## TL;DR
 
 ```console

--- a/bitnami/dataplatform-bp1/templates/NOTES.txt
+++ b/bitnami/dataplatform-bp1/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The project behind this solution has been discontinued.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}

--- a/bitnami/dataplatform-bp2/Chart.yaml
+++ b/bitnami/dataplatform-bp2/Chart.yaml
@@ -28,7 +28,9 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: This Helm chart can be used for the automated deployment of a data platform blueprint containing Kafka, Apache Spark and Elasticsearch. It covers optimized pod sizing and placement diversity rules.
+# This Helm chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED This Helm chart can be used for the automated deployment of a data platform blueprint containing Kafka, Apache Spark and Elasticsearch. It covers optimized pod sizing and placement diversity rules.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/dataplatform-bp2
 icon: https://bitnami.com/assets/stacks/dataplatform-bp1/img/dataplatform-bp1-stack-220x234.png
@@ -43,9 +45,7 @@ keywords:
   - apache
   - tanzuobservability
   - wavefront
-maintainers:
-  - email: containers@bitnami.com
-    name: Bitnami
+maintainers: []
 name: dataplatform-bp2
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
@@ -58,4 +58,4 @@ sources:
   - https://www.elastic.co/products/logstash
   - https://zookeeper.apache.org/
   - https://github.com/bitnami/bitnami-docker-zookeeper
-version: 13.0.1
+version: 13.0.2

--- a/bitnami/dataplatform-bp2/README.md
+++ b/bitnami/dataplatform-bp2/README.md
@@ -6,7 +6,9 @@ This Helm chart can be used for the automated deployment of a data platform blue
 
 [Overview of Data Platform Blueprint 2](https://github.com/bitnami/dataplatform-emitter)
 
+## This Helm chart is deprecated
 
+The project behind this solution has been discontinued.
 
 ## TL;DR
 

--- a/bitnami/dataplatform-bp2/templates/NOTES.txt
+++ b/bitnami/dataplatform-bp2/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The project behind this solution has been discontinued.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}


### PR DESCRIPTION
### Description of the change

The Dataplatform BPs Helm charts will be deprecated

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
