### PR TITLE
[bitnami/kafka] component labels for jmx & kafka exporter

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/bitnami-docker-kafka
   - https://kafka.apache.org/
-version: 17.2.5
+version: 17.2.6

--- a/bitnami/kafka/templates/jmx-configmap.yaml
+++ b/bitnami/kafka/templates/jmx-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ printf "%s-jmx-configuration" (include "common.names.fullname" .) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/kafka/templates/kafka-metrics-deployment.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ include "kafka.metrics.kafka.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: metrics
+    app.kubernetes.io/component: cluster-metrics
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -21,11 +21,11 @@ spec:
   replicas: 1
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
-      app.kubernetes.io/component: metrics
+      app.kubernetes.io/component: cluster-metrics
   template:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
-        app.kubernetes.io/component: metrics
+        app.kubernetes.io/component: cluster-metrics
         {{- if .Values.metrics.kafka.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.metrics.kafka.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/kafka/templates/kafka-metrics-serviceaccount.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ template "kafka.metrics.kafka.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: metrics
+    app.kubernetes.io/component: cluster-metrics
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/kafka/templates/kafka-metrics-svc.yaml
+++ b/bitnami/kafka/templates/kafka-metrics-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ printf "%s-metrics" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: metrics
+    app.kubernetes.io/component: cluster-metrics
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -30,5 +30,5 @@ spec:
       protocol: TCP
       targetPort: metrics
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
-    app.kubernetes.io/component: metrics
+    app.kubernetes.io/component: cluster-metrics
 {{- end }}

--- a/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-jmx-metrics.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: kafka
+    app.kubernetes.io/component: metrics
     {{- if .Values.metrics.serviceMonitor.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/kafka/templates/servicemonitor-metrics.yaml
+++ b/bitnami/kafka/templates/servicemonitor-metrics.yaml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: metrics
+    app.kubernetes.io/component: cluster-metrics
     {{- if .Values.metrics.serviceMonitor.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -28,7 +28,7 @@ spec:
       {{- if .Values.metrics.serviceMonitor.selector }}
       {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}
-      app.kubernetes.io/component: metrics
+      app.kubernetes.io/component: cluster-metrics
   endpoints:
     - port: http-metrics
       path: "/metrics"


### PR DESCRIPTION
### Description of the change

change the app.kubernetes.io/component for kafka-exporter to differenciate it from jmx-exporter

### Benefits

separate service & servicemonitor for kafka-exporter & jmx-exporter

### Possible drawbacks

### Applicable issues

  - fixes #10470 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
