### PR TITLE
[bitnami/discourse] Fix topologySpreadConstraints default values

### DIFF
--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 7.3.3
+version: 7.3.4

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -81,52 +81,52 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Discourse Common parameters
 
-| Name                            | Description                                                                                                              | Value                 |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------- |
-| `image.registry`                | Discourse image registry                                                                                                 | `docker.io`           |
-| `image.repository`              | Discourse image repository                                                                                               | `bitnami/discourse`   |
-| `image.tag`                     | Discourse image tag                                                                                                      | `2.8.3-debian-10-r36` |
-| `image.pullPolicy`              | Discourse image pull policy                                                                                              | `IfNotPresent`        |
-| `image.pullSecrets`             | Discourse image pull secrets                                                                                             | `[]`                  |
-| `image.debug`                   | Enable image debug mode                                                                                                  | `false`               |
-| `auth.email`                    | Discourse admin user email                                                                                               | `user@example.com`    |
-| `auth.username`                 | Discourse admin user                                                                                                     | `user`                |
-| `auth.password`                 | Discourse admin password. WARNING: Minimum length of 10 characters                                                       | `""`                  |
-| `auth.existingSecret`           | Name of an existing secret to use for Discourse credentials                                                              | `""`                  |
-| `host`                          | Hostname to create application URLs (include the port if =/= 80)                                                         | `""`                  |
-| `siteName`                      | Discourse site name                                                                                                      | `My Site!`            |
-| `smtp.enabled`                  | Enable/disable SMTP                                                                                                      | `false`               |
-| `smtp.host`                     | SMTP host name                                                                                                           | `""`                  |
-| `smtp.port`                     | SMTP port number                                                                                                         | `""`                  |
-| `smtp.user`                     | SMTP account user name                                                                                                   | `""`                  |
-| `smtp.password`                 | SMTP account password                                                                                                    | `""`                  |
-| `smtp.protocol`                 | SMTP protocol (Allowed values: tls, ssl)                                                                                 | `""`                  |
-| `smtp.auth`                     | SMTP authentication method                                                                                               | `""`                  |
-| `smtp.existingSecret`           | Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password`                | `""`                  |
-| `replicaCount`                  | Number of Discourse & Sidekiq replicas                                                                                   | `1`                   |
-| `podSecurityContext.enabled`    | Enabled Discourse pods' Security Context                                                                                 | `false`               |
-| `podSecurityContext.fsGroup`    | Set Discourse pod's Security Context fsGroup                                                                             | `0`                   |
-| `hostAliases`                   | Add deployment host aliases                                                                                              | `[]`                  |
-| `podAnnotations`                | Additional pod annotations                                                                                               | `{}`                  |
-| `podLabels`                     | Additional pod labels                                                                                                    | `{}`                  |
-| `podAffinityPreset`             | Pod affinity preset. Allowed values: soft, hard                                                                          | `""`                  |
-| `podAntiAffinityPreset`         | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                |
-| `nodeAffinityPreset.type`       | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                  |
-| `nodeAffinityPreset.key`        | Node label key to match Ignored if `affinity` is set.                                                                    | `""`                  |
-| `nodeAffinityPreset.values`     | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                  |
-| `affinity`                      | Affinity for pod assignment                                                                                              | `{}`                  |
-| `nodeSelector`                  | Node labels for pod assignment.                                                                                          | `{}`                  |
-| `tolerations`                   | Tolerations for pod assignment.                                                                                          | `[]`                  |
-| `topologySpreadConstraints`     | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                  |
-| `priorityClassName`             | Priority Class Name                                                                                                      | `""`                  |
-| `schedulerName`                 | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                  |
-| `terminationGracePeriodSeconds` | Seconds Discourse pod needs to terminate gracefully                                                                      | `""`                  |
-| `updateStrategy.type`           | Discourse deployment strategy type                                                                                       | `RollingUpdate`       |
-| `updateStrategy.rollingUpdate`  | Discourse deployment rolling update configuration parameters                                                             | `{}`                  |
-| `sidecars`                      | Add additional sidecar containers to the Discourse pods                                                                  | `[]`                  |
-| `initContainers`                | Add additional init containers to the Discourse pods                                                                     | `[]`                  |
-| `extraVolumeMounts`             | Optionally specify extra list of additional volumeMounts for the Discourse pods                                          | `[]`                  |
-| `extraVolumes`                  | Optionally specify extra list of additional volumes for the Discourse pods                                               | `[]`                  |
+| Name                            | Description                                                                                                              | Value                |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------- |
+| `image.registry`                | Discourse image registry                                                                                                 | `docker.io`          |
+| `image.repository`              | Discourse image repository                                                                                               | `bitnami/discourse`  |
+| `image.tag`                     | Discourse image tag                                                                                                      | `2.8.3-debian-11-r0` |
+| `image.pullPolicy`              | Discourse image pull policy                                                                                              | `IfNotPresent`       |
+| `image.pullSecrets`             | Discourse image pull secrets                                                                                             | `[]`                 |
+| `image.debug`                   | Enable image debug mode                                                                                                  | `false`              |
+| `auth.email`                    | Discourse admin user email                                                                                               | `user@example.com`   |
+| `auth.username`                 | Discourse admin user                                                                                                     | `user`               |
+| `auth.password`                 | Discourse admin password. WARNING: Minimum length of 10 characters                                                       | `""`                 |
+| `auth.existingSecret`           | Name of an existing secret to use for Discourse credentials                                                              | `""`                 |
+| `host`                          | Hostname to create application URLs (include the port if =/= 80)                                                         | `""`                 |
+| `siteName`                      | Discourse site name                                                                                                      | `My Site!`           |
+| `smtp.enabled`                  | Enable/disable SMTP                                                                                                      | `false`              |
+| `smtp.host`                     | SMTP host name                                                                                                           | `""`                 |
+| `smtp.port`                     | SMTP port number                                                                                                         | `""`                 |
+| `smtp.user`                     | SMTP account user name                                                                                                   | `""`                 |
+| `smtp.password`                 | SMTP account password                                                                                                    | `""`                 |
+| `smtp.protocol`                 | SMTP protocol (Allowed values: tls, ssl)                                                                                 | `""`                 |
+| `smtp.auth`                     | SMTP authentication method                                                                                               | `""`                 |
+| `smtp.existingSecret`           | Name of an existing Kubernetes secret. The secret must have the following key configured: `smtp-password`                | `""`                 |
+| `replicaCount`                  | Number of Discourse & Sidekiq replicas                                                                                   | `1`                  |
+| `podSecurityContext.enabled`    | Enabled Discourse pods' Security Context                                                                                 | `false`              |
+| `podSecurityContext.fsGroup`    | Set Discourse pod's Security Context fsGroup                                                                             | `0`                  |
+| `hostAliases`                   | Add deployment host aliases                                                                                              | `[]`                 |
+| `podAnnotations`                | Additional pod annotations                                                                                               | `{}`                 |
+| `podLabels`                     | Additional pod labels                                                                                                    | `{}`                 |
+| `podAffinityPreset`             | Pod affinity preset. Allowed values: soft, hard                                                                          | `""`                 |
+| `podAntiAffinityPreset`         | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`               |
+| `nodeAffinityPreset.type`       | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                 |
+| `nodeAffinityPreset.key`        | Node label key to match Ignored if `affinity` is set.                                                                    | `""`                 |
+| `nodeAffinityPreset.values`     | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                 |
+| `affinity`                      | Affinity for pod assignment                                                                                              | `{}`                 |
+| `nodeSelector`                  | Node labels for pod assignment.                                                                                          | `{}`                 |
+| `tolerations`                   | Tolerations for pod assignment.                                                                                          | `[]`                 |
+| `topologySpreadConstraints`     | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                 |
+| `priorityClassName`             | Priority Class Name                                                                                                      | `""`                 |
+| `schedulerName`                 | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                 |
+| `terminationGracePeriodSeconds` | Seconds Discourse pod needs to terminate gracefully                                                                      | `""`                 |
+| `updateStrategy.type`           | Discourse deployment strategy type                                                                                       | `RollingUpdate`      |
+| `updateStrategy.rollingUpdate`  | Discourse deployment rolling update configuration parameters                                                             | `{}`                 |
+| `sidecars`                      | Add additional sidecar containers to the Discourse pods                                                                  | `[]`                 |
+| `initContainers`                | Add additional init containers to the Discourse pods                                                                     | `[]`                 |
+| `extraVolumeMounts`             | Optionally specify extra list of additional volumeMounts for the Discourse pods                                          | `[]`                 |
+| `extraVolumes`                  | Optionally specify extra list of additional volumes for the Discourse pods                                               | `[]`                 |
 
 
 ### Discourse container parameters

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -196,7 +196,7 @@ tolerations: []
 ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 ##
-topologySpreadConstraints: {}
+topologySpreadConstraints: []
 ## @param priorityClassName Priority Class Name
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 ##


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

