### PR TITLE
[bitnami/redmine] Fix topologySpreadConstraints default values

### DIFF
--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/bitnami-docker-redmine
   - https://www.redmine.org/
-version: 20.2.4
+version: 20.2.5

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -93,7 +93,7 @@ helm install my-release bitnami/redmine --set databaseType=postgresql
 | ----------------------- | ---------------------------------------------------------------------- | -------------------- |
 | `image.registry`        | Redmine image registry                                                 | `docker.io`          |
 | `image.repository`      | Redmine image repository                                               | `bitnami/redmine`    |
-| `image.tag`             | Redmine image tag (immutable tags are recommended)                     | `5.0.1-debian-10-r7` |
+| `image.tag`             | Redmine image tag (immutable tags are recommended)                     | `5.0.1-debian-11-r0` |
 | `image.pullPolicy`      | Redmine image pull policy                                              | `IfNotPresent`       |
 | `image.pullSecrets`     | Redmine image pull secrets                                             | `[]`                 |
 | `image.debug`           | Enable image debug mode                                                | `false`              |
@@ -168,7 +168,7 @@ helm install my-release bitnami/redmine --set databaseType=postgresql
 | `priorityClassName`                  | Redmine pods' Priority Class Name                                                                                        | `""`            |
 | `schedulerName`                      | Alternate scheduler                                                                                                      | `""`            |
 | `terminationGracePeriodSeconds`      | Seconds Redmine pod needs to terminate gracefully                                                                        | `""`            |
-| `topologySpreadConstraints`          | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`            |
+| `topologySpreadConstraints`          | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`            |
 | `updateStrategy.type`                | Redmine statefulset strategy type                                                                                        | `RollingUpdate` |
 | `updateStrategy.rollingUpdate`       | Redmine statefulset rolling update configuration parameters                                                              | `{}`            |
 | `extraVolumes`                       | Optionally specify extra list of additional volumes for Redmine pods                                                     | `[]`            |
@@ -346,7 +346,7 @@ helm install my-release bitnami/redmine --set databaseType=postgresql
 | `certificates.customCA`                              | Defines a list of secrets to import into the container trust store | `[]`                                     |
 | `certificates.image.registry`                        | Redmine image registry                                             | `docker.io`                              |
 | `certificates.image.repository`                      | Redmine image repository                                           | `bitnami/bitnami-shell`                  |
-| `certificates.image.tag`                             | Redmine image tag (immutable tags are recommended)                 | `10-debian-10-r434`                      |
+| `certificates.image.tag`                             | Redmine image tag (immutable tags are recommended)                 | `11-debian-11-r0`                        |
 | `certificates.image.pullPolicy`                      | Redmine image pull policy                                          | `IfNotPresent`                           |
 | `certificates.image.pullSecrets`                     | Redmine image pull secrets                                         | `[]`                                     |
 | `certificates.extraEnvVars`                          | Container sidecar extra environment variables (e.g. proxy)         | `[]`                                     |

--- a/bitnami/redmine/values.yaml
+++ b/bitnami/redmine/values.yaml
@@ -324,7 +324,7 @@ terminationGracePeriodSeconds: ""
 ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 ##
-topologySpreadConstraints: {}
+topologySpreadConstraints: []
 ## @param updateStrategy.type Redmine statefulset strategy type
 ## @param updateStrategy.rollingUpdate Redmine statefulset rolling update configuration parameters
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

