### PR TITLE
  [bitnami/mongodb] Replicaset environment variable typo

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb
   - https://mongodb.org
-version: 12.1.13
+version: 12.1.14

--- a/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
+++ b/bitnami/mongodb/templates/replicaset/scripts-configmap.yaml
@@ -127,7 +127,7 @@ data:
     elif ! is_empty_value "$current_primary" && [[ "$MONGODB_ADVERTISED_HOSTNAME:$MONGODB_ADVERTISED_PORT_NUMBER" != "$current_primary" ]]; then
         info "Current primary is different from this node. Configuring the node as replica of ${current_primary}"
         export MONGODB_REPLICA_SET_MODE="secondary"
-        export MONOGDB_INITIAL_PRIMARY_HOST="${current_primary%:*}"
+        export MONGODB_INITIAL_PRIMARY_HOST="${current_primary%:*}"
         export MONGODB_INITIAL_PRIMARY_PORT_NUMBER="${current_primary#*:}"
         export MONGODB_SET_SECONDARY_OK="yes"
     elif [[ "$MY_POD_NAME" = "{{ $fullname }}-0" ]]; then


### PR DESCRIPTION

### Description of the change

Fixes typo that was preventing MONGODB_INITIAL_PRIMARY_HOST from being set correctly.

### Benefits

There are two scenarios where this typo causes issues:
1. When externalAccess.enabled is set and externalAccess.service.type is set to NodePort the secondary/replica would attempt to connect to {kubernetes cluster domain}:{nodeport} instead of {hostname/ip}:{nodeport}
2. If the primary host in the replicaset has changed from the default, the secondary will fail to join

### Applicable issues

  - I believe this fixes #8594 (stale)
  - fixes #10458

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
