### PR TITLE
[bitnami/external-dns] Fix duplicated service type

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 6.5.0
+version: 6.5.1

--- a/bitnami/external-dns/templates/service.yaml
+++ b/bitnami/external-dns/templates/service.yaml
@@ -46,5 +46,4 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   selector: {{ include "external-dns.matchLabels" . | nindent 4 }}
-  type: {{ .Values.service.type }}
 {{- end }}

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -56,7 +56,7 @@ kubeVersion: ""
 image:
   registry: docker.io
   repository: bitnami/external-dns
-  tag: 0.12.0-debian-10-r0
+  tag: 0.12.0-debian-10-r2
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

`type: {{ .Values.service.type }}` is duplicated within the same service manifest:
* https://github.com/bitnami/charts/blob/master/bitnami/external-dns/templates/service.yaml#L15
* https://github.com/bitnami/charts/blob/master/bitnami/external-dns/templates/service.yaml#L49

This produce some issues when rendering the k8s manifests:
```
yaml: unmarshal errors:
line 25: mapping key "type" already defined at line 15
```

### Benefits

k8s manifests are properly rendered

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #10468

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)