### PR TITLE
[bitnami/postgresql-ha] Updated README no match release notes variable names

### DIFF
--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -663,11 +663,11 @@ It's necessary to specify the existing passwords while performing a upgrade to e
 
 ```bash
 $ helm upgrade my-release bitnami/postgresql-ha \
-    --set postgresql.password=[POSTGRESQL_PASSWORD] \
+    --set postgresql.password=[POSTGRES_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD]
 ```
 
-> Note: you need to substitute the placeholders _[POSTGRESQL_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes.
+> Note: you need to substitute the placeholders _[POSTGRES_PASSWORD]_, and _[REPMGR_PASSWORD]_ with the values obtained from instructions in the installation notes.
 
 > Note: As general rule, it is always wise to do a backup before the upgrading procedures.
 


### PR DESCRIPTION
This is a very minor change in the upgrade notes of the documentation of postgresql-ha. The release notes use `POSTGRES_PASSWORD` to export the password (https://github.com/bitnami/charts/blob/master/bitnami/postgresql-ha/templates/NOTES.txt#L41). This variable name is matching the documentation (instead `POSTGRESQL_PASSWORD`) from now on.

I did only change the general upgrade documentation and not those for previous major upgrades.

### Benefits

No different variable names for the same thing.

### Possible drawbacks

None.