### PR TITLE
[bitnami/redis] Add existingClaim in replicas as we have in master

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.10.1
+version: 16.11.0

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -435,6 +435,10 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+  {{- else if .Values.replica.persistence.existingClaim }}
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: {{ printf "%s" (tpl .Values.replica.persistence.existingClaim .) }}
   {{- else }}
   volumeClaimTemplates:
     - metadata:

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -823,6 +823,10 @@ replica:
     ## @param replica.persistence.dataSource Custom PVC data source
     ##
     dataSource: {}
+    ## @param replica.persistence.existingClaim Use a existing PVC which must be created manually before bound
+    ## NOTE: requires replica.persistence.enabled: true
+    ##
+    existingClaim: ""
   ## Redis&trade; replicas service parameters
   ##
   service:


### PR DESCRIPTION
### Description of the change

Add `existingClaim` in the replicas as we have in the master

### Benefits

This will allow users to specify on which pre-created volume claim their replica can be stored

### Applicable issues

  - fixes #10498

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)