### PR TITLE
[bitnami solr] Fix probes for cloudEnabled=false config

### DIFF
--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -262,7 +262,7 @@ spec:
                 {{- if .Values.auth.enabled }}
                 SOLR_AUTH_TYPE=basic SOLR_AUTHENTICATION_OPTS="-Dbasicauth=${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" \
                 {{- end }}
-                solr assert --timeout {{ printf "%v000" .Values.livenessProbe.timeoutSeconds | quote }} --cloud "{{ ternary "https" "http" .Values.tls.enabled }}://localhost:${SOLR_PORT_NUMBER}/solr/"
+                solr assert --timeout {{ printf "%v000" .Values.livenessProbe.timeoutSeconds | quote }} --{{ ternary "" "not-" .Values.cloudEnabled }}cloud "{{ ternary "https" "http" .Values.tls.enabled }}://localhost:${SOLR_PORT_NUMBER}/solr/"
           {{- else if .Values.customLivenessProbe }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -281,7 +281,7 @@ spec:
                 {{- if .Values.auth.enabled }}
                 SOLR_AUTH_TYPE=basic SOLR_AUTHENTICATION_OPTS="-Dbasicauth=${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" \
                 {{- end }}
-                solr assert --timeout {{ printf "%v000" .Values.readinessProbe.timeoutSeconds | quote }} --cloud "{{ ternary "https" "http" .Values.tls.enabled }}://localhost:${SOLR_PORT_NUMBER}/solr/"
+                solr assert --timeout {{ printf "%v000" .Values.readinessProbe.timeoutSeconds | quote }} --{{ ternary "" "not-" .Values.cloudEnabled }}cloud "{{ ternary "https" "http" .Values.tls.enabled }}://localhost:${SOLR_PORT_NUMBER}/solr/"
           {{- else if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
@@ -300,7 +300,7 @@ spec:
                 {{- if .Values.auth.enabled }}
                 SOLR_AUTH_TYPE=basic SOLR_AUTHENTICATION_OPTS="-Dbasicauth=${SOLR_ADMIN_USERNAME}:${SOLR_ADMIN_PASSWORD}" \
                 {{- end }}
-                solr assert --timeout {{ printf "%v000" .Values.readinessProbe.timeoutSeconds | quote }} --cloud "{{ ternary "https" "http" .Values.tls.enabled }}://localhost:${SOLR_PORT_NUMBER}/solr/"
+                solr assert --timeout {{ printf "%v000" .Values.readinessProbe.timeoutSeconds | quote }} --{{ ternary "" "not-" .Values.cloudEnabled }}cloud "{{ ternary "https" "http" .Values.tls.enabled }}://localhost:${SOLR_PORT_NUMBER}/solr/"
           {{- else if .Values.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes probes for solr when cloudEnabled=false

### Benefits

Probes are working.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/charts/issues/10592

### Additional information
Quick test (you should see '--not-cloud' in the output of the second command:
```
helm install solr-test --namespace solr-test --create-namespace . --set cloudEnabled=false --set cloudBootstrap=false --set collectionReplicas=1 --set replicaCount=1 --set auth.enabled=false --set zookeeper.enabled=false
kubectl get -n solr-test pod/solr-test-0 -o jsonpath='{.spec.containers[0].livenessProbe.exec.command}{"\n"}'
helm delete solr-test --namespace solr-test
kubectl delete namespace solr-test
```
Fix uses either --cloud or --not-cloud parameter:
```
solr assert
usage: bin/solr assert [-m <message>] [-e] [-rR] [-s <url>] [-S <url>] [-c
                <url>] [-C <url>] [-u <dir>] [-x <dir>] [-X <dir>]
 -c,--cloud <url>              Asserts that Solr is running in cloud mode.
                               Also fails if Solr not running.  URL should
                               be for root Solr path.
 -C,--not-cloud <url>          Asserts that Solr is not running in cloud
                               mode.  Also fails if Solr not running.  URL
                               should be for root Solr path.
 -e,--exitcode                 Return an exit code instead of printing
                               error message on assert fail.
 -help                         Print this message
 -m,--message <message>        Exception message to be used in place of
                               the default error message.
 -R,--not-root                 Asserts that we are NOT the root user.
 -r,--root                     Asserts that we are the root user.
 -S,--not-started <url>        Asserts that Solr is NOT running on a
                               certain URL. Default timeout is 1000ms.
 -s,--started <url>            Asserts that Solr is running on a certain
                               URL. Default timeout is 1000ms.
 -t,--timeout <ms>             Timeout in ms for commands supporting a
                               timeout.
 -u,--same-user <directory>    Asserts that we run as same user that owns
                               <directory>.
 -verbose                      Generate verbose log messages
 -x,--exists <directory>       Asserts that directory <directory> exists.
 -X,--not-exists <directory>   Asserts that directory <directory> does NOT
                               exist.

```

I can still see exceptions in the pod logs regarding "Solr instance is not running in SolrCloud mode." as something else is probably calling these URLs:
```
2022-06-06 15:57:57.751 INFO  (qtp795748540-19) [] o.a.s.s.HttpSolrCall [admin] webapp=null path=/admin/info/system params={wt=json} status=0 QTime=33
2022-06-06 15:57:57.904 ERROR (qtp795748540-18) [] o.a.s.h.RequestHandlerBase org.apache.solr.common.SolrException: Solr instance is not running in SolrCloud mode. => org.apache.solr.common.SolrException: Solr instance is not running in SolrCloud mode.

2022-06-06 16:00:30.380 INFO  (qtp795748540-18) [] o.a.s.s.HttpSolrCall [admin] webapp=null path=/admin/collections params={action=CLUSTERSTATUS&wt=javabin&version=2} status=400 QTime=9
2022-06-06 16:00:30.489 ERROR (qtp795748540-24) [] o.a.s.h.RequestHandlerBase org.apache.solr.common.SolrException: Solr instance is not running in SolrCloud mode. => org.apache.solr.common.SolrException: Solr instance is not running in SolrCloud mode.
```


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
