### PR TITLE
[bitnami/thanos] Implement ServiceAccount.create and ServiceAccount.name with BWC

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 10.4.3
+version: 10.5.0

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -107,19 +107,22 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 
 ### Thanos common parameters
 
-| Name                          | Description                                                                               | Value               |
-| ----------------------------- | ----------------------------------------------------------------------------------------- | ------------------- |
-| `image.registry`              | Thanos image registry                                                                     | `docker.io`         |
-| `image.repository`            | Thanos image repository                                                                   | `bitnami/thanos`    |
-| `image.tag`                   | Thanos image tag (immutable tags are recommended)                                         | `0.26.0-scratch-r0` |
-| `image.pullPolicy`            | Thanos image pull policy                                                                  | `IfNotPresent`      |
-| `image.pullSecrets`           | Specify docker-registry secret names as an array                                          | `[]`                |
-| `objstoreConfig`              | The [objstore configuration](https://thanos.io/tip/thanos/storage.md/)                    | `""`                |
-| `indexCacheConfig`            | The [index cache configuration](https://thanos.io/tip/components/store.md/)               | `""`                |
-| `bucketCacheConfig`           | The [bucket cache configuration](https://thanos.io/tip/components/store.md/)              | `""`                |
-| `existingObjstoreSecret`      | Secret with Objstore Configuration                                                        | `""`                |
-| `existingObjstoreSecretItems` | Optional item list for specifying a custom Secret key. If so, path should be objstore.yml | `[]`                |
-| `existingServiceAccount`      | Provide a common service account to be shared with all components                         | `""`                |
+| Name                                          | Description                                                                                                         | Value               |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `image.registry`                              | Thanos image registry                                                                                               | `docker.io`         |
+| `image.repository`                            | Thanos image repository                                                                                             | `bitnami/thanos`    |
+| `image.tag`                                   | Thanos image tag (immutable tags are recommended)                                                                   | `0.26.0-scratch-r2` |
+| `image.pullPolicy`                            | Thanos image pull policy                                                                                            | `IfNotPresent`      |
+| `image.pullSecrets`                           | Specify docker-registry secret names as an array                                                                    | `[]`                |
+| `objstoreConfig`                              | The [objstore configuration](https://thanos.io/tip/thanos/storage.md/)                                              | `""`                |
+| `indexCacheConfig`                            | The [index cache configuration](https://thanos.io/tip/components/store.md/)                                         | `""`                |
+| `bucketCacheConfig`                           | The [bucket cache configuration](https://thanos.io/tip/components/store.md/)                                        | `""`                |
+| `existingObjstoreSecret`                      | Secret with Objstore Configuration                                                                                  | `""`                |
+| `existingObjstoreSecretItems`                 | Optional item list for specifying a custom Secret key. If so, path should be objstore.yml                           | `[]`                |
+| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                | `false`             |
+| `serviceAccount.name`                         | Name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `""`                |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                                      | `true`              |
+| `serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                          | `{}`                |
 
 
 ### Thanos Query parameters
@@ -220,8 +223,9 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `query.service.labelSelectorsOverride`                    | Selector for Thanos Query service                                                                                                       | `{}`                     |
 | `query.service.additionalHeadless`                        | Additional Headless service                                                                                                             | `false`                  |
 | `query.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the deployment                                                       | `true`                   |
+| `query.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                                                    | `true`                   |
+| `query.serviceAccount.name`                               | Name of the service account to use. If not set and create is true, a name is generated using the fullname template.                     | `""`                     |
 | `query.serviceAccount.annotations`                        | Annotations for Thanos Query Service Account                                                                                            | `{}`                     |
-| `query.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Query Service Account                                                                                       | `""`                     |
 | `query.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                               | `true`                   |
 | `query.rbac.create`                                       | Create a ClusterRole and ClusterRoleBinding for the Thanos Query Service Account                                                        | `false`                  |
 | `query.rbac.rules`                                        | Custom RBAC rules to set                                                                                                                | `[]`                     |
@@ -339,8 +343,9 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `queryFrontend.service.extraPorts`                                | Extra ports to expose in the Thanos Query Frontend service                                                                       | `[]`                     |
 | `queryFrontend.service.labelSelectorsOverride`                    | Selector for Thanos Query service                                                                                                | `{}`                     |
 | `queryFrontend.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the deployment                                                | `true`                   |
+| `queryFrontend.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                                             | `true`                   |
+| `queryFrontend.serviceAccount.name`                               | Name of the service account to use. If not set and create is true, a name is generated using the fullname template.              | `""`                     |
 | `queryFrontend.serviceAccount.annotations`                        | Annotations for Thanos Query Frontend Service Account                                                                            | `{}`                     |
-| `queryFrontend.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Query Frontend Service Account                                                                       | `""`                     |
 | `queryFrontend.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                        | `true`                   |
 | `queryFrontend.rbac.create`                                       | Create a ClusterRole and ClusterRoleBinding for the Thanos Query Frontend Service Account                                        | `false`                  |
 | `queryFrontend.rbac.rules`                                        | Custom RBAC rules to set                                                                                                         | `[]`                     |
@@ -445,8 +450,9 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `bucketweb.service.extraPorts`                                | Extra ports to expose in the Thanos Bucket Web service                                                                           | `[]`                     |
 | `bucketweb.service.labelSelectorsOverride`                    | Selector for Thanos Query service                                                                                                | `{}`                     |
 | `bucketweb.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the deployment                                                | `true`                   |
+| `bucketweb.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                                             | `true`                   |
+| `bucketweb.serviceAccount.name`                               | Name of the service account to use. If not set and create is true, a name is generated using the fullname template.              | `""`                     |
 | `bucketweb.serviceAccount.annotations`                        | Annotations for Thanos Bucket Web Service Account                                                                                | `{}`                     |
-| `bucketweb.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Bucket Web Service Account                                                                           | `""`                     |
 | `bucketweb.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                        | `true`                   |
 | `bucketweb.autoscaling.enabled`                               | Enable autoscaling for Thanos Bucket Web                                                                                         | `false`                  |
 | `bucketweb.autoscaling.minReplicas`                           | Minimum number of Thanos Bucket Web replicas                                                                                     | `""`                     |
@@ -549,8 +555,9 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `compactor.service.extraPorts`                                | Extra ports to expose in the Thanos Compactor service                                                                            | `[]`                     |
 | `compactor.service.labelSelectorsOverride`                    | Selector for Thanos Query service                                                                                                | `{}`                     |
 | `compactor.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the deployment                                                | `true`                   |
+| `compactor.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                                             | `true`                   |
+| `compactor.serviceAccount.name`                               | Name of the service account to use. If not set and create is true, a name is generated using the fullname template.              | `""`                     |
 | `compactor.serviceAccount.annotations`                        | Annotations for Thanos Compactor Service Account                                                                                 | `{}`                     |
-| `compactor.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Compactor Service Account                                                                            | `""`                     |
 | `compactor.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                        | `true`                   |
 | `compactor.ingress.enabled`                                   | Enable ingress controller resource                                                                                               | `false`                  |
 | `compactor.ingress.hostname`                                  | Default host for the ingress resource                                                                                            | `thanos-compactor.local` |
@@ -666,8 +673,9 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `storegateway.persistence.annotations`                           | Annotations for the PVC                                                                                                                  | `{}`                        |
 | `storegateway.persistence.existingClaim`                         | Name of an existing PVC to use                                                                                                           | `""`                        |
 | `storegateway.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the sts                                                               | `true`                      |
+| `storegateway.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                                                     | `true`                      |
+| `storegateway.serviceAccount.name`                               | Name of the service account to use. If not set and create is true, a name is generated using the fullname template.                      | `""`                        |
 | `storegateway.serviceAccount.annotations`                        | Annotations for Thanos Store Gateway Service Account                                                                                     | `{}`                        |
-| `storegateway.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Store Gateway Service Account                                                                                | `""`                        |
 | `storegateway.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                                | `true`                      |
 | `storegateway.autoscaling.enabled`                               | Enable autoscaling for Thanos Store Gateway                                                                                              | `false`                     |
 | `storegateway.autoscaling.minReplicas`                           | Minimum number of Thanos Store Gateway replicas                                                                                          | `""`                        |
@@ -805,8 +813,9 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `ruler.persistence.annotations`                           | Annotations for the PVC                                                                                                          | `{}`                     |
 | `ruler.persistence.existingClaim`                         | Name of an existing PVC to use                                                                                                   | `""`                     |
 | `ruler.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the sts                                                       | `true`                   |
+| `ruler.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                                             | `true`                   |
+| `ruler.serviceAccount.name`                               | Name of the service account to use. If not set and create is true, a name is generated using the fullname template.              | `""`                     |
 | `ruler.serviceAccount.annotations`                        | Annotations for Thanos Ruler Service Account                                                                                     | `{}`                     |
-| `ruler.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Ruler Service Account                                                                                | `""`                     |
 | `ruler.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                        | `true`                   |
 | `ruler.autoscaling.enabled`                               | Enable autoscaling for Thanos Ruler                                                                                              | `false`                  |
 | `ruler.autoscaling.minReplicas`                           | Minimum number of Thanos Ruler replicas                                                                                          | `""`                     |
@@ -923,8 +932,9 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `receive.service.labelSelectorsOverride`                    | Selector for Thanos receive service                                                                                              | `{}`                     |
 | `receive.service.additionalHeadless`                        | Additional Headless service                                                                                                      | `false`                  |
 | `receive.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the sts                                                       | `true`                   |
+| `receive.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                                             | `true`                   |
+| `receive.serviceAccount.name`                               | Name of the service account to use. If not set and create is true, a name is generated using the fullname template.              | `""`                     |
 | `receive.serviceAccount.annotations`                        | Annotations for Thanos Receive Service Account                                                                                   | `{}`                     |
-| `receive.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Receive Service Account                                                                              | `""`                     |
 | `receive.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                        | `true`                   |
 | `receive.autoscaling.enabled`                               | Enable autoscaling for Thanos Receive                                                                                            | `false`                  |
 | `receive.autoscaling.minReplicas`                           | Minimum number of Thanos Receive replicas                                                                                        | `""`                     |
@@ -1022,8 +1032,9 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `receiveDistributor.schedulerName`                                     | Name of the k8s scheduler (other than default) for Thanos Receive Distributor pods                                          | `""`            |
 | `receiveDistributor.topologySpreadConstraints`                         | Topology Spread Constraints for Thanos Receive Distributor pods assignment spread across your cluster among failure-domains | `[]`            |
 | `receiveDistributor.automountServiceAccountToken`                      | Enable/disable auto mounting of the service account token only for the deployment                                           | `true`          |
+| `receiveDistributor.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created                                                                        | `true`          |
+| `receiveDistributor.serviceAccount.name`                               | Name of the service account to use. If not set and create is true, a name is generated using the fullname template.         | `""`            |
 | `receiveDistributor.serviceAccount.annotations`                        | Annotations for Thanos Receive Distributor Service Account                                                                  | `{}`            |
-| `receiveDistributor.serviceAccount.existingServiceAccount`             | Name for an existing Thanos Receive Distributor Service Account                                                             | `""`            |
 | `receiveDistributor.serviceAccount.automountServiceAccountToken`       | Enable/disable auto mounting of the service account token                                                                   | `true`          |
 | `receiveDistributor.autoscaling.enabled`                               | Enable autoscaling for Thanos Receive Distributor                                                                           | `false`         |
 | `receiveDistributor.autoscaling.minReplicas`                           | Minimum number of Thanos Receive Distributor replicas                                                                       | `""`            |
@@ -1062,7 +1073,7 @@ Check the section [Integrate Thanos with Prometheus and Alertmanager](#integrate
 | `volumePermissions.enabled`           | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`    | Init container volume-permissions image registry                                                | `docker.io`             |
 | `volumePermissions.image.repository`  | Init container volume-permissions image repository                                              | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`         | Init container volume-permissions image tag                                                     | `10-debian-10-r416`     |
+| `volumePermissions.image.tag`         | Init container volume-permissions image tag                                                     | `10-debian-10-r435`     |
 | `volumePermissions.image.pullPolicy`  | Init container volume-permissions image pull policy                                             | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets` | Specify docker-registry secret names as an array                                                | `[]`                    |
 

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -288,17 +288,22 @@ Usage:
 {{ include "thanos.serviceAccount.name" (dict "component" "bucketweb" "context" $) }}
 */}}
 {{- define "thanos.serviceAccount.name" -}}
-{{- $component := index .Values .component -}}
-{{- if not (include "thanos.serviceAccount.useExisting" (dict "component" .component "context" $) -}}
+{{- $component := index .context.Values .component -}}
+{{- if eq .component "query-frontend" -}}
+{{- $component = index .context.Values "queryFrontend" -}}
+{{- else if eq .component "receive-distributor" -}}
+{{- $component = index .context.Values "receiveDistributor" -}}
+{{- end -}}
+{{- if not (include "thanos.serviceAccount.useExisting" (dict "component" .component "context" .context)) -}}
     {{- if $component.serviceAccount.create -}}
-        {{ default (printf "%s-%s" (include "common.names.fullname" .) .component) $component.serviceAccount.name }}
-    {{- else if .Values.serviceAccount.create -}}
-        {{ default (include "common.names.fullname" .) .Values.serviceAccount.name  }}
+        {{ default (printf "%s-%s" (include "common.names.fullname" .context) .component) $component.serviceAccount.name }}
+    {{- else if .context.Values.serviceAccount.create -}}
+        {{ default (include "common.names.fullname" .context) .context.Values.serviceAccount.name  }}
     {{- else -}}
-        {{ default "default" (coalesce $component.serviceAccount.name .Values.serviceAccount.name ) }}
+        {{ default "default" (coalesce $component.serviceAccount.name .context.Values.serviceAccount.name ) }}
     {{- end -}}
 {{- else -}}
-    {{- default (printf "%s-%s" (include "common.names.fullname" .) .component) (coalesce $component.serviceAccount.existingServiceAccount .Values.existingServiceAccount) -}}
+    {{ default (printf "%s-%s" (include "common.names.fullname" .context) .component) (coalesce $component.serviceAccount.existingServiceAccount .context.Values.existingServiceAccount) }}
 {{- end -}}
 {{- end -}}
 
@@ -307,6 +312,11 @@ Usage:
 */}}
 {{- define "thanos.serviceAccount.useExisting" -}}
 {{- $component := index .context.Values .component -}}
+{{- if eq .component "query-frontend" -}}
+{{- $component = index .context.Values "queryFrontend" -}}
+{{- else if eq .component "receive-distributor" -}}
+{{- $component = index .context.Values "receiveDistributor" -}}
+{{- end -}}
 {{- if .context.Values.existingServiceAccount -}}
     {{- true -}}
 {{- else if $component.serviceAccount.existingServiceAccount -}}

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -288,18 +288,18 @@ Usage:
 {{ include "thanos.serviceAccount.name" (dict "component" "bucketweb" "context" $) }}
 */}}
 {{- define "thanos.serviceAccount.name" -}}
-{{- $name := printf "%s-%s" (include "common.names.fullname" .context) .component -}}
-
-{{- if .context.Values.existingServiceAccount -}}
-    {{- $name = .context.Values.existingServiceAccount -}}
+{{- $component := index .Values .component -}}
+{{- if not (include "thanos.serviceAccount.useExisting" (dict "component" .component "context" $) -}}
+    {{- if $component.serviceAccount.create -}}
+        {{ default (printf "%s-%s" (include "common.names.fullname" .) .component) $component.serviceAccount.name }}
+    {{- else if .Values.serviceAccount.create -}}
+        {{ default (include "common.names.fullname" .) .Values.serviceAccount.name  }}
+    {{- else -}}
+        {{ default "default" (coalesce $component.serviceAccount.name .Values.serviceAccount.name ) }}
+    {{- end -}}
+{{- else -}}
+    {{- default (printf "%s-%s" (include "common.names.fullname" .) .component) (coalesce $component.serviceAccount.existingServiceAccount .Values.existingServiceAccount) -}}
 {{- end -}}
-
-{{- $component := index .context.Values .component -}}
-{{- if $component.serviceAccount.existingServiceAccount -}}
-    {{- $name = $component.serviceAccount.existingServiceAccount -}}
-{{- end -}}
-
-{{- printf "%s" $name -}}
 {{- end -}}
 
 {{/* Service account use existing

--- a/bitnami/thanos/templates/bucketweb/serviceaccount.yaml
+++ b/bitnami/thanos/templates/bucketweb/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.bucketweb.enabled (not (include "thanos.serviceAccount.useExisting" (dict "component" "bucketweb" "context" $))) }}
+{{- if and .Values.bucketweb.enabled .Values.bucketweb.serviceAccount.create (not (include "thanos.serviceAccount.useExisting" (dict "component" "bucketweb" "context" $))) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/thanos/templates/compactor/serviceaccount.yaml
+++ b/bitnami/thanos/templates/compactor/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.compactor.enabled (not (include "thanos.serviceAccount.useExisting" (dict "component" "compactor" "context" $))) }}
+{{- if and .Values.compactor.enabled .Values.compactor.serviceAccount.create (not (include "thanos.serviceAccount.useExisting" (dict "component" "compactor" "context" $))) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/thanos/templates/query-frontend/serviceaccount.yaml
+++ b/bitnami/thanos/templates/query-frontend/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.queryFrontend.enabled (not (include "thanos.serviceAccount.useExisting" (dict "component" "query-frontend" "context" $))) }}
+{{- if and .Values.queryFrontend.enabled .Values.queryFrontend.serviceAccount.create (not (include "thanos.serviceAccount.useExisting" (dict "component" "query-frontend" "context" $))) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/thanos/templates/query/serviceaccount.yaml
+++ b/bitnami/thanos/templates/query/serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- $query := (include "thanos.query.values" . | fromYaml) -}}
-{{- if and $query.enabled (not (include "thanos.serviceAccount.useExisting" (dict "component" "query" "context" $))) }}
+{{- if and $query.enabled .Values.query.serviceAccount.create (not (include "thanos.serviceAccount.useExisting" (dict "component" "query" "context" $))) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/thanos/templates/receive-distributor/serviceaccount.yaml
+++ b/bitnami/thanos/templates/receive-distributor/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.receiveDistributor.enabled (not (include "thanos.serviceAccount.useExisting" (dict "component" "receive-distributor" "context" $))) }}
+{{- if and .Values.receiveDistributor.enabled .Values.receiveDistributor.serviceAccount.create (not (include "thanos.serviceAccount.useExisting" (dict "component" "receive-distributor" "context" $))) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/thanos/templates/receive/serviceaccount.yaml
+++ b/bitnami/thanos/templates/receive/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.receive.enabled (not (include "thanos.serviceAccount.useExisting" (dict "component" "receive" "context" $))) }}
+{{- if and .Values.receive.enabled .Values.receive.serviceAccount.create (not (include "thanos.serviceAccount.useExisting" (dict "component" "receive" "context" $))) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/thanos/templates/ruler/serviceaccount.yaml
+++ b/bitnami/thanos/templates/ruler/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ruler.enabled (not (include "thanos.serviceAccount.useExisting" (dict "component" "ruler" "context" $))) }}
+{{- if and .Values.ruler.enabled .Values.ruler.serviceAccount.create (not (include "thanos.serviceAccount.useExisting" (dict "component" "ruler" "context" $))) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/thanos/templates/serviceaccount.yaml
+++ b/bitnami/thanos/templates/serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.serviceAccount.create (not .Values.existingServiceAccount) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: storegateway
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/bitnami/thanos/templates/storegateway/serviceaccount.yaml
+++ b/bitnami/thanos/templates/storegateway/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.storegateway.enabled (not (include "thanos.serviceAccount.useExisting" (dict "component" "storegateway" "context" $))) }}
+{{- if and .Values.storegateway.enabled .Values.storegateway.serviceAccount.create (not (include "thanos.serviceAccount.useExisting" (dict "component" "storegateway" "context" $))) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/bitnami/thanos/values.yaml
+++ b/bitnami/thanos/values.yaml
@@ -85,9 +85,23 @@ existingObjstoreSecret: ""
 ## @param existingObjstoreSecretItems Optional item list for specifying a custom Secret key. If so, path should be objstore.yml
 ##
 existingObjstoreSecretItems: []
-## @param existingServiceAccount Provide a common service account to be shared with all components
+
+## Common Service Account
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+## @param serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
+## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
+## @param serviceAccount.annotations Annotations for service account. Evaluated as a template. Only used if `create` is `true`.
 ##
-existingServiceAccount: ""
+serviceAccount:
+  create: false
+  name: ""
+  automountServiceAccountToken: true
+  annotations: {}
+
+## DEPRECATED - existingServiceAccount. This value has been deprecated and will be removed in a future release, please use `serviceAccount.name` in combination with `serviceAccount.create=false` instead
+##
+## existingServiceAccount: ""
 
 ## @section Thanos Query parameters
 
@@ -444,14 +458,18 @@ query:
   ##
   automountServiceAccountToken: true
   ## ServiceAccount configuration
+  ## @param query.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param query.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   ## @param query.serviceAccount.annotations Annotations for Thanos Query Service Account
-  ## @param query.serviceAccount.existingServiceAccount Name for an existing Thanos Query Service Account
   ## @param query.serviceAccount.automountServiceAccountToken Enable/disable auto mounting of the service account token
+  ## DEPRECATED query.serviceAccount.existingServiceAccount - This value has been deprecated and will be removed in a future release, please use `serviceAccount.name` in combination with `serviceAccount.create=false` instead
   ##
   serviceAccount:
+    create: true
+    name: ""
     annotations: {}
-    existingServiceAccount: ""
     automountServiceAccountToken: true
+    ## existingServiceAccount: ""
   ## RBAC configuration
   ##
   rbac:
@@ -563,7 +581,7 @@ query:
     ## - host: example.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:
@@ -660,7 +678,7 @@ query:
       ## - host: example.local
       ##     http:
       ##       path: /
-      ##       backend: 
+      ##       backend:
       ##         service:
       ##           name: example-svc
       ##           port:
@@ -963,14 +981,18 @@ queryFrontend:
   ##
   automountServiceAccountToken: true
   ## ServiceAccount configuration
+  ## @param queryFrontend.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param queryFrontend.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   ## @param queryFrontend.serviceAccount.annotations Annotations for Thanos Query Frontend Service Account
-  ## @param queryFrontend.serviceAccount.existingServiceAccount Name for an existing Thanos Query Frontend Service Account
   ## @param queryFrontend.serviceAccount.automountServiceAccountToken Enable/disable auto mounting of the service account token
+  ## DEPRECATED queryFrontend.serviceAccount.existingServiceAccount - This value has been deprecated and will be removed in a future release, please use `serviceAccount.name` in combination with `serviceAccount.create=false` instead
   ##
   serviceAccount:
+    create: true
+    name: ""
     annotations: {}
-    existingServiceAccount: ""
     automountServiceAccountToken: true
+    ## existingServiceAccount: ""
   ## RBAC configuration
   ##
   rbac:
@@ -1082,7 +1104,7 @@ queryFrontend:
     ## - host: example.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:
@@ -1381,14 +1403,18 @@ bucketweb:
   ##
   automountServiceAccountToken: true
   ## ServiceAccount configuration
+  ## @param bucketweb.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param bucketweb.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   ## @param bucketweb.serviceAccount.annotations Annotations for Thanos Bucket Web Service Account
-  ## @param bucketweb.serviceAccount.existingServiceAccount Name for an existing Thanos Bucket Web Service Account
   ## @param bucketweb.serviceAccount.automountServiceAccountToken Enable/disable auto mounting of the service account token
+  ## DEPRECATED bucketweb.serviceAccount.existingServiceAccount - This value has been deprecated and will be removed in a future release, please use `serviceAccount.name` in combination with `serviceAccount.create=false` instead
   ##
   serviceAccount:
+    create: true
+    name: ""
     annotations: {}
-    existingServiceAccount: ""
     automountServiceAccountToken: true
+    ## existingServiceAccount: ""
   ## Thanos Bucket Web Autoscaling configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
   ## @param bucketweb.autoscaling.enabled Enable autoscaling for Thanos Bucket Web
@@ -1478,7 +1504,7 @@ bucketweb:
     ## - host: example.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:
@@ -1781,14 +1807,18 @@ compactor:
   ##
   automountServiceAccountToken: true
   ## ServiceAccount configuration
+  ## @param compactor.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param compactor.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   ## @param compactor.serviceAccount.annotations Annotations for Thanos Compactor Service Account
-  ## @param compactor.serviceAccount.existingServiceAccount Name for an existing Thanos Compactor Service Account
   ## @param compactor.serviceAccount.automountServiceAccountToken Enable/disable auto mounting of the service account token
+  ## DEPRECATED compactor.serviceAccount.existingServiceAccount - This value has been deprecated and will be removed in a future release, please use `serviceAccount.name` in combination with `serviceAccount.create=false` instead
   ##
   serviceAccount:
+    create: true
+    name: ""
     annotations: {}
-    existingServiceAccount: ""
     automountServiceAccountToken: true
+    ## existingServiceAccount: ""
   ## Configure the ingress resource that allows you to access Thanos Query Frontend
   ## ref: https://kubernetes.io/docs/user-guide/ingress/
   ##
@@ -1854,7 +1884,7 @@ compactor:
     ## - host: example.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:
@@ -2251,14 +2281,18 @@ storegateway:
   ##
   automountServiceAccountToken: true
   ## ServiceAccount configuration
+  ## @param storegateway.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param storegateway.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   ## @param storegateway.serviceAccount.annotations Annotations for Thanos Store Gateway Service Account
-  ## @param storegateway.serviceAccount.existingServiceAccount Name for an existing Thanos Store Gateway Service Account
   ## @param storegateway.serviceAccount.automountServiceAccountToken Enable/disable auto mounting of the service account token
+  ## DEPRECATED storegateway.serviceAccount.existingServiceAccount - This value has been deprecated and will be removed in a future release, please use `serviceAccount.name` in combination with `serviceAccount.create=false` instead
   ##
   serviceAccount:
+    create: true
+    name: ""
     annotations: {}
-    existingServiceAccount: ""
     automountServiceAccountToken: true
+    ## existingServiceAccount: ""
   ## Thanos Store Gateway Autoscaling configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
   ## @param storegateway.autoscaling.enabled Enable autoscaling for Thanos Store Gateway
@@ -2348,7 +2382,7 @@ storegateway:
     ## - host: example.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:
@@ -2445,7 +2479,7 @@ storegateway:
       ## - host: example.local
       ##     http:
       ##       path: /
-      ##       backend: 
+      ##       backend:
       ##         service:
       ##           name: example-svc
       ##           port:
@@ -2855,14 +2889,18 @@ ruler:
   ##
   automountServiceAccountToken: true
   ## ServiceAccount configuration
+  ## @param ruler.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param ruler.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   ## @param ruler.serviceAccount.annotations Annotations for Thanos Ruler Service Account
-  ## @param ruler.serviceAccount.existingServiceAccount Name for an existing Thanos Ruler Service Account
   ## @param ruler.serviceAccount.automountServiceAccountToken Enable/disable auto mounting of the service account token
+  ## DEPRECATED ruler.serviceAccount.existingServiceAccount - This value has been deprecated and will be removed in a future release, please use `serviceAccount.name` in combination with `serviceAccount.create=false` instead
   ##
   serviceAccount:
+    create: true
+    name: ""
     annotations: {}
-    existingServiceAccount: ""
     automountServiceAccountToken: true
+    ## existingServiceAccount: ""
   ## Thanos Ruler Autoscaling configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
   ## @param ruler.autoscaling.enabled Enable autoscaling for Thanos Ruler
@@ -2952,7 +2990,7 @@ ruler:
     ## - host: example.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:
@@ -3307,14 +3345,18 @@ receive:
   ##
   automountServiceAccountToken: true
   ## ServiceAccount configuration
+  ## @param receive.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param receive.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   ## @param receive.serviceAccount.annotations Annotations for Thanos Receive Service Account
-  ## @param receive.serviceAccount.existingServiceAccount Name for an existing Thanos Receive Service Account
   ## @param receive.serviceAccount.automountServiceAccountToken Enable/disable auto mounting of the service account token
+  ## DEPRECATED receive.serviceAccount.existingServiceAccount - This value has been deprecated and will be removed in a future release, please use `serviceAccount.name` in combination with `serviceAccount.create=false` instead
   ##
   serviceAccount:
+    create: true
+    name: ""
     annotations: {}
-    existingServiceAccount: ""
     automountServiceAccountToken: true
+    ## existingServiceAccount: ""
   ## Thanos Receive Autoscaling configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
   ## @param receive.autoscaling.enabled Enable autoscaling for Thanos Receive
@@ -3431,7 +3473,7 @@ receive:
     ## - host: example.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:
@@ -3688,14 +3730,18 @@ receiveDistributor:
   ##
   automountServiceAccountToken: true
   ## ServiceAccount configuration
+  ## @param receiveDistributor.serviceAccount.create Specifies whether a ServiceAccount should be created
+  ## @param receiveDistributor.serviceAccount.name Name of the service account to use. If not set and create is true, a name is generated using the fullname template.
   ## @param receiveDistributor.serviceAccount.annotations Annotations for Thanos Receive Distributor Service Account
-  ## @param receiveDistributor.serviceAccount.existingServiceAccount Name for an existing Thanos Receive Distributor Service Account
   ## @param receiveDistributor.serviceAccount.automountServiceAccountToken Enable/disable auto mounting of the service account token
+  ## DEPRECATED receive.serviceAccount.existingServiceAccount - This value has been deprecated and will be removed in a future release, please use `serviceAccount.name` in combination with `serviceAccount.create=false` instead
   ##
   serviceAccount:
+    create: true
+    name: ""
     annotations: {}
-    existingServiceAccount: ""
     automountServiceAccountToken: true
+    ## existingServiceAccount: ""
   ## Thanos Receive Distributor Autoscaling configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
   ## @param receiveDistributor.autoscaling.enabled Enable autoscaling for Thanos Receive Distributor


### PR DESCRIPTION
### Description of the change

Implements the values `serviceAccount.create` and `serviceAccount.name` in a backward-compatible way

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
