### PR TITLE
[bitnami/kube-state-metrics] Modify naming of cluster-wide resources

### DIFF
--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -23,4 +23,4 @@ name: kube-state-metrics
 sources:
   - https://github.com/bitnami/bitnami-docker-kube-state-metrics
   - https://github.com/kubernetes/kube-state-metrics
-version: 3.0.5
+version: 3.1.0

--- a/bitnami/kube-state-metrics/templates/clusterrole.yaml
+++ b/bitnami/kube-state-metrics/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname.namespace" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/bitnami/kube-state-metrics/templates/clusterrolebinding.yaml
+++ b/bitnami/kube-state-metrics/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname.namespace" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -14,7 +14,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname.namespace" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}

--- a/bitnami/kube-state-metrics/templates/psp-clusterrole.yaml
+++ b/bitnami/kube-state-metrics/templates/psp-clusterrole.yaml
@@ -3,7 +3,7 @@
 kind: ClusterRole
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
-  name: {{ template "common.names.fullname" . }}-psp
+  name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "psp" }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -17,5 +17,5 @@ rules:
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames:
-      - {{ template "common.names.fullname" . }}
+      - {{ template "common.names.fullname.namespace" . }}
 {{- end }}

--- a/bitnami/kube-state-metrics/templates/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-state-metrics/templates/psp-clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "common.names.fullname" . }}-psp
+  name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "psp" }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -15,7 +15,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "common.names.fullname" . }}-psp
+  name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "psp" }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "kube-state-metrics.serviceAccountName" . }}

--- a/bitnami/kube-state-metrics/templates/psp.yaml
+++ b/bitnami/kube-state-metrics/templates/psp.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname.namespace" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}


### PR DESCRIPTION
### Description of the change

The cluster-wide resources in this chart get their name from the `common.names.fullname` function, which only takes into account the deployment name. As such, when installing the same chart with the same deploy name but different namespaces, you get installation errors of the following type"

```
Error: rendered manifests contain a resource that already exists. Unable to continue with install: PodSecurityPolicy "alpha-kube-state-metrics" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-namespace" must equal "gamma": current value is "default"
```

To solve this, we'll use the new `common.names.fullname.namespace` function added in #10462.

### Benefits

Solves a chart design issue and allows for the actions of our VIB pipelines to run in parallel in the affected charts.

### Possible drawbacks

There shouldn't be any drawbacks. The upgrade process has been tested without issues.

### Additional information

To avoid modifying extensively the current chart, only those resources affected by this issue (cluster-wide ones) will be modified.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
