### PR TITLE
[bitnami/zookeeper] Major release 10: Rename client-server authentication parameters and add support for server-server authentication

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/bitnami-docker-zookeeper
   - https://zookeeper.apache.org/
-version: 9.2.4
+version: 10.0.0

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -420,6 +420,11 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 10.0.0
+
+This new version of the chart adds support for server-server authentication.
+The chart previously supported client-server authentication, to avioud confusion, the previous parameters have been renamed from `auth.*` to `auth.client.*`.
+
 ### To 9.0.0
 
 This new version of the chart includes the new ZooKeeper major version 3.8.0. Upgrade compatibility is not guaranteed.

--- a/bitnami/zookeeper/templates/NOTES.txt
+++ b/bitnami/zookeeper/templates/NOTES.txt
@@ -2,8 +2,7 @@ CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}
 
-{{- if contains .Values.service.type "LoadBalancer" }}
-{{- if not .Values.auth.clientPassword }}
+{{- if and (not .Values.auth.client.enabled) (eq .Values.service.type "LoadBalancer") }}
 -------------------------------------------------------------------------------
  WARNING
 
@@ -16,7 +15,6 @@ APP VERSION: {{ .Chart.AppVersion }}
     "auth.clientPassword" parameter.
 
 -------------------------------------------------------------------------------
-{{- end }}
 {{- end }}
 
 ** Please be patient while the chart is being deployed **
@@ -52,13 +50,13 @@ To connect to your ZooKeeper server run the following commands:
 
 To connect to your ZooKeeper server from outside the cluster execute the following commands:
 
-{{- if contains "NodePort" .Values.service.type }}
+{{- if eq .Values.service.type "NodePort" }}
 
     export NODE_IP=$(kubectl get nodes --namespace {{ template "zookeeper.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
     export NODE_PORT=$(kubectl get --namespace {{ template "zookeeper.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
     zkCli.sh $NODE_IP:$NODE_PORT
 
-{{- else if contains "LoadBalancer" .Values.service.type }}
+{{- else if eq .Values.service.type "LoadBalancer" }}
 
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ template "zookeeper.namespace" . }} -w {{ template "common.names.fullname" . }}'
@@ -66,7 +64,7 @@ To connect to your ZooKeeper server from outside the cluster execute the followi
     export SERVICE_IP=$(kubectl get svc --namespace {{ template "zookeeper.namespace" . }} {{ template "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
     zkCli.sh $SERVICE_IP:{{ .Values.service.ports.client }}
 
-{{- else if contains "ClusterIP" .Values.service.type }}
+{{- else if eq .Values.service.type "ClusterIP" }}
 
     kubectl port-forward --namespace {{ template "zookeeper.namespace" . }} svc/{{ template "common.names.fullname" . }} {{ .Values.service.ports.client }}:{{ .Values.containerPorts.client }} &
     zkCli.sh 127.0.0.1:{{ .Values.service.ports.client }}

--- a/bitnami/zookeeper/templates/secrets.yaml
+++ b/bitnami/zookeeper/templates/secrets.yaml
@@ -1,8 +1,8 @@
-{{- if (include "zookeeper.createSecret" .) }}
+{{- if (include "zookeeper.client.createSecret" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-auth" (include "common.names.fullname" .) }}
+  name: {{ printf "%s-client-auth" (include "common.names.fullname" .) }}
   namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: zookeeper
@@ -14,8 +14,28 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  client-password: {{ include "zookeeper.client.password" . | b64enc | quote }}
-  server-password: {{ include "zookeeper.server.password" . | b64enc | quote }}
+  client-password: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-client-auth" (include "common.names.fullname" .)) "key" "client-password" "providedValues" (list "auth.client.clientPassword") "context" $) }}
+  server-password: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-client-auth" (include "common.names.fullname" .)) "key" "server-password" "providedValues" (list "auth.client.serverPasswords") "context" $) }}
+{{- end }}
+{{- if (include "zookeeper.quorum.createSecret" .) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-quorum-auth" (include "common.names.fullname" .) }}
+  namespace: {{ template "zookeeper.namespace" . }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: zookeeper
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  quorum-learner-password: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-client-auth" (include "common.names.fullname" .)) "key" "quorum-learner-password" "providedValues" (list "auth.quorum.learnerPassword") "context" $) }}
+  quorum-server-password: {{ include "common.secrets.passwords.manage" (dict "secret" (printf "%s-client-auth" (include "common.names.fullname" .)) "key" "quorum-server-password" "providedValues" (list "auth.quorum.serverPasswords") "context" $) }}
 {{- end }}
 {{- if (include "zookeeper.client.createTlsPasswordsSecret" .) }}
 ---

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         {{- if (include "zookeeper.createConfigmap" .) }}
         checksum/configuration: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if or (include "zookeeper.createSecret" .) (include "zookeeper.client.createTlsPasswordsSecret" .) (include "zookeeper.quorum.createTlsPasswordsSecret" .) }}
+        {{- if or (include "zookeeper.quorum.createSecret" .) (include "zookeeper.client.createSecret" .) (include "zookeeper.client.createTlsPasswordsSecret" .) (include "zookeeper.quorum.createTlsPasswordsSecret" .) }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
         {{- end }}
         {{- if or (include "zookeeper.client.createTlsSecret" .) (include "zookeeper.quorum.createTlsSecret" .) }}
@@ -228,29 +228,47 @@ spec:
               {{- $clusterDomain := .Values.clusterDomain }}
               value: {{ range $i, $e := until $replicaCount }}{{ $zookeeperFullname }}-{{ $e }}.{{ $zookeeperHeadlessServiceName }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ $followerPort }}:{{ $electionPort }}::{{ add $e $minServerId }} {{ end }}
             - name: ZOO_ENABLE_AUTH
-              value: {{ ternary "yes" "no" .Values.auth.enabled | quote }}
-            {{- if .Values.auth.enabled }}
+              value: {{ ternary "yes" "no" .Values.auth.client.enabled | quote }}
+            {{- if .Values.auth.client.enabled }}
             - name: ZOO_CLIENT_USER
-              value: {{ .Values.auth.clientUser | quote }}
+              value: {{ .Values.auth.client.clientUser | quote }}
             - name: ZOO_CLIENT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "zookeeper.secretName" . }}
+                  name: {{ include "zookeeper.client.secretName" . }}
                   key: client-password
             - name: ZOO_SERVER_USERS
-              value: {{ .Values.auth.serverUsers | quote }}
+              value: {{ .Values.auth.client.serverUsers | quote }}
             - name: ZOO_SERVER_PASSWORDS
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "zookeeper.secretName" . }}
+                  name: {{ include "zookeeper.client.secretName" . }}
                   key: server-password
+            {{- end }}
+            - name: ZOO_ENABLE_QUORUM_AUTH
+              value: {{ ternary "yes" "no" .Values.auth.quorum.enabled | quote }}
+            {{- if .Values.auth.quorum.enabled }}
+            - name: ZOO_QUORUM_LEARNER_USER
+              value: {{ .Values.auth.quorum.learnerUser | quote }}
+            - name: ZOO_QUORUM_LEARNER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zookeeper.quorum.secretName" . }}
+                  key: quorum-learner-password
+            - name: ZOO_QUORUM_SERVER_USERS
+              value: {{ .Values.auth.quorum.serverUsers | quote }}
+            - name: ZOO_QUORUM_SERVER_PASSWORDS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "zookeeper.quorum.secretName" . }}
+                  key: quorum-server-password
             {{- end }}
             - name: ZOO_HEAP_SIZE
               value: {{ .Values.heapSize | quote }}
             - name: ZOO_LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
             - name: ALLOW_ANONYMOUS_LOGIN
-              value: {{ ternary "no" "yes" .Values.auth.enabled | quote }}
+              value: {{ ternary "no" "yes" .Values.auth.client.enabled | quote }}
             {{- if .Values.jvmFlags }}
             - name: JVMFLAGS
               value: {{ .Values.jvmFlags | quote }}
@@ -291,7 +309,7 @@ spec:
             - name: ZOO_TLS_QUORUM_ENABLE
               value: {{ .Values.tls.quorum.enabled | quote }}
             - name: ZOO_TLS_QUORUM_CLIENT_AUTH
-              value: {{ .Values.tls.quorum.auth | quote }}
+              value: {{ .Values.tls.auth.quorum | quote }}
             - name: ZOO_TLS_QUORUM_KEYSTORE_FILE
               value: {{ .Values.tls.quorum.keystorePath | quote }}
             - name: ZOO_TLS_QUORUM_TRUSTSTORE_FILE

--- a/bitnami/zookeeper/values.yaml
+++ b/bitnami/zookeeper/values.yaml
@@ -95,26 +95,49 @@ image:
 ## Authentication parameters
 ##
 auth:
-  ## @param auth.enabled Enable ZooKeeper auth. It uses SASL/Digest-MD5
-  ##
-  enabled: false
-  ## @param auth.clientUser User that will use ZooKeeper clients to auth
-  ##
-  clientUser: ""
-  ## @param auth.clientPassword Password that will use ZooKeeper clients to auth
-  ##
-  clientPassword: ""
-  ## @param auth.serverUsers Comma, semicolon or whitespace separated list of user to be created
-  ## Specify them as a string, for example: "user1,user2,admin"
-  ##
-  serverUsers: ""
-  ## @param auth.serverPasswords Comma, semicolon or whitespace separated list of passwords to assign to users when created
-  ## Specify them as a string, for example: "pass4user1, pass4user2, pass4admin"
-  ##
-  serverPasswords: ""
-  ## @param auth.existingSecret Use existing secret (ignores previous passwords)
-  ##
-  existingSecret: ""
+  client:
+    ## @param auth.enabled Enable ZooKeeper client-server authentication. It uses SASL/Digest-MD5
+    ##
+    enabled: false
+    ## @param auth.clientUser User that will use ZooKeeper clients to auth
+    ##
+    clientUser: ""
+    ## @param auth.clientPassword Password that will use ZooKeeper clients to auth
+    ##
+    clientPassword: ""
+    ## @param auth.serverUsers Comma, semicolon or whitespace separated list of user to be created
+    ## Specify them as a string, for example: "user1,user2,admin"
+    ##
+    serverUsers: ""
+    ## @param auth.serverPasswords Comma, semicolon or whitespace separated list of passwords to assign to users when created
+    ## Specify them as a string, for example: "pass4user1, pass4user2, pass4admin"
+    ##
+    serverPasswords: ""
+    ## @param auth.existingSecret Use existing secret (ignores previous passwords)
+    ##
+    existingSecret: ""
+  quorum:
+    ## @param auth.quorum.enabled Enable ZooKeeper server-server authentication. It uses SASL/Digest-MD5
+    ##
+    enabled: true
+    ## @param auth.quorum.learnerUser User that the ZooKeeper quorumLearner will use to authenticate to quorumServers.
+    ## Note: Make sure the user is included in auth.quorum.serverUsers
+    ##
+    learnerUser: "test"
+    ## @param auth.quorum.learnerPassword Password that the ZooKeeper quorumLearner will use to authenticate to quorumServers.
+    ##
+    learnerPassword: "test"
+    ## @param auth.quorum.serverUsers Comma, semicolon or whitespace separated list of users for the quorumServers.
+    ## Specify them as a string, for example: "user1,user2,admin"
+    ##
+    serverUsers: "test"
+    ## @param auth.quorum.serverPasswords Comma, semicolon or whitespace separated list of passwords to assign to users when created
+    ## Specify them as a string, for example: "pass4user1, pass4user2, pass4admin"
+    ##
+    serverPasswords: "test"
+    ## @param auth.quorum.existingSecret Use existing secret (ignores previous passwords)
+    ##
+    existingSecret: ""
 ## @param tickTime Basic time unit (in milliseconds) used by ZooKeeper for heartbeats
 ##
 tickTime: 2000


### PR DESCRIPTION
### Description of the change

This major release adds support for server-server authentication.

The chart previously supported client-server authentication, the previous parameters have been renamed from `auth.*` to `auth.client.*`.

### Benefits

Adds support for server-server authentication

### Possible drawbacks

None known.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/bitnami-docker-zookeeper/issues/13

### Additional information

https://cwiki.apache.org/confluence/display/ZOOKEEPER/Server-Server+mutual+authentication

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
