### PR TITLE
[bitnami/wordpress] Replace maintainers email by url

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -29,10 +29,10 @@ keywords:
   - web
   - wordpress
 maintainers:
-  - email: containers@bitnami.com
+  - url: https://github.com/bitnami/charts
     name: Bitnami
 name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress
   - https://wordpress.org/
-version: 14.3.2
+version: 14.3.3

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -29,8 +29,8 @@ keywords:
   - web
   - wordpress
 maintainers:
-  - url: https://github.com/bitnami/charts
-    name: Bitnami
+  - name: Bitnami
+    url: https://github.com/bitnami/charts
 name: wordpress
 sources:
   - https://github.com/bitnami/bitnami-docker-wordpress


### PR DESCRIPTION
### Description of the change

The `containers@bitnami.com` mail is going to be sunset and it was not used for providing support. The proper place to reach out to the Helm charts maintainers and receive support is through this repository.

According to the [official Helm specification](https://helm.sh/docs/topics/charts/#the-chartyaml-file), the `maintainers` object can contain the following config:
```yaml
maintainers: # (optional)
  - name: The maintainers name (required for each maintainer)
    email: The maintainers email (optional for each maintainer)
    url: A URL for the maintainer (optional for each maintainer)
```

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)