### PR TITLE
[bitnami/external-dns] Fix YAML syntax

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 6.4.4
+version: 6.4.5

--- a/bitnami/external-dns/templates/deployment.yaml
+++ b/bitnami/external-dns/templates/deployment.yaml
@@ -183,7 +183,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Values.aws.zonesCacheDuration }}
-             - --aws-zones-cache-duration={{ .Values.aws.zonesCacheDuration }}
+            - --aws-zones-cache-duration={{ .Values.aws.zonesCacheDuration }}
             {{- end }}
             {{- range .Values.aws.zoneTags }}
             - --aws-zone-tags={{ . }}


### PR DESCRIPTION
### Description of the change

Two args were previously rendering as a single line. For example:
```
--aws-zone-type=private
--aws-batch-change-size=1000 - --aws-zones-cache-duration=1h
```

After this fix, the args render correctly. For example:
```
--aws-zone-type=private
--aws-batch-change-size=1000
--aws-zones-cache-duration=1h
```

### Benefits

This is a bug fix.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

This bug was introduced in https://github.com/bitnami/charts/pull/10007

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
