### PR TITLE
[bitnami/airflow] worker podTemplate's configmap rendered using common.tplvalues.render

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 12.5.7
+version: 12.5.8

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -20,7 +20,7 @@ data:
   {{- if $kube }}
   pod_template.yaml: |-
   {{- if .Values.worker.podTemplate }}
-    {{ .Values.worker.podTemplate | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.worker.podTemplate "context" $) | nindent 4 }}
   {{- else }}
     apiVersion: v1
     kind: Pod


### PR DESCRIPTION
Signed-off-by: Tung Le Thanh <nothing5lose@gmail.com>


### Description of the change

For Resolve: https://github.com/bitnami/charts/issues/10720

### Benefits

worker podTemplate's configmap should be rendered using common.tplvalues.render.
Now it's not functional correct (template literal value rendered)

### Possible drawbacks

N/A

### Applicable issues

  - fixes #10720

### Additional information

N/A

### Checklist


- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
