### PR TITLE
[bitnami/airflow] Fix topologySpreadConstraints default values

### DIFF
--- a/.vib/airflow/vib-verify.json
+++ b/.vib/airflow/vib-verify.json
@@ -35,7 +35,8 @@
           "action_id": "trivy",
           "params": {
             "threshold": "CRITICAL",
-            "vuln_type": ["OS"]
+            "vuln_type": ["OS"],
+            "timeout": "15m" 
           }
         },
         {

--- a/.vib/airflow/vib-verify.json
+++ b/.vib/airflow/vib-verify.json
@@ -35,8 +35,7 @@
           "action_id": "trivy",
           "params": {
             "threshold": "CRITICAL",
-            "vuln_type": ["OS"],
-            "timeout": "15m" 
+            "vuln_type": ["OS"]
           }
         },
         {

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 12.5.5
+version: 12.5.6

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -91,7 +91,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dags.existingConfigmap` | Name of an existing ConfigMap with all the DAGs files you want to load in Airflow                                                              | `""`                    |
 | `dags.image.registry`    | Init container load-dags image registry                                                                                                        | `docker.io`             |
 | `dags.image.repository`  | Init container load-dags image repository                                                                                                      | `bitnami/bitnami-shell` |
-| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `10-debian-10-r434`     |
+| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `11-debian-11-r0`       |
 | `dags.image.pullPolicy`  | Init container load-dags image pull policy                                                                                                     | `IfNotPresent`          |
 | `dags.image.pullSecrets` | Init container load-dags image pull secrets                                                                                                    | `[]`                    |
 | `extraEnvVars`           | Add extra environment variables for all the Airflow pods                                                                                       | `[]`                    |
@@ -110,7 +110,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------- |
 | `web.image.registry`                        | Airflow image registry                                                                                                   | `docker.io`          |
 | `web.image.repository`                      | Airflow image repository                                                                                                 | `bitnami/airflow`    |
-| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.3.0-debian-10-r6` |
+| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.3.2-debian-11-r0` |
 | `web.image.pullPolicy`                      | Airflow image pull policy                                                                                                | `IfNotPresent`       |
 | `web.image.pullSecrets`                     | Airflow image pull secrets                                                                                               | `[]`                 |
 | `web.image.debug`                           | Enable image debug mode                                                                                                  | `false`              |
@@ -164,7 +164,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `web.podAffinityPreset`                     | Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.                                 | `""`                 |
 | `web.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`.                            | `soft`               |
 | `web.tolerations`                           | Tolerations for Airflow web pods assignment                                                                              | `[]`                 |
-| `web.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                 |
+| `web.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                 |
 | `web.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                 |
 | `web.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                 |
 | `web.terminationGracePeriodSeconds`         | Seconds Airflow web pod needs to terminate gracefully                                                                    | `""`                 |
@@ -185,7 +185,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
 | `scheduler.image.registry`                        | Airflow Scheduler image registry                                                                                         | `docker.io`                 |
 | `scheduler.image.repository`                      | Airflow Scheduler image repository                                                                                       | `bitnami/airflow-scheduler` |
-| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.3.0-debian-10-r21`       |
+| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.3.2-debian-11-r0`        |
 | `scheduler.image.pullPolicy`                      | Airflow Scheduler image pull policy                                                                                      | `IfNotPresent`              |
 | `scheduler.image.pullSecrets`                     | Airflow Scheduler image pull secrets                                                                                     | `[]`                        |
 | `scheduler.image.debug`                           | Enable image debug mode                                                                                                  | `false`                     |
@@ -218,7 +218,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scheduler.podAffinityPreset`                     | Pod affinity preset. Ignored if `scheduler.affinity` is set. Allowed values: `soft` or `hard`.                           | `""`                        |
 | `scheduler.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `scheduler.affinity` is set. Allowed values: `soft` or `hard`.                      | `soft`                      |
 | `scheduler.tolerations`                           | Tolerations for Airflow scheduler pods assignment                                                                        | `[]`                        |
-| `scheduler.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                        |
+| `scheduler.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                        |
 | `scheduler.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                        |
 | `scheduler.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                        |
 | `scheduler.terminationGracePeriodSeconds`         | Seconds Airflow scheduler pod needs to terminate gracefully                                                              | `""`                        |
@@ -239,7 +239,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | `worker.image.registry`                        | Airflow Worker image registry                                                                                            | `docker.io`              |
 | `worker.image.repository`                      | Airflow Worker image repository                                                                                          | `bitnami/airflow-worker` |
-| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.3.0-debian-10-r21`    |
+| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.3.2-debian-11-r0`     |
 | `worker.image.pullPolicy`                      | Airflow Worker image pull policy                                                                                         | `IfNotPresent`           |
 | `worker.image.pullSecrets`                     | Airflow Worker image pull secrets                                                                                        | `[]`                     |
 | `worker.image.debug`                           | Enable image debug mode                                                                                                  | `false`                  |
@@ -291,7 +291,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.podAffinityPreset`                     | Pod affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`.                              | `""`                     |
 | `worker.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `worker.affinity` is set. Allowed values: `soft` or `hard`.                         | `soft`                   |
 | `worker.tolerations`                           | Tolerations for Airflow worker pods assignment                                                                           | `[]`                     |
-| `worker.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                     |
+| `worker.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                     |
 | `worker.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                     |
 | `worker.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                     |
 | `worker.terminationGracePeriodSeconds`         | Seconds Airflow worker pod needs to terminate gracefully                                                                 | `""`                     |
@@ -315,32 +315,32 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Airflow git sync parameters
 
-| Name                           | Description                                                                            | Value                  |
-| ------------------------------ | -------------------------------------------------------------------------------------- | ---------------------- |
-| `git.image.registry`           | Git image registry                                                                     | `docker.io`            |
-| `git.image.repository`         | Git image repository                                                                   | `bitnami/git`          |
-| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.36.1-debian-10-r16` |
-| `git.image.pullPolicy`         | Git image pull policy                                                                  | `IfNotPresent`         |
-| `git.image.pullSecrets`        | Git image pull secrets                                                                 | `[]`                   |
-| `git.dags.enabled`             | Enable in order to download DAG files from git repositories.                           | `false`                |
-| `git.dags.repositories`        | Array of repositories from which to download DAG files                                 | `[]`                   |
-| `git.plugins.enabled`          | Enable in order to download Plugins files from git repositories.                       | `false`                |
-| `git.plugins.repositories`     | Array of repositories from which to download DAG files                                 | `[]`                   |
-| `git.clone.command`            | Override cmd                                                                           | `[]`                   |
-| `git.clone.args`               | Override args                                                                          | `[]`                   |
-| `git.clone.extraVolumeMounts`  | Add extra volume mounts                                                                | `[]`                   |
-| `git.clone.extraEnvVars`       | Add extra environment variables                                                        | `[]`                   |
-| `git.clone.extraEnvVarsCM`     | ConfigMap with extra environment variables                                             | `""`                   |
-| `git.clone.extraEnvVarsSecret` | Secret with extra environment variables                                                | `""`                   |
-| `git.clone.resources`          | Clone init container resource requests and limits                                      | `{}`                   |
-| `git.sync.interval`            | Interval in seconds to pull the git repository containing the plugins and/or DAG files | `60`                   |
-| `git.sync.command`             | Override cmd                                                                           | `[]`                   |
-| `git.sync.args`                | Override args                                                                          | `[]`                   |
-| `git.sync.extraVolumeMounts`   | Add extra volume mounts                                                                | `[]`                   |
-| `git.sync.extraEnvVars`        | Add extra environment variables                                                        | `[]`                   |
-| `git.sync.extraEnvVarsCM`      | ConfigMap with extra environment variables                                             | `""`                   |
-| `git.sync.extraEnvVarsSecret`  | Secret with extra environment variables                                                | `""`                   |
-| `git.sync.resources`           | Sync sidecar container resource requests and limits                                    | `{}`                   |
+| Name                           | Description                                                                            | Value                 |
+| ------------------------------ | -------------------------------------------------------------------------------------- | --------------------- |
+| `git.image.registry`           | Git image registry                                                                     | `docker.io`           |
+| `git.image.repository`         | Git image repository                                                                   | `bitnami/git`         |
+| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.36.1-debian-11-r0` |
+| `git.image.pullPolicy`         | Git image pull policy                                                                  | `IfNotPresent`        |
+| `git.image.pullSecrets`        | Git image pull secrets                                                                 | `[]`                  |
+| `git.dags.enabled`             | Enable in order to download DAG files from git repositories.                           | `false`               |
+| `git.dags.repositories`        | Array of repositories from which to download DAG files                                 | `[]`                  |
+| `git.plugins.enabled`          | Enable in order to download Plugins files from git repositories.                       | `false`               |
+| `git.plugins.repositories`     | Array of repositories from which to download DAG files                                 | `[]`                  |
+| `git.clone.command`            | Override cmd                                                                           | `[]`                  |
+| `git.clone.args`               | Override args                                                                          | `[]`                  |
+| `git.clone.extraVolumeMounts`  | Add extra volume mounts                                                                | `[]`                  |
+| `git.clone.extraEnvVars`       | Add extra environment variables                                                        | `[]`                  |
+| `git.clone.extraEnvVarsCM`     | ConfigMap with extra environment variables                                             | `""`                  |
+| `git.clone.extraEnvVarsSecret` | Secret with extra environment variables                                                | `""`                  |
+| `git.clone.resources`          | Clone init container resource requests and limits                                      | `{}`                  |
+| `git.sync.interval`            | Interval in seconds to pull the git repository containing the plugins and/or DAG files | `60`                  |
+| `git.sync.command`             | Override cmd                                                                           | `[]`                  |
+| `git.sync.args`                | Override args                                                                          | `[]`                  |
+| `git.sync.extraVolumeMounts`   | Add extra volume mounts                                                                | `[]`                  |
+| `git.sync.extraEnvVars`        | Add extra environment variables                                                        | `[]`                  |
+| `git.sync.extraEnvVarsCM`      | ConfigMap with extra environment variables                                             | `""`                  |
+| `git.sync.extraEnvVarsSecret`  | Secret with extra environment variables                                                | `""`                  |
+| `git.sync.resources`           | Sync sidecar container resource requests and limits                                    | `{}`                  |
 
 
 ### Airflow ldap parameters
@@ -409,52 +409,52 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Airflow metrics parameters
 
-| Name                                            | Description                                                                                         | Value                        |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `metrics.enabled`                               | Whether or not to create a standalone Airflow exporter to expose Airflow metrics                    | `false`                      |
-| `metrics.image.registry`                        | Airflow exporter image registry                                                                     | `docker.io`                  |
-| `metrics.image.repository`                      | Airflow exporter image repository                                                                   | `bitnami/airflow-exporter`   |
-| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-10-r71` |
-| `metrics.image.pullPolicy`                      | Airflow exporter image pull policy                                                                  | `IfNotPresent`               |
-| `metrics.image.pullSecrets`                     | Airflow exporter image pull secrets                                                                 | `[]`                         |
-| `metrics.extraEnvVars`                          | Array with extra environment variables to add Airflow exporter pods                                 | `[]`                         |
-| `metrics.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow exporter pods                          | `""`                         |
-| `metrics.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow exporter pods | `""`                         |
-| `metrics.containerPorts.http`                   | Airflow exporter metrics container port                                                             | `9112`                       |
-| `metrics.resources.limits`                      | The resources limits for the container                                                              | `{}`                         |
-| `metrics.resources.requests`                    | The requested resources for the container                                                           | `{}`                         |
-| `metrics.podSecurityContext.enabled`            | Enable security context for the pods                                                                | `true`                       |
-| `metrics.podSecurityContext.fsGroup`            | Set Airflow exporter pod's Security Context fsGroup                                                 | `1001`                       |
-| `metrics.containerSecurityContext.enabled`      | Enable Airflow exporter containers' Security Context                                                | `true`                       |
-| `metrics.containerSecurityContext.runAsUser`    | Set Airflow exporter containers' Security Context runAsUser                                         | `1001`                       |
-| `metrics.containerSecurityContext.runAsNonRoot` | Set Airflow exporter containers' Security Context runAsNonRoot                                      | `true`                       |
-| `metrics.lifecycleHooks`                        | for the Airflow exporter container(s) to automate configuration before or after startup             | `{}`                         |
-| `metrics.hostAliases`                           | Airflow exporter pods host aliases                                                                  | `[]`                         |
-| `metrics.podLabels`                             | Extra labels for Airflow exporter pods                                                              | `{}`                         |
-| `metrics.podAnnotations`                        | Extra annotations for Airflow exporter pods                                                         | `{}`                         |
-| `metrics.podAffinityPreset`                     | Pod affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`         | `""`                         |
-| `metrics.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`    | `soft`                       |
-| `metrics.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`   | `""`                         |
-| `metrics.nodeAffinityPreset.key`                | Node label key to match Ignored if `metrics.affinity` is set.                                       | `""`                         |
-| `metrics.nodeAffinityPreset.values`             | Node label values to match. Ignored if `metrics.affinity` is set.                                   | `[]`                         |
-| `metrics.affinity`                              | Affinity for pod assignment                                                                         | `{}`                         |
-| `metrics.nodeSelector`                          | Node labels for pod assignment                                                                      | `{}`                         |
-| `metrics.tolerations`                           | Tolerations for pod assignment                                                                      | `[]`                         |
-| `metrics.schedulerName`                         | Name of the k8s scheduler (other than default) for Airflow exporter                                 | `""`                         |
-| `metrics.service.ports.http`                    | Airflow exporter metrics service port                                                               | `9112`                       |
-| `metrics.service.clusterIP`                     | Static clusterIP or None for headless services                                                      | `""`                         |
-| `metrics.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                    | `None`                       |
-| `metrics.service.annotations`                   | Annotations for the Airflow exporter service                                                        | `{}`                         |
-| `metrics.serviceMonitor.enabled`                | if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.enabled` to be `true`)   | `false`                      |
-| `metrics.serviceMonitor.namespace`              | Namespace in which Prometheus is running                                                            | `""`                         |
-| `metrics.serviceMonitor.interval`               | Interval at which metrics should be scraped                                                         | `""`                         |
-| `metrics.serviceMonitor.scrapeTimeout`          | Timeout after which the scrape is ended                                                             | `""`                         |
-| `metrics.serviceMonitor.labels`                 | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus               | `{}`                         |
-| `metrics.serviceMonitor.selector`               | Prometheus instance selector labels                                                                 | `{}`                         |
-| `metrics.serviceMonitor.relabelings`            | RelabelConfigs to apply to samples before scraping                                                  | `[]`                         |
-| `metrics.serviceMonitor.metricRelabelings`      | MetricRelabelConfigs to apply to samples before ingestion                                           | `[]`                         |
-| `metrics.serviceMonitor.honorLabels`            | Specify honorLabels parameter to add the scrape endpoint                                            | `false`                      |
-| `metrics.serviceMonitor.jobLabel`               | The name of the label on the target service to use as the job name in prometheus.                   | `""`                         |
+| Name                                            | Description                                                                                         | Value                       |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------------- |
+| `metrics.enabled`                               | Whether or not to create a standalone Airflow exporter to expose Airflow metrics                    | `false`                     |
+| `metrics.image.registry`                        | Airflow exporter image registry                                                                     | `docker.io`                 |
+| `metrics.image.repository`                      | Airflow exporter image repository                                                                   | `bitnami/airflow-exporter`  |
+| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-11-r0` |
+| `metrics.image.pullPolicy`                      | Airflow exporter image pull policy                                                                  | `IfNotPresent`              |
+| `metrics.image.pullSecrets`                     | Airflow exporter image pull secrets                                                                 | `[]`                        |
+| `metrics.extraEnvVars`                          | Array with extra environment variables to add Airflow exporter pods                                 | `[]`                        |
+| `metrics.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow exporter pods                          | `""`                        |
+| `metrics.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow exporter pods | `""`                        |
+| `metrics.containerPorts.http`                   | Airflow exporter metrics container port                                                             | `9112`                      |
+| `metrics.resources.limits`                      | The resources limits for the container                                                              | `{}`                        |
+| `metrics.resources.requests`                    | The requested resources for the container                                                           | `{}`                        |
+| `metrics.podSecurityContext.enabled`            | Enable security context for the pods                                                                | `true`                      |
+| `metrics.podSecurityContext.fsGroup`            | Set Airflow exporter pod's Security Context fsGroup                                                 | `1001`                      |
+| `metrics.containerSecurityContext.enabled`      | Enable Airflow exporter containers' Security Context                                                | `true`                      |
+| `metrics.containerSecurityContext.runAsUser`    | Set Airflow exporter containers' Security Context runAsUser                                         | `1001`                      |
+| `metrics.containerSecurityContext.runAsNonRoot` | Set Airflow exporter containers' Security Context runAsNonRoot                                      | `true`                      |
+| `metrics.lifecycleHooks`                        | for the Airflow exporter container(s) to automate configuration before or after startup             | `{}`                        |
+| `metrics.hostAliases`                           | Airflow exporter pods host aliases                                                                  | `[]`                        |
+| `metrics.podLabels`                             | Extra labels for Airflow exporter pods                                                              | `{}`                        |
+| `metrics.podAnnotations`                        | Extra annotations for Airflow exporter pods                                                         | `{}`                        |
+| `metrics.podAffinityPreset`                     | Pod affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`         | `""`                        |
+| `metrics.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`    | `soft`                      |
+| `metrics.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`   | `""`                        |
+| `metrics.nodeAffinityPreset.key`                | Node label key to match Ignored if `metrics.affinity` is set.                                       | `""`                        |
+| `metrics.nodeAffinityPreset.values`             | Node label values to match. Ignored if `metrics.affinity` is set.                                   | `[]`                        |
+| `metrics.affinity`                              | Affinity for pod assignment                                                                         | `{}`                        |
+| `metrics.nodeSelector`                          | Node labels for pod assignment                                                                      | `{}`                        |
+| `metrics.tolerations`                           | Tolerations for pod assignment                                                                      | `[]`                        |
+| `metrics.schedulerName`                         | Name of the k8s scheduler (other than default) for Airflow exporter                                 | `""`                        |
+| `metrics.service.ports.http`                    | Airflow exporter metrics service port                                                               | `9112`                      |
+| `metrics.service.clusterIP`                     | Static clusterIP or None for headless services                                                      | `""`                        |
+| `metrics.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                    | `None`                      |
+| `metrics.service.annotations`                   | Annotations for the Airflow exporter service                                                        | `{}`                        |
+| `metrics.serviceMonitor.enabled`                | if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.enabled` to be `true`)   | `false`                     |
+| `metrics.serviceMonitor.namespace`              | Namespace in which Prometheus is running                                                            | `""`                        |
+| `metrics.serviceMonitor.interval`               | Interval at which metrics should be scraped                                                         | `""`                        |
+| `metrics.serviceMonitor.scrapeTimeout`          | Timeout after which the scrape is ended                                                             | `""`                        |
+| `metrics.serviceMonitor.labels`                 | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus               | `{}`                        |
+| `metrics.serviceMonitor.selector`               | Prometheus instance selector labels                                                                 | `{}`                        |
+| `metrics.serviceMonitor.relabelings`            | RelabelConfigs to apply to samples before scraping                                                  | `[]`                        |
+| `metrics.serviceMonitor.metricRelabelings`      | MetricRelabelConfigs to apply to samples before ingestion                                           | `[]`                        |
+| `metrics.serviceMonitor.honorLabels`            | Specify honorLabels parameter to add the scrape endpoint                                            | `false`                     |
+| `metrics.serviceMonitor.jobLabel`               | The name of the label on the target service to use as the job name in prometheus.                   | `""`                        |
 
 
 ### Airflow database parameters

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -364,7 +364,7 @@ web:
   ## @param web.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
   ## @param web.priorityClassName Priority Class Name
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##
@@ -566,7 +566,7 @@ scheduler:
   ## @param scheduler.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
   ## @param scheduler.priorityClassName Priority Class Name
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##
@@ -816,7 +816,7 @@ worker:
   ## @param worker.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
   ## @param worker.priorityClassName Priority Class Name
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

