### PR TITLE
[bitnami/grafana-loki] Modify naming of cluster-wide resources

### DIFF
--- a/bitnami/grafana-loki/Chart.lock
+++ b/bitnami/grafana-loki/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.0.22
+  version: 6.1.0
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.0.22
+  version: 6.1.0
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.0.22
+  version: 6.1.0
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.0.22
+  version: 6.1.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.14.1
-digest: sha256:7fef9b74609f5aa699b0a145433e9a7c2844eed4a9abedbce593e5b50544725d
-generated: "2022-05-25T09:34:28.755965507Z"
+  version: 1.15.1
+digest: sha256:8db205b88816fd1931d60041390381ae42473475e982af08816d6617732b8aaf
+generated: "2022-06-02T09:39:27.206272+02:00"

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -44,4 +44,4 @@ name: grafana-loki
 sources:
   - https://github.com/bitnami/bitnami-docker-grafana-loki
   - https://github.com/grafana/loki/
-version: 2.0.5
+version: 2.1.0

--- a/bitnami/grafana-loki/templates/promtail/clusterrole.yaml
+++ b/bitnami/grafana-loki/templates/promtail/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ template "grafana-loki.promtail.fullname" . }}
+  name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "promtail" }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}

--- a/bitnami/grafana-loki/templates/promtail/clusterrolebinding.yaml
+++ b/bitnami/grafana-loki/templates/promtail/clusterrolebinding.yaml
@@ -8,14 +8,14 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  name: {{ template "grafana-loki.promtail.fullname" . }}
+  name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "promtail" }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "grafana-loki.promtail.fullname" . }}
+  name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "promtail" }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "grafana-loki.promtail.serviceAccountName" . }}


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The cluster-wide resources in this chart get their name from the `common.names.fullname` function, which only takes into account the deployment name. As such, when installing the same chart with the same deploy name but different namespaces, you get installation errors of the following type"

```
Error: INSTALLATION FAILED: rendered manifests contain a resource that already exists. Unable to continue with install: ClusterRole "grafana-loki-promtail" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "test": current value is "default"
```

To solve this, we'll use the new `common.names.fullname.namespace` function added in #10462.

### Benefits

Solves a chart design issue and allows for the actions of our VIB pipelines to run in parallel in the affected charts.

### Possible drawbacks

There shouldn't be any drawbacks. The upgrade process has been tested without issues.

### Additional information

To avoid modifying extensively the current chart, only those resources affected by this issue (cluster-wide ones) will be modified.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
