### PR TITLE
[bitnami/jupyterhub] Fix topologySpreadConstraints default values

### DIFF
--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -26,4 +26,4 @@ name: jupyterhub
 sources:
   - https://github.com/bitnami/bitnami-docker-jupyterhub
   - https://github.com/jupyterhub/jupyterhub
-version: 1.3.4
+version: 1.3.5

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -83,78 +83,78 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Hub deployment parameters
 
-| Name                                        | Description                                                                                                              | Value                  |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
-| `hub.image.registry`                        | Hub image registry                                                                                                       | `docker.io`            |
-| `hub.image.repository`                      | Hub image repository                                                                                                     | `bitnami/jupyterhub`   |
-| `hub.image.tag`                             | Hub image tag (immutable tags are recommended)                                                                           | `1.5.0-debian-10-r169` |
-| `hub.image.pullPolicy`                      | Hub image pull policy                                                                                                    | `IfNotPresent`         |
-| `hub.image.pullSecrets`                     | Hub image pull secrets                                                                                                   | `[]`                   |
-| `hub.baseUrl`                               | Hub base URL                                                                                                             | `/`                    |
-| `hub.adminUser`                             | Hub Dummy authenticator admin user                                                                                       | `user`                 |
-| `hub.password`                              | Hub Dummy authenticator password                                                                                         | `""`                   |
-| `hub.configuration`                         | Hub configuration file (to be used by jupyterhub_config.py)                                                              | `""`                   |
-| `hub.existingConfigmap`                     | Configmap with Hub init scripts (replaces the scripts in templates/hub/configmap.yml)                                    | `""`                   |
-| `hub.existingSecret`                        | Secret with hub configuration (replaces the hub.configuration value) and proxy token                                     | `""`                   |
-| `hub.command`                               | Override Hub default command                                                                                             | `[]`                   |
-| `hub.args`                                  | Override Hub default args                                                                                                | `[]`                   |
-| `hub.extraEnvVars`                          | Add extra environment variables to the Hub container                                                                     | `[]`                   |
-| `hub.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                                                     | `""`                   |
-| `hub.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                                                        | `""`                   |
-| `hub.containerPorts.http`                   | Hub container port                                                                                                       | `8081`                 |
-| `hub.startupProbe.enabled`                  | Enable startupProbe on Hub containers                                                                                    | `true`                 |
-| `hub.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `10`                   |
-| `hub.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `10`                   |
-| `hub.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `3`                    |
-| `hub.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `30`                   |
-| `hub.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                    |
-| `hub.livenessProbe.enabled`                 | Enable livenessProbe on Hub containers                                                                                   | `true`                 |
-| `hub.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `10`                   |
-| `hub.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `10`                   |
-| `hub.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `3`                    |
-| `hub.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `30`                   |
-| `hub.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                    |
-| `hub.readinessProbe.enabled`                | Enable readinessProbe on Hub containers                                                                                  | `true`                 |
-| `hub.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `10`                   |
-| `hub.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                   |
-| `hub.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `3`                    |
-| `hub.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `30`                   |
-| `hub.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                    |
-| `hub.customStartupProbe`                    | Override default startup probe                                                                                           | `{}`                   |
-| `hub.customLivenessProbe`                   | Override default liveness probe                                                                                          | `{}`                   |
-| `hub.customReadinessProbe`                  | Override default readiness probe                                                                                         | `{}`                   |
-| `hub.resources.limits`                      | The resources limits for the Hub containers                                                                              | `{}`                   |
-| `hub.resources.requests`                    | The requested resources for the Hub containers                                                                           | `{}`                   |
-| `hub.containerSecurityContext.enabled`      | Enabled Hub containers' Security Context                                                                                 | `true`                 |
-| `hub.containerSecurityContext.runAsUser`    | Set Hub container's Security Context runAsUser                                                                           | `1000`                 |
-| `hub.containerSecurityContext.runAsNonRoot` | Set Hub container's Security Context runAsNonRoot                                                                        | `true`                 |
-| `hub.podSecurityContext.enabled`            | Enabled Hub pods' Security Context                                                                                       | `true`                 |
-| `hub.podSecurityContext.fsGroup`            | Set Hub pod's Security Context fsGroup                                                                                   | `1001`                 |
-| `hub.lifecycleHooks`                        | LifecycleHooks for the Hub container to automate configuration before or after startup                                   | `{}`                   |
-| `hub.hostAliases`                           | Add deployment host aliases                                                                                              | `[]`                   |
-| `hub.podLabels`                             | Add extra labels to the Hub pods                                                                                         | `{}`                   |
-| `hub.podAnnotations`                        | Add extra annotations to the Hub pods                                                                                    | `{}`                   |
-| `hub.podAffinityPreset`                     | Pod affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                   |
-| `hub.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                             | `soft`                 |
-| `hub.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                            | `""`                   |
-| `hub.nodeAffinityPreset.key`                | Node label key to match. Ignored if `hub.affinity` is set                                                                | `""`                   |
-| `hub.nodeAffinityPreset.values`             | Node label values to match. Ignored if `hub.affinity` is set                                                             | `[]`                   |
-| `hub.affinity`                              | Affinity for pod assignment.                                                                                             | `{}`                   |
-| `hub.nodeSelector`                          | Node labels for pod assignment.                                                                                          | `{}`                   |
-| `hub.tolerations`                           | Tolerations for pod assignment.                                                                                          | `[]`                   |
-| `hub.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                   |
-| `hub.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                   |
-| `hub.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                   |
-| `hub.terminationGracePeriodSeconds`         | Seconds Hub pod needs to terminate gracefully                                                                            | `""`                   |
-| `hub.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                           | `RollingUpdate`        |
-| `hub.updateStrategy.rollingUpdate`          | Hub deployment rolling update configuration parameters                                                                   | `{}`                   |
-| `hub.extraVolumes`                          | Optionally specify extra list of additional volumes for Hub pods                                                         | `[]`                   |
-| `hub.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for Hub container(s)                                            | `[]`                   |
-| `hub.initContainers`                        | Add additional init containers to the Hub pods                                                                           | `[]`                   |
-| `hub.sidecars`                              | Add additional sidecar containers to the Hub pod                                                                         | `[]`                   |
-| `hub.pdb.create`                            | Deploy Hub PodDisruptionBudget                                                                                           | `false`                |
-| `hub.pdb.minAvailable`                      | Set minimum available hub instances                                                                                      | `""`                   |
-| `hub.pdb.maxUnavailable`                    | Set maximum available hub instances                                                                                      | `""`                   |
+| Name                                        | Description                                                                                                              | Value                |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------- |
+| `hub.image.registry`                        | Hub image registry                                                                                                       | `docker.io`          |
+| `hub.image.repository`                      | Hub image repository                                                                                                     | `bitnami/jupyterhub` |
+| `hub.image.tag`                             | Hub image tag (immutable tags are recommended)                                                                           | `1.5.0-debian-11-r0` |
+| `hub.image.pullPolicy`                      | Hub image pull policy                                                                                                    | `IfNotPresent`       |
+| `hub.image.pullSecrets`                     | Hub image pull secrets                                                                                                   | `[]`                 |
+| `hub.baseUrl`                               | Hub base URL                                                                                                             | `/`                  |
+| `hub.adminUser`                             | Hub Dummy authenticator admin user                                                                                       | `user`               |
+| `hub.password`                              | Hub Dummy authenticator password                                                                                         | `""`                 |
+| `hub.configuration`                         | Hub configuration file (to be used by jupyterhub_config.py)                                                              | `""`                 |
+| `hub.existingConfigmap`                     | Configmap with Hub init scripts (replaces the scripts in templates/hub/configmap.yml)                                    | `""`                 |
+| `hub.existingSecret`                        | Secret with hub configuration (replaces the hub.configuration value) and proxy token                                     | `""`                 |
+| `hub.command`                               | Override Hub default command                                                                                             | `[]`                 |
+| `hub.args`                                  | Override Hub default args                                                                                                | `[]`                 |
+| `hub.extraEnvVars`                          | Add extra environment variables to the Hub container                                                                     | `[]`                 |
+| `hub.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                                                     | `""`                 |
+| `hub.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                                                        | `""`                 |
+| `hub.containerPorts.http`                   | Hub container port                                                                                                       | `8081`               |
+| `hub.startupProbe.enabled`                  | Enable startupProbe on Hub containers                                                                                    | `true`               |
+| `hub.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `10`                 |
+| `hub.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `10`                 |
+| `hub.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `3`                  |
+| `hub.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `30`                 |
+| `hub.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                  |
+| `hub.livenessProbe.enabled`                 | Enable livenessProbe on Hub containers                                                                                   | `true`               |
+| `hub.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `10`                 |
+| `hub.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `10`                 |
+| `hub.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `3`                  |
+| `hub.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `30`                 |
+| `hub.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                  |
+| `hub.readinessProbe.enabled`                | Enable readinessProbe on Hub containers                                                                                  | `true`               |
+| `hub.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `10`                 |
+| `hub.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                 |
+| `hub.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `3`                  |
+| `hub.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `30`                 |
+| `hub.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                  |
+| `hub.customStartupProbe`                    | Override default startup probe                                                                                           | `{}`                 |
+| `hub.customLivenessProbe`                   | Override default liveness probe                                                                                          | `{}`                 |
+| `hub.customReadinessProbe`                  | Override default readiness probe                                                                                         | `{}`                 |
+| `hub.resources.limits`                      | The resources limits for the Hub containers                                                                              | `{}`                 |
+| `hub.resources.requests`                    | The requested resources for the Hub containers                                                                           | `{}`                 |
+| `hub.containerSecurityContext.enabled`      | Enabled Hub containers' Security Context                                                                                 | `true`               |
+| `hub.containerSecurityContext.runAsUser`    | Set Hub container's Security Context runAsUser                                                                           | `1000`               |
+| `hub.containerSecurityContext.runAsNonRoot` | Set Hub container's Security Context runAsNonRoot                                                                        | `true`               |
+| `hub.podSecurityContext.enabled`            | Enabled Hub pods' Security Context                                                                                       | `true`               |
+| `hub.podSecurityContext.fsGroup`            | Set Hub pod's Security Context fsGroup                                                                                   | `1001`               |
+| `hub.lifecycleHooks`                        | LifecycleHooks for the Hub container to automate configuration before or after startup                                   | `{}`                 |
+| `hub.hostAliases`                           | Add deployment host aliases                                                                                              | `[]`                 |
+| `hub.podLabels`                             | Add extra labels to the Hub pods                                                                                         | `{}`                 |
+| `hub.podAnnotations`                        | Add extra annotations to the Hub pods                                                                                    | `{}`                 |
+| `hub.podAffinityPreset`                     | Pod affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                 |
+| `hub.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                             | `soft`               |
+| `hub.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                            | `""`                 |
+| `hub.nodeAffinityPreset.key`                | Node label key to match. Ignored if `hub.affinity` is set                                                                | `""`                 |
+| `hub.nodeAffinityPreset.values`             | Node label values to match. Ignored if `hub.affinity` is set                                                             | `[]`                 |
+| `hub.affinity`                              | Affinity for pod assignment.                                                                                             | `{}`                 |
+| `hub.nodeSelector`                          | Node labels for pod assignment.                                                                                          | `{}`                 |
+| `hub.tolerations`                           | Tolerations for pod assignment.                                                                                          | `[]`                 |
+| `hub.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                 |
+| `hub.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                 |
+| `hub.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                 |
+| `hub.terminationGracePeriodSeconds`         | Seconds Hub pod needs to terminate gracefully                                                                            | `""`                 |
+| `hub.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                           | `RollingUpdate`      |
+| `hub.updateStrategy.rollingUpdate`          | Hub deployment rolling update configuration parameters                                                                   | `{}`                 |
+| `hub.extraVolumes`                          | Optionally specify extra list of additional volumes for Hub pods                                                         | `[]`                 |
+| `hub.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for Hub container(s)                                            | `[]`                 |
+| `hub.initContainers`                        | Add additional init containers to the Hub pods                                                                           | `[]`                 |
+| `hub.sidecars`                              | Add additional sidecar containers to the Hub pod                                                                         | `[]`                 |
+| `hub.pdb.create`                            | Deploy Hub PodDisruptionBudget                                                                                           | `false`              |
+| `hub.pdb.minAvailable`                      | Set minimum available hub instances                                                                                      | `""`                 |
+| `hub.pdb.maxUnavailable`                    | Set maximum available hub instances                                                                                      | `""`                 |
 
 
 ### Hub RBAC parameters
@@ -214,7 +214,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
 | `proxy.image.registry`                        | Proxy image registry                                                                                                     | `docker.io`                       |
 | `proxy.image.repository`                      | Proxy image repository                                                                                                   | `bitnami/configurable-http-proxy` |
-| `proxy.image.tag`                             | Proxy image tag (immutable tags are recommended)                                                                         | `4.5.1-debian-10-r81`             |
+| `proxy.image.tag`                             | Proxy image tag (immutable tags are recommended)                                                                         | `4.5.1-debian-11-r0`              |
 | `proxy.image.pullPolicy`                      | Proxy image pull policy                                                                                                  | `IfNotPresent`                    |
 | `proxy.image.pullSecrets`                     | Proxy image pull secrets                                                                                                 | `[]`                              |
 | `proxy.image.debug`                           | Activate verbose output                                                                                                  | `false`                           |
@@ -267,7 +267,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `proxy.affinity`                              | Affinity for pod assignment. Evaluated as a template.                                                                    | `{}`                              |
 | `proxy.nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                                                 | `{}`                              |
 | `proxy.tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                                                 | `[]`                              |
-| `proxy.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                              |
+| `proxy.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                              |
 | `proxy.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                              |
 | `proxy.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                              |
 | `proxy.terminationGracePeriodSeconds`         | Seconds Proxy pod needs to terminate gracefully                                                                          | `""`                              |
@@ -388,7 +388,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `imagePuller.affinity`                              | Affinity for pod assignment. Evaluated as a template.                                                                    | `{}`            |
 | `imagePuller.nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                                                 | `{}`            |
 | `imagePuller.tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                                                 | `[]`            |
-| `imagePuller.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`            |
+| `imagePuller.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`            |
 | `imagePuller.priorityClassName`                     | Priority Class Name                                                                                                      | `""`            |
 | `imagePuller.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`            |
 | `imagePuller.terminationGracePeriodSeconds`         | Seconds ImagePuller pod needs to terminate gracefully                                                                    | `""`            |
@@ -406,7 +406,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------ |
 | `singleuser.image.registry`                     | Single User image registry                                                                          | `docker.io`                          |
 | `singleuser.image.repository`                   | Single User image repository                                                                        | `bitnami/jupyter-base-notebook`      |
-| `singleuser.image.tag`                          | Single User image tag (immutabe tags are recommended)                                               | `1.5.0-debian-10-r177`               |
+| `singleuser.image.tag`                          | Single User image tag (immutabe tags are recommended)                                               | `1.5.0-debian-11-r0`                 |
 | `singleuser.image.pullPolicy`                   | Single User image pull policy                                                                       | `IfNotPresent`                       |
 | `singleuser.image.pullSecrets`                  | Single User image pull secrets                                                                      | `[]`                                 |
 | `singleuser.notebookDir`                        | Notebook directory (it will be the same as the PVC volume mount)                                    | `/opt/bitnami/jupyterhub-singleuser` |
@@ -468,7 +468,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ---------------------------- | --------------------------------------------------- | ----------------------- |
 | `auxiliaryImage.registry`    | Auxiliary image registry                            | `docker.io`             |
 | `auxiliaryImage.repository`  | Auxiliary image repository                          | `bitnami/bitnami-shell` |
-| `auxiliaryImage.tag`         | Auxiliary image tag (immutabe tags are recommended) | `10-debian-10-r426`     |
+| `auxiliaryImage.tag`         | Auxiliary image tag (immutabe tags are recommended) | `11-debian-11-r0`       |
 | `auxiliaryImage.pullPolicy`  | Auxiliary image pull policy                         | `IfNotPresent`          |
 | `auxiliaryImage.pullSecrets` | Auxiliary image pull secrets                        | `[]`                    |
 

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -403,7 +403,7 @@ hub:
   ## @param hub.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
   ## @param hub.priorityClassName Priority Class Name
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##
@@ -817,7 +817,7 @@ proxy:
   ## @param proxy.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
   ## @param proxy.priorityClassName Priority Class Name
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##
@@ -1319,7 +1319,7 @@ imagePuller:
   ## @param imagePuller.topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
   ##
-  topologySpreadConstraints: {}
+  topologySpreadConstraints: []
   ## @param imagePuller.priorityClassName Priority Class Name
   ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   ##


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

