### PR TITLE
[bitnami/minio] Enable back & fix minio test

### DIFF
--- a/.vib/minio/cypress/cypress/integration/minio_spec.js
+++ b/.vib/minio/cypress/cypress/integration/minio_spec.js
@@ -65,8 +65,5 @@ it('allows creating a service account and downloading credentials', () => {
   cy.get('[aria-label="Create service account"]').click();
   cy.contains('button[type="submit"]', 'Create').click();
   cy.get('#download-button').click();
-  // Temporarily disable credentials file check, as there is an upstream
-  // issue affecting its generation:
-  //    https://github.com/minio/console/issues/2031
-  // cy.readFile('cypress/downloads/credentials.json').should('exist');
+  cy.readFile('cypress/downloads/credentials.json').should('exist');
 });

--- a/.vib/minio/cypress/cypress/integration/minio_spec.js
+++ b/.vib/minio/cypress/cypress/integration/minio_spec.js
@@ -3,7 +3,7 @@ import { random } from './utils';
 
 it('allows user to log in and log out', () => {
   cy.login();
-  cy.get('[data-testid="ErrorOutlineIcon"]').should('not.exist');
+  cy.get('div.alert').should('not.exist');
   cy.get('#logout').scrollIntoView().click();
 });
 


### PR DESCRIPTION
### Description of the change

In https://github.com/bitnami/charts/pull/10382, one of our Cypress tests detected a faulty feature in a new version of MinIO. As action, we decided to report it and disable the check for the moment.

A [new version of MinIO](https://github.com/minio/minio/releases/tag/RELEASE.2022-06-03T01-40-53Z) addressing the bug has been released, so the test should be enabled back again. Additionally, it seems that the DOM element that shows error has changed, so this PR also updates its selector accordingly.

### Benefits

- The Cypress test suite for MinIO is completely enabled again.
- Tests work with the latest version of the asset.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - relates to https://github.com/bitnami/charts/pull/10382

### Additional information

- Successful proof of execution: https://github.com/joancafom/charts/pull/50
- MinIO Console (UI) release addressing the reported issue(https://github.com/minio/console/issues/2031): https://github.com/minio/console/releases/tag/v0.17.3
- Below you may find a screenshot that shows that the old selector is no longer effective to check errors in the UI:

![MinIO_wrong_selector_error_UI](https://user-images.githubusercontent.com/24253844/172144134-87ef1f7d-39ec-4cc6-be7c-451bdf86874a.png)


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
