### PR TITLE
[bitnami/redis] Fix for REDIS_MASTER_HOST

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 16.12.2
+version: 16.12.3

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -126,7 +126,7 @@ spec:
             - name: REDIS_REPLICATION_MODE
               value: slave
             - name: REDIS_MASTER_HOST
-            {{- if eq (int64 .Values.master.count) 1 }}
+            {{- if and (eq (int64 .Values.master.count) 1) (ne .Values.master.kind "Deployment") }}
               value: {{ template "common.names.fullname" . }}-master-0.{{ template "common.names.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
             {{- else }}
               value: {{ template "common.names.fullname" . }}-master.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->
Signed-off-by: AJ Romito <ajromito@gmail.com>

### Description of the change

Issue introduced in #10047
When installing redis master as a deployment, with count = 1, the endpoint/url of the service is changed and cannot support the current value in the template.  
Conditional expanded to set REDIS_MASTER_HOST to the regular service endpoint when master.kind = Deployment.

### Benefits

Allows redis replicas to come online and make connection to master.

### Possible drawbacks



### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #10621 

### Additional information

Deployment kind for master helps us maintain redis uptime in eks, as non-graceful shutdown can occur and causes issues with statefulset.  We prefer data loss over extended downtime.
ToDo: Add support for replica of kind deployment to further support quick recovery

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
