### PR TITLE
Replace maintainer/committer email in GH workflows and chart scaffolding

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -60,6 +60,6 @@ jobs:
           cd charts
           if git status -s | grep bitnami; then
             git config user.name "Bitnami Containers"
-            git config user.email "containers@bitnami.com"
+            git config user.email "bitnami-bot@vmware.com"
             git add . && git commit -am "Update README.md with readme-generator-for-helm" --signoff && git push
           fi

--- a/.github/workflows/vib-publish.yaml
+++ b/.github/workflows/vib-publish.yaml
@@ -110,5 +110,5 @@ jobs:
           cd index
           # Push changes
           git config user.name "Bitnami Containers"
-          git config user.email containers@bitnami.com
+          git config user.email "bitnami-bot@vmware.com"
           git add bitnami/index.yaml && git commit -m "${chart}-${chart_version}: Update index.yaml" -s && git push

--- a/template/CHART_NAME/Chart.yaml
+++ b/template/CHART_NAME/Chart.yaml
@@ -21,8 +21,8 @@ keywords:
   - %%UPSTREAM_PROJECT_KEYWORD%%
   - ...
 maintainers:
-  - email: containers@bitnami.com
-    name: Bitnami
+  - name: Bitnami
+    url: https://github.com/bitnami/charts
 name: %%CHART_NAME%%
 sources:
   - https://github.com/bitnami/bitnami-docker-%%IMAGE_NAME%%


### PR DESCRIPTION
### Description of the change

This PR replaces the maintainer/committer email in GH workflows and chart scaffolding in order to use a corporative VMware account replacing the old Bitnami one

### Checklist

- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)