### PR TITLE
[bitnami/postgresql-ha] Fix postgres user password configuration

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -27,4 +27,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 9.1.6
+version: 9.1.7

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -130,6 +130,13 @@ Return true if PostgreSQL postgres user password has been provided
         {{- if .Values.global.postgresql.postgresPassword -}}
             {{- true -}}
         {{- end -}}
+        {{- if .Values.postgresql.postgresPassword -}}
+            {{- true -}}
+        {{- end -}}
+    {{- else -}}
+        {{- if .Values.postgresql.postgresPassword -}}
+            {{- true -}}
+        {{- end -}}
     {{- end -}}
 {{- else -}}
     {{- if .Values.postgresql.postgresPassword -}}


### PR DESCRIPTION
### Description of the change

Set the define postgresql-ha.postgresqlPasswordProvided correct, if postgresql.postgresPassword instead of global.postgresql.postgresPassword is used and the values global or global.postgresql exists.

### Benefits

The following configuration will work as expected and create a password for the postgresql user:
```
helm install --namespace test postgresql bitnami/postgresql-ha \
  --set postgresql.postgresPassword=supersecret \
  --set postgresql.password=secret \
  --set postgresql.username=test \
  --set postgresql.database=test
```
Because with the current chart trying to login as postgres user with the postgres user password supersecret on one of the postgresql pods with the command `kubectl exec -it -n test postgresql-postgresql-ha-postgresql-0 -- psql -U postgres` fails with the error message: `FATAL:  password authentication failed for user "postgres"`

### Possible drawbacks
None known.

### Applicable issues
None.

### Additional information
`kubectl logs -n test postgresql-postgresql-ha-postgresql-0` shows:
```
FATAL:  password authentication failed for user "postgres"
DETAIL:  User "postgres" has no password assigned.
Connection matched pg_hba.conf line 10: "local    all              all                    md5"
```
`kubectl describe pod -n test postgresql-postgresql-ha-postgresql-0` shows that the environment variable POSTGRES_POSTGRES_PASSWORD is not configured (POSTGRES_PASSWORD is configured and works).

Signed-off-by: Vicinus, Reinhard <r.vicinus@metaways.de>

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
