### PR TITLE
[bitnami/sealed-secrets] Fix topologySpreadConstraints default values

### DIFF
--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -23,4 +23,4 @@ name: sealed-secrets
 sources:
   - https://github.com/bitnami/bitnami-docker-sealed-secrets
   - https://github.com/bitnami-labs/sealed-secrets
-version: 1.0.5
+version: 1.0.6

--- a/bitnami/sealed-secrets/README.md
+++ b/bitnami/sealed-secrets/README.md
@@ -131,7 +131,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tolerations`                                     | Tolerations for Sealed Secret pods assignment                                                                            | `[]`                     |
 | `updateStrategy.type`                             | Sealed Secret statefulset strategy type                                                                                  | `RollingUpdate`          |
 | `priorityClassName`                               | Sealed Secret pods' priorityClassName                                                                                    | `""`                     |
-| `topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                     |
+| `topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                     |
 | `schedulerName`                                   | Name of the k8s scheduler (other than default) for Sealed Secret pods                                                    | `""`                     |
 | `terminationGracePeriodSeconds`                   | Seconds Redmine pod needs to terminate gracefully                                                                        | `""`                     |
 | `lifecycleHooks`                                  | for the Sealed Secret container(s) to automate configuration before or after startup                                     | `{}`                     |

--- a/bitnami/sealed-secrets/values.yaml
+++ b/bitnami/sealed-secrets/values.yaml
@@ -232,7 +232,7 @@ priorityClassName: ""
 ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 ##
-topologySpreadConstraints: {}
+topologySpreadConstraints: []
 ## @param schedulerName Name of the k8s scheduler (other than default) for Sealed Secret pods
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

