### PR TITLE
[bitnami/elasticsearch] Fix ingress service name

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 18.2.7
+version: 18.2.8

--- a/bitnami/elasticsearch/templates/ingress.yaml
+++ b/bitnami/elasticsearch/templates/ingress.yaml
@@ -46,7 +46,7 @@ spec:
             {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
             {{- end }}
-            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "restAPI" "context" $) | nindent 14 }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "tcp-rest-api" "context" $) | nindent 14 }}
     {{- end }}
     {{- if .Values.ingress.extraRules }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraRules "context" $ ) | nindent 4 }}


### PR DESCRIPTION
The service name of the ingress was set to "restApi" which is an invalid value for Kubernetes. It should have been "tcp-rest-api".

Fixes #10460

Signed-off-by: Tonny Miousse <tonny.miousse@telus.com>