### PR TITLE
[bitnami/argo-workflows] Add missing serviceAccount.* parameters

### DIFF
--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-argo-workflow-controller
   - https://github.com/bitnami/bitnami-docker-argo-workflow-exec
   - https://argoproj.github.io/workflows/
-version: 2.1.1
+version: 2.2.0

--- a/bitnami/argo-workflows/README.md
+++ b/bitnami/argo-workflows/README.md
@@ -78,104 +78,105 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Argo Workflows Server configuration parameters
 
-| Name                                                     | Description                                                                                             | Value                       |
-| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `server.image.registry`                                  | server image registry                                                                                   | `docker.io`                 |
-| `server.image.repository`                                | server image repository                                                                                 | `bitnami/argo-workflow-cli` |
-| `server.image.tag`                                       | server image tag (immutable tags are recommended)                                                       | `3.3.5-scratch-r0`          |
-| `server.image.pullPolicy`                                | server image pull policy                                                                                | `Always`                    |
-| `server.image.pullSecrets`                               | server image pull secrets                                                                               | `[]`                        |
-| `server.enabled`                                         | Enable server deployment                                                                                | `true`                      |
-| `server.replicaCount`                                    | Number of server replicas to deploy                                                                     | `1`                         |
-| `server.livenessProbe.enabled`                           | Enable livenessProbe on server nodes                                                                    | `true`                      |
-| `server.livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                 | `10`                        |
-| `server.livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                        | `20`                        |
-| `server.livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                                       | `1`                         |
-| `server.livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                                     | `3`                         |
-| `server.livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                                     | `1`                         |
-| `server.readinessProbe.enabled`                          | Enable readinessProbe on server nodes                                                                   | `true`                      |
-| `server.readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                                | `10`                        |
-| `server.readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                                       | `20`                        |
-| `server.readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                                      | `1`                         |
-| `server.readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                                    | `3`                         |
-| `server.readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                                    | `1`                         |
-| `server.startupProbe.enabled`                            | Enable startupProbe                                                                                     | `false`                     |
-| `server.startupProbe.path`                               | Path to check for startupProbe                                                                          | `/`                         |
-| `server.startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                                  | `300`                       |
-| `server.startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                                         | `10`                        |
-| `server.startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                                        | `5`                         |
-| `server.startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                                      | `6`                         |
-| `server.startupProbe.successThreshold`                   | Success threshold for startupProbe                                                                      | `1`                         |
-| `server.customLivenessProbe`                             | Server custom livenessProbe that overrides the default one                                              | `{}`                        |
-| `server.customReadinessProbe`                            | Server custom readinessProbe that overrides the default one                                             | `{}`                        |
-| `server.customStartupProbe`                              | Server custom startupProbe that overrides the default one                                               | `{}`                        |
-| `server.resources.limits`                                | The resources limits for the server containers                                                          | `{}`                        |
-| `server.resources.requests`                              | The requested resources for the server containers                                                       | `{}`                        |
-| `server.podSecurityContext.enabled`                      | Enabled server pods' Security Context                                                                   | `true`                      |
-| `server.podSecurityContext.fsGroup`                      | Set server pod's Security Context fsGroup                                                               | `1001`                      |
-| `server.containerSecurityContext.enabled`                | Enabled server containers' Security Context                                                             | `true`                      |
-| `server.containerSecurityContext.runAsUser`              | Set server containers' Security Context runAsUser                                                       | `1001`                      |
-| `server.containerSecurityContext.runAsNonRoot`           | Set server containers' Security Context runAsNonRoot                                                    | `true`                      |
-| `server.containerSecurityContext.readOnlyRootFilesystem` | Set read only root file system pod's Security Conte                                                     | `true`                      |
-| `server.rbac.create`                                     | Create RBAC resources for the Argo workflows server                                                     | `true`                      |
-| `server.extraArgs`                                       | Extra arguments for the server command line                                                             | `""`                        |
-| `server.auth.enabled`                                    | Enable authentication                                                                                   | `true`                      |
-| `server.auth.mode`                                       | Set authentication mode. Either `server`, `client` or `sso`.                                            | `client`                    |
-| `server.auth.sso.enabled`                                | Enable SSO configuration for the server auth mode                                                       | `false`                     |
-| `server.auth.sso.issuer`                                 | Root URL for the OIDC identity provider                                                                 | `""`                        |
-| `server.auth.sso.clientId.name`                          | Name of the secret containing the OIDC client ID                                                        | `""`                        |
-| `server.auth.sso.clientId.key`                           | Key in the secret to obtain the OIDC client ID                                                          | `""`                        |
-| `server.auth.sso.clientSecret.name`                      | Name of the secret containing the OIDC client secret                                                    | `""`                        |
-| `server.auth.sso.clientSecret.key`                       | Key in the secret to obtain the OIDC client secret                                                      | `""`                        |
-| `server.auth.sso.redirectUrl`                            | The OIDC redirect URL. Should be in the form <argo-root-url>/oauth2/callback.                           | `""`                        |
-| `server.auth.sso.rbac.enabled`                           | Create RBAC resources for SSO                                                                           | `true`                      |
-| `server.auth.sso.rbac.secretWhitelist`                   | Restricts the secrets that the server can read                                                          | `[]`                        |
-| `server.auth.sso.scopes`                                 | Scopes requested from the SSO ID provider                                                               | `[]`                        |
-| `server.clusterWorkflowTemplates.enabled`                | Create ClusterRole and CRB for the controoler to access ClusterWorkflowTemplates                        | `true`                      |
-| `server.clusterWorkflowTemplates.enableEditing`          | Give the server permissions to edit ClusterWorkflowTemplates                                            | `true`                      |
-| `server.pdb.enabled`                                     | Create Pod Disruption Budget for the server component                                                   | `false`                     |
-| `server.pdb.minAvailable`                                | Sets the min number of pods availables for the Pod Disruption Budget                                    | `1`                         |
-| `server.pdb.maxUnavailable`                              | Sets the max number of pods unavailable for the Pod Disruption Budget                                   | `1`                         |
-| `server.secure`                                          | Run Argo server in secure mode                                                                          | `false`                     |
-| `server.baseHref`                                        | Base href of the Argo Workflows deployment                                                              | `/`                         |
-| `server.containerPorts.web`                              | argo Server container port                                                                              | `2746`                      |
-| `server.serviceAccount.create`                           | Specifies whether a ServiceAccount should be created                                                    | `true`                      |
-| `server.serviceAccount.name`                             | The name of the ServiceAccount to use.                                                                  | `""`                        |
-| `server.serviceAccount.automountServiceAccountToken`     | Automount service account token for the server service account                                          | `true`                      |
-| `server.command`                                         | Override default container command (useful when using custom images)                                    | `[]`                        |
-| `server.args`                                            | Override default container args (useful when using custom images)                                       | `[]`                        |
-| `server.hostAliases`                                     | server pods host aliases                                                                                | `[]`                        |
-| `server.podLabels`                                       | Extra labels for server pods                                                                            | `{}`                        |
-| `server.podAnnotations`                                  | Annotations for server pods                                                                             | `{}`                        |
-| `server.podAffinityPreset`                               | Pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`              | `""`                        |
-| `server.podAntiAffinityPreset`                           | Pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`         | `soft`                      |
-| `server.nodeAffinityPreset.type`                         | Node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`        | `""`                        |
-| `server.nodeAffinityPreset.key`                          | Node label key to match. Ignored if `server.affinity` is set                                            | `""`                        |
-| `server.nodeAffinityPreset.values`                       | Node label values to match. Ignored if `server.affinity` is set                                         | `[]`                        |
-| `server.affinity`                                        | Affinity for server pods assignment                                                                     | `{}`                        |
-| `server.nodeSelector`                                    | Node labels for server pods assignment                                                                  | `{}`                        |
-| `server.tolerations`                                     | Tolerations for server pods assignment                                                                  | `[]`                        |
-| `server.updateStrategy.type`                             | server statefulset strategy type                                                                        | `RollingUpdate`             |
-| `server.topologySpreadConstraints`                       | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in | `[]`                        |
-| `server.schedulerName`                                   | Alternate scheduler for the server deployment                                                           | `""`                        |
-| `server.priorityClassName`                               | server pods' priorityClassName                                                                          | `""`                        |
-| `server.lifecycleHooks`                                  | for the server container(s) to automate configuration before or after startup                           | `{}`                        |
-| `server.extraEnvVars`                                    | Array with extra environment variables to add to server nodes                                           | `[]`                        |
-| `server.extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars for server nodes                                   | `""`                        |
-| `server.extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars for server nodes                                      | `""`                        |
-| `server.extraVolumes`                                    | Optionally specify extra list of additional volumes for the server pod(s)                               | `[]`                        |
-| `server.extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the server container(s)                    | `[]`                        |
-| `server.sidecars`                                        | Add additional sidecar containers to the server pod(s)                                                  | `{}`                        |
-| `server.initContainers`                                  | Add additional init containers to the server pod(s)                                                     | `{}`                        |
-| `server.service.type`                                    | server service type                                                                                     | `ClusterIP`                 |
-| `server.service.ports.http`                              | server service HTTP port                                                                                | `80`                        |
-| `server.service.nodePorts.http`                          | Node port for HTTP                                                                                      | `""`                        |
-| `server.service.clusterIP`                               | server service Cluster IP                                                                               | `""`                        |
-| `server.service.loadBalancerIP`                          | server service Load Balancer IP                                                                         | `""`                        |
-| `server.service.loadBalancerSourceRanges`                | server service Load Balancer sources                                                                    | `[]`                        |
-| `server.service.externalTrafficPolicy`                   | server service external traffic policy                                                                  | `Cluster`                   |
-| `server.service.annotations`                             | Additional custom annotations for server service                                                        | `{}`                        |
-| `server.service.extraPorts`                              | Extra port to expose on the server service                                                              | `[]`                        |
+| Name                                                     | Description                                                                                                         | Value                       |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `server.image.registry`                                  | server image registry                                                                                               | `docker.io`                 |
+| `server.image.repository`                                | server image repository                                                                                             | `bitnami/argo-workflow-cli` |
+| `server.image.tag`                                       | server image tag (immutable tags are recommended)                                                                   | `3.3.5-scratch-r1`          |
+| `server.image.pullPolicy`                                | server image pull policy                                                                                            | `Always`                    |
+| `server.image.pullSecrets`                               | server image pull secrets                                                                                           | `[]`                        |
+| `server.enabled`                                         | Enable server deployment                                                                                            | `true`                      |
+| `server.replicaCount`                                    | Number of server replicas to deploy                                                                                 | `1`                         |
+| `server.livenessProbe.enabled`                           | Enable livenessProbe on server nodes                                                                                | `true`                      |
+| `server.livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                             | `10`                        |
+| `server.livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                                    | `20`                        |
+| `server.livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                                                   | `1`                         |
+| `server.livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                                                 | `3`                         |
+| `server.livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                                                 | `1`                         |
+| `server.readinessProbe.enabled`                          | Enable readinessProbe on server nodes                                                                               | `true`                      |
+| `server.readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                                            | `10`                        |
+| `server.readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                                                   | `20`                        |
+| `server.readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                                                  | `1`                         |
+| `server.readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                                                | `3`                         |
+| `server.readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                                                | `1`                         |
+| `server.startupProbe.enabled`                            | Enable startupProbe                                                                                                 | `false`                     |
+| `server.startupProbe.path`                               | Path to check for startupProbe                                                                                      | `/`                         |
+| `server.startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                                              | `300`                       |
+| `server.startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                                                     | `10`                        |
+| `server.startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                                                    | `5`                         |
+| `server.startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                                                  | `6`                         |
+| `server.startupProbe.successThreshold`                   | Success threshold for startupProbe                                                                                  | `1`                         |
+| `server.customLivenessProbe`                             | Server custom livenessProbe that overrides the default one                                                          | `{}`                        |
+| `server.customReadinessProbe`                            | Server custom readinessProbe that overrides the default one                                                         | `{}`                        |
+| `server.customStartupProbe`                              | Server custom startupProbe that overrides the default one                                                           | `{}`                        |
+| `server.resources.limits`                                | The resources limits for the server containers                                                                      | `{}`                        |
+| `server.resources.requests`                              | The requested resources for the server containers                                                                   | `{}`                        |
+| `server.podSecurityContext.enabled`                      | Enabled server pods' Security Context                                                                               | `true`                      |
+| `server.podSecurityContext.fsGroup`                      | Set server pod's Security Context fsGroup                                                                           | `1001`                      |
+| `server.containerSecurityContext.enabled`                | Enabled server containers' Security Context                                                                         | `true`                      |
+| `server.containerSecurityContext.runAsUser`              | Set server containers' Security Context runAsUser                                                                   | `1001`                      |
+| `server.containerSecurityContext.runAsNonRoot`           | Set server containers' Security Context runAsNonRoot                                                                | `true`                      |
+| `server.containerSecurityContext.readOnlyRootFilesystem` | Set read only root file system pod's Security Conte                                                                 | `true`                      |
+| `server.rbac.create`                                     | Create RBAC resources for the Argo workflows server                                                                 | `true`                      |
+| `server.extraArgs`                                       | Extra arguments for the server command line                                                                         | `""`                        |
+| `server.auth.enabled`                                    | Enable authentication                                                                                               | `true`                      |
+| `server.auth.mode`                                       | Set authentication mode. Either `server`, `client` or `sso`.                                                        | `client`                    |
+| `server.auth.sso.enabled`                                | Enable SSO configuration for the server auth mode                                                                   | `false`                     |
+| `server.auth.sso.issuer`                                 | Root URL for the OIDC identity provider                                                                             | `""`                        |
+| `server.auth.sso.clientId.name`                          | Name of the secret containing the OIDC client ID                                                                    | `""`                        |
+| `server.auth.sso.clientId.key`                           | Key in the secret to obtain the OIDC client ID                                                                      | `""`                        |
+| `server.auth.sso.clientSecret.name`                      | Name of the secret containing the OIDC client secret                                                                | `""`                        |
+| `server.auth.sso.clientSecret.key`                       | Key in the secret to obtain the OIDC client secret                                                                  | `""`                        |
+| `server.auth.sso.redirectUrl`                            | The OIDC redirect URL. Should be in the form <argo-root-url>/oauth2/callback.                                       | `""`                        |
+| `server.auth.sso.rbac.enabled`                           | Create RBAC resources for SSO                                                                                       | `true`                      |
+| `server.auth.sso.rbac.secretWhitelist`                   | Restricts the secrets that the server can read                                                                      | `[]`                        |
+| `server.auth.sso.scopes`                                 | Scopes requested from the SSO ID provider                                                                           | `[]`                        |
+| `server.clusterWorkflowTemplates.enabled`                | Create ClusterRole and CRB for the controoler to access ClusterWorkflowTemplates                                    | `true`                      |
+| `server.clusterWorkflowTemplates.enableEditing`          | Give the server permissions to edit ClusterWorkflowTemplates                                                        | `true`                      |
+| `server.pdb.enabled`                                     | Create Pod Disruption Budget for the server component                                                               | `false`                     |
+| `server.pdb.minAvailable`                                | Sets the min number of pods availables for the Pod Disruption Budget                                                | `1`                         |
+| `server.pdb.maxUnavailable`                              | Sets the max number of pods unavailable for the Pod Disruption Budget                                               | `1`                         |
+| `server.secure`                                          | Run Argo server in secure mode                                                                                      | `false`                     |
+| `server.baseHref`                                        | Base href of the Argo Workflows deployment                                                                          | `/`                         |
+| `server.containerPorts.web`                              | argo Server container port                                                                                          | `2746`                      |
+| `server.serviceAccount.create`                           | Specifies whether a ServiceAccount should be created                                                                | `true`                      |
+| `server.serviceAccount.name`                             | Name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`                        |
+| `server.serviceAccount.automountServiceAccountToken`     | Automount service account token for the server service account                                                      | `true`                      |
+| `server.serviceAccount.annotations`                      | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                          | `{}`                        |
+| `server.command`                                         | Override default container command (useful when using custom images)                                                | `[]`                        |
+| `server.args`                                            | Override default container args (useful when using custom images)                                                   | `[]`                        |
+| `server.hostAliases`                                     | server pods host aliases                                                                                            | `[]`                        |
+| `server.podLabels`                                       | Extra labels for server pods                                                                                        | `{}`                        |
+| `server.podAnnotations`                                  | Annotations for server pods                                                                                         | `{}`                        |
+| `server.podAffinityPreset`                               | Pod affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                          | `""`                        |
+| `server.podAntiAffinityPreset`                           | Pod anti-affinity preset. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                     | `soft`                      |
+| `server.nodeAffinityPreset.type`                         | Node affinity preset type. Ignored if `server.affinity` is set. Allowed values: `soft` or `hard`                    | `""`                        |
+| `server.nodeAffinityPreset.key`                          | Node label key to match. Ignored if `server.affinity` is set                                                        | `""`                        |
+| `server.nodeAffinityPreset.values`                       | Node label values to match. Ignored if `server.affinity` is set                                                     | `[]`                        |
+| `server.affinity`                                        | Affinity for server pods assignment                                                                                 | `{}`                        |
+| `server.nodeSelector`                                    | Node labels for server pods assignment                                                                              | `{}`                        |
+| `server.tolerations`                                     | Tolerations for server pods assignment                                                                              | `[]`                        |
+| `server.updateStrategy.type`                             | server statefulset strategy type                                                                                    | `RollingUpdate`             |
+| `server.topologySpreadConstraints`                       | Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in             | `[]`                        |
+| `server.schedulerName`                                   | Alternate scheduler for the server deployment                                                                       | `""`                        |
+| `server.priorityClassName`                               | server pods' priorityClassName                                                                                      | `""`                        |
+| `server.lifecycleHooks`                                  | for the server container(s) to automate configuration before or after startup                                       | `{}`                        |
+| `server.extraEnvVars`                                    | Array with extra environment variables to add to server nodes                                                       | `[]`                        |
+| `server.extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars for server nodes                                               | `""`                        |
+| `server.extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars for server nodes                                                  | `""`                        |
+| `server.extraVolumes`                                    | Optionally specify extra list of additional volumes for the server pod(s)                                           | `[]`                        |
+| `server.extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the server container(s)                                | `[]`                        |
+| `server.sidecars`                                        | Add additional sidecar containers to the server pod(s)                                                              | `{}`                        |
+| `server.initContainers`                                  | Add additional init containers to the server pod(s)                                                                 | `{}`                        |
+| `server.service.type`                                    | server service type                                                                                                 | `ClusterIP`                 |
+| `server.service.ports.http`                              | server service HTTP port                                                                                            | `80`                        |
+| `server.service.nodePorts.http`                          | Node port for HTTP                                                                                                  | `""`                        |
+| `server.service.clusterIP`                               | server service Cluster IP                                                                                           | `""`                        |
+| `server.service.loadBalancerIP`                          | server service Load Balancer IP                                                                                     | `""`                        |
+| `server.service.loadBalancerSourceRanges`                | server service Load Balancer sources                                                                                | `[]`                        |
+| `server.service.externalTrafficPolicy`                   | server service external traffic policy                                                                              | `Cluster`                   |
+| `server.service.annotations`                             | Additional custom annotations for server service                                                                    | `{}`                        |
+| `server.service.extraPorts`                              | Extra port to expose on the server service                                                                          | `[]`                        |
 
 
 ### Argo Workflows Controller configuration parameters
@@ -242,8 +243,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.pdb.minAvailable`                                | Sets the min number of pods availables for the Pod Disruption Budget                                                          | `1`                                |
 | `controller.pdb.maxUnavailable`                              | Sets the max number of pods unavailable for the Pod Disruption Budget                                                         | `1`                                |
 | `controller.serviceAccount.create`                           | Specifies whether a ServiceAccount should be created                                                                          | `true`                             |
-| `controller.serviceAccount.name`                             | Name for the service account                                                                                                  | `""`                               |
-| `controller.serviceAccount.automountServiceAccountToken`     | Automount service account token for the controller service account                                                            | `true`                             |
+| `controller.serviceAccount.name`                             | Name of the service account to use. If not set and create is true, a name is generated using the fullname template.           | `""`                               |
+| `controller.serviceAccount.automountServiceAccountToken`     | Automount service account token for the server service account                                                                | `true`                             |
+| `controller.serviceAccount.annotations`                      | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                                    | `{}`                               |
 | `controller.command`                                         | Override default container command (useful when using custom images)                                                          | `[]`                               |
 | `controller.args`                                            | Override default container args (useful when using custom images)                                                             | `[]`                               |
 | `controller.hostAliases`                                     | controller pods host aliases                                                                                                  | `[]`                               |
@@ -288,7 +290,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ---------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------- |
 | `executor.image.registry`                                  | executor image registry                                       | `docker.io`                  |
 | `executor.image.repository`                                | executor image repository                                     | `bitnami/argo-workflow-exec` |
-| `executor.image.tag`                                       | executor image tag (immutable tags are recommended)           | `3.3.4-debian-10-r4`         |
+| `executor.image.tag`                                       | executor image tag (immutable tags are recommended)           | `3.3.5-debian-10-r13`        |
 | `executor.image.pullPolicy`                                | executor image pull policy                                    | `Always`                     |
 | `executor.image.pullSecrets`                               | executor image pull secrets                                   | `[]`                         |
 | `executor.resources.limits`                                | The resources limits for the init container                   | `{}`                         |
@@ -321,12 +323,13 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Workflows configuration
 
-| Name                                                    | Description                                                       | Value   |
-| ------------------------------------------------------- | ----------------------------------------------------------------- | ------- |
-| `workflows.serviceAccount.create`                       | Whether to create a service account to run workflows              | `false` |
-| `workflows.serviceAccount.name`                         | Service account name to run workflows                             | `""`    |
-| `workflows.serviceAccount.automountServiceAccountToken` | Automount service account token for the workflows service account | `true`  |
-| `workflows.rbac.create`                                 | Whether to create RBAC resource to run workflows                  | `true`  |
+| Name                                                    | Description                                                                                | Value   |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------- |
+| `workflows.serviceAccount.create`                       | Whether to create a service account to run workflows                                       | `false` |
+| `workflows.serviceAccount.name`                         | Service account name to run workflows                                                      | `""`    |
+| `workflows.serviceAccount.automountServiceAccountToken` | Automount service account token for the workflows service account                          | `true`  |
+| `workflows.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`. | `{}`    |
+| `workflows.rbac.create`                                 | Whether to create RBAC resource to run workflows                                           | `true`  |
 
 
 ### PostgreSQL subchart

--- a/bitnami/argo-workflows/templates/controller/service-account.yaml
+++ b/bitnami/argo-workflows/templates/controller/service-account.yaml
@@ -10,8 +10,12 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.controller.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.controller.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
 automountServiceAccountToken: {{ .Values.controller.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/bitnami/argo-workflows/templates/controller/workflow-serviceaccount.yaml
+++ b/bitnami/argo-workflows/templates/controller/workflow-serviceaccount.yaml
@@ -1,10 +1,9 @@
-{{- if .Values.workflows.serviceAccount.create -}}
+{{- if .Values.workflows.serviceAccount.create }}
 {{- $namespaces := list .Release.Namespace }}
 {{- if and (not .Values.rbac.singleNamespace) .Values.controller.workflowNamespaces }}
-{{- $namespaces := .Values.controller.workflowNamespaces }}
+{{- $namespaces = .Values.controller.workflowNamespaces }}
 {{- end }}
 {{- range $namespaces }}
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -16,9 +15,14 @@ metadata:
     {{- if $.Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if $.Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
-  {{- end }}
-automountServiceAccountToken: {{ .Values.workflows.serviceAccount.automountServiceAccountToken }}
+  annotations:
+    {{- if $.Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if $.Values.workflows.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" $.Values.workflows.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ $.Values.workflows.serviceAccount.automountServiceAccountToken }}
+---
+{{- end }}
 {{- end }}

--- a/bitnami/argo-workflows/templates/server/service-account.yaml
+++ b/bitnami/argo-workflows/templates/server/service-account.yaml
@@ -10,8 +10,11 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.server.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.server.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
 automountServiceAccountToken: {{ .Values.server.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/bitnami/argo-workflows/values.yaml
+++ b/bitnami/argo-workflows/values.yaml
@@ -272,19 +272,18 @@ server:
   containerPorts:
     web: 2746
 
-  ## ServiceAccount configuration
+  ## Server Service Account
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  ## @param server.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param server.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
+  ## @param server.serviceAccount.automountServiceAccountToken Automount service account token for the server service account
+  ## @param server.serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
   ##
   serviceAccount:
-    ## @param server.serviceAccount.create Specifies whether a ServiceAccount should be created
-    ##
     create: true
-    ## @param server.serviceAccount.name The name of the ServiceAccount to use.
-    ## If not set and create is true, a name is generated using the common.names.fullname template
-    ##
     name: ""
-    ## @param server.serviceAccount.automountServiceAccountToken Automount service account token for the server service account
-    ##
     automountServiceAccountToken: true
+    annotations: {}
 
   ## @param server.command Override default container command (useful when using custom images)
   ##
@@ -756,18 +755,18 @@ controller:
     enabled: false
     minAvailable: 1
     maxUnavailable: 1
-  ## Service Account configuration
+  ## Controller Service Account
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   ## @param controller.serviceAccount.create Specifies whether a ServiceAccount should be created
-  ## @param controller.serviceAccount.name Name for the service account
+  ## @param controller.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
+  ## @param controller.serviceAccount.automountServiceAccountToken Automount service account token for the server service account
+  ## @param controller.serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
   ##
   serviceAccount:
     create: true
-    ## If not set and create is true, a name is generated using the common.names.fullname template
-    ##
     name: ""
-    ## @param controller.serviceAccount.automountServiceAccountToken Automount service account token for the controller service account
-    ##
     automountServiceAccountToken: true
+    annotations: {}
 
   ## @param controller.command Override default container command (useful when using custom images)
   ##
@@ -1103,7 +1102,7 @@ ingress:
   ## - host: server.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: server-svc
   ##           port:
@@ -1119,11 +1118,13 @@ workflows:
   ## @param workflows.serviceAccount.create Whether to create a service account to run workflows
   ## @param workflows.serviceAccount.name Service account name to run workflows
   ## @param workflows.serviceAccount.automountServiceAccountToken Automount service account token for the workflows service account
+  ## @param workflows.serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
   ##
   serviceAccount:
     create: false
     name: ""
     automountServiceAccountToken: true
+    annotations: {}
   ## Create RBAC resources to run workflows.
   ## A Role and Role Bindding are created per namespace in controller.workflowNamespaces
   ## @param workflows.rbac.create Whether to create RBAC resource to run workflows


### PR DESCRIPTION
### Description of the change

This PR adds serviceAccount.* parameters that were missing them.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
