### PR TITLE
[bitnami/cassandra] Cassandra commit log mount fixed

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -23,4 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/bitnami-docker-cassandra
   - http://cassandra.apache.org
-version: 9.2.3
+version: 9.2.4

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -83,7 +83,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`              | Cassandra image registry                                                                                               | `docker.io`          |
 | `image.repository`            | Cassandra image repository                                                                                             | `bitnami/cassandra`  |
-| `image.tag`                   | Cassandra image tag (immutable tags are recommended)                                                                   | `4.0.4-debian-10-r3` |
+| `image.tag`                   | Cassandra image tag (immutable tags are recommended)                                                                   | `4.0.4-debian-11-r0` |
 | `image.pullPolicy`            | image pull policy                                                                                                      | `IfNotPresent`       |
 | `image.pullSecrets`           | Cassandra image pull secrets                                                                                           | `[]`                 |
 | `image.debug`                 | Enable image debug mode                                                                                                | `false`              |
@@ -212,17 +212,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Persistence parameters
 
-| Name                             | Description                                                                                                                                  | Value                          |
-| -------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|
-| `persistence.enabled`            | Enable Cassandra data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir                                           | `true`                         |
-| `persistence.storageClass`       | PVC Storage Class for Cassandra data volume                                                                                                  | `""`                           |
-| `persistence.commitStorageClass` | PVC Storage Class for Cassandra Commit Log volume                                                                                            | `""`                           |
-| `persistence.annotations`        | Persistent Volume Claim annotations                                                                                                          | `{}`                           |
-| `persistence.accessModes`        | Persistent Volume Access Mode                                                                                                                | `["ReadWriteOnce"]`            |
-| `persistence.size`               | PVC Storage Request for Cassandra data volume                                                                                                | `8Gi`                          |
-| `persistence.mountPath`          | The path the data volume will be mounted at                                                                                                  | `/bitnami/cassandra`           |
-| `persistence.commitLogsize`      | PVC Storage Request for Cassandra Commit Log volume. Disabled by default.                                                                    | `2Gi`                          |
-| `persistence.commitLogMountPath` | The path the Commit Log volume will be mounted at. Disabled by default. Recommended for better performance. Set it to use a Commit Log volume | `/bitnami/cassandra/commitlog` |
+| Name                             | Description                                                                                        | Value                |
+| -------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------- |
+| `persistence.enabled`            | Enable Cassandra data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir | `true`               |
+| `persistence.storageClass`       | PVC Storage Class for Cassandra data volume                                                        | `""`                 |
+| `persistence.commitStorageClass` | PVC Storage Class for Cassandra Commit Log volume                                                  | `""`                 |
+| `persistence.annotations`        | Persistent Volume Claim annotations                                                                | `{}`                 |
+| `persistence.accessModes`        | Persistent Volume Access Mode                                                                      | `["ReadWriteOnce"]`  |
+| `persistence.size`               | PVC Storage Request for Cassandra data volume                                                      | `8Gi`                |
+| `persistence.mountPath`          | The path the data volume will be mounted at                                                        | `/bitnami/cassandra` |
+
 
 ### Volume Permissions parameters
 
@@ -231,7 +230,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                   | Enable init container that changes the owner and group of the persistent volume | `false`                 |
 | `volumePermissions.image.registry`            | Init container volume                                                           | `docker.io`             |
 | `volumePermissions.image.repository`          | Init container volume                                                           | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                 | Init container volume                                                           | `10-debian-10-r431`     |
+| `volumePermissions.image.tag`                 | Init container volume                                                           | `11-debian-11-r0`       |
 | `volumePermissions.image.pullPolicy`          | Init container volume                                                           | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                | `[]`                    |
 | `volumePermissions.resources.limits`          | The resources limits for the container                                          | `{}`                    |
@@ -246,7 +245,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                          | Start a side-car prometheus exporter                                                                   | `false`                      |
 | `metrics.image.registry`                   | Cassandra exporter image registry                                                                      | `docker.io`                  |
 | `metrics.image.repository`                 | Cassandra exporter image name                                                                          | `bitnami/cassandra-exporter` |
-| `metrics.image.tag`                        | Cassandra exporter image tag                                                                           | `2.3.8-debian-10-r54`        |
+| `metrics.image.tag`                        | Cassandra exporter image tag                                                                           | `2.3.8-debian-11-r0`         |
 | `metrics.image.pullPolicy`                 | image pull policy                                                                                      | `IfNotPresent`               |
 | `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                       | `[]`                         |
 | `metrics.resources.limits`                 | The resources limits for the container                                                                 | `{}`                         |

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -212,15 +212,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Persistence parameters
 
-| Name                             | Description                                                                                        | Value                |
-| -------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------- |
-| `persistence.enabled`            | Enable Cassandra data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir | `true`               |
-| `persistence.storageClass`       | PVC Storage Class for Cassandra data volume                                                        | `""`                 |
-| `persistence.commitStorageClass` | PVC Storage Class for Cassandra Commit Log volume                                                  | `""`                 |
-| `persistence.annotations`        | Persistent Volume Claim annotations                                                                | `{}`                 |
-| `persistence.accessModes`        | Persistent Volume Access Mode                                                                      | `["ReadWriteOnce"]`  |
-| `persistence.size`               | PVC Storage Request for Cassandra data volume                                                      | `8Gi`                |
-| `persistence.mountPath`          | The path the data volume will be mounted at                                                        | `/bitnami/cassandra` |
+| Name                             | Description                                                                                                                                          | Value                |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `persistence.enabled`            | Enable Cassandra data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir                                                   | `true`               |
+| `persistence.storageClass`       | PVC Storage Class for Cassandra data volume                                                                                                          | `""`                 |
+| `persistence.commitStorageClass` | PVC Storage Class for Cassandra Commit Log volume                                                                                                    | `""`                 |
+| `persistence.annotations`        | Persistent Volume Claim annotations                                                                                                                  | `{}`                 |
+| `persistence.accessModes`        | Persistent Volume Access Mode                                                                                                                        | `["ReadWriteOnce"]`  |
+| `persistence.size`               | PVC Storage Request for Cassandra data volume                                                                                                        | `8Gi`                |
+| `persistence.commitLogsize`      | PVC Storage Request for Cassandra commit log volume. Unset by default                                                                                | `2Gi`                |
+| `persistence.mountPath`          | The path the data volume will be mounted at                                                                                                          | `/bitnami/cassandra` |
+| `persistence.commitLogMountPath` | The path the commit log volume will be mounted at. Unset by default. Set it to '/bitnami/cassandra/commitlog' to enable a separate commit log volume | `""`                 |
 
 
 ### Volume Permissions parameters

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -212,16 +212,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Persistence parameters
 
-| Name                             | Description                                                                                        | Value                |
-| -------------------------------- | -------------------------------------------------------------------------------------------------- | -------------------- |
-| `persistence.enabled`            | Enable Cassandra data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir | `true`               |
-| `persistence.storageClass`       | PVC Storage Class for Cassandra data volume                                                        | `""`                 |
-| `persistence.commitStorageClass` | PVC Storage Class for Cassandra Commit Log volume                                                  | `""`                 |
-| `persistence.annotations`        | Persistent Volume Claim annotations                                                                | `{}`                 |
-| `persistence.accessModes`        | Persistent Volume Access Mode                                                                      | `["ReadWriteOnce"]`  |
-| `persistence.size`               | PVC Storage Request for Cassandra data volume                                                      | `8Gi`                |
-| `persistence.mountPath`          | The path the data volume will be mounted at                                                        | `/bitnami/cassandra` |
-
+| Name                             | Description                                                                                                                                  | Value                          |
+| -------------------------------- |----------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------|
+| `persistence.enabled`            | Enable Cassandra data persistence using PVC, use a Persistent Volume Claim, If false, use emptyDir                                           | `true`                         |
+| `persistence.storageClass`       | PVC Storage Class for Cassandra data volume                                                                                                  | `""`                           |
+| `persistence.commitStorageClass` | PVC Storage Class for Cassandra Commit Log volume                                                                                            | `""`                           |
+| `persistence.annotations`        | Persistent Volume Claim annotations                                                                                                          | `{}`                           |
+| `persistence.accessModes`        | Persistent Volume Access Mode                                                                                                                | `["ReadWriteOnce"]`            |
+| `persistence.size`               | PVC Storage Request for Cassandra data volume                                                                                                | `8Gi`                          |
+| `persistence.mountPath`          | The path the data volume will be mounted at                                                                                                  | `/bitnami/cassandra`           |
+| `persistence.commitLogsize`      | PVC Storage Request for Cassandra Commit Log volume. Disabled by default.                                                                    | `2Gi`                          |
+| `persistence.commitLogMountPath` | The path the Commit Log volume will be mounted at. Disabled by default. Recommended for better performance. Set it to use a Commit Log volume | `/bitnami/cassandra/commitlog` |
 
 ### Volume Permissions parameters
 

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -95,7 +95,7 @@ spec:
                 xargs chown -R {{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }}
               {{- end }}
               {{- end }}
-            {{- if .Values.persistence.commitStorageClass }}
+            {{- if .Values.persistence.commitLogMountPath }}
             - /bin/sh
             - -cx
             - |
@@ -426,7 +426,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
-            {{- if .Values.persistence.commitStorageClass }}
+            {{- if .Values.persistence.commitLogMountPath }}
             - name: commitlog
               mountPath: {{ .Values.persistence.commitLogMountPath }}
             {{- end }}

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -558,13 +558,13 @@ persistence:
   ## @param persistence.size PVC Storage Request for Cassandra data volume
   ##
   size: 8Gi
-  ## @skip persistence.commitLogsize PVC Storage Request for Cassandra commit log volume
+  ## @param persistence.commitLogsize PVC Storage Request for Cassandra commit log volume. Unset by default
   ##
   # commitLogsize: 2Gi
   ## @param persistence.mountPath The path the data volume will be mounted at
   ##
   mountPath: /bitnami/cassandra
-  ## @skip persistence.commitLogMountPath The path the commit log volume will be mounted at
+  ## @param persistence.commitLogMountPath The path the commit log volume will be mounted at. Unset by default
   ## Set this parameter to add separate PVCs with the prefix "commitlog" and mount the commit log on a different volume
   ##
   # commitLogMountPath: /bitnami/cassandra/commitlog

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -560,14 +560,14 @@ persistence:
   size: 8Gi
   ## @param persistence.commitLogsize PVC Storage Request for Cassandra commit log volume. Unset by default
   ##
-  # commitLogsize: 2Gi
+  commitLogsize: 2Gi
   ## @param persistence.mountPath The path the data volume will be mounted at
   ##
   mountPath: /bitnami/cassandra
-  ## @param persistence.commitLogMountPath The path the commit log volume will be mounted at. Unset by default
-  ## Set this parameter to add separate PVCs with the prefix "commitlog" and mount the commit log on a different volume
+  ## @param persistence.commitLogMountPath The path the commit log volume will be mounted at. Unset by default. Set it to '/bitnami/cassandra/commitlog' to enable a separate commit log volume
   ##
   # commitLogMountPath: /bitnami/cassandra/commitlog
+  commitLogMountPath: ""
 
 ## @section Volume Permissions parameters
 ##

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -565,6 +565,7 @@ persistence:
   ##
   mountPath: /bitnami/cassandra
   ## @skip persistence.commitLogMountPath The path the commit log volume will be mounted at
+  ## Set this parameter to add separate PVCs with the prefix "commitlog" and mount the commit log on a different volume
   ##
   # commitLogMountPath: /bitnami/cassandra/commitlog
 


### PR DESCRIPTION
Cassandra commit log mount fixed 

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

- Cassandra commit log mount fixed ( if commitStorageClass is replaced with commitLogMountPath)
- a few lines are added to the readme
- comment added on default values 

### Benefits

<!-- What benefits will be realized by the code change? -->

Before there was unclear behavior when PVCs for commit log were created, but not mounted until you not define the particular `--set persistence.commitStorageClass=gp3 `. The preferred behavior is to use the default storage class. I suggest creating and mounting PVC by a single parameter `--set persistence.commitLogMountPath=/bitnami/cassandra/commitlog`. Some documentation was improved to make it easy to start.

The issue looks like this:
```
helm upgrade --install cassandra bitnami/cassandra --version 9.1.11 \
  --set replicaCount=3 \
  --set persistence.size=100Gi \
  --set persistence.commitLogsize=2Gi \
  --set persistence.commitLogMountPath=/bitnami/cassandra/commitlog \
  --set cluster.name=cassandra \
  --set cluster.datacenter=datacenter1 \
  --set cluster.seedCount=3
```
![image](https://user-images.githubusercontent.com/79898499/172812901-b5b2217a-8d06-48be-ac82-8d893e1f44a8.png)
![image](https://user-images.githubusercontent.com/79898499/172813187-57a43077-3104-409f-946b-1a7c0f8c4eea.png)

As you might notice, the PVCs created, but not mounted

To work around the issue today I need to add an extra parameter with a particular storage class
```
  --set persistence.commitStorageClass=gp3 \
```

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
