### PR TITLE
[bitnami/mysql] Fix mysql slave auth after applying helm

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/bitnami-docker-mysql
   - https://mysql.com
-version: 9.0.4
+version: 9.0.5

--- a/bitnami/mysql/templates/secrets.yaml
+++ b/bitnami/mysql/templates/secrets.yaml
@@ -16,6 +16,6 @@ data:
   mysql-root-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "mysql-root-password" "length" 10 "providedValues" (list "auth.rootPassword") "context" $) }}
   mysql-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "mysql-password" "length" 10 "providedValues" (list "auth.password") "context" $) }}
   {{- if eq .Values.architecture "replication" }}
-  mysql-replication-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "mysql-replication-password" "length" 10 "providedValues" (list "auth.replicationPassword") "context" $) | b64enc | quote }}
+  mysql-replication-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "mysql-replication-password" "length" 10 "providedValues" (list "auth.replicationPassword") "context" $) }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Fix SQL authentication (master/slave) due to improper `replicationPassword` value parsing

### Benefits

Slave can authenticate with Master after chart applied.
In helm template, mysql chart v9.0.4, after apply, decoded secret will be:
```
mysql-password: vwzcwef
mysql-replication-password: '"asf3efwf"'
mysql-root-password: fwef23
```
The issue is in the _quote_ in mysql-replication-password.

### Possible drawbacks

N/A

### Applicable issues
  - fixes #10366

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
