### PR TITLE
[bitnami/grafana-loki] Replace maintainers email by url

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage. 
+description: Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage.
 engine: gotpl
 home: https://github.com/grafana/loki/
 icon: https://bitnami.com/assets/stacks/grafana-loki/img/grafana-loki-stack-220x234.png
@@ -38,10 +38,10 @@ keywords:
   - metrics
   - infrastructure
 maintainers:
-  - email: containers@bitnami.com
+  - url: https://github.com/bitnami/charts
     name: Bitnami
 name: grafana-loki
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana-loki
   - https://github.com/grafana/loki/
-version: 2.0.4
+version: 2.0.5

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -38,8 +38,8 @@ keywords:
   - metrics
   - infrastructure
 maintainers:
-  - url: https://github.com/bitnami/charts
-    name: Bitnami
+  - name: Bitnami
+    url: https://github.com/bitnami/charts
 name: grafana-loki
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana-loki


### PR DESCRIPTION
### Description of the change

The `containers@bitnami.com` mail is going to be sunset and it was not used for providing support. The proper place to reach out to the Helm charts maintainers and receive support is through this repository.

According to the [official Helm specification](https://helm.sh/docs/topics/charts/#the-chartyaml-file), the `maintainers` object can contain the following config:
```yaml
maintainers: # (optional)
  - name: The maintainers name (required for each maintainer)
    email: The maintainers email (optional for each maintainer)
    url: A URL for the maintainer (optional for each maintainer)
```

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)