### PR TITLE
feat: support additional common labels

### DIFF
--- a/bitnami/external-dns/templates/_helpers.tpl
+++ b/bitnami/external-dns/templates/_helpers.tpl
@@ -42,6 +42,12 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 {{- end -}}
 
+{{/* Common labels */}}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end }}
+
 {{/* matchLabels */}}
 {{- define "external-dns.matchLabels" -}}
 app.kubernetes.io/name: {{ template "external-dns.name" . }}


### PR DESCRIPTION
**Description of the change**
Add the possibility to have common labels for all resources deployed by the cert-manager charts.

**Benefits**
It's can be useful for policy manager as Kyverno