### PR TITLE
[bitnami/odoo] Fix topologySpreadConstraints default values

### DIFF
--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -27,4 +27,4 @@ name: odoo
 sources:
   - https://github.com/bitnami/bitnami-docker-odoo
   - https://www.odoo.com/
-version: 21.4.3
+version: 21.4.4

--- a/bitnami/odoo/README.md
+++ b/bitnami/odoo/README.md
@@ -68,24 +68,24 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                     | Description                                                                             | Value                         |
-| ------------------------ | --------------------------------------------------------------------------------------- | ----------------------------- |
-| `kubeVersion`            | Override Kubernetes version                                                             | `""`                          |
-| `nameOverride`           | String to partially override common.names.fullname                                      | `""`                          |
-| `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`                          |
-| `commonLabels`           | Labels to add to all deployed objects                                                   | `{}`                          |
-| `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`                          |
-| `clusterDomain`          | Default Kubernetes cluster domain                                                       | `cluster.local`               |
-| `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`                          |
-| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`                       |
-| `diagnosticMode.command` | Command to override all containers in the the statefulset                               | `["sleep"]`                   |
-| `diagnosticMode.args`    | Args to override all containers in the the statefulset                                  | `["infinity"]`                |
-| `image.registry`         | Odoo image registry                                                                     | `docker.io`                   |
-| `image.repository`       | Odoo image repository                                                                   | `bitnami/odoo`                |
-| `image.tag`              | Odoo image tag (immutable tags are recommended)                                         | `15.0.20220510-debian-10-r12` |
-| `image.pullPolicy`       | Odoo image pull policy                                                                  | `IfNotPresent`                |
-| `image.pullSecrets`      | Odoo image pull secrets                                                                 | `[]`                          |
-| `image.debug`            | Enable image debug mode                                                                 | `false`                       |
+| Name                     | Description                                                                             | Value                        |
+| ------------------------ | --------------------------------------------------------------------------------------- | ---------------------------- |
+| `kubeVersion`            | Override Kubernetes version                                                             | `""`                         |
+| `nameOverride`           | String to partially override common.names.fullname                                      | `""`                         |
+| `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`                         |
+| `commonLabels`           | Labels to add to all deployed objects                                                   | `{}`                         |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`                         |
+| `clusterDomain`          | Default Kubernetes cluster domain                                                       | `cluster.local`              |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`                         |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`                      |
+| `diagnosticMode.command` | Command to override all containers in the the statefulset                               | `["sleep"]`                  |
+| `diagnosticMode.args`    | Args to override all containers in the the statefulset                                  | `["infinity"]`               |
+| `image.registry`         | Odoo image registry                                                                     | `docker.io`                  |
+| `image.repository`       | Odoo image repository                                                                   | `bitnami/odoo`               |
+| `image.tag`              | Odoo image tag (immutable tags are recommended)                                         | `15.0.20220510-debian-11-r0` |
+| `image.pullPolicy`       | Odoo image pull policy                                                                  | `IfNotPresent`               |
+| `image.pullSecrets`      | Odoo image pull secrets                                                                 | `[]`                         |
+| `image.debug`            | Enable image debug mode                                                                 | `false`                      |
 
 
 ### Odoo Configuration parameters
@@ -160,7 +160,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `affinity`                           | Affinity for pod assignment                                                                                              | `{}`            |
 | `nodeSelector`                       | Node labels for pod assignment                                                                                           | `{}`            |
 | `tolerations`                        | Tolerations for pod assignment                                                                                           | `[]`            |
-| `topologySpreadConstraints`          | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`            |
+| `topologySpreadConstraints`          | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`            |
 | `priorityClassName`                  | Odoo pods' Priority Class Name                                                                                           | `""`            |
 | `schedulerName`                      | Use an alternate scheduler, e.g. "stork".                                                                                | `""`            |
 | `terminationGracePeriodSeconds`      | Seconds Odoo pod needs to terminate gracefully                                                                           | `""`            |

--- a/bitnami/odoo/values.yaml
+++ b/bitnami/odoo/values.yaml
@@ -318,7 +318,7 @@ tolerations: []
 ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 ##
-topologySpreadConstraints: {}
+topologySpreadConstraints: []
 ## @param priorityClassName Odoo pods' Priority Class Name
 ## ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 ##


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

