### PR TITLE
[bitnami/postgresql] Make existing secret key names choosable

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 11.2.5
+version: 11.3.5

--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -2,12 +2,14 @@
 
 # PostgreSQL packaged by Bitnami
 
-PostgreSQL (Postgres) is an open source object-relational database known for reliability and data integrity. ACID-compliant, it supports foreign keys, joins, views, triggers and stored procedures.
+PostgreSQL (Postgres) is an open source object-relational database known for reliability and data integrity.
+ACID-compliant, it supports foreign keys, joins, views, triggers and stored procedures.
 
 [Overview of PostgreSQL](http://www.postgresql.org)
 
-Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned
+by the respective companies, and use of them does not imply any affiliation or endorsement.
+
 ## TL;DR
 
 ```bash
@@ -17,11 +19,14 @@ helm install my-release bitnami/postgresql
 
 ## Introduction
 
-This chart bootstraps a [PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) deployment on
+a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 For HA, please see [this repo](https://github.com/bitnami/charts/tree/master/bitnami/postgresql-ha)
 
-Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This chart has been tested to work with NGINX Ingress, cert-manager, fluentd and Prometheus on top of the [BKPR](https://kubeprod.io/).
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in
+clusters. This chart has been tested to work with NGINX Ingress, cert-manager, fluentd and Prometheus on top of
+the [BKPR](https://kubeprod.io/).
 
 ## Prerequisites
 
@@ -37,7 +42,8 @@ To install the chart with the release name `my-release`:
 helm install my-release bitnami/postgresql
 ```
 
-The command deploys PostgreSQL on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+The command deploys PostgreSQL on the Kubernetes cluster in the default configuration. The [Parameters](#parameters)
+section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -63,23 +69,26 @@ kubectl delete pvc -l release=my-release
 
 ### Global parameters
 
-| Name                                         | Description                                                                                 | Value |
-| -------------------------------------------- | ------------------------------------------------------------------------------------------- | ----- |
-| `global.imageRegistry`                       | Global Docker image registry                                                                | `""`  |
-| `global.imagePullSecrets`                    | Global Docker registry secret names as an array                                             | `[]`  |
-| `global.storageClass`                        | Global StorageClass for Persistent Volume(s)                                                | `""`  |
-| `global.postgresql.auth.postgresPassword`    | Password for the "postgres" admin user (overrides `auth.postgresPassword`)                  | `""`  |
-| `global.postgresql.auth.username`            | Name for a custom user to create (overrides `auth.username`)                                | `""`  |
-| `global.postgresql.auth.password`            | Password for the custom user to create (overrides `auth.password`)                          | `""`  |
-| `global.postgresql.auth.database`            | Name for a custom database to create (overrides `auth.database`)                            | `""`  |
-| `global.postgresql.auth.existingSecret`      | Name of existing secret to use for PostgreSQL credentials (overrides `auth.existingSecret`) | `""`  |
-| `global.postgresql.service.ports.postgresql` | PostgreSQL service port (overrides `service.ports.postgresql`)                              | `""`  |
-
+| Name                                                           | Description                                                                                     | Value     |
+|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------|-----------|
+| `global.imageRegistry`                                         | Global Docker image registry                                                                    | `""`      |
+| `global.imagePullSecrets`                                      | Global Docker registry secret names as an array                                                 | `[]`      |
+| `global.storageClass`                                          | Global StorageClass for Persistent Volume(s)                                                    | `""`      |
+| `global.postgresql.auth.postgresPassword`                      | Password for the "postgres" admin user (overrides `auth.postgresPassword`)                      | `""`      |
+| `global.postgresql.auth.username`                              | Name for a custom user to create (overrides `auth.username`)                                    | `""`      |
+| `global.postgresql.auth.password`                              | Password for the custom user to create (overrides `auth.password`)                              | `""`      |
+| `global.postgresql.auth.database`                              | Name for a custom database to create (overrides `auth.database`)                                | `""`      |
+| `global.postgresql.auth.existingSecret.enabled`                | Enable the use an existing secret for PostgreSQL credentials (overrides `auth.existingSecret`). | `"false"` |
+| `global.postgresql.auth.existingSecret.secretName`             | Name of existing secret to use for PostgreSQL credentials.                                      | `""`      |
+| `global.postgresql.auth.existingSecret.adminPasswordKey`       | Name of key in existing secret to use for PostgreSQL credentials.                               | `""`      |
+| `global.postgresql.auth.existingSecret.userPasswordKey`        | Name of key in existing secret to use for PostgreSQL credentials.                               | `""`      |
+| `global.postgresql.auth.existingSecret.replicationPasswordKey` | Name of key in existing secret to use for PostgreSQL credentials.                               | `""`      |
+| `global.postgresql.service.ports.postgresql`                   | PostgreSQL service port (overrides `service.ports.postgresql`)                                  | `""`      |
 
 ### Common parameters
 
 | Name                     | Description                                                                                  | Value           |
-| ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
+|--------------------------|----------------------------------------------------------------------------------------------|-----------------|
 | `kubeVersion`            | Override Kubernetes version                                                                  | `""`            |
 | `nameOverride`           | String to partially override common.names.fullname template (will maintain the release name) | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname template                                      | `""`            |
@@ -91,65 +100,67 @@ kubectl delete pvc -l release=my-release
 | `diagnosticMode.command` | Command to override all containers in the statefulset                                        | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the statefulset                                           | `["infinity"]`  |
 
-
 ### PostgreSQL common parameters
 
-| Name                                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Value                      |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `image.registry`                     | PostgreSQL image registry                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | `docker.io`                |
-| `image.repository`                   | PostgreSQL image repository                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `bitnami/postgresql`       |
-| `image.tag`                          | PostgreSQL image tag (immutable tags are recommended)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | `14.2.0-debian-10-r58`     |
-| `image.pullPolicy`                   | PostgreSQL image pull policy                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | `IfNotPresent`             |
-| `image.pullSecrets`                  | Specify image pull secrets                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `[]`                       |
-| `image.debug`                        | Specify if debug values should be set                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | `false`                    |
-| `auth.enablePostgresUser`            | Assign a password to the "postgres" admin user. Otherwise, remote access will be blocked for this user                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | `true`                     |
-| `auth.postgresPassword`              | Password for the "postgres" admin user. Ignored if `auth.existingSecret` with key `postgres-password` is provided                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `""`                       |
-| `auth.username`                      | Name for a custom user to create                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | `""`                       |
-| `auth.password`                      | Password for the custom user to create. Ignored if `auth.existingSecret` with key `password` is provided                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | `""`                       |
-| `auth.database`                      | Name for a custom database to create                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `""`                       |
-| `auth.replicationUsername`           | Name of the replication user                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | `repl_user`                |
-| `auth.replicationPassword`           | Password for the replication user. Ignored if `auth.existingSecret` with key `replication-password` is provided                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `""`                       |
-| `auth.existingSecret`                | Name of existing secret to use for PostgreSQL credentials. The secret must contain the keys `postgres-password` (which is the password for "postgres" admin user), `password` (which is the password for the custom user to create when `auth.username` is set) and `replication-password` (which is the password for replication user). `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case. | `""`                       |
-| `auth.usePasswordFiles`              | Mount credentials as a files instead of using an environment variable                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | `false`                    |
-| `architecture`                       | PostgreSQL architecture (`standalone` or `replication`)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `standalone`               |
-| `replication.synchronousCommit`      | Set synchronous commit mode. Allowed values: `on`, `remote_apply`, `remote_write`, `local` and `off`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `off`                      |
-| `replication.numSynchronousReplicas` | Number of replicas that will have synchronous replication. Note: Cannot be greater than `readReplicas.replicaCount`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `0`                        |
-| `replication.applicationName`        | Cluster application name. Useful for advanced replication settings                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | `my_application`           |
-| `containerPorts.postgresql`          | PostgreSQL container port                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | `5432`                     |
-| `audit.logHostname`                  | Log client hostnames                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `false`                    |
-| `audit.logConnections`               | Add client log-in operations to the log file                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | `false`                    |
-| `audit.logDisconnections`            | Add client log-outs operations to the log file                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | `false`                    |
-| `audit.pgAuditLog`                   | Add operations to log using the pgAudit extension                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `""`                       |
-| `audit.pgAuditLogCatalog`            | Log catalog using pgAudit                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | `off`                      |
-| `audit.clientMinMessages`            | Message log level to share with the user                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | `error`                    |
-| `audit.logLinePrefix`                | Template for log line prefix (default if not set)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | `""`                       |
-| `audit.logTimezone`                  | Timezone for the log timestamps                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `""`                       |
-| `ldap.enabled`                       | Enable LDAP support                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | `false`                    |
-| `ldap.url`                           | LDAP URL beginning in the form `ldap[s]://host[:port]/basedn`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `""`                       |
-| `ldap.server`                        | IP address or name of the LDAP server.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | `""`                       |
-| `ldap.port`                          | Port number on the LDAP server to connect to                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | `""`                       |
-| `ldap.prefix`                        | String to prepend to the user name when forming the DN to bind                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | `""`                       |
-| `ldap.suffix`                        | String to append to the user name when forming the DN to bind                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `""`                       |
-| `ldap.baseDN`                        | Root DN to begin the search for the user in                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `""`                       |
-| `ldap.bindDN`                        | DN of user to bind to LDAP                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `""`                       |
-| `ldap.bind_password`                 | Password for the user to bind to LDAP                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | `""`                       |
-| `ldap.search_attr`                   | Attribute to match against the user name in the search                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | `""`                       |
-| `ldap.search_filter`                 | The search filter to use when doing search+bind authentication                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | `""`                       |
-| `ldap.scheme`                        | Set to `ldaps` to use LDAPS                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `""`                       |
-| `ldap.tls`                           | Set to `1` to use TLS encryption                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | `""`                       |
-| `postgresqlDataDir`                  | PostgreSQL data dir folder                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `/bitnami/postgresql/data` |
-| `postgresqlSharedPreloadLibraries`   | Shared preload libraries (comma-separated list)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | `pgaudit`                  |
-| `shmVolume.enabled`                  | Enable emptyDir volume for /dev/shm for PostgreSQL pod(s)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | `true`                     |
-| `shmVolume.sizeLimit`                | Set this to enable a size limit on the shm tmpfs                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | `""`                       |
-| `tls.enabled`                        | Enable TLS traffic support                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | `false`                    |
-| `tls.autoGenerated`                  | Generate automatically self-signed TLS certificates                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | `false`                    |
-| `tls.preferServerCiphers`            | Whether to use the server's TLS cipher preferences rather than the client's                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `true`                     |
-| `tls.certificatesSecret`             | Name of an existing secret that contains the certificates                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | `""`                       |
-| `tls.certFilename`                   | Certificate filename                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | `""`                       |
-| `tls.certKeyFilename`                | Certificate key filename                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | `""`                       |
-| `tls.certCAFilename`                 | CA Certificate filename                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | `""`                       |
-| `tls.crlFilename`                    | File containing a Certificate Revocation List                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | `""`                       |
-
+| Name                                         | Description                                                                                                                                                                                                                                                                                                                                      | Value                      |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
+| `image.registry`                             | PostgreSQL image registry                                                                                                                                                                                                                                                                                                                        | `docker.io`                |
+| `image.repository`                           | PostgreSQL image repository                                                                                                                                                                                                                                                                                                                      | `bitnami/postgresql`       |
+| `image.tag`                                  | PostgreSQL image tag (immutable tags are recommended)                                                                                                                                                                                                                                                                                            | `14.2.0-debian-10-r58`     |
+| `image.pullPolicy`                           | PostgreSQL image pull policy                                                                                                                                                                                                                                                                                                                     | `IfNotPresent`             |
+| `image.pullSecrets`                          | Specify image pull secrets                                                                                                                                                                                                                                                                                                                       | `[]`                       |
+| `image.debug`                                | Specify if debug values should be set                                                                                                                                                                                                                                                                                                            | `false`                    |
+| `auth.enablePostgresUser`                    | Assign a password to the "postgres" admin user. Otherwise, remote access will be blocked for this user                                                                                                                                                                                                                                           | `true`                     |
+| `auth.postgresPassword`                      | Password for the "postgres" admin user. Ignored if `auth.existingSecret` with key `postgres-password` is provided                                                                                                                                                                                                                                | `""`                       |
+| `auth.username`                              | Name for a custom user to create                                                                                                                                                                                                                                                                                                                 | `""`                       |
+| `auth.password`                              | Password for the custom user to create. Ignored if `auth.existingSecret` with key `password` is provided                                                                                                                                                                                                                                         | `""`                       |
+| `auth.database`                              | Name for a custom database to create                                                                                                                                                                                                                                                                                                             | `""`                       |
+| `auth.replicationUsername`                   | Name of the replication user                                                                                                                                                                                                                                                                                                                     | `repl_user`                |
+| `auth.replicationPassword`                   | Password for the replication user. Ignored if `auth.existingSecret` with key `replication-password` is provided                                                                                                                                                                                                                                  | `""`                       |
+| `auth.existingSecret.enabled`                | Enable the use an existing secret for PostgreSQL credentials. `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case. | `"false"`                  |
+| `auth.existingSecret.secretName`             | Name of existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                       | `""`                       |
+| `auth.existingSecret.adminPasswordKey`       | Name of key in existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                | `""`                       |
+| `auth.existingSecret.userPasswordKey`        | Name of key in existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                | `""`                       |
+| `auth.existingSecret.replicationPasswordKey` | Name of key in existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                | `""`                       |
+| `auth.usePasswordFiles`                      | Mount credentials as a files instead of using an environment variable                                                                                                                                                                                                                                                                            | `false`                    |
+| `architecture`                               | PostgreSQL architecture (`standalone` or `replication`)                                                                                                                                                                                                                                                                                          | `standalone`               |
+| `replication.synchronousCommit`              | Set synchronous commit mode. Allowed values: `on`, `remote_apply`, `remote_write`, `local` and `off`                                                                                                                                                                                                                                             | `off`                      |
+| `replication.numSynchronousReplicas`         | Number of replicas that will have synchronous replication. Note: Cannot be greater than `readReplicas.replicaCount`.                                                                                                                                                                                                                             | `0`                        |
+| `replication.applicationName`                | Cluster application name. Useful for advanced replication settings                                                                                                                                                                                                                                                                               | `my_application`           |
+| `containerPorts.postgresql`                  | PostgreSQL container port                                                                                                                                                                                                                                                                                                                        | `5432`                     |
+| `audit.logHostname`                          | Log client hostnames                                                                                                                                                                                                                                                                                                                             | `false`                    |
+| `audit.logConnections`                       | Add client log-in operations to the log file                                                                                                                                                                                                                                                                                                     | `false`                    |
+| `audit.logDisconnections`                    | Add client log-outs operations to the log file                                                                                                                                                                                                                                                                                                   | `false`                    |
+| `audit.pgAuditLog`                           | Add operations to log using the pgAudit extension                                                                                                                                                                                                                                                                                                | `""`                       |
+| `audit.pgAuditLogCatalog`                    | Log catalog using pgAudit                                                                                                                                                                                                                                                                                                                        | `off`                      |
+| `audit.clientMinMessages`                    | Message log level to share with the user                                                                                                                                                                                                                                                                                                         | `error`                    |
+| `audit.logLinePrefix`                        | Template for log line prefix (default if not set)                                                                                                                                                                                                                                                                                                | `""`                       |
+| `audit.logTimezone`                          | Timezone for the log timestamps                                                                                                                                                                                                                                                                                                                  | `""`                       |
+| `ldap.enabled`                               | Enable LDAP support                                                                                                                                                                                                                                                                                                                              | `false`                    |
+| `ldap.url`                                   | LDAP URL beginning in the form `ldap[s]://host[:port]/basedn`                                                                                                                                                                                                                                                                                    | `""`                       |
+| `ldap.server`                                | IP address or name of the LDAP server.                                                                                                                                                                                                                                                                                                           | `""`                       |
+| `ldap.port`                                  | Port number on the LDAP server to connect to                                                                                                                                                                                                                                                                                                     | `""`                       |
+| `ldap.prefix`                                | String to prepend to the user name when forming the DN to bind                                                                                                                                                                                                                                                                                   | `""`                       |
+| `ldap.suffix`                                | String to append to the user name when forming the DN to bind                                                                                                                                                                                                                                                                                    | `""`                       |
+| `ldap.baseDN`                                | Root DN to begin the search for the user in                                                                                                                                                                                                                                                                                                      | `""`                       |
+| `ldap.bindDN`                                | DN of user to bind to LDAP                                                                                                                                                                                                                                                                                                                       | `""`                       |
+| `ldap.bind_password`                         | Password for the user to bind to LDAP                                                                                                                                                                                                                                                                                                            | `""`                       |
+| `ldap.search_attr`                           | Attribute to match against the user name in the search                                                                                                                                                                                                                                                                                           | `""`                       |
+| `ldap.search_filter`                         | The search filter to use when doing search+bind authentication                                                                                                                                                                                                                                                                                   | `""`                       |
+| `ldap.scheme`                                | Set to `ldaps` to use LDAPS                                                                                                                                                                                                                                                                                                                      | `""`                       |
+| `ldap.tls`                                   | Set to `1` to use TLS encryption                                                                                                                                                                                                                                                                                                                 | `""`                       |
+| `postgresqlDataDir`                          | PostgreSQL data dir folder                                                                                                                                                                                                                                                                                                                       | `/bitnami/postgresql/data` |
+| `postgresqlSharedPreloadLibraries`           | Shared preload libraries (comma-separated list)                                                                                                                                                                                                                                                                                                  | `pgaudit`                  |
+| `shmVolume.enabled`                          | Enable emptyDir volume for /dev/shm for PostgreSQL pod(s)                                                                                                                                                                                                                                                                                        | `true`                     |
+| `shmVolume.sizeLimit`                        | Set this to enable a size limit on the shm tmpfs                                                                                                                                                                                                                                                                                                 | `""`                       |
+| `tls.enabled`                                | Enable TLS traffic support                                                                                                                                                                                                                                                                                                                       | `false`                    |
+| `tls.autoGenerated`                          | Generate automatically self-signed TLS certificates                                                                                                                                                                                                                                                                                              | `false`                    |
+| `tls.preferServerCiphers`                    | Whether to use the server's TLS cipher preferences rather than the client's                                                                                                                                                                                                                                                                      | `true`                     |
+| `tls.certificatesSecret`                     | Name of an existing secret that contains the certificates                                                                                                                                                                                                                                                                                        | `""`                       |
+| `tls.certFilename`                           | Certificate filename                                                                                                                                                                                                                                                                                                                             | `""`                       |
+| `tls.certKeyFilename`                        | Certificate key filename                                                                                                                                                                                                                                                                                                                         | `""`                       |
+| `tls.certCAFilename`                         | CA Certificate filename                                                                                                                                                                                                                                                                                                                          | `""`                       |
+| `tls.crlFilename`                            | File containing a Certificate Revocation List                                                                                                                                                                                                                                                                                                    | `""`                       |
 
 ### PostgreSQL Primary parameters
 
@@ -250,7 +261,6 @@ kubectl delete pvc -l release=my-release
 | `primary.persistence.selector`               | Selector to match an existing Persistent Volume (this value is evaluated as a template)                                  | `{}`                  |
 | `primary.persistence.dataSource`             | Custom PVC data source                                                                                                   | `{}`                  |
 
-
 ### PostgreSQL read only replica parameters
 
 | Name                                              | Description                                                                                                              | Value                 |
@@ -335,7 +345,6 @@ kubectl delete pvc -l release=my-release
 | `readReplicas.persistence.selector`               | Selector to match an existing Persistent Volume (this value is evaluated as a template)                                  | `{}`                  |
 | `readReplicas.persistence.dataSource`             | Custom PVC data source                                                                                                   | `{}`                  |
 
-
 ### NetworkPolicy parameters
 
 | Name                                                                      | Description                                                                                                                                        | Value   |
@@ -355,7 +364,6 @@ kubectl delete pvc -l release=my-release
 | `networkPolicy.egressRules.denyConnectionsToExternal`                     | Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).                                                     | `false` |
 | `networkPolicy.egressRules.customRules`                                   | Custom network policy rule                                                                                                                         | `{}`    |
 
-
 ### Volume Permissions parameters
 
 | Name                                                   | Description                                                                     | Value                   |
@@ -370,7 +378,6 @@ kubectl delete pvc -l release=my-release
 | `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                             | `{}`                    |
 | `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                  | `0`                     |
 
-
 ### Other Parameters
 
 | Name                                          | Description                                                                                                                                 | Value   |
@@ -382,7 +389,6 @@ kubectl delete pvc -l release=my-release
 | `rbac.create`                                 | Create Role and RoleBinding (required for PSP to work)                                                                                      | `false` |
 | `rbac.rules`                                  | Custom RBAC rules to set                                                                                                                    | `[]`    |
 | `psp.create`                                  | Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later | `false` |
-
 
 ### Metrics Parameters
 
@@ -442,7 +448,6 @@ kubectl delete pvc -l release=my-release
 | `metrics.prometheusRule.labels`                 | Additional labels that can be used so PrometheusRule will be discovered by Prometheus | `{}`                        |
 | `metrics.prometheusRule.rules`                  | PrometheusRule definitions                                                            | `[]`                        |
 
-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```bash
@@ -453,9 +458,12 @@ $ helm install my-release \
 
 The above command sets the PostgreSQL `postgres` account password to `secretpassword`.
 
-> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
+> NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as
+> usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent
+> volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For
+example,
 
 ```bash
 helm install my-release -f values.yaml bitnami/postgresql
@@ -467,37 +475,56 @@ helm install my-release -f values.yaml bitnami/postgresql
 
 ### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
 
-It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not
+change automatically if the same tag is updated with a different image.
 
-Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or
+critical vulnerabilities exist.
 
 ### Customizing primary and read replica services in a replicated configuration
 
-At the top level, there is a service object which defines the services for both primary and readReplicas. For deeper customization, there are service objects for both the primary and read types individually. This allows you to override the values in the top level service object so that the primary and read can be of different service types and with different clusterIPs / nodePorts. Also in the case you want the primary and read to be of type nodePort, you will need to set the nodePorts to different values to prevent a collision. The values that are deeper in the primary.service or readReplicas.service objects will take precedence over the top level service object.
+At the top level, there is a service object which defines the services for both primary and readReplicas. For deeper
+customization, there are service objects for both the primary and read types individually. This allows you to override
+the values in the top level service object so that the primary and read can be of different service types and with
+different clusterIPs / nodePorts. Also in the case you want the primary and read to be of type nodePort, you will need
+to set the nodePorts to different values to prevent a collision. The values that are deeper in the primary.service or
+readReplicas.service objects will take precedence over the top level service object.
 
 ### Use a different PostgreSQL version
 
-To modify the application version used in this chart, specify a different version of the image using the `image.tag` parameter and/or a different repository using the `image.repository` parameter. Refer to the [chart documentation for more information on these parameters and how to use them with images from a private registry](https://docs.bitnami.com/kubernetes/infrastructure/postgresql/configuration/change-image-version/).
+To modify the application version used in this chart, specify a different version of the image using the `image.tag`
+parameter and/or a different repository using the `image.repository` parameter. Refer to
+the [chart documentation for more information on these parameters and how to use them with images from a private registry](https://docs.bitnami.com/kubernetes/infrastructure/postgresql/configuration/change-image-version/)
+.
 
 ### postgresql.conf / pg_hba.conf files as configMap
 
-This helm chart also supports to customize the PostgreSQL configuration file. You can add additional PostgreSQL configuration parameters using the `primary.extendedConfiguration` parameter as a string. Alternatively, to replace the entire default configuration use `primary.configuration`.
+This helm chart also supports to customize the PostgreSQL configuration file. You can add additional PostgreSQL
+configuration parameters using the `primary.extendedConfiguration` parameter as a string. Alternatively, to replace the
+entire default configuration use `primary.configuration`.
 
 You can also add a custom pg_hba.conf using the `primary.pgHbaConfiguration` parameter.
 
-In addition to these options, you can also set an external ConfigMap with all the configuration files. This is done by setting the `primary.existingConfigmap` parameter. Note that this will override the two previous options.
+In addition to these options, you can also set an external ConfigMap with all the configuration files. This is done by
+setting the `primary.existingConfigmap` parameter. Note that this will override the two previous options.
 
 ### Initialize a fresh instance
 
-The [Bitnami PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, you can specify custom scripts using the `primary.initdb.scripts` parameter as a string.
+The [Bitnami PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image allows you to use your custom
+scripts to initialize a fresh instance. In order to execute the scripts, you can specify custom scripts using
+the `primary.initdb.scripts` parameter as a string.
 
-In addition, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the `primary.initdb.scriptsConfigMap` parameter. Note that this will override the two previous options. If your initialization scripts contain sensitive information such as credentials or passwords, you can use the `primary.initdb.scriptsSecret` parameter.
+In addition, you can also set an external ConfigMap with all the initialization scripts. This is done by setting
+the `primary.initdb.scriptsConfigMap` parameter. Note that this will override the two previous options. If your
+initialization scripts contain sensitive information such as credentials or passwords, you can use
+the `primary.initdb.scriptsSecret` parameter.
 
 The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
 
 ### Securing traffic using TLS
 
-TLS support can be enabled in the chart by specifying the `tls.` parameters while creating a release. The following parameters should be configured to properly enable the TLS support in the chart:
+TLS support can be enabled in the chart by specifying the `tls.` parameters while creating a release. The following
+parameters should be configured to properly enable the TLS support in the chart:
 
 - `tls.enabled`: Enable TLS support. Defaults to `false`
 - `tls.certificatesSecret`: Name of an existing secret that contains the certificates. No defaults.
@@ -522,38 +549,51 @@ For example:
     tls.certKeyFilename="cert.key"
     ```
 
-    > Note TLS and VolumePermissions: PostgreSQL requires certain permissions on sensitive files (such as certificate keys) to start up. Due to an on-going [issue](https://github.com/kubernetes/kubernetes/issues/57923) regarding kubernetes permissions and the use of `containerSecurityContext.runAsUser`, you must enable `volumePermissions` to ensure everything works as expected.
+  > Note TLS and VolumePermissions: PostgreSQL requires certain permissions on sensitive files (such as certificate
+  keys) to start up. Due to an on-going [issue](https://github.com/kubernetes/kubernetes/issues/57923) regarding
+  kubernetes permissions and the use of `containerSecurityContext.runAsUser`, you must enable `volumePermissions` to
+  ensure everything works as expected.
 
 ### Sidecars
 
-If you need  additional containers to run within the same pod as PostgreSQL (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
+If you need additional containers to run within the same pod as PostgreSQL (e.g. an additional metrics or logging
+exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes
+container spec.
 
 ```yaml
 # For the PostgreSQL primary
 primary:
   sidecars:
-  - name: your-image-name
-    image: your-image
-    imagePullPolicy: Always
-    ports:
-    - name: portname
-     containerPort: 1234
+    - name: your-image-name
+      image: your-image
+      imagePullPolicy: Always
+      ports:
+        - name: portname
+        containerPort: 1234
 # For the PostgreSQL replicas
 readReplicas:
   sidecars:
-  - name: your-image-name
-    image: your-image
-    imagePullPolicy: Always
-    ports:
-    - name: portname
-     containerPort: 1234
+    - name: your-image-name
+      image: your-image
+      imagePullPolicy: Always
+      ports:
+        - name: portname
+        containerPort: 1234
 ```
 
 ### Metrics
 
-The chart optionally can start a metrics exporter for [prometheus](https://prometheus.io). The metrics endpoint (port 9187) is not exposed and it is expected that the metrics are collected from inside the k8s cluster using something similar as the described in the [example Prometheus scrape configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml).
+The chart optionally can start a metrics exporter for [prometheus](https://prometheus.io). The metrics endpoint (port
 
-The exporter allows to create custom metrics from additional SQL queries. See the Chart's `values.yaml` for an example and consult the [exporters documentation](https://github.com/wrouesnel/postgres_exporter#adding-new-metrics-via-a-config-file) for more details.
+9187) is not exposed and it is expected that the metrics are collected from inside the k8s cluster using something
+      similar as the described in
+      the [example Prometheus scrape configuration](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml)
+      .
+
+The exporter allows to create custom metrics from additional SQL queries. See the Chart's `values.yaml` for an example
+and consult
+the [exporters documentation](https://github.com/wrouesnel/postgres_exporter#adding-new-metrics-via-a-config-file) for
+more details.
 
 ### Use of global variables
 
@@ -577,7 +617,9 @@ In more complex scenarios, we may have the following tree of dependencies
 +--------------+    +---------------+  +---------------+
 ```
 
-The three charts below depend on the parent chart Chart 1. However, subcharts 1 and 2 may need to connect to PostgreSQL as well. In order to do so, subcharts 1 and 2 need to know the PostgreSQL credentials, so one option for deploying could be deploy Chart 1 with the following parameters:
+The three charts below depend on the parent chart Chart 1. However, subcharts 1 and 2 may need to connect to PostgreSQL
+as well. In order to do so, subcharts 1 and 2 need to know the PostgreSQL credentials, so one option for deploying could
+be deploy Chart 1 with the following parameters:
 
 ```
 postgresql.auth.password=testuser
@@ -591,7 +633,8 @@ subchart1.postgresql.auth.database=testdb
 subchart2.postgresql.auth.database=testdb
 ```
 
-If the number of dependent sub-charts increases, installing the chart with parameters can become increasingly difficult. An alternative would be to set the credentials using global variables as follows:
+If the number of dependent sub-charts increases, installing the chart with parameters can become increasingly difficult.
+An alternative would be to set the credentials using global variables as follows:
 
 ```
 global.postgresql.auth.username=testuser
@@ -603,18 +646,24 @@ This way, the credentials will be available in all of the subcharts.
 
 ## Persistence
 
-The [Bitnami PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image stores the PostgreSQL data and configurations at the `/bitnami/postgresql` path of the container.
+The [Bitnami PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image stores the PostgreSQL data and
+configurations at the `/bitnami/postgresql` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
 
-If you already have data in it, you will fail to sync to standby nodes for all commits, details can refer to [code](https://github.com/bitnami/bitnami-docker-postgresql/blob/8725fe1d7d30ebe8d9a16e9175d05f7ad9260c93/9.6/debian-9/rootfs/libpostgresql.sh#L518-L556). If you need to use those data, please covert them to sql and import after `helm install` finished.
+If you already have data in it, you will fail to sync to standby nodes for all commits, details can refer
+to [code](https://github.com/bitnami/bitnami-docker-postgresql/blob/8725fe1d7d30ebe8d9a16e9175d05f7ad9260c93/9.6/debian-9/rootfs/libpostgresql.sh#L518-L556)
+. If you need to use those data, please covert them to sql and import after `helm install` finished.
 
 ## NetworkPolicy
 
-To enable network policy for PostgreSQL, install [a networking plugin that implements the Kubernetes NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin), and set `networkPolicy.enabled` to `true`.
+To enable network policy for PostgreSQL,
+install [a networking plugin that implements the Kubernetes NetworkPolicy spec](https://kubernetes.io/docs/tasks/administer-cluster/declare-network-policy#before-you-begin)
+, and set `networkPolicy.enabled` to `true`.
 
-For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting the DefaultDeny namespace annotation. Note: this will enforce policy for _all_ pods in the namespace:
+For Kubernetes v1.5 & v1.6, you must also turn on NetworkPolicy by setting the DefaultDeny namespace annotation. Note:
+this will enforce policy for _all_ pods in the namespace:
 
 ```bash
 kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ingress\":{\"isolation\":\"DefaultDeny\"}}"
@@ -622,28 +671,45 @@ kubectl annotate namespace default "net.beta.kubernetes.io/network-policy={\"ing
 
 With NetworkPolicy enabled, traffic will be limited to just port 5432.
 
-For more precise policy, set `networkPolicy.allowExternal=false`. This will only allow pods with the generated client label to connect to PostgreSQL.
+For more precise policy, set `networkPolicy.allowExternal=false`. This will only allow pods with the generated client
+label to connect to PostgreSQL.
 This label will be displayed in the output of a successful install.
 
 ## Differences between Bitnami PostgreSQL image and [Docker Official](https://hub.docker.com/_/postgres) image
 
-- The Docker Official PostgreSQL image does not support replication. If you pass any replication environment variable, this would be ignored. The only environment variables supported by the Docker Official image are POSTGRES_USER, POSTGRES_DB, POSTGRES_PASSWORD, POSTGRES_INITDB_ARGS, POSTGRES_INITDB_WALDIR and PGDATA. All the remaining environment variables are specific to the Bitnami PostgreSQL image.
-- The Bitnami PostgreSQL image is non-root by default. This requires that you run the pod with `securityContext` and updates the permissions of the volume with an `initContainer`. A key benefit of this configuration is that the pod follows security best practices and is prepared to run on Kubernetes distributions with hard security constraints like OpenShift.
-- For OpenShift, one may either define the runAsUser and fsGroup accordingly, or try this more dynamic option: volumePermissions.securityContext.runAsUser="auto",securityContext.enabled=false,containerSecurityContext.enabled=false,shmVolume.chmod.enabled=false
+- The Docker Official PostgreSQL image does not support replication. If you pass any replication environment variable,
+  this would be ignored. The only environment variables supported by the Docker Official image are POSTGRES_USER,
+  POSTGRES_DB, POSTGRES_PASSWORD, POSTGRES_INITDB_ARGS, POSTGRES_INITDB_WALDIR and PGDATA. All the remaining environment
+  variables are specific to the Bitnami PostgreSQL image.
+- The Bitnami PostgreSQL image is non-root by default. This requires that you run the pod with `securityContext` and
+  updates the permissions of the volume with an `initContainer`. A key benefit of this configuration is that the pod
+  follows security best practices and is prepared to run on Kubernetes distributions with hard security constraints like
+  OpenShift.
+- For OpenShift, one may either define the runAsUser and fsGroup accordingly, or try this more dynamic option:
+  volumePermissions.securityContext.runAsUser="auto"
+  ,securityContext.enabled=false,containerSecurityContext.enabled=false,shmVolume.chmod.enabled=false
 
 ### Setting Pod's affinity
 
-This chart allows you to set your custom affinity using the `XXX.affinity` parameter(s). Find more information about Pod's affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+This chart allows you to set your custom affinity using the `XXX.affinity` parameter(s). Find more information about
+Pod's affinity in
+the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+.
 
-As an alternative, you can use of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do so, set the `XXX.podAffinityPreset`, `XXX.podAntiAffinityPreset`, or `XXX.nodeAffinityPreset` parameters.
+As an alternative, you can use of the preset configurations for pod affinity, pod anti-affinity, and node affinity
+available at the [bitnami/common](https://github.com/bitnami/charts/tree/master/bitnami/common#affinities) chart. To do
+so, set the `XXX.podAffinityPreset`, `XXX.podAntiAffinityPreset`, or `XXX.nodeAffinityPreset` parameters.
 
 ## Troubleshooting
 
-Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+Find more information about how to deal with common errors related to Bitnami's Helm charts
+in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
 
 ## Upgrading
 
-Refer to the [chart documentation for more information about how to upgrade from previous releases](https://docs.bitnami.com/kubernetes/infrastructure/postgresql/administration/upgrade/).
+Refer to
+the [chart documentation for more information about how to upgrade from previous releases](https://docs.bitnami.com/kubernetes/infrastructure/postgresql/administration/upgrade/)
+.
 
 ## License
 

--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -69,26 +69,27 @@ kubectl delete pvc -l release=my-release
 
 ### Global parameters
 
-| Name                                                           | Description                                                                                     | Value     |
-|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------|-----------|
-| `global.imageRegistry`                                         | Global Docker image registry                                                                    | `""`      |
-| `global.imagePullSecrets`                                      | Global Docker registry secret names as an array                                                 | `[]`      |
-| `global.storageClass`                                          | Global StorageClass for Persistent Volume(s)                                                    | `""`      |
-| `global.postgresql.auth.postgresPassword`                      | Password for the "postgres" admin user (overrides `auth.postgresPassword`)                      | `""`      |
-| `global.postgresql.auth.username`                              | Name for a custom user to create (overrides `auth.username`)                                    | `""`      |
-| `global.postgresql.auth.password`                              | Password for the custom user to create (overrides `auth.password`)                              | `""`      |
-| `global.postgresql.auth.database`                              | Name for a custom database to create (overrides `auth.database`)                                | `""`      |
-| `global.postgresql.auth.existingSecret.enabled`                | Enable the use an existing secret for PostgreSQL credentials (overrides `auth.existingSecret`). | `"false"` |
-| `global.postgresql.auth.existingSecret.secretName`             | Name of existing secret to use for PostgreSQL credentials.                                      | `""`      |
-| `global.postgresql.auth.existingSecret.adminPasswordKey`       | Name of key in existing secret to use for PostgreSQL credentials.                               | `""`      |
-| `global.postgresql.auth.existingSecret.userPasswordKey`        | Name of key in existing secret to use for PostgreSQL credentials.                               | `""`      |
-| `global.postgresql.auth.existingSecret.replicationPasswordKey` | Name of key in existing secret to use for PostgreSQL credentials.                               | `""`      |
-| `global.postgresql.service.ports.postgresql`                   | PostgreSQL service port (overrides `service.ports.postgresql`)                                  | `""`      |
+| Name                                                           | Description                                                                                     | Value                  |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------- |
+| `global.imageRegistry`                                         | Global Docker image registry                                                                    | `""`                   |
+| `global.imagePullSecrets`                                      | Global Docker registry secret names as an array                                                 | `[]`                   |
+| `global.storageClass`                                          | Global StorageClass for Persistent Volume(s)                                                    | `""`                   |
+| `global.postgresql.auth.postgresPassword`                      | Password for the "postgres" admin user (overrides `auth.postgresPassword`)                      | `""`                   |
+| `global.postgresql.auth.username`                              | Name for a custom user to create (overrides `auth.username`)                                    | `""`                   |
+| `global.postgresql.auth.password`                              | Password for the custom user to create (overrides `auth.password`)                              | `""`                   |
+| `global.postgresql.auth.database`                              | Name for a custom database to create (overrides `auth.database`)                                | `""`                   |
+| `global.postgresql.auth.existingSecret.enabled`                | Enable the use an existing secret for PostgreSQL credentials (overrides `auth.existingSecret`). | `false`                |
+| `global.postgresql.auth.existingSecret.secretName`             | Name of existing secret to use for PostgreSQL credentials.                                      | `name-of-secret`       |
+| `global.postgresql.auth.existingSecret.adminPasswordKey`       | Name of key in existing secret to use for PostgreSQL credentials.                               | `admin-password`       |
+| `global.postgresql.auth.existingSecret.userPasswordKey`        | Name of key in existing secret to use for PostgreSQL credentials.                               | `user-password`        |
+| `global.postgresql.auth.existingSecret.replicationPasswordKey` | Name of key in existing secret to use for PostgreSQL credentials.                               | `replication-password` |
+| `global.postgresql.service.ports.postgresql`                   | PostgreSQL service port (overrides `service.ports.postgresql`)                                  | `""`                   |
+
 
 ### Common parameters
 
 | Name                     | Description                                                                                  | Value           |
-|--------------------------|----------------------------------------------------------------------------------------------|-----------------|
+| ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
 | `kubeVersion`            | Override Kubernetes version                                                                  | `""`            |
 | `nameOverride`           | String to partially override common.names.fullname template (will maintain the release name) | `""`            |
 | `fullnameOverride`       | String to fully override common.names.fullname template                                      | `""`            |
@@ -100,13 +101,14 @@ kubectl delete pvc -l release=my-release
 | `diagnosticMode.command` | Command to override all containers in the statefulset                                        | `["sleep"]`     |
 | `diagnosticMode.args`    | Args to override all containers in the statefulset                                           | `["infinity"]`  |
 
+
 ### PostgreSQL common parameters
 
 | Name                                         | Description                                                                                                                                                                                                                                                                                                                                      | Value                      |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
 | `image.registry`                             | PostgreSQL image registry                                                                                                                                                                                                                                                                                                                        | `docker.io`                |
 | `image.repository`                           | PostgreSQL image repository                                                                                                                                                                                                                                                                                                                      | `bitnami/postgresql`       |
-| `image.tag`                                  | PostgreSQL image tag (immutable tags are recommended)                                                                                                                                                                                                                                                                                            | `14.2.0-debian-10-r58`     |
+| `image.tag`                                  | PostgreSQL image tag (immutable tags are recommended)                                                                                                                                                                                                                                                                                            | `14.3.0-debian-10-r7`      |
 | `image.pullPolicy`                           | PostgreSQL image pull policy                                                                                                                                                                                                                                                                                                                     | `IfNotPresent`             |
 | `image.pullSecrets`                          | Specify image pull secrets                                                                                                                                                                                                                                                                                                                       | `[]`                       |
 | `image.debug`                                | Specify if debug values should be set                                                                                                                                                                                                                                                                                                            | `false`                    |
@@ -117,11 +119,11 @@ kubectl delete pvc -l release=my-release
 | `auth.database`                              | Name for a custom database to create                                                                                                                                                                                                                                                                                                             | `""`                       |
 | `auth.replicationUsername`                   | Name of the replication user                                                                                                                                                                                                                                                                                                                     | `repl_user`                |
 | `auth.replicationPassword`                   | Password for the replication user. Ignored if `auth.existingSecret` with key `replication-password` is provided                                                                                                                                                                                                                                  | `""`                       |
-| `auth.existingSecret.enabled`                | Enable the use an existing secret for PostgreSQL credentials. `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case. | `"false"`                  |
-| `auth.existingSecret.secretName`             | Name of existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                       | `""`                       |
-| `auth.existingSecret.adminPasswordKey`       | Name of key in existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                | `""`                       |
-| `auth.existingSecret.userPasswordKey`        | Name of key in existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                | `""`                       |
-| `auth.existingSecret.replicationPasswordKey` | Name of key in existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                | `""`                       |
+| `auth.existingSecret.enabled`                | Enable the use an existing secret for PostgreSQL credentials. `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case. | `false`                    |
+| `auth.existingSecret.secretName`             | Name of existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                       | `name-of-secret`           |
+| `auth.existingSecret.adminPasswordKey`       | Name of key in existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                | `admin-password`           |
+| `auth.existingSecret.userPasswordKey`        | Name of key in existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                | `user-password`            |
+| `auth.existingSecret.replicationPasswordKey` | Name of key in existing secret to use for PostgreSQL credentials.                                                                                                                                                                                                                                                                                | `replication-password`     |
 | `auth.usePasswordFiles`                      | Mount credentials as a files instead of using an environment variable                                                                                                                                                                                                                                                                            | `false`                    |
 | `architecture`                               | PostgreSQL architecture (`standalone` or `replication`)                                                                                                                                                                                                                                                                                          | `standalone`               |
 | `replication.synchronousCommit`              | Set synchronous commit mode. Allowed values: `on`, `remote_apply`, `remote_write`, `local` and `off`                                                                                                                                                                                                                                             | `off`                      |
@@ -161,6 +163,7 @@ kubectl delete pvc -l release=my-release
 | `tls.certKeyFilename`                        | Certificate key filename                                                                                                                                                                                                                                                                                                                         | `""`                       |
 | `tls.certCAFilename`                         | CA Certificate filename                                                                                                                                                                                                                                                                                                                          | `""`                       |
 | `tls.crlFilename`                            | File containing a Certificate Revocation List                                                                                                                                                                                                                                                                                                    | `""`                       |
+
 
 ### PostgreSQL Primary parameters
 
@@ -261,6 +264,7 @@ kubectl delete pvc -l release=my-release
 | `primary.persistence.selector`               | Selector to match an existing Persistent Volume (this value is evaluated as a template)                                  | `{}`                  |
 | `primary.persistence.dataSource`             | Custom PVC data source                                                                                                   | `{}`                  |
 
+
 ### PostgreSQL read only replica parameters
 
 | Name                                              | Description                                                                                                              | Value                 |
@@ -345,6 +349,7 @@ kubectl delete pvc -l release=my-release
 | `readReplicas.persistence.selector`               | Selector to match an existing Persistent Volume (this value is evaluated as a template)                                  | `{}`                  |
 | `readReplicas.persistence.dataSource`             | Custom PVC data source                                                                                                   | `{}`                  |
 
+
 ### NetworkPolicy parameters
 
 | Name                                                                      | Description                                                                                                                                        | Value   |
@@ -364,6 +369,7 @@ kubectl delete pvc -l release=my-release
 | `networkPolicy.egressRules.denyConnectionsToExternal`                     | Enable egress rule that denies outgoing traffic outside the cluster, except for DNS (port 53).                                                     | `false` |
 | `networkPolicy.egressRules.customRules`                                   | Custom network policy rule                                                                                                                         | `{}`    |
 
+
 ### Volume Permissions parameters
 
 | Name                                                   | Description                                                                     | Value                   |
@@ -371,12 +377,13 @@ kubectl delete pvc -l release=my-release
 | `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume | `false`                 |
 | `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                | `docker.io`             |
 | `volumePermissions.image.repository`                   | Init container volume-permissions image repository                              | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)    | `10-debian-10-r388`     |
+| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)    | `10-debian-10-r430`     |
 | `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                             | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                            | `[]`                    |
 | `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                               | `{}`                    |
 | `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                             | `{}`                    |
 | `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                  | `0`                     |
+
 
 ### Other Parameters
 
@@ -390,6 +397,7 @@ kubectl delete pvc -l release=my-release
 | `rbac.rules`                                  | Custom RBAC rules to set                                                                                                                    | `[]`    |
 | `psp.create`                                  | Whether to create a PodSecurityPolicy. WARNING: PodSecurityPolicy is deprecated in Kubernetes v1.21 or later, unavailable in v1.25 or later | `false` |
 
+
 ### Metrics Parameters
 
 | Name                                            | Description                                                                           | Value                       |
@@ -397,7 +405,7 @@ kubectl delete pvc -l release=my-release
 | `metrics.enabled`                               | Start a prometheus exporter                                                           | `false`                     |
 | `metrics.image.registry`                        | PostgreSQL Prometheus Exporter image registry                                         | `docker.io`                 |
 | `metrics.image.repository`                      | PostgreSQL Prometheus Exporter image repository                                       | `bitnami/postgres-exporter` |
-| `metrics.image.tag`                             | PostgreSQL Prometheus Exporter image tag (immutable tags are recommended)             | `0.10.1-debian-10-r76`      |
+| `metrics.image.tag`                             | PostgreSQL Prometheus Exporter image tag (immutable tags are recommended)             | `0.10.1-debian-10-r117`     |
 | `metrics.image.pullPolicy`                      | PostgreSQL Prometheus Exporter image pull policy                                      | `IfNotPresent`              |
 | `metrics.image.pullSecrets`                     | Specify image pull secrets                                                            | `[]`                        |
 | `metrics.customMetrics`                         | Define additional custom metrics                                                      | `{}`                        |
@@ -447,6 +455,7 @@ kubectl delete pvc -l release=my-release
 | `metrics.prometheusRule.namespace`              | Namespace for the PrometheusRule Resource (defaults to the Release Namespace)         | `""`                        |
 | `metrics.prometheusRule.labels`                 | Additional labels that can be used so PrometheusRule will be discovered by Prometheus | `{}`                        |
 | `metrics.prometheusRule.rules`                  | PrometheusRule definitions                                                            | `[]`                        |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -218,7 +218,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.secretName" . }}
-                  key: postgres-password
+                  key: {{ include "postgresql.adminPasswordKey" . }}
             {{- end }}
             {{- end }}
           {{- end }}
@@ -230,7 +230,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.secretName" . }}
-                  key: {{ ternary "password" "postgres-password" (and (not (empty $customUser)) (ne $customUser "postgres")) }}
+                  key: {{ include "postgresql.userPasswordKey" . }}
             {{- end }}
             {{- if (include "postgresql.database" .) }}
             - name: POSTGRES_DB
@@ -250,7 +250,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.secretName" . }}
-                  key: replication-password
+                  key: {{ include "postgresql.replicationPasswordKey" . }}
             {{- end }}
             {{- if not (eq .Values.replication.synchronousCommit "off") }}
             - name: POSTGRES_SYNCHRONOUS_COMMIT_MODE
@@ -501,7 +501,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.secretName" . }}
-                  key: {{ ternary "password" "postgres-password" (and (not (empty $customUser)) (ne $customUser "postgres")) }}
+                  key: {{ include "postgresql.userPasswordKey" . }}
             {{- end }}
             - name: DATA_SOURCE_USER
               value: {{ default "postgres" $customUser | quote }}

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -210,7 +210,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.secretName" . }}
-                  key: postgres-password
+                  key: {{ include "postgresql.adminPasswordKey" . }}
             {{- end }}
           {{- end }}
             {{- if .Values.auth.usePasswordFiles }}
@@ -221,7 +221,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.secretName" . }}
-                  key: {{ ternary "password" "postgres-password" (and (not (empty $customUser)) (ne $customUser "postgres")) }}
+                  key: {{ include "postgresql.userPasswordKey" . }}
             {{- end }}
             # Replication
             - name: POSTGRES_REPLICATION_MODE
@@ -236,7 +236,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql.secretName" . }}
-                  key: replication-password
+                  key: {{ include "postgresql.replicationPasswordKey" . }}
             {{- end }}
             - name: POSTGRES_CLUSTER_APP_NAME
               value: {{ .Values.replication.applicationName }}
@@ -408,7 +408,7 @@ spec:
                 valueFrom:
                   secretKeyRef:
                     name: {{ include "postgresql.secretName" . }}
-                    key: {{ ternary "password" "postgres-password" (and (not (empty $customUser)) (ne $customUser "postgres")) }}
+                    key: {{ include "postgresql.userPasswordKey" . }}
               {{- end }}
               - name: DATA_SOURCE_USER
                 value: {{ default "postgres" $customUser | quote }}

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -19,14 +19,23 @@ global:
     ## @param global.postgresql.auth.username Name for a custom user to create (overrides `auth.username`)
     ## @param global.postgresql.auth.password Password for the custom user to create (overrides `auth.password`)
     ## @param global.postgresql.auth.database Name for a custom database to create (overrides `auth.database`)
-    ## @param global.postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials (overrides `auth.existingSecret`)
+    ## @param global.postgresql.auth.existingSecret.enabled Enable the use an existing secret for PostgreSQL credentials (overrides `auth.existingSecret`).
+    ## @param global.postgresql.auth.existingSecret.secretName Name of existing secret to use for PostgreSQL credentials.
+    ## @param global.postgresql.auth.existingSecret.adminPasswordKey Name of key in existing secret to use for PostgreSQL credentials.
+    ## @param global.postgresql.auth.existingSecret.userPasswordKey Name of key in existing secret to use for PostgreSQL credentials.
+    ## @param global.postgresql.auth.existingSecret.replicationPasswordKey Name of key in existing secret to use for PostgreSQL credentials.
     ##
     auth:
       postgresPassword: ""
       username: ""
       password: ""
       database: ""
-      existingSecret: ""
+      existingSecret:
+        enabled: false
+        secretName: name-of-secret
+        adminPasswordKey: admin-password
+        userPasswordKey: user-password
+        replicationPasswordKey: replication-password
     ## @param global.postgresql.service.ports.postgresql PostgreSQL service port (overrides `service.ports.postgresql`)
     ##
     service:
@@ -131,10 +140,18 @@ auth:
   ## @param auth.replicationPassword Password for the replication user. Ignored if `auth.existingSecret` with key `replication-password` is provided
   ##
   replicationPassword: ""
-  ## @param auth.existingSecret Name of existing secret to use for PostgreSQL credentials. The secret must contain the keys `postgres-password` (which is the password for "postgres" admin user), `password` (which is the password for the custom user to create when `auth.username` is set) and `replication-password` (which is the password for replication user). `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case.
-  ## The value is evaluated as a template.
+  ## @param auth.existingSecret.enabled Enable the use an existing secret for PostgreSQL credentials. `auth.postgresPassword`, `auth.password`, and `auth.replicationPassword` will be ignored and picked up from this secret. The secret might also contains the key `ldap-password` if LDAP is enabled. `ldap.bind_password` will be ignored and picked from this secret in this case.
+  ## @param auth.existingSecret.secretName Name of existing secret to use for PostgreSQL credentials.
+  ## @param auth.existingSecret.adminPasswordKey Name of key in existing secret to use for PostgreSQL credentials.
+  ## @param auth.existingSecret.userPasswordKey Name of key in existing secret to use for PostgreSQL credentials.
+  ## @param auth.existingSecret.replicationPasswordKey Name of key in existing secret to use for PostgreSQL credentials.
   ##
-  existingSecret: ""
+  existingSecret:
+    enabled: false
+    secretName: name-of-secret
+    adminPasswordKey: admin-password
+    userPasswordKey: user-password
+    replicationPasswordKey: replication-password
   ## @param auth.usePasswordFiles Mount credentials as a files instead of using an environment variable
   ##
   usePasswordFiles: false


### PR DESCRIPTION
Signed-off-by: Tobias Effner <tobias.effner@rackspace.com>

### Make existing secret key names choosable

This PR will enable developers to choose their own secret key name in an existing secret.

### Benefits

It adds freedom in the existing secret to match existing patterns in the developers code.

### Possible drawbacks

None.

### Applicable issues

None.

### Additional information

I kept the logic the chart uses to prioritize the different passwords.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
