### PR TITLE
[bitnami/nginx] Fix tolerations default values

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 12.0.2
+version: 12.0.3

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -80,20 +80,20 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### NGINX parameters
 
-| Name                 | Description                                                          | Value                   |
-| -------------------- | -------------------------------------------------------------------- | ----------------------- |
-| `image.registry`     | NGINX image registry                                                 | `docker.io`             |
-| `image.repository`   | NGINX image repository                                               | `bitnami/nginx`         |
-| `image.tag`          | NGINX image tag (immutable tags are recommended)                     | `1.21.6-debian-10-r105` |
-| `image.pullPolicy`   | NGINX image pull policy                                              | `IfNotPresent`          |
-| `image.pullSecrets`  | Specify docker-registry secret names as an array                     | `[]`                    |
-| `image.debug`        | Set to true if you would like to see extra information on logs       | `false`                 |
-| `hostAliases`        | Deployment pod host aliases                                          | `[]`                    |
-| `command`            | Override default container command (useful when using custom images) | `[]`                    |
-| `args`               | Override default container args (useful when using custom images)    | `[]`                    |
-| `extraEnvVars`       | Extra environment variables to be set on NGINX containers            | `[]`                    |
-| `extraEnvVarsCM`     | ConfigMap with extra environment variables                           | `""`                    |
-| `extraEnvVarsSecret` | Secret with extra environment variables                              | `""`                    |
+| Name                 | Description                                                          | Value                 |
+| -------------------- | -------------------------------------------------------------------- | --------------------- |
+| `image.registry`     | NGINX image registry                                                 | `docker.io`           |
+| `image.repository`   | NGINX image repository                                               | `bitnami/nginx`       |
+| `image.tag`          | NGINX image tag (immutable tags are recommended)                     | `1.22.0-debian-11-r0` |
+| `image.pullPolicy`   | NGINX image pull policy                                              | `IfNotPresent`        |
+| `image.pullSecrets`  | Specify docker-registry secret names as an array                     | `[]`                  |
+| `image.debug`        | Set to true if you would like to see extra information on logs       | `false`               |
+| `hostAliases`        | Deployment pod host aliases                                          | `[]`                  |
+| `command`            | Override default container command (useful when using custom images) | `[]`                  |
+| `args`               | Override default container args (useful when using custom images)    | `[]`                  |
+| `extraEnvVars`       | Extra environment variables to be set on NGINX containers            | `[]`                  |
+| `extraEnvVarsCM`     | ConfigMap with extra environment variables                           | `""`                  |
+| `extraEnvVarsSecret` | Secret with extra environment variables                              | `""`                  |
 
 
 ### NGINX deployment parameters
@@ -114,7 +114,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `hostNetwork`                                 | Specify if host network should be enabled for NGINX pod                                   | `false`         |
 | `hostIPC`                                     | Specify if host IPC should be enabled for NGINX pod                                       | `false`         |
 | `nodeSelector`                                | Node labels for pod assignment. Evaluated as a template.                                  | `{}`            |
-| `tolerations`                                 | Tolerations for pod assignment. Evaluated as a template.                                  | `{}`            |
+| `tolerations`                                 | Tolerations for pod assignment. Evaluated as a template.                                  | `[]`            |
 | `priorityClassName`                           | NGINX pods' priorityClassName                                                             | `""`            |
 | `schedulerName`                               | Name of the k8s scheduler (other than default)                                            | `""`            |
 | `terminationGracePeriodSeconds`               | In seconds, time the given to the NGINX pod needs to terminate gracefully                 | `""`            |
@@ -177,7 +177,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cloneStaticSiteFromGit.enabled`           | Get the server static content from a Git repository                                               | `false`               |
 | `cloneStaticSiteFromGit.image.registry`    | Git image registry                                                                                | `docker.io`           |
 | `cloneStaticSiteFromGit.image.repository`  | Git image repository                                                                              | `bitnami/git`         |
-| `cloneStaticSiteFromGit.image.tag`         | Git image tag (immutable tags are recommended)                                                    | `2.36.1-debian-10-r4` |
+| `cloneStaticSiteFromGit.image.tag`         | Git image tag (immutable tags are recommended)                                                    | `2.36.1-debian-11-r0` |
 | `cloneStaticSiteFromGit.image.pullPolicy`  | Git image pull policy                                                                             | `IfNotPresent`        |
 | `cloneStaticSiteFromGit.image.pullSecrets` | Specify docker-registry secret names as an array                                                  | `[]`                  |
 | `cloneStaticSiteFromGit.repository`        | Git Repository to clone static content from                                                       | `""`                  |
@@ -249,7 +249,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.port`                             | NGINX Container Status Port scraped by Prometheus Exporter                                                                                | `""`                     |
 | `metrics.image.registry`                   | NGINX Prometheus exporter image registry                                                                                                  | `docker.io`              |
 | `metrics.image.repository`                 | NGINX Prometheus exporter image repository                                                                                                | `bitnami/nginx-exporter` |
-| `metrics.image.tag`                        | NGINX Prometheus exporter image tag (immutable tags are recommended)                                                                      | `0.10.0-debian-10-r137`  |
+| `metrics.image.tag`                        | NGINX Prometheus exporter image tag (immutable tags are recommended)                                                                      | `0.10.0-debian-11-r0`    |
 | `metrics.image.pullPolicy`                 | NGINX Prometheus exporter image pull policy                                                                                               | `IfNotPresent`           |
 | `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                                                          | `[]`                     |
 | `metrics.podAnnotations`                   | Additional annotations for NGINX Prometheus exporter pod(s)                                                                               | `{}`                     |

--- a/bitnami/nginx/values.yaml
+++ b/bitnami/nginx/values.yaml
@@ -176,7 +176,7 @@ nodeSelector: {}
 ## @param tolerations Tolerations for pod assignment. Evaluated as a template.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
-tolerations: {}
+tolerations: []
 ## @param priorityClassName NGINX pods' priorityClassName
 ##
 priorityClassName: ""


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

