### PR TITLE
[bitnami/thanos] Fix customStartupProbe for thanos receive statefulset

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 10.5.2
+version: 10.5.3

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -146,7 +146,7 @@ spec:
             httpGet:
               path: /-/ready
               port: http
-          {{- else if .Values.bucketweb.customReadinessProbe }}
+          {{- else if .Values.bucketweb.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.bucketweb.lifecycleHooks }}

--- a/bitnami/thanos/templates/compactor/deployment.yaml
+++ b/bitnami/thanos/templates/compactor/deployment.yaml
@@ -161,7 +161,7 @@ spec:
             httpGet:
               path: /-/ready
               port: http
-          {{- else if .Values.compactor.customReadinessProbe }}
+          {{- else if .Values.compactor.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.compactor.lifecycleHooks }}

--- a/bitnami/thanos/templates/query-frontend/deployment.yaml
+++ b/bitnami/thanos/templates/query-frontend/deployment.yaml
@@ -146,7 +146,7 @@ spec:
             httpGet:
               path: /-/ready
               port: http
-          {{- else if .Values.queryFrontend.customReadinessProbe }}
+          {{- else if .Values.queryFrontend.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.queryFrontend.lifecycleHooks }}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -195,7 +195,7 @@ spec:
             httpGet:
               path: /-/ready
               port: http
-          {{- else if .Values.query.customReadinessProbe }}
+          {{- else if .Values.query.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.query.lifecycleHooks }}

--- a/bitnami/thanos/templates/receive-distributor/deployment.yaml
+++ b/bitnami/thanos/templates/receive-distributor/deployment.yaml
@@ -166,7 +166,7 @@ spec:
             httpGet:
               path: /-/ready
               port: http
-          {{- else if .Values.receiveDistributor.customReadinessProbe }}
+          {{- else if .Values.receiveDistributor.customStartupProbe  }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.receiveDistributor.lifecycleHooks }}

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -202,7 +202,7 @@ spec:
             httpGet:
               path: /-/ready
               port: http
-          {{- else if .Values.receive.customReadinessProbe }}
+          {{- else if .Values.receive.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receive.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.receive.lifecycleHooks }}

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -188,7 +188,7 @@ spec:
             httpGet:
               path: /-/ready
               port: http
-          {{- else if .Values.ruler.customReadinessProbe }}
+          {{- else if .Values.ruler.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.ruler.lifecycleHooks }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
       serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "storegateway" "context" $) }}
-      automountServiceAccountToken: {{ .Values.storegateway.automountServiceAccountToken }}            
+      automountServiceAccountToken: {{ .Values.storegateway.automountServiceAccountToken }}
       {{- if .Values.storegateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.hostAliases "context" $) | nindent 8 }}
       {{- end }}
@@ -181,7 +181,7 @@ spec:
             httpGet:
               path: /-/ready
               port: http
-          {{- else if .Values.storegateway.customReadinessProbe }}
+          {{- else if .Values.storegateway.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.storegateway.lifecycleHooks }}


### PR DESCRIPTION
Fixes https://github.com/bitnami/charts/issues/10778

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
