### PR TITLE
[bitnami/wavefront-adapter-for-istio] Fix topologySpreadConstraints default values

### DIFF
--- a/bitnami/wavefront-adapter-for-istio/Chart.yaml
+++ b/bitnami/wavefront-adapter-for-istio/Chart.yaml
@@ -30,4 +30,4 @@ maintainers:
 name: wavefront-adapter-for-istio
 sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-adapter-for-istio
-version: 2.0.2
+version: 2.0.3

--- a/bitnami/wavefront-adapter-for-istio/README.md
+++ b/bitnami/wavefront-adapter-for-istio/README.md
@@ -96,7 +96,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
 | `image.registry`                        | Adapter image registry                                                                                                   | `docker.io`                           |
 | `image.repository`                      | Adapter image repository                                                                                                 | `bitnami/wavefront-adapter-for-istio` |
-| `image.tag`                             | Adapter image tag (immutabe tags are recommended)                                                                        | `0.1.5-debian-10-r347`                |
+| `image.tag`                             | Adapter image tag (immutabe tags are recommended)                                                                        | `0.1.5-debian-11-r0`                  |
 | `image.pullPolicy`                      | Adapter image pull policy                                                                                                | `IfNotPresent`                        |
 | `image.pullSecrets`                     | Adapter image pull secrets                                                                                               | `[]`                                  |
 | `startupProbe.enabled`                  | Enable startupProbe                                                                                                      | `true`                                |
@@ -138,7 +138,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podLabels`                             | Extra labels for Adapter pods                                                                                            | `{}`                                  |
 | `priorityClassName`                     | Adapter pod priority                                                                                                     | `""`                                  |
 | `schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                                  |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`                                  |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                                  |
 | `terminationGracePeriodSeconds`         | Termination grace period in seconds                                                                                      | `""`                                  |
 | `lifecycleHooks`                        | Add lifecycle hooks to the Adapter deployment                                                                            | `{}`                                  |
 | `customLivenessProbe`                   | Override default liveness probe                                                                                          | `{}`                                  |

--- a/bitnami/wavefront-adapter-for-istio/values.yaml
+++ b/bitnami/wavefront-adapter-for-istio/values.yaml
@@ -256,7 +256,7 @@ schedulerName: ""
 ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 ##
-topologySpreadConstraints: {}
+topologySpreadConstraints: []
 ## @param terminationGracePeriodSeconds Termination grace period in seconds
 ##
 terminationGracePeriodSeconds: ""


### PR DESCRIPTION
### Description of the change

Fixes the default value for `tolerations` and/or `topologySpreadConstraints`.

### Benefits

No warnings deploying the chart.

### Possible drawbacks

None.

### Applicable issues

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

