### PR TITLE
[bitnami/postgresql] fix postgresql.replicationPasswordKey secret key logic

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 11.6.7
+version: 11.6.8

--- a/bitnami/postgresql/templates/_helpers.tpl
+++ b/bitnami/postgresql/templates/_helpers.tpl
@@ -108,6 +108,8 @@ Get the replication-password key.
         {{- printf "%s" (tpl .Values.global.postgresql.auth.secretKeys.replicationPasswordKey $) -}}
     {{- else if .Values.auth.secretKeys.replicationPasswordKey -}}
         {{- printf "%s" (tpl .Values.auth.secretKeys.replicationPasswordKey $) -}}
+    {{- else -}}
+        {{- "replication-password" -}}
     {{- end -}}
 {{- else -}}
     {{- "replication-password" -}}

--- a/bitnami/postgresql/templates/_helpers.tpl
+++ b/bitnami/postgresql/templates/_helpers.tpl
@@ -108,9 +108,9 @@ Get the replication-password key.
         {{- printf "%s" (tpl .Values.global.postgresql.auth.secretKeys.replicationPasswordKey $) -}}
     {{- else if .Values.auth.secretKeys.replicationPasswordKey -}}
         {{- printf "%s" (tpl .Values.auth.secretKeys.replicationPasswordKey $) -}}
-    {{- else -}}
-        {{- "replication-password" -}}
     {{- end -}}
+{{- else -}}
+    {{- "replication-password" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: Adrian Axelsson <adrian.axelsson@hotmail.se>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
When deploying the current version of the postgresql chart with replication, without specifying an existing secret, postgresql.replicationPasswordKey will not default to "replication-password". 
This change fixes the if/else logic

### Benefits

<!-- What benefits will be realized by the code change? -->
The chart can be installed successfully with architecture=replication without having to specify an existing secret

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
