### PR TITLE
[bitnami/spring-cloud-dataflow] Fix tolerations default values

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 11.0.2
+version: 11.0.3

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -58,6 +58,7 @@ helm uninstall my-release
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
+
 ### Common parameters
 
 | Name                | Description                                                                           | Value           |
@@ -70,20 +71,21 @@ helm uninstall my-release
 | `clusterDomain`     | Default Kubernetes cluster domain                                                     | `cluster.local` |
 | `extraDeploy`       | Array of extra objects to deploy with the release                                     | `[]`            |
 
+
 ### Dataflow Server parameters
 
 | Name                                                | Description                                                                                                                      | Value                                                |
 | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | `server.image.registry`                             | Spring Cloud Dataflow image registry                                                                                             | `docker.io`                                          |
 | `server.image.repository`                           | Spring Cloud Dataflow image repository                                                                                           | `bitnami/spring-cloud-dataflow`                      |
-| `server.image.tag`                                  | Spring Cloud Dataflow image tag (immutable tags are recommended)                                                                 | `2.9.4-debian-10-r33`                                |
+| `server.image.tag`                                  | Spring Cloud Dataflow image tag (immutable tags are recommended)                                                                 | `2.9.4-debian-11-r0`                                 |
 | `server.image.pullPolicy`                           | Spring Cloud Dataflow image pull policy                                                                                          | `IfNotPresent`                                       |
 | `server.image.pullSecrets`                          | Specify docker-registry secret names as an array                                                                                 | `[]`                                                 |
 | `server.image.debug`                                | Enable image debug mode                                                                                                          | `false`                                              |
 | `server.hostAliases`                                | Deployment pod host aliases                                                                                                      | `[]`                                                 |
 | `server.composedTaskRunner.image.registry`          | Spring Cloud Dataflow Composed Task Runner image registry                                                                        | `docker.io`                                          |
 | `server.composedTaskRunner.image.repository`        | Spring Cloud Dataflow Composed Task Runner image repository                                                                      | `bitnami/spring-cloud-dataflow-composed-task-runner` |
-| `server.composedTaskRunner.image.tag`               | Spring Cloud Dataflow Composed Task Runner image tag (immutable tags are recommended)                                            | `2.9.4-debian-10-r44`                                |
+| `server.composedTaskRunner.image.tag`               | Spring Cloud Dataflow Composed Task Runner image tag (immutable tags are recommended)                                            | `2.9.4-debian-11-r0`                                 |
 | `server.configuration.streamingEnabled`             | Enables or disables streaming data processing                                                                                    | `true`                                               |
 | `server.configuration.batchEnabled`                 | Enables or disables batch data (tasks and schedules) processing                                                                  | `true`                                               |
 | `server.configuration.accountName`                  | The name of the account to configure for the Kubernetes platform                                                                 | `default`                                            |
@@ -184,6 +186,7 @@ helm uninstall my-release
 | `server.proxy`                                      | Add proxy configuration for SCDF server                                                                                          | `{}`                                                 |
 | `server.applicationProperties`                      | Specify common application properties added by SCDF server to streams and/or tasks                                               | `{}`                                                 |
 
+
 ### Dataflow Skipper parameters
 
 | Name                                         | Description                                                                                               | Value                          |
@@ -192,7 +195,7 @@ helm uninstall my-release
 | `skipper.hostAliases`                        | Deployment pod host aliases                                                                               | `[]`                           |
 | `skipper.image.registry`                     | Spring Cloud Skipper image registry                                                                       | `docker.io`                    |
 | `skipper.image.repository`                   | Spring Cloud Skipper image repository                                                                     | `bitnami/spring-cloud-skipper` |
-| `skipper.image.tag`                          | Spring Cloud Skipper image tag (immutable tags are recommended)                                           | `2.8.4-debian-10-r44`          |
+| `skipper.image.tag`                          | Spring Cloud Skipper image tag (immutable tags are recommended)                                           | `2.8.4-debian-11-r0`           |
 | `skipper.image.pullPolicy`                   | Spring Cloud Skipper image pull policy                                                                    | `IfNotPresent`                 |
 | `skipper.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                          | `[]`                           |
 | `skipper.image.debug`                        | Enable image debug mode                                                                                   | `false`                        |
@@ -275,6 +278,7 @@ helm uninstall my-release
 | `externalSkipper.host`                       | Host of a external Skipper Server                                                                         | `localhost`                    |
 | `externalSkipper.port`                       | External Skipper Server port number                                                                       | `7577`                         |
 
+
 ### Deployer parameters
 
 | Name                                          | Description                                                                                                                                     | Value          |
@@ -284,7 +288,7 @@ helm uninstall my-release
 | `deployer.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                                        | `120`          |
 | `deployer.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                                         | `90`           |
 | `deployer.nodeSelector`                       | The node selectors to apply to the streaming applications deployments in "key:value" format                                                     | `""`           |
-| `deployer.tolerations`                        | Streaming applications tolerations                                                                                                              | `{}`           |
+| `deployer.tolerations`                        | Streaming applications tolerations                                                                                                              | `[]`           |
 | `deployer.volumeMounts`                       | Streaming applications extra volume mounts                                                                                                      | `{}`           |
 | `deployer.volumes`                            | Streaming applications extra volumes                                                                                                            | `{}`           |
 | `deployer.environmentVariables`               | Streaming applications environment variables                                                                                                    | `[]`           |
@@ -294,6 +298,7 @@ helm uninstall my-release
 | `deployer.secretRefs`                         | Streaming applications secretRefs                                                                                                               | `[]`           |
 | `deployer.entryPointStyle`                    | An entry point style affects how application properties are passed to the container to be deployed. Allowed values: exec (default), shell, boot | `exec`         |
 | `deployer.imagePullPolicy`                    | An image pull policy defines when a Docker image should be pulled to the local registry. Allowed values: IfNotPresent (default), Always, Never  | `IfNotPresent` |
+
 
 ### RBAC parameters
 
@@ -305,6 +310,7 @@ helm uninstall my-release
 | `serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                              | `{}`   |
 | `rbac.create`                                 | Whether to create and use RBAC resources or not                                                                         | `true` |
 
+
 ### Metrics parameters
 
 | Name                                         | Description                                                                                                                | Value                              |
@@ -312,7 +318,7 @@ helm uninstall my-release
 | `metrics.enabled`                            | Enable Prometheus metrics                                                                                                  | `false`                            |
 | `metrics.image.registry`                     | Prometheus Rsocket Proxy image registry                                                                                    | `docker.io`                        |
 | `metrics.image.repository`                   | Prometheus Rsocket Proxy image repository                                                                                  | `bitnami/prometheus-rsocket-proxy` |
-| `metrics.image.tag`                          | Prometheus Rsocket Proxy image tag (immutable tags are recommended)                                                        | `1.4.0-debian-10-r83`              |
+| `metrics.image.tag`                          | Prometheus Rsocket Proxy image tag (immutable tags are recommended)                                                        | `1.4.0-debian-11-r0`               |
 | `metrics.image.pullPolicy`                   | Prometheus Rsocket Proxy image pull policy                                                                                 | `IfNotPresent`                     |
 | `metrics.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                                           | `[]`                               |
 | `metrics.resources.limits`                   | The resources limits for the Prometheus Rsocket Proxy container                                                            | `{}`                               |
@@ -381,6 +387,7 @@ helm uninstall my-release
 | `metrics.autoscaling.targetCPU`              | Target CPU utilization percentage                                                                                          | `""`                               |
 | `metrics.autoscaling.targetMemory`           | Target Memory utilization percentage                                                                                       | `""`                               |
 
+
 ### Init Container parameters
 
 | Name                                 | Description                                                                                       | Value                 |
@@ -388,11 +395,12 @@ helm uninstall my-release
 | `waitForBackends.enabled`            | Wait for the database and other services (such as Kafka or RabbitMQ) used when enabling streaming | `true`                |
 | `waitForBackends.image.registry`     | Init container wait-for-backend image registry                                                    | `docker.io`           |
 | `waitForBackends.image.repository`   | Init container wait-for-backend image name                                                        | `bitnami/kubectl`     |
-| `waitForBackends.image.tag`          | Init container wait-for-backend image tag                                                         | `1.24.0-debian-10-r2` |
+| `waitForBackends.image.tag`          | Init container wait-for-backend image tag                                                         | `1.24.1-debian-11-r0` |
 | `waitForBackends.image.pullPolicy`   | Init container wait-for-backend image pull policy                                                 | `IfNotPresent`        |
 | `waitForBackends.image.pullSecrets`  | Specify docker-registry secret names as an array                                                  | `[]`                  |
 | `waitForBackends.resources.limits`   | Init container wait-for-backend resource limits                                                   | `{}`                  |
 | `waitForBackends.resources.requests` | Init container wait-for-backend resource requests                                                 | `{}`                  |
+
 
 ### Database parameters
 
@@ -423,6 +431,7 @@ helm uninstall my-release
 | `externalDatabase.skipper.username`       | Existing username in the external db to be used by Skipper server                                   | `skipper`    |
 | `externalDatabase.hibernateDialect`       | Hibernate Dialect used by Dataflow/Skipper servers                                                  | `""`         |
 
+
 ### RabbitMQ chart parameters
 
 | Name                                      | Description                                                                     | Value       |
@@ -437,6 +446,7 @@ helm uninstall my-release
 | `externalRabbitmq.vhost`                  | External RabbitMQ virtual host. It will be saved in a kubernetes secret         | `""`        |
 | `externalRabbitmq.existingPasswordSecret` | Existing secret with RabbitMQ password. It will be saved in a kubernetes secret | `""`        |
 
+
 ### Kafka chart parameters
 
 | Name                                  | Description                             | Value            |
@@ -448,6 +458,7 @@ helm uninstall my-release
 | `externalKafka.enabled`               | Enable/disable external Kafka           | `false`          |
 | `externalKafka.brokers`               | External Kafka brokers                  | `localhost:9092` |
 | `externalKafka.zkNodes`               | External Zookeeper nodes                | `localhost:2181` |
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -978,7 +978,7 @@ deployer:
   nodeSelector: ""
   ## @param deployer.tolerations Streaming applications tolerations
   ##
-  tolerations: {}
+  tolerations: []
   ## @param deployer.volumeMounts Streaming applications extra volume mounts
   ##
   volumeMounts: {}


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

