### PR TITLE
[bitnami/*] Use VIB to publish mongodb, kibana and solr

### DIFF
--- a/.github/workflows/vib-publish.yaml
+++ b/.github/workflows/vib-publish.yaml
@@ -4,10 +4,13 @@ on: # rebuild any PRs and main branch changes
     branches:
       - master
     paths:
-      - 'bitnami/wordpress/Chart.yaml'
       - 'bitnami/grafana-loki/Chart.yaml'
       - 'bitnami/haproxy-intel/Chart.yaml'
+      - 'bitnami/kibana/Chart.yaml'
+      - 'bitnami/mongodb/Chart.yaml'
       - 'bitnami/sealed-secrets/Chart.yaml'
+      - 'bitnami/solr/Chart.yaml'
+      - 'bitnami/wordpress/Chart.yaml'
 env:
   CSP_API_URL: https://console.cloud.vmware.com
   CSP_API_TOKEN: ${{ secrets.CSP_API_TOKEN }}


### PR DESCRIPTION
### Description of the change

Add MongoDB, Kibana, and SolR to the list of assets published using VMware Image Builder.

### Benefits

Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
