### PR TITLE
[bitnami/pytorch] Fix topologySpreadConstraints default values

### DIFF
--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -24,4 +24,4 @@ name: pytorch
 sources:
   - https://github.com/bitnami/bitnami-docker-pytorch
   - https://pytorch.org/
-version: 2.4.8
+version: 2.4.9

--- a/bitnami/pytorch/README.md
+++ b/bitnami/pytorch/README.md
@@ -81,80 +81,80 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### PyTorch parameters
 
-| Name                                              | Description                                                                                                              | Value                  |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
-| `image.registry`                                  | PyTorch image registry                                                                                                   | `docker.io`            |
-| `image.repository`                                | PyTorch image repository                                                                                                 | `bitnami/pytorch`      |
-| `image.tag`                                       | PyTorch image tag (immutable tags are recommended)                                                                       | `1.11.0-debian-10-r24` |
-| `image.pullPolicy`                                | Image pull policy                                                                                                        | `IfNotPresent`         |
-| `image.pullSecrets`                               | Specify docker-registry secret names as an array                                                                         | `[]`                   |
-| `worldSize`                                       | Number of nodes that will run the code                                                                                   | `1`                    |
-| `containerPorts.pytorch`                          | PyTorch master port. `MASTER_PORT` will be set to this value                                                             | `49875`                |
-| `livenessProbe.enabled`                           | Enable livenessProbe                                                                                                     | `true`                 |
-| `livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                                  | `5`                    |
-| `livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                                         | `5`                    |
-| `livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                                                        | `5`                    |
-| `livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                                                      | `5`                    |
-| `livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                                                      | `1`                    |
-| `readinessProbe.enabled`                          | Enable readinessProbe                                                                                                    | `true`                 |
-| `readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                                                 | `5`                    |
-| `readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                                                        | `5`                    |
-| `readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                                                       | `3`                    |
-| `readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                                                     | `5`                    |
-| `readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                                                     | `1`                    |
-| `startupProbe.enabled`                            | Enable startupProbe                                                                                                      | `true`                 |
-| `startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                                                   | `5`                    |
-| `startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                                                          | `5`                    |
-| `startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                                                         | `3`                    |
-| `startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                                                       | `5`                    |
-| `startupProbe.successThreshold`                   | Success threshold for startupProbe                                                                                       | `1`                    |
-| `customLivenessProbe`                             | Custom livenessProbe that overrides the default one                                                                      | `{}`                   |
-| `customReadinessProbe`                            | Custom readinessProbe that overrides the default one                                                                     | `{}`                   |
-| `customStartupProbe`                              | Custom startupProbe that overrides the default one                                                                       | `{}`                   |
-| `podSecurityContext.enabled`                      | Enabled Pytorch pods' Security Context                                                                                   | `true`                 |
-| `podSecurityContext.fsGroup`                      | Set Pytorch pods' Security Context fsGroup                                                                               | `1001`                 |
-| `podSecurityContext.runAsUser`                    | Set Pytorch pods' Security Context runAsUser                                                                             | `1001`                 |
-| `containerSecurityContext.enabled`                | Enabled Pytorch containers' Security Context                                                                             | `true`                 |
-| `containerSecurityContext.runAsUser`              | Set Pytorch containers' Security Context runAsUser                                                                       | `1001`                 |
-| `containerSecurityContext.runAsNonRoot`           | Set Pytorch containers' Security Context runAsNonRoot                                                                    | `true`                 |
-| `containerSecurityContext.readOnlyRootFilesystem` | Set Pytorch containers' Security Context runAsNonRoot                                                                    | `false`                |
-| `resources.limits`                                | The resources limits for the Pytorch containers                                                                          | `{}`                   |
-| `resources.requests`                              | The requested resources for the Pytorch containers                                                                       | `{}`                   |
-| `entrypoint.file`                                 | Main entrypoint to your application                                                                                      | `""`                   |
-| `entrypoint.args`                                 | Args required by your entrypoint                                                                                         | `[]`                   |
-| `architecture`                                    | Run PyTorch in standalone or distributed mode. Possible values: `standalone`, `distributed`                              | `standalone`           |
-| `hostAliases`                                     | Deployment pod host aliases                                                                                              | `[]`                   |
-| `command`                                         | Override default container command (useful when using custom images)                                                     | `[]`                   |
-| `args`                                            | Override default container args (useful when using custom images)                                                        | `[]`                   |
-| `podLabels`                                       | Extra labels for Pytorch pods                                                                                            | `{}`                   |
-| `podAnnotations`                                  | Annotations for Pytorch pods                                                                                             | `{}`                   |
-| `existingConfigmap`                               | Config map that contains the files you want to load in PyTorch                                                           | `""`                   |
-| `cloneFilesFromGit.enabled`                       | Enable in order to download files from git repository                                                                    | `false`                |
-| `cloneFilesFromGit.repository`                    | Repository that holds the files                                                                                          | `""`                   |
-| `cloneFilesFromGit.revision`                      | Revision from the repository to checkout                                                                                 | `""`                   |
-| `cloneFilesFromGit.extraVolumeMounts`             | Add extra volume mounts for the Git container                                                                            | `[]`                   |
-| `podAffinityPreset`                               | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                   |
-| `podAntiAffinityPreset`                           | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                 |
-| `nodeAffinityPreset.type`                         | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                   |
-| `nodeAffinityPreset.key`                          | Node label key to match Ignored if `affinity` is set.                                                                    | `""`                   |
-| `nodeAffinityPreset.values`                       | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                   |
-| `affinity`                                        | Affinity for pod assignment. Evaluated as a template.                                                                    | `{}`                   |
-| `nodeSelector`                                    | Node labels for pod assignment. Evaluated as a template.                                                                 | `{}`                   |
-| `tolerations`                                     | Tolerations for pod assignment. Evaluated as a template.                                                                 | `[]`                   |
-| `updateStrategy.type`                             | Pytorch statefulset strategy type                                                                                        | `RollingUpdate`        |
-| `podManagementPolicy`                             | Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join                       | `OrderedReady`         |
-| `priorityClassName`                               | Pytorch pods' priorityClassName                                                                                          | `""`                   |
-| `topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                   |
-| `schedulerName`                                   | Name of the k8s scheduler (other than default) for Pytorch pods                                                          | `""`                   |
-| `terminationGracePeriodSeconds`                   | Seconds Redmine pod needs to terminate gracefully                                                                        | `""`                   |
-| `lifecycleHooks`                                  | for the Pytorch container(s) to automate configuration before or after startup                                           | `{}`                   |
-| `extraEnvVars`                                    | Array with extra environment variables to add to Pytorch nodes                                                           | `[]`                   |
-| `extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars for Pytorch nodes                                                   | `""`                   |
-| `extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars for Pytorch nodes                                                      | `""`                   |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the Pytorch pod(s)                                               | `[]`                   |
-| `extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the Pytorch container(s)                                    | `[]`                   |
-| `sidecars`                                        | Add additional sidecar containers to the Pytorch pod(s)                                                                  | `{}`                   |
-| `initContainers`                                  | Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)                                                     | `{}`                   |
+| Name                                              | Description                                                                                                              | Value                 |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------- |
+| `image.registry`                                  | PyTorch image registry                                                                                                   | `docker.io`           |
+| `image.repository`                                | PyTorch image repository                                                                                                 | `bitnami/pytorch`     |
+| `image.tag`                                       | PyTorch image tag (immutable tags are recommended)                                                                       | `1.11.0-debian-11-r0` |
+| `image.pullPolicy`                                | Image pull policy                                                                                                        | `IfNotPresent`        |
+| `image.pullSecrets`                               | Specify docker-registry secret names as an array                                                                         | `[]`                  |
+| `worldSize`                                       | Number of nodes that will run the code                                                                                   | `1`                   |
+| `containerPorts.pytorch`                          | PyTorch master port. `MASTER_PORT` will be set to this value                                                             | `49875`               |
+| `livenessProbe.enabled`                           | Enable livenessProbe                                                                                                     | `true`                |
+| `livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                                  | `5`                   |
+| `livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                                         | `5`                   |
+| `livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                                                        | `5`                   |
+| `livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                                                      | `5`                   |
+| `livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                                                      | `1`                   |
+| `readinessProbe.enabled`                          | Enable readinessProbe                                                                                                    | `true`                |
+| `readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                                                 | `5`                   |
+| `readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                                                        | `5`                   |
+| `readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                                                       | `3`                   |
+| `readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                                                     | `5`                   |
+| `readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                                                     | `1`                   |
+| `startupProbe.enabled`                            | Enable startupProbe                                                                                                      | `true`                |
+| `startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                                                   | `5`                   |
+| `startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                                                          | `5`                   |
+| `startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                                                         | `3`                   |
+| `startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                                                       | `5`                   |
+| `startupProbe.successThreshold`                   | Success threshold for startupProbe                                                                                       | `1`                   |
+| `customLivenessProbe`                             | Custom livenessProbe that overrides the default one                                                                      | `{}`                  |
+| `customReadinessProbe`                            | Custom readinessProbe that overrides the default one                                                                     | `{}`                  |
+| `customStartupProbe`                              | Custom startupProbe that overrides the default one                                                                       | `{}`                  |
+| `podSecurityContext.enabled`                      | Enabled Pytorch pods' Security Context                                                                                   | `true`                |
+| `podSecurityContext.fsGroup`                      | Set Pytorch pods' Security Context fsGroup                                                                               | `1001`                |
+| `podSecurityContext.runAsUser`                    | Set Pytorch pods' Security Context runAsUser                                                                             | `1001`                |
+| `containerSecurityContext.enabled`                | Enabled Pytorch containers' Security Context                                                                             | `true`                |
+| `containerSecurityContext.runAsUser`              | Set Pytorch containers' Security Context runAsUser                                                                       | `1001`                |
+| `containerSecurityContext.runAsNonRoot`           | Set Pytorch containers' Security Context runAsNonRoot                                                                    | `true`                |
+| `containerSecurityContext.readOnlyRootFilesystem` | Set Pytorch containers' Security Context runAsNonRoot                                                                    | `false`               |
+| `resources.limits`                                | The resources limits for the Pytorch containers                                                                          | `{}`                  |
+| `resources.requests`                              | The requested resources for the Pytorch containers                                                                       | `{}`                  |
+| `entrypoint.file`                                 | Main entrypoint to your application                                                                                      | `""`                  |
+| `entrypoint.args`                                 | Args required by your entrypoint                                                                                         | `[]`                  |
+| `architecture`                                    | Run PyTorch in standalone or distributed mode. Possible values: `standalone`, `distributed`                              | `standalone`          |
+| `hostAliases`                                     | Deployment pod host aliases                                                                                              | `[]`                  |
+| `command`                                         | Override default container command (useful when using custom images)                                                     | `[]`                  |
+| `args`                                            | Override default container args (useful when using custom images)                                                        | `[]`                  |
+| `podLabels`                                       | Extra labels for Pytorch pods                                                                                            | `{}`                  |
+| `podAnnotations`                                  | Annotations for Pytorch pods                                                                                             | `{}`                  |
+| `existingConfigmap`                               | Config map that contains the files you want to load in PyTorch                                                           | `""`                  |
+| `cloneFilesFromGit.enabled`                       | Enable in order to download files from git repository                                                                    | `false`               |
+| `cloneFilesFromGit.repository`                    | Repository that holds the files                                                                                          | `""`                  |
+| `cloneFilesFromGit.revision`                      | Revision from the repository to checkout                                                                                 | `""`                  |
+| `cloneFilesFromGit.extraVolumeMounts`             | Add extra volume mounts for the Git container                                                                            | `[]`                  |
+| `podAffinityPreset`                               | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                  |
+| `podAntiAffinityPreset`                           | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                |
+| `nodeAffinityPreset.type`                         | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                  |
+| `nodeAffinityPreset.key`                          | Node label key to match Ignored if `affinity` is set.                                                                    | `""`                  |
+| `nodeAffinityPreset.values`                       | Node label values to match. Ignored if `affinity` is set.                                                                | `[]`                  |
+| `affinity`                                        | Affinity for pod assignment. Evaluated as a template.                                                                    | `{}`                  |
+| `nodeSelector`                                    | Node labels for pod assignment. Evaluated as a template.                                                                 | `{}`                  |
+| `tolerations`                                     | Tolerations for pod assignment. Evaluated as a template.                                                                 | `[]`                  |
+| `updateStrategy.type`                             | Pytorch statefulset strategy type                                                                                        | `RollingUpdate`       |
+| `podManagementPolicy`                             | Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join                       | `OrderedReady`        |
+| `priorityClassName`                               | Pytorch pods' priorityClassName                                                                                          | `""`                  |
+| `topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                  |
+| `schedulerName`                                   | Name of the k8s scheduler (other than default) for Pytorch pods                                                          | `""`                  |
+| `terminationGracePeriodSeconds`                   | Seconds Redmine pod needs to terminate gracefully                                                                        | `""`                  |
+| `lifecycleHooks`                                  | for the Pytorch container(s) to automate configuration before or after startup                                           | `{}`                  |
+| `extraEnvVars`                                    | Array with extra environment variables to add to Pytorch nodes                                                           | `[]`                  |
+| `extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars for Pytorch nodes                                                   | `""`                  |
+| `extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars for Pytorch nodes                                                      | `""`                  |
+| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the Pytorch pod(s)                                               | `[]`                  |
+| `extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the Pytorch container(s)                                    | `[]`                  |
+| `sidecars`                                        | Add additional sidecar containers to the Pytorch pod(s)                                                                  | `{}`                  |
+| `initContainers`                                  | Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)                                                     | `{}`                  |
 
 
 ### Traffic Exposure Parameters
@@ -180,13 +180,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | `git.registry`                         | Git image registry                                                                                                                                        | `docker.io`             |
 | `git.repository`                       | Git image repository                                                                                                                                      | `bitnami/git`           |
-| `git.tag`                              | Git image tag (immutable tags are recommended)                                                                                                            | `2.35.1-debian-10-r67`  |
+| `git.tag`                              | Git image tag (immutable tags are recommended)                                                                                                            | `2.36.1-debian-11-r0`   |
 | `git.pullPolicy`                       | Git image pull policy                                                                                                                                     | `IfNotPresent`          |
 | `git.pullSecrets`                      | Specify docker-registry secret names as an array                                                                                                          | `[]`                    |
 | `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                 |
 | `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                                          | `docker.io`             |
 | `volumePermissions.image.repository`   | Init container volume-permissions image repository                                                                                                        | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag (immutable tags are recommended)                                                                              | `10-debian-10-r388`     |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag (immutable tags are recommended)                                                                              | `11-debian-11-r0`       |
 | `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                                                       | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                                          | `[]`                    |
 | `volumePermissions.resources.limits`   | The resources limits for the container                                                                                                                    | `{}`                    |

--- a/bitnami/pytorch/values.yaml
+++ b/bitnami/pytorch/values.yaml
@@ -295,7 +295,7 @@ priorityClassName: ""
 ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 ##
-topologySpreadConstraints: {}
+topologySpreadConstraints: []
 ## @param schedulerName Name of the k8s scheduler (other than default) for Pytorch pods
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

