### PR TITLE
[bitnami/keycloak] Fix topologySpreadConstraints default values

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 9.2.3
+version: 9.2.4

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -84,7 +84,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | -------------------------------- | --------------------------------------------------------------------------------------------- | --------------------- |
 | `image.registry`                 | Keycloak image registry                                                                       | `docker.io`           |
 | `image.repository`               | Keycloak image repository                                                                     | `bitnami/keycloak`    |
-| `image.tag`                      | Keycloak image tag (immutable tags are recommended)                                           | `18.0.0-debian-10-r6` |
+| `image.tag`                      | Keycloak image tag (immutable tags are recommended)                                           | `18.0.0-debian-11-r0` |
 | `image.pullPolicy`               | Keycloak image pull policy                                                                    | `IfNotPresent`        |
 | `image.pullSecrets`              | Specify docker-registry secret names as an array                                              | `[]`                  |
 | `image.debug`                    | Specify if debug logs should be enabled                                                       | `false`               |
@@ -167,7 +167,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `affinity`                              | Affinity for pod assignment                                                                                              | `{}`            |
 | `nodeSelector`                          | Node labels for pod assignment                                                                                           | `{}`            |
 | `tolerations`                           | Tolerations for pod assignment                                                                                           | `[]`            |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`            |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`            |
 | `podManagementPolicy`                   | Pod management policy for the Keycloak statefulset                                                                       | `Parallel`      |
 | `priorityClassName`                     | Keycloak pods' Priority Class Name                                                                                       | `""`            |
 | `schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`            |
@@ -268,7 +268,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `keycloakConfigCli.enabled`                               | Whether to enable keycloak-config-cli job                                                       | `false`                       |
 | `keycloakConfigCli.image.registry`                        | keycloak-config-cli container image registry                                                    | `docker.io`                   |
 | `keycloakConfigCli.image.repository`                      | keycloak-config-cli container image repository                                                  | `bitnami/keycloak-config-cli` |
-| `keycloakConfigCli.image.tag`                             | keycloak-config-cli container image tag                                                         | `5.2.0-debian-10-r15`         |
+| `keycloakConfigCli.image.tag`                             | keycloak-config-cli container image tag                                                         | `5.2.0-debian-11-r0`          |
 | `keycloakConfigCli.image.pullPolicy`                      | keycloak-config-cli container image pull policy                                                 | `IfNotPresent`                |
 | `keycloakConfigCli.image.pullSecrets`                     | keycloak-config-cli container image pull secrets                                                | `[]`                          |
 | `keycloakConfigCli.annotations`                           | Annotations for keycloak-config-cli job                                                         | `{}`                          |

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -409,7 +409,7 @@ tolerations: []
 ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 ##
-topologySpreadConstraints: {}
+topologySpreadConstraints: []
 ## @param podManagementPolicy Pod management policy for the Keycloak statefulset
 ##
 podManagementPolicy: Parallel


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

