### PR TITLE
Use descriptive name for extra VIB verify workflows

### DIFF
--- a/.github/workflows/vib-verify-extra-redis.yaml
+++ b/.github/workflows/vib-verify-extra-redis.yaml
@@ -1,5 +1,5 @@
 # Multiple deployments pipelines are custom per asset. All single deployments pipelines are handled by vib-verify.yaml
-name: 'VIB'
+name: 'VIB extra Redis'
 on: # rebuild any PRs and main branch changes
   pull_request_target:
     types:

--- a/.github/workflows/vib-verify-extra-thanos.yaml
+++ b/.github/workflows/vib-verify-extra-thanos.yaml
@@ -1,5 +1,5 @@
 # Multiple deployments pipelines are custom per asset. All single deployments pipelines are handled by vib-verify.yaml
-name: 'VIB'
+name: 'VIB extra Thanos'
 on: # rebuild any PRs and main branch changes
   pull_request_target:
     types:


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <carlosrh@vmware.com>

### Description of the change

When using an extra VIB verify pipeline to test some specific features/configuration of a Helm chart, the name used is simply _VIB_, the same name used by the generic VIB pipeline.

Currently, there are 3 VIB actions (the generic one and the other two with the extra tests for Redis and Thanos); but in the future, when this number grows, it won't be easy to navigate over the [actions view](https://github.com/bitnami/charts/actions).

### Benefits

There is a descriptive name to be shown in the [actions view](https://github.com/bitnami/charts/actions) instead of the current
![Screenshot 2022-06-05 at 18 37 02](https://user-images.githubusercontent.com/13216600/172061258-0b62b417-b21f-494f-92e9-8ff24a917587.png)