### PR TITLE
[bitnami/Keycloak] Fix tls ingress documentation

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 9.2.7
+version: 9.2.8

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -402,14 +402,7 @@ The chart also facilitates the creation of TLS secrets for use with the Ingress 
 
 ### Use with ingress offloading SSL
 
-If your ingress controller has the SSL Termination, you should set `proxyAddressForwarding` to `true` or you should add the following env vars in `extraEnvVars`
-
-```yaml
-- name: KEYCLOAK_PROXY_ADDRESS_FORWARDING
-  value: "true"
-- name: KEYCLOAK_FRONTEND_URL
-  value: "https://keycloak.xxx"
-```
+If your ingress controller has the SSL Termination, you should set `proxy` to `edge`.
 
 ### Manage secrets and passwords
 


### PR DESCRIPTION
### Description of the change

The paragraph about tls ingress was outdated, I fixed it.

### Benefits

No more outdated documentation.

### Possible drawbacks

Now documentation may be wrong.

### Applicable issues

NA

### Additional information

.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
