### PR TITLE
[bitnami/memcached] Add support for terminationGracePeriod and service.sessionAffinityConfig

### DIFF
--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/bitnami-docker-memcached
   - http://memcached.org/
-version: 6.0.22
+version: 6.1.0

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -78,23 +78,23 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Memcached parameters
 
-| Name                 | Description                                                              | Value                 |
-| -------------------- | ------------------------------------------------------------------------ | --------------------- |
-| `image.registry`     | Memcached image registry                                                 | `docker.io`           |
-| `image.repository`   | Memcached image repository                                               | `bitnami/memcached`   |
-| `image.tag`          | Memcached image tag (immutable tags are recommended)                     | `1.6.13-debian-10-r0` |
-| `image.pullPolicy`   | Memcached image pull policy                                              | `IfNotPresent`        |
-| `image.pullSecrets`  | Specify docker-registry secret names as an array                         | `[]`                  |
-| `image.debug`        | Specify if debug values should be set                                    | `false`               |
-| `architecture`       | Memcached architecture. Allowed values: standalone or high-availability  | `standalone`          |
-| `auth.enabled`       | Enable Memcached authentication                                          | `false`               |
-| `auth.username`      | Memcached admin user                                                     | `""`                  |
-| `auth.password`      | Memcached admin password                                                 | `""`                  |
-| `command`            | Override default container command (useful when using custom images)     | `[]`                  |
-| `args`               | Override default container args (useful when using custom images)        | `[]`                  |
-| `extraEnvVars`       | Array with extra environment variables to add to Memcached nodes         | `[]`                  |
-| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars for Memcached nodes | `""`                  |
-| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars for Memcached nodes    | `""`                  |
+| Name                 | Description                                                              | Value                  |
+| -------------------- | ------------------------------------------------------------------------ | ---------------------- |
+| `image.registry`     | Memcached image registry                                                 | `docker.io`            |
+| `image.repository`   | Memcached image repository                                               | `bitnami/memcached`    |
+| `image.tag`          | Memcached image tag (immutable tags are recommended)                     | `1.6.15-debian-10-r50` |
+| `image.pullPolicy`   | Memcached image pull policy                                              | `IfNotPresent`         |
+| `image.pullSecrets`  | Specify docker-registry secret names as an array                         | `[]`                   |
+| `image.debug`        | Specify if debug values should be set                                    | `false`                |
+| `architecture`       | Memcached architecture. Allowed values: standalone or high-availability  | `standalone`           |
+| `auth.enabled`       | Enable Memcached authentication                                          | `false`                |
+| `auth.username`      | Memcached admin user                                                     | `""`                   |
+| `auth.password`      | Memcached admin password                                                 | `""`                   |
+| `command`            | Override default container command (useful when using custom images)     | `[]`                   |
+| `args`               | Override default container args (useful when using custom images)        | `[]`                   |
+| `extraEnvVars`       | Array with extra environment variables to add to Memcached nodes         | `[]`                   |
+| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars for Memcached nodes | `""`                   |
+| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars for Memcached nodes    | `""`                   |
 
 
 ### Deployment/Statefulset parameters
@@ -148,6 +148,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podManagementPolicy`                   | StatefulSet controller supports relax its ordering guarantees while preserving its uniqueness and identity guarantees. There are two valid pod management policies: `OrderedReady` and `Parallel` | `Parallel`      |
 | `priorityClassName`                     | Name of the existing priority class to be used by Memcached pods, priority class needs to be created beforehand                                                                                   | `""`            |
 | `schedulerName`                         | Kubernetes pod scheduler registry                                                                                                                                                                 | `""`            |
+| `terminationGracePeriodSeconds`         | In seconds, time the given to the memcached pod needs to terminate gracefully                                                                                                                     | `""`            |
 | `updateStrategy.type`                   | Memcached statefulset strategy type                                                                                                                                                               | `RollingUpdate` |
 | `updateStrategy.rollingUpdate`          | Memcached statefulset rolling update configuration parameters                                                                                                                                     | `{}`            |
 | `extraVolumes`                          | Optionally specify extra list of additional volumes for the Memcached pod(s)                                                                                                                      | `[]`            |
@@ -172,6 +173,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.ports.memcached`          | Memcached service port                                                                  | `11211`     |
 | `service.nodePorts.memcached`      | Node port for Memcached                                                                 | `""`        |
 | `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                        | `None`      |
+| `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                             | `{}`        |
 | `service.clusterIP`                | Memcached service Cluster IP                                                            | `""`        |
 | `service.loadBalancerIP`           | Memcached service Load Balancer IP                                                      | `""`        |
 | `service.loadBalancerSourceRanges` | Memcached service Load Balancer sources                                                 | `[]`        |
@@ -192,15 +194,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Persistence parameters
 
-| Name                        | Description                                                              | Value               |
-| --------------------------- | ------------------------------------------------------------------------ | ------------------- |
-| `persistence.enabled`       | Enable Memcached data persistence using PVC. If false, use emptyDir      | `false`             |
-| `persistence.existingClaim` | Name of an existing PVC to use (only when deploying a single replica)    | `""`                |
-| `persistence.storageClass`  | PVC Storage Class for Memcached data volume                              | `""`                |
-| `persistence.accessModes`   | PVC Access modes                                                         | `["ReadWriteOnce"]` |
-| `persistence.size`          | PVC Storage Request for Memcached data volume                            | `8Gi`               |
-| `persistence.annotations`   | Annotations for the PVC                                                  | `{}`                |
-| `persistence.selector`      | Selector to match an existing Persistent Volume for Memcached's data PVC | `{}`                |
+| Name                       | Description                                                              | Value               |
+| -------------------------- | ------------------------------------------------------------------------ | ------------------- |
+| `persistence.enabled`      | Enable Memcached data persistence using PVC. If false, use emptyDir      | `false`             |
+| `persistence.storageClass` | PVC Storage Class for Memcached data volume                              | `""`                |
+| `persistence.accessModes`  | PVC Access modes                                                         | `["ReadWriteOnce"]` |
+| `persistence.size`         | PVC Storage Request for Memcached data volume                            | `8Gi`               |
+| `persistence.annotations`  | Annotations for the PVC                                                  | `{}`                |
+| `persistence.selector`     | Selector to match an existing Persistent Volume for Memcached's data PVC | `{}`                |
 
 
 ### Volume Permissions parameters
@@ -210,7 +211,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume       | `false`                      |
 | `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                      | `docker.io`                  |
 | `volumePermissions.image.repository`                   | Init container volume-permissions image repository                                    | `bitnami/bitnami-shell`      |
-| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)          | `10-debian-10-r304`          |
+| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)          | `10-debian-10-r431`          |
 | `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                                   | `IfNotPresent`               |
 | `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                                  | `[]`                         |
 | `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                                     | `{}`                         |
@@ -219,7 +220,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                                      | Start a side-car prometheus exporter                                                  | `false`                      |
 | `metrics.image.registry`                               | Memcached exporter image registry                                                     | `docker.io`                  |
 | `metrics.image.repository`                             | Memcached exporter image repository                                                   | `bitnami/memcached-exporter` |
-| `metrics.image.tag`                                    | Memcached exporter image tag (immutable tags are recommended)                         | `0.9.0-debian-10-r268`       |
+| `metrics.image.tag`                                    | Memcached exporter image tag (immutable tags are recommended)                         | `0.9.0-debian-10-r393`       |
 | `metrics.image.pullPolicy`                             | Image pull policy                                                                     | `IfNotPresent`               |
 | `metrics.image.pullSecrets`                            | Specify docker-registry secret names as an array                                      | `[]`                         |
 | `metrics.containerPorts.metrics`                       | Memcached Prometheus Exporter container port                                          | `9150`                       |
@@ -255,7 +256,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.serviceMonitor.namespace`                     | Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)         | `""`                         |
 | `metrics.serviceMonitor.interval`                      | Interval at which metrics should be scraped.                                          | `""`                         |
 | `metrics.serviceMonitor.scrapeTimeout`                 | Timeout after which the scrape is ended                                               | `""`                         |
-| `metrics.serviceMonitor.additionalLabels`              | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`                         |
+| `metrics.serviceMonitor.labels`                        | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`                         |
 | `metrics.serviceMonitor.selector`                      | Prometheus instance selector labels                                                   | `{}`                         |
 | `metrics.serviceMonitor.relabelings`                   | RelabelConfigs to apply to samples before scraping                                    | `[]`                         |
 | `metrics.serviceMonitor.metricRelabelings`             | MetricRelabelConfigs to apply to samples before ingestion                             | `[]`                         |

--- a/bitnami/memcached/templates/deployment.yaml
+++ b/bitnami/memcached/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       serviceAccountName: {{ template "memcached.serviceAccountName" . }}
       {{- if .Values.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}

--- a/bitnami/memcached/templates/service.yaml
+++ b/bitnami/memcached/templates/service.yaml
@@ -16,16 +16,21 @@ metadata:
     {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
   {{- if and (eq .Values.service.type "ClusterIP") .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
   externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
   {{- end }}
-  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerSourceRanges)) }}
   loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
-  {{ end }}
+  {{- end }}
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}

--- a/bitnami/memcached/templates/statefulset.yaml
+++ b/bitnami/memcached/templates/statefulset.yaml
@@ -15,6 +15,9 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.podManagementPolicy }}
+  podManagementPolicy: {{ .Values.podManagementPolicy | quote }}
+  {{- end }}
   serviceName: {{ template "common.names.fullname" . }}
   {{- if .Values.updateStrategy }}
   updateStrategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
@@ -65,6 +68,9 @@ spec:
       {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
       serviceAccountName: {{ template "memcached.serviceAccountName" . }}
       {{- if or .Values.persistence.enabled .Values.initContainers }}

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -290,6 +290,10 @@ priorityClassName: ""
 ## https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
 schedulerName: ""
+## @param terminationGracePeriodSeconds In seconds, time the given to the memcached pod needs to terminate gracefully
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+##
+terminationGracePeriodSeconds: ""
 ## @param updateStrategy.type Memcached statefulset strategy type
 ## @param updateStrategy.rollingUpdate Memcached statefulset rolling update configuration parameters
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
@@ -390,6 +394,12 @@ service:
   ## ref: https://kubernetes.io/docs/user-guide/services/
   ##
   sessionAffinity: None
+  ## @param service.sessionAffinityConfig Additional settings for the sessionAffinity
+  ## sessionAffinityConfig:
+  ##   clientIP:
+  ##     timeoutSeconds: 300
+  ##
+  sessionAffinityConfig: {}
   ## @param service.clusterIP Memcached service Cluster IP
   ## e.g.:
   ## clusterIP: None


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

### Description of the change

Add support for terminationGracePeriodSeconds and service.sessionAffinityConfig
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
