### PR TITLE
[bitnami/haproxy-intel] Replace maintainers email by url

### DIFF
--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -20,8 +20,8 @@ keywords:
   - infrastructure
   - intel
 maintainers:
-  - url: https://github.com/bitnami/charts
-    name: Bitnami
+  - name: Bitnami
+    url: https://github.com/bitnami/charts
 name: haproxy-intel
 sources:
   - https://github.com/bitnami/bitnami-docker-haproxy-intel

--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -20,10 +20,10 @@ keywords:
   - infrastructure
   - intel
 maintainers:
-  - email: containers@bitnami.com
+  - url: https://github.com/bitnami/charts
     name: Bitnami
 name: haproxy-intel
 sources:
   - https://github.com/bitnami/bitnami-docker-haproxy-intel
   - https://github.com/haproxytech/haproxy
-version: 0.1.3
+version: 0.1.4


### PR DESCRIPTION
### Description of the change

The `containers@bitnami.com` mail is going to be sunset and it was not used for providing support. The proper place to reach out to the Helm charts maintainers and receive support is through this repository.

According to the [official Helm specification](https://helm.sh/docs/topics/charts/#the-chartyaml-file), the `maintainers` object can contain the following config:
```yaml
maintainers: # (optional)
  - name: The maintainers name (required for each maintainer)
    email: The maintainers email (optional for each maintainer)
    url: A URL for the maintainer (optional for each maintainer)
```

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)