### PR TITLE
[bitnami/sealed-secrets] Replace maintainers email by url

### DIFF
--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -17,8 +17,8 @@ keywords:
   - sealed-secrets
 kubeVersion: '>=1.16.0-0'
 maintainers:
-  - url: https://github.com/bitnami/charts
-    name: Bitnami
+  - name: Bitnami
+    url: https://github.com/bitnami/charts
 name: sealed-secrets
 sources:
   - https://github.com/bitnami/bitnami-docker-sealed-secrets


### PR DESCRIPTION
### Description of the change

The `containers@bitnami.com` mail is going to be sunset and it was not used for providing support. The proper place to reach out to the Helm charts maintainers and receive support is through this repository.

According to the [official Helm specification](https://helm.sh/docs/topics/charts/#the-chartyaml-file), the `maintainers` object can contain the following config:
```yaml
maintainers: # (optional)
  - name: The maintainers name (required for each maintainer)
    email: The maintainers email (optional for each maintainer)
    url: A URL for the maintainer (optional for each maintainer)
```

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)