### PR TITLE
[bitnami/airflow] Allows for LocalKubernetesExecutor to be used, as added in Airflow 2.3 (#10659)

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/bitnami-docker-airflow
   - https://airflow.apache.org/
-version: 12.5.8
+version: 12.5.9

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -77,31 +77,31 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Airflow common parameters
 
-| Name                     | Description                                                                                                                                    | Value                   |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `auth.username`          | Username to access web UI                                                                                                                      | `user`                  |
-| `auth.password`          | Password to access web UI                                                                                                                      | `""`                    |
-| `auth.fernetKey`         | Fernet key to secure connections                                                                                                               | `""`                    |
-| `auth.secretKey`         | Secret key to run your flask app                                                                                                               | `""`                    |
-| `auth.existingSecret`    | Name of an existing secret to use for Airflow credentials                                                                                      | `""`                    |
-| `executor`               | Airflow executor. Allowed values: `SequentialExecutor`, `LocalExecutor`, `CeleryExecutor`, `KubernetesExecutor` and `CeleryKubernetesExecutor` | `CeleryExecutor`        |
-| `loadExamples`           | Switch to load some Airflow examples                                                                                                           | `false`                 |
-| `configuration`          | Specify content for Airflow config file (auto-generated based on other env. vars otherwise)                                                    | `""`                    |
-| `existingConfigmap`      | Name of an existing ConfigMap with the Airflow config file                                                                                     | `""`                    |
-| `dags.existingConfigmap` | Name of an existing ConfigMap with all the DAGs files you want to load in Airflow                                                              | `""`                    |
-| `dags.image.registry`    | Init container load-dags image registry                                                                                                        | `docker.io`             |
-| `dags.image.repository`  | Init container load-dags image repository                                                                                                      | `bitnami/bitnami-shell` |
-| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                            | `11-debian-11-r0`       |
-| `dags.image.pullPolicy`  | Init container load-dags image pull policy                                                                                                     | `IfNotPresent`          |
-| `dags.image.pullSecrets` | Init container load-dags image pull secrets                                                                                                    | `[]`                    |
-| `extraEnvVars`           | Add extra environment variables for all the Airflow pods                                                                                       | `[]`                    |
-| `extraEnvVarsCM`         | ConfigMap with extra environment variables for all the Airflow pods                                                                            | `""`                    |
-| `extraEnvVarsSecret`     | Secret with extra environment variables for all the Airflow pods                                                                               | `""`                    |
-| `extraEnvVarsSecrets`    | List of secrets with extra environment variables for all the Airflow pods                                                                      | `[]`                    |
-| `sidecars`               | Add additional sidecar containers to all the Airflow pods                                                                                      | `[]`                    |
-| `initContainers`         | Add additional init containers to all the Airflow pods                                                                                         | `[]`                    |
-| `extraVolumeMounts`      | Optionally specify extra list of additional volumeMounts for all the Airflow pods                                                              | `[]`                    |
-| `extraVolumes`           | Optionally specify extra list of additional volumes for the all the Airflow pods                                                               | `[]`                    |
+| Name                     | Description                                                                                                                                                               | Value                   |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `auth.username`          | Username to access web UI                                                                                                                                                 | `user`                  |
+| `auth.password`          | Password to access web UI                                                                                                                                                 | `""`                    |
+| `auth.fernetKey`         | Fernet key to secure connections                                                                                                                                          | `""`                    |
+| `auth.secretKey`         | Secret key to run your flask app                                                                                                                                          | `""`                    |
+| `auth.existingSecret`    | Name of an existing secret to use for Airflow credentials                                                                                                                 | `""`                    |
+| `executor`               | Airflow executor. Allowed values: `SequentialExecutor`, `LocalExecutor`, `CeleryExecutor`, `KubernetesExecutor`, `CeleryKubernetesExecutor` and `LocalKubernetesExecutor` | `CeleryExecutor`        |
+| `loadExamples`           | Switch to load some Airflow examples                                                                                                                                      | `false`                 |
+| `configuration`          | Specify content for Airflow config file (auto-generated based on other env. vars otherwise)                                                                               | `""`                    |
+| `existingConfigmap`      | Name of an existing ConfigMap with the Airflow config file                                                                                                                | `""`                    |
+| `dags.existingConfigmap` | Name of an existing ConfigMap with all the DAGs files you want to load in Airflow                                                                                         | `""`                    |
+| `dags.image.registry`    | Init container load-dags image registry                                                                                                                                   | `docker.io`             |
+| `dags.image.repository`  | Init container load-dags image repository                                                                                                                                 | `bitnami/bitnami-shell` |
+| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                                                       | `11-debian-11-r0`       |
+| `dags.image.pullPolicy`  | Init container load-dags image pull policy                                                                                                                                | `IfNotPresent`          |
+| `dags.image.pullSecrets` | Init container load-dags image pull secrets                                                                                                                               | `[]`                    |
+| `extraEnvVars`           | Add extra environment variables for all the Airflow pods                                                                                                                  | `[]`                    |
+| `extraEnvVarsCM`         | ConfigMap with extra environment variables for all the Airflow pods                                                                                                       | `""`                    |
+| `extraEnvVarsSecret`     | Secret with extra environment variables for all the Airflow pods                                                                                                          | `""`                    |
+| `extraEnvVarsSecrets`    | List of secrets with extra environment variables for all the Airflow pods                                                                                                 | `[]`                    |
+| `sidecars`               | Add additional sidecar containers to all the Airflow pods                                                                                                                 | `[]`                    |
+| `initContainers`         | Add additional init containers to all the Airflow pods                                                                                                                    | `[]`                    |
+| `extraVolumeMounts`      | Optionally specify extra list of additional volumeMounts for all the Airflow pods                                                                                         | `[]`                    |
+| `extraVolumes`           | Optionally specify extra list of additional volumes for the all the Airflow pods                                                                                          | `[]`                    |
 
 
 ### Airflow web parameters
@@ -650,6 +650,9 @@ Local executor runs tasks by spawning processes in the Scheduler pods. To enable
 executor=LocalExecutor
 redis.enabled=false
 ```
+### LocalKubernetesExecutor
+
+The LocalKubernetesExecutor is introduced in Airflow 2.3 and is a combination of both the Local and the Kubernetes executors. Tasks will be executed in the scheduler by default, but those tasks that require it can be executed in a Kubernetes pod using the 'kubernetes' queue.
 
 #### SequentialExecutor
 

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -91,7 +91,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dags.existingConfigmap` | Name of an existing ConfigMap with all the DAGs files you want to load in Airflow                                                                                         | `""`                    |
 | `dags.image.registry`    | Init container load-dags image registry                                                                                                                                   | `docker.io`             |
 | `dags.image.repository`  | Init container load-dags image repository                                                                                                                                 | `bitnami/bitnami-shell` |
-| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                                                       | `11-debian-11-r0`       |
+| `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                                                       | `11-debian-11-r3`       |
 | `dags.image.pullPolicy`  | Init container load-dags image pull policy                                                                                                                                | `IfNotPresent`          |
 | `dags.image.pullSecrets` | Init container load-dags image pull secrets                                                                                                                               | `[]`                    |
 | `extraEnvVars`           | Add extra environment variables for all the Airflow pods                                                                                                                  | `[]`                    |
@@ -110,7 +110,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------- |
 | `web.image.registry`                        | Airflow image registry                                                                                                   | `docker.io`          |
 | `web.image.repository`                      | Airflow image repository                                                                                                 | `bitnami/airflow`    |
-| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.3.2-debian-11-r0` |
+| `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.3.2-debian-11-r3` |
 | `web.image.pullPolicy`                      | Airflow image pull policy                                                                                                | `IfNotPresent`       |
 | `web.image.pullSecrets`                     | Airflow image pull secrets                                                                                               | `[]`                 |
 | `web.image.debug`                           | Enable image debug mode                                                                                                  | `false`              |
@@ -185,7 +185,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------- |
 | `scheduler.image.registry`                        | Airflow Scheduler image registry                                                                                         | `docker.io`                 |
 | `scheduler.image.repository`                      | Airflow Scheduler image repository                                                                                       | `bitnami/airflow-scheduler` |
-| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.3.2-debian-11-r0`        |
+| `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.3.2-debian-11-r3`        |
 | `scheduler.image.pullPolicy`                      | Airflow Scheduler image pull policy                                                                                      | `IfNotPresent`              |
 | `scheduler.image.pullSecrets`                     | Airflow Scheduler image pull secrets                                                                                     | `[]`                        |
 | `scheduler.image.debug`                           | Enable image debug mode                                                                                                  | `false`                     |
@@ -239,7 +239,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
 | `worker.image.registry`                        | Airflow Worker image registry                                                                                            | `docker.io`              |
 | `worker.image.repository`                      | Airflow Worker image repository                                                                                          | `bitnami/airflow-worker` |
-| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.3.2-debian-11-r0`     |
+| `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.3.2-debian-11-r3`     |
 | `worker.image.pullPolicy`                      | Airflow Worker image pull policy                                                                                         | `IfNotPresent`           |
 | `worker.image.pullSecrets`                     | Airflow Worker image pull secrets                                                                                        | `[]`                     |
 | `worker.image.debug`                           | Enable image debug mode                                                                                                  | `false`                  |
@@ -319,7 +319,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------ | -------------------------------------------------------------------------------------- | --------------------- |
 | `git.image.registry`           | Git image registry                                                                     | `docker.io`           |
 | `git.image.repository`         | Git image repository                                                                   | `bitnami/git`         |
-| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.36.1-debian-11-r0` |
+| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.36.1-debian-11-r3` |
 | `git.image.pullPolicy`         | Git image pull policy                                                                  | `IfNotPresent`        |
 | `git.image.pullSecrets`        | Git image pull secrets                                                                 | `[]`                  |
 | `git.dags.enabled`             | Enable in order to download DAG files from git repositories.                           | `false`               |
@@ -414,7 +414,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                               | Whether or not to create a standalone Airflow exporter to expose Airflow metrics                    | `false`                     |
 | `metrics.image.registry`                        | Airflow exporter image registry                                                                     | `docker.io`                 |
 | `metrics.image.repository`                      | Airflow exporter image repository                                                                   | `bitnami/airflow-exporter`  |
-| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-11-r0` |
+| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-11-r3` |
 | `metrics.image.pullPolicy`                      | Airflow exporter image pull policy                                                                  | `IfNotPresent`              |
 | `metrics.image.pullSecrets`                     | Airflow exporter image pull secrets                                                                 | `[]`                        |
 | `metrics.extraEnvVars`                          | Array with extra environment variables to add Airflow exporter pods                                 | `[]`                        |

--- a/bitnami/airflow/templates/_helpers.tpl
+++ b/bitnami/airflow/templates/_helpers.tpl
@@ -338,7 +338,7 @@ Add environment variables to configure database values
 Add environment variables to configure redis values
 */}}
 {{- define "airflow.configure.redis" -}}
-{{- if (not (eq .Values.executor "KubernetesExecutor" )) }}
+{{- if (not (or (eq .Values.executor "KubernetesExecutor" ) (eq .Values.executor "LocalKubernetesExecutor" ))) }}
 - name: REDIS_HOST
   value: {{ ternary (include "airflow.redis.fullname" .) .Values.externalRedis.host .Values.redis.enabled | quote }}
 - name: REDIS_PORT_NUMBER
@@ -383,7 +383,7 @@ Add environment variables to configure airflow common values
 Add environment variables to configure airflow kubernetes executor
 */}}
 {{- define "airflow.configure.airflow.kubernetesExecutor" -}}
-{{- if or (eq .Values.executor "KubernetesExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
+{{- if (contains .Values.executor "KubernetesExecutor") }}
 - name: AIRFLOW__KUBERNETES__NAMESPACE
   value: {{ .Release.Namespace }}
 - name: AIRFLOW__KUBERNETES__WORKER_CONTAINER_REPOSITORY

--- a/bitnami/airflow/templates/config/configmap.yaml
+++ b/bitnami/airflow/templates/config/configmap.yaml
@@ -1,4 +1,4 @@
-{{- $kube := or (eq .Values.executor "KubernetesExecutor") (eq .Values.executor "CeleryKubernetesExecutor") -}}
+{{- $kube := (contains .Values.executor "KubernetesExecutor") -}}
 {{- if or .Values.configuration $kube }}
 apiVersion: v1
 kind: ConfigMap

--- a/bitnami/airflow/templates/config/secret-external-redis.yaml
+++ b/bitnami/airflow/templates/config/secret-external-redis.yaml
@@ -1,4 +1,4 @@
-{{- if and (not .Values.redis.enabled) (not .Values.externalRedis.existingSecret) (not .Values.redis.existingSecret) (not (eq .Values.executor "KubernetesExecutor" )) }}
+{{- if and (not .Values.redis.enabled) (not .Values.externalRedis.existingSecret) (not .Values.redis.existingSecret) (not (eq .Values.executor "KubernetesExecutor" )) (not (eq .Values.executor "LocalKubernetesExecutor" )) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/airflow/templates/scheduler/deployment.yaml
+++ b/bitnami/airflow/templates/scheduler/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $kube := or (eq .Values.executor "KubernetesExecutor") (eq .Values.executor "CeleryKubernetesExecutor") -}}
+{{- $kube := (contains .Values.executor "KubernetesExecutor") -}}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:

--- a/bitnami/airflow/templates/scheduler/service-headless.yaml
+++ b/bitnami/airflow/templates/scheduler/service-headless.yaml
@@ -1,4 +1,4 @@
-{{- if (or (eq .Values.executor "LocalExecutor") (eq .Values.executor "SequentialExecutor")) }}
+{{- if (or (eq .Values.executor "LocalExecutor") (eq .Values.executor "LocalKubernetesExecutor") (eq .Values.executor "SequentialExecutor")) }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -81,7 +81,7 @@ auth:
   ## The value is evaluated as a template
   ##
   existingSecret: ""
-## @param executor Airflow executor. Allowed values: `SequentialExecutor`, `LocalExecutor`, `CeleryExecutor`, `KubernetesExecutor` and `CeleryKubernetesExecutor`
+## @param executor Airflow executor. Allowed values: `SequentialExecutor`, `LocalExecutor`, `CeleryExecutor`, `KubernetesExecutor`, `CeleryKubernetesExecutor` and `LocalKubernetesExecutor`
 ## ref: http://airflow.apache.org/docs/stable/executor/index.html
 ##
 executor: CeleryExecutor


### PR DESCRIPTION
### Description of the change

Adds support for the new `LocalKubernetesExecutor`. Fixes https://github.com/bitnami/charts/issues/10659

### Benefits

Can now select if a task runs in the scheduler, or in a kubernetes pod

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
