### PR TITLE
[bitnami/grafana-loki] Replace base64 --decode with base64 -d

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -44,4 +44,4 @@ name: grafana-loki
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana-loki
   - https://github.com/grafana/loki/
-version: 2.0.2
+version: 2.0.3

--- a/bitnami/grafana-loki/templates/NOTES.txt
+++ b/bitnami/grafana-loki/templates/NOTES.txt
@@ -77,7 +77,7 @@ Installed components:
 2. Login with the following credentials below to see your blog:
 
   echo Username: {{ .Values.gateway.auth.username }}
-  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "grafana-loki.gateway.secretName" . }} -o jsonpath="{.data.password}" | base64 --decode)
+  echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "grafana-loki.gateway.secretName" . }} -o jsonpath="{.data.password}" | base64 -d)
 {{- end }}
 {{- else }}
 1. Get the query-frontend URL by running these commands:


### PR DESCRIPTION
### Description of the change

Replace base64 --decode with base64 -d

### Benefits
The `base64` tool used for decoding the secretes in our Helm charts support `-d` and `--decode` in some versions/distros but only `-d` in others (such as Alpine).

In order to make our charts as much compatible as possible with different distros and distro versions, we should replace the currently used `--decode` flag with `-d` since it is more extended across platforms:

```console
$ docker run -it docker.io/bitnami/minideb base64 --help
Usage: base64 [OPTION]... [FILE]
Base64 encode or decode FILE, or standard input, to standard output.

With no FILE, or when FILE is -, read standard input.

Mandatory arguments to long options are mandatory for short options too.
  -d, --decode          decode data
  -i, --ignore-garbage  when decoding, ignore non-alphabet characters
  -w, --wrap=COLS       wrap encoded lines after COLS character (default 76).
                          Use 0 to disable line wrapping

      --help     display this help and exit
      --version  output version information and exit

$ docker run -it docker.io/alpine base64 --help
BusyBox v1.35.0 (2022-05-09 17:27:12 UTC) multi-call binary.

Usage: base64 [-d] [-w COL] [FILE]

Base64 encode or decode FILE to standard output

	-d	Decode data
	-w COL	Wrap lines at COL (default 76, 0 disables)
```

### Possible drawbacks

None, as expected, in both cases the result is the same
```console
$ echo 'Nzc3Nzk5Cg==' | base64 --decode
777799
$ echo 'Nzc3Nzk5Cg==' | base64 -d
777799
```

### Applicable issues

  - fixes #10486

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)