### PR TITLE
[bitnami/kong] Fix topologySpreadConstraints default values

### DIFF
--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -34,4 +34,4 @@ name: kong
 sources:
   - https://github.com/bitnami/bitnami-docker-kong
   - https://konghq.com/
-version: 6.3.5
+version: 6.3.6

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -79,15 +79,15 @@ To uninstall/delete the `my-release` deployment:
 
 ### Kong common parameters
 
-| Name                | Description                                                                     | Value                 |
-| ------------------- | ------------------------------------------------------------------------------- | --------------------- |
-| `image.registry`    | kong image registry                                                             | `docker.io`           |
-| `image.repository`  | kong image repository                                                           | `bitnami/kong`        |
-| `image.tag`         | kong image tag (immutable tags are recommended)                                 | `2.8.1-debian-10-r48` |
-| `image.pullPolicy`  | kong image pull policy                                                          | `IfNotPresent`        |
-| `image.pullSecrets` | Specify docker-registry secret names as an array                                | `[]`                  |
-| `image.debug`       | Enable image debug mode                                                         | `false`               |
-| `database`          | Select which database backend Kong will use. Can be 'postgresql' or 'cassandra' | `postgresql`          |
+| Name                | Description                                                                     | Value                |
+| ------------------- | ------------------------------------------------------------------------------- | -------------------- |
+| `image.registry`    | kong image registry                                                             | `docker.io`          |
+| `image.repository`  | kong image repository                                                           | `bitnami/kong`       |
+| `image.tag`         | kong image tag (immutable tags are recommended)                                 | `2.8.1-debian-11-r0` |
+| `image.pullPolicy`  | kong image pull policy                                                          | `IfNotPresent`       |
+| `image.pullSecrets` | Specify docker-registry secret names as an array                                | `[]`                 |
+| `image.debug`       | Enable image debug mode                                                         | `false`              |
+| `database`          | Select which database backend Kong will use. Can be 'postgresql' or 'cassandra' | `postgresql`         |
 
 
 ### Kong deployment / daemonset parameters
@@ -104,7 +104,7 @@ To uninstall/delete the `my-release` deployment:
 | `updateStrategy.type`                   | Kong update strategy                                                                                                               | `RollingUpdate` |
 | `updateStrategy.rollingUpdate`          | Kong deployment rolling update configuration parameters                                                                            | `{}`            |
 | `hostAliases`                           | Add deployment host aliases                                                                                                        | `[]`            |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template           | `{}`            |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template           | `[]`            |
 | `priorityClassName`                     | Priority Class Name                                                                                                                | `""`            |
 | `schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                          | `""`            |
 | `terminationGracePeriodSeconds`         | Seconds Kong pod needs to terminate gracefully                                                                                     | `""`            |
@@ -218,7 +218,7 @@ To uninstall/delete the `my-release` deployment:
 | `ingressController.enabled`                                     | Enable/disable the Kong Ingress Controller                                                                                                    | `true`                            |
 | `ingressController.image.registry`                              | Kong Ingress Controller image registry                                                                                                        | `docker.io`                       |
 | `ingressController.image.repository`                            | Kong Ingress Controller image name                                                                                                            | `bitnami/kong-ingress-controller` |
-| `ingressController.image.tag`                                   | Kong Ingress Controller image tag                                                                                                             | `2.3.1-debian-10-r45`             |
+| `ingressController.image.tag`                                   | Kong Ingress Controller image tag                                                                                                             | `2.3.1-debian-11-r0`              |
 | `ingressController.image.pullPolicy`                            | Kong Ingress Controller image pull policy                                                                                                     | `IfNotPresent`                    |
 | `ingressController.image.pullSecrets`                           | Specify docker-registry secret names as an array                                                                                              | `[]`                              |
 | `ingressController.proxyReadyTimeout`                           | Maximum time (in seconds) to wait for the Kong container to be ready                                                                          | `300`                             |
@@ -282,26 +282,26 @@ To uninstall/delete the `my-release` deployment:
 
 ### PostgreSQL Parameters
 
-| Name                                            | Description                                                             | Value                   |
-| ----------------------------------------------- | ----------------------------------------------------------------------- | ----------------------- |
-| `postgresql.enabled`                            | Switch to enable or disable the PostgreSQL helm chart                   | `true`                  |
-| `postgresql.auth.postgresPassword`              | Password for the "postgres" admin user                                  | `""`                    |
-| `postgresql.auth.username`                      | Name for a custom user to create                                        | `kong`                  |
-| `postgresql.auth.password`                      | Password for the custom user to create                                  | `""`                    |
-| `postgresql.auth.database`                      | Name for a custom database to create                                    | `kong`                  |
-| `postgresql.auth.existingSecret`                | Name of existing secret to use for PostgreSQL credentials               | `""`                    |
-| `postgresql.auth.usePasswordFiles`              | Mount credentials as a files instead of using an environment variable   | `false`                 |
-| `postgresql.architecture`                       | PostgreSQL architecture (`standalone` or `replication`)                 | `standalone`            |
-| `postgresql.image.registry`                     | PostgreSQL image registry                                               | `docker.io`             |
-| `postgresql.image.repository`                   | PostgreSQL image repository                                             | `bitnami/postgresql`    |
-| `postgresql.image.tag`                          | PostgreSQL image tag (immutable tags are recommended)                   | `11.16.0-debian-10-r12` |
-| `postgresql.external.host`                      | Database host                                                           | `""`                    |
-| `postgresql.external.port`                      | Database port number                                                    | `5432`                  |
-| `postgresql.external.user`                      | Non-root username for Kong                                              | `kong`                  |
-| `postgresql.external.password`                  | Password for the non-root username for Kong                             | `""`                    |
-| `postgresql.external.database`                  | Kong database name                                                      | `kong`                  |
-| `postgresql.external.existingSecret`            | Name of an existing secret resource containing the database credentials | `""`                    |
-| `postgresql.external.existingSecretPasswordKey` | Name of an existing secret key containing the database credentials      | `""`                    |
+| Name                                            | Description                                                             | Value                  |
+| ----------------------------------------------- | ----------------------------------------------------------------------- | ---------------------- |
+| `postgresql.enabled`                            | Switch to enable or disable the PostgreSQL helm chart                   | `true`                 |
+| `postgresql.auth.postgresPassword`              | Password for the "postgres" admin user                                  | `""`                   |
+| `postgresql.auth.username`                      | Name for a custom user to create                                        | `kong`                 |
+| `postgresql.auth.password`                      | Password for the custom user to create                                  | `""`                   |
+| `postgresql.auth.database`                      | Name for a custom database to create                                    | `kong`                 |
+| `postgresql.auth.existingSecret`                | Name of existing secret to use for PostgreSQL credentials               | `""`                   |
+| `postgresql.auth.usePasswordFiles`              | Mount credentials as a files instead of using an environment variable   | `false`                |
+| `postgresql.architecture`                       | PostgreSQL architecture (`standalone` or `replication`)                 | `standalone`           |
+| `postgresql.image.registry`                     | PostgreSQL image registry                                               | `docker.io`            |
+| `postgresql.image.repository`                   | PostgreSQL image repository                                             | `bitnami/postgresql`   |
+| `postgresql.image.tag`                          | PostgreSQL image tag (immutable tags are recommended)                   | `11.16.0-debian-11-r0` |
+| `postgresql.external.host`                      | Database host                                                           | `""`                   |
+| `postgresql.external.port`                      | Database port number                                                    | `5432`                 |
+| `postgresql.external.user`                      | Non-root username for Kong                                              | `kong`                 |
+| `postgresql.external.password`                  | Password for the non-root username for Kong                             | `""`                   |
+| `postgresql.external.database`                  | Kong database name                                                      | `kong`                 |
+| `postgresql.external.existingSecret`            | Name of an existing secret resource containing the database credentials | `""`                   |
+| `postgresql.external.existingSecretPasswordKey` | Name of an existing secret key containing the database credentials      | `""`                   |
 
 
 ### Cassandra Parameters

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -138,7 +138,7 @@ hostAliases: []
 ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 ##
-topologySpreadConstraints: {}
+topologySpreadConstraints: []
 ## @param priorityClassName Priority Class Name
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
 ##


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

