### PR TITLE
[bitnami/kube-prometheus] Patch additionalPrometheusRules and alertmanager.templateFiles

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-prometheus
   - https://github.com/bitnami/bitnami-docker-alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 8.0.1
+version: 8.0.2

--- a/bitnami/kube-prometheus/templates/alertmanager/secrets.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/secrets.yaml
@@ -12,8 +12,8 @@ metadata:
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
   {{- end }}
 data:
-  alertmanager.yaml: {{ include "common.tplvalues.render" (dict "value" .Values.alertmanager.config  "context" $) | b64enc | quote }}
+  alertmanager.yaml: {{ toYaml .Values.alertmanager.config | b64enc | quote }}
   {{- range $key, $val := .Values.alertmanager.templateFiles }}
-  {{ $key }}: {{ include "common.tplvalues.render" (dict "value" $val "context" $) | b64enc | quote }}
+  {{ $key }}: {{ $val | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/bitnami/kube-prometheus/templates/prometheus/additionalPrometheusRules.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/additionalPrometheusRules.yaml
@@ -14,6 +14,6 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  groups: {{- include "common.tplvalues.render" ( dict "value" .groups "context" $ ) | nindent 4 }}
+  groups: {{- toYaml .groups | nindent 4 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Revert `templates/alertmanager/secrets.yaml` and `templates/prometheus/additionalPrometheusRules.yaml` (<7.0.0)

### Benefits

Prometheus rules and AlertManager configurations contain many go templates.
This PR allows to reuse the configurations as before without having to escape each line

This PR also patches the values file which currently contains non-functional examples

### Applicable issues

- fixes #10496

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
