### PR TITLE
Automate merge process of CI's PRs

### DIFF
--- a/.github/workflows/vib-verify.yaml
+++ b/.github/workflows/vib-verify.yaml
@@ -135,6 +135,6 @@ jobs:
           --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
           --header 'content-type: application/json' \
           --data '{
-            "reviewers": ["carrodher", "dgomezleon", "Mauraza", "marcosbc", "mdhont", "migruiz4"]
+            "team_reviewers": ["build-maintainers"]
             }' \
           --fail


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR, in conjunction with the necessary internal changes to our CI, allows for the PRs created by `bitnami-bot` in the internal pipeline `Helm Charts (GitHub push)` stage to merge automatically once the `VIB Verify` workflow succeeds. 

For this, the internal pipeline will now add an `auto-merge` label and enable de auto-merge feature in its PRs. Once the `Verify` job is finished successfully, the workflow will approve the PR and it will be merged once any missing actions succeed.

If the `Verify` job fails, the related agents will be added as reviewers and the `auto-merge` label will be removed. Once said label is removed, the workflow won't be able to automatically approve the PR. As such, a reviewer will need to check the failures in the `Verify` workflow before rerunning it and approving the PR.

### Benefits

The PRs created by `bitnami-bot` as part of `Helm Charts (GitHub push)` CI stage no longer would require manual intervention unless an error in the `Verify` job appears.

### Additional information

Tested internally with a `bitnami/charts` fork as the testing environment. A couple of PRs, 1 made to succeed and 1 to fail, can be found there:

- https://github.com/FraPazGal/charts/pull/25
- https://github.com/FraPazGal/charts/pull/30

> NOTE: the failed README action is an expected error related to missing credentials in the fork, though it doesn't impact the final result.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
