### PR TITLE
[bitnami/index] Archive full index automation

### DIFF
--- a/.github/workflows/archive-full-index.yaml
+++ b/.github/workflows/archive-full-index.yaml
@@ -103,8 +103,8 @@ jobs:
         name: Checks there are not missing releases
         # Available URLs should be fine if everything went well during the merge & deduplication.
         run: |
-          yq eval '.entries[][].urls' last_index.yaml | awk '{print $2}' |sort| uniq > last_index_urls
-          yq eval '.entries[][].urls' index.yaml | awk '{print $2}' |sort| uniq > index_urls
+          yq eval '.entries[][].urls[]' last_index.yaml |sort| uniq > last_index_urls
+          yq eval '.entries[][].urls[]' index.yaml | sort| uniq > index_urls
           for i in `cat last_index_urls`; do  grep -q $i index_urls || exit 1 ; done
           echo "No missing releases detected"
   update:

--- a/.github/workflows/archive-full-index.yaml
+++ b/.github/workflows/archive-full-index.yaml
@@ -117,5 +117,4 @@ jobs:
           cp index.yaml bitnami/index.yaml
           git config user.name "Bitnami Containers"
           git config user.email "bitnami-bot@vmware.com"
-          git checkout archive-full-index
           git add bitnami/index.yaml && git commit -m "[bitnami/index]: Update the full index archive" -s && git push

--- a/.github/workflows/archive-full-index.yaml
+++ b/.github/workflows/archive-full-index.yaml
@@ -3,43 +3,28 @@ on:
   push:
     branches:
       - index
-env:
-  LAST_INDEX_URL: https://charts.bitnami.com/bitnami/index.yaml
-  INDEXES_DIR: indexes
 jobs:
   get:
     runs-on: ubuntu-latest
     name: Get
     steps:
-      - id: checkout-repo-index-branch
+      - id: checkout-repo-index
         name: Checkout repo
         uses: actions/checkout@v3
         with:
           ref: index
-          path: index_branch
-      - id: checkout-repo-full-index-branch
+          path: index
+      - id: checkout-repo-full-index
         name: Checkout repo
         uses: actions/checkout@v3
         with:
-          ref: archive-full-index
-          path: archive-full-index_branch
+          ref: full-index
+          path: full-index
       - id: get-last-indexes
         name: Get indexes
         run: |
-          cp index_branch/bitnami/index.yaml ./last_index.yaml
-          cp archive-full-index_branch/bitnami/index.yaml ./old_index.yaml
-      - id: indexes-lint
-        name: Lint indexes
-        run: |
-          cat << EOF > config
-          extends: relaxed
-
-          rules:
-            indentation:
-              level: error
-            line-length: disable
-          EOF
-          yamllint -c config ./*index.yaml
+          cp index/bitnami/index.yaml ./last_index.yaml
+          cp full-index/bitnami/index.yaml ./previous_index.yaml
       - id: upload-artifact
         name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -60,7 +45,7 @@ jobs:
           name: indexes
       - id: merge
         name: Merge
-        run: yq eval-all '. as $item ireduce ({}; . *+ $item )' old_index.yaml last_index.yaml > duplicates_index.yaml
+        run: yq eval-all '. as $item ireduce ({}; . *+ $item )' previous_index.yaml last_index.yaml > duplicates_index.yaml
       - id: remove
         name: Remove duplicates
         # Removes duplicates per entry using 'digest' as value.
@@ -119,6 +104,8 @@ jobs:
       - id: checkout-repo
         name: Checkout repo
         uses: actions/checkout@v3
+        with:
+          ref: archive-full-index
       - id: download-artifact-archive-full-index
         name: Download artifacts
         uses: actions/download-artifact@v3
@@ -131,4 +118,4 @@ jobs:
           git config user.name "Bitnami Containers"
           git config user.email "bitnami-bot@vmware.com"
           git checkout archive-full-index
-          git add bitnami/index.yaml && git commit -m "[bitnami/index]: Update index.yaml" -s && git push
+          git add bitnami/index.yaml && git commit -m "[bitnami/index]: Update the full index archive" -s && git push

--- a/.github/workflows/archive-full-index.yaml
+++ b/.github/workflows/archive-full-index.yaml
@@ -105,7 +105,11 @@ jobs:
         run: |
           yq eval '.entries[][].urls[]' last_index.yaml |sort| uniq > last_index_urls
           yq eval '.entries[][].urls[]' index.yaml | sort| uniq > index_urls
-          for i in `cat last_index_urls`; do  grep -q $i index_urls || exit 1 ; done
+          missing_urls="$(comm -13 index_urls last_index_urls)"
+          if [ -n "${missing_urls}" ]; then
+              echo "Found missing URLs:\n${missing_urls}"
+              exit 1
+          fi
           echo "No missing releases detected"
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/archive-full-index.yaml
+++ b/.github/workflows/archive-full-index.yaml
@@ -18,7 +18,7 @@ jobs:
         name: Checkout repo
         uses: actions/checkout@v3
         with:
-          ref: full-index
+          ref: archive-full-index
           path: full-index
       - id: get-last-indexes
         name: Get indexes

--- a/.github/workflows/archive-full-index.yaml
+++ b/.github/workflows/archive-full-index.yaml
@@ -1,0 +1,130 @@
+name: Generate the full index archive for Bitnami Charts
+on:
+  push:
+    branches:
+      - index
+env:
+  LAST_INDEX_URL: https://charts.bitnami.com/bitnami/index.yaml
+  INDEXES_DIR: indexes
+jobs:
+  get:
+    runs-on: ubuntu-latest
+    name: Get
+    steps:
+      - id: checkout-repo-index-branch
+        name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: index
+          path: index_branch
+      - id: checkout-repo-full-index-branch
+        name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          ref: archive-full-index
+          path: archive-full-index_branch
+      - id: get-last-indexes
+        name: Get indexes
+        run: |
+          cp index_branch/bitnami/index.yaml ./last_index.yaml
+          cp archive-full-index_branch/bitnami/index.yaml ./old_index.yaml
+      - id: indexes-lint
+        name: Lint indexes
+        run: |
+          cat << EOF > config
+          extends: relaxed
+
+          rules:
+            indentation:
+              level: error
+            line-length: disable
+          EOF
+          yamllint -c config ./*index.yaml
+      - id: upload-artifact
+        name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: indexes
+          path: ./*index.yaml
+          retention-days: 2
+          if-no-files-found: error
+  merge:
+    runs-on: ubuntu-latest
+    needs: get
+    name: Merge
+    steps:
+      - id: download-artifact
+        name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: indexes
+      - id: merge
+        name: Merge
+        run: yq eval-all '. as $item ireduce ({}; . *+ $item )' old_index.yaml last_index.yaml > duplicates_index.yaml
+      - id: remove
+        name: Remove duplicates
+        # Removes duplicates per entry using 'digest' as value.
+        run: yq eval '.entries[] |= unique_by(.digest)' duplicates_index.yaml > index.yaml
+      - id: upload-artifact
+        name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: archive-full-index
+          path: index.yaml
+          retention-days: 2
+          if-no-files-found: error
+  checks:
+    runs-on: ubuntu-latest
+    needs: merge
+    name: Checks
+    steps:
+      - id: download-artifacts
+        name: Download artifacts
+        uses: actions/download-artifact@v3
+      - id: index-lint
+        name: Lint archive full index
+        # Lint the resulting archive full index using ignoring identation and lin-length rules.
+        run: |
+          cat << EOF > config
+          extends: relaxed
+
+          rules:
+            indentation:
+              level: error
+            line-length: disable
+          EOF
+          yamllint -c config archive-full-index/index.yaml
+      - id: check-no-dups
+        name: Checks there are not any duplicates
+        # Try to find duplicate digest attributes which would mean there are duplicates.
+        run: |
+          yq eval '.entries[][].digest' index.yaml | sort | uniq -d | ( ! grep sha256 )
+      - id: check-missing-releases
+        name: Checks there are not missing releases
+        # Available URLs should be fine if everything went well during the merge & deduplication.
+        run: |
+          yq eval '.entries[][].urls' last_index.yaml | awk '{print $2}' |sort| uniq > last_index_urls
+          yq eval '.entries[][].urls' index.yaml | awk '{print $2}' |sort| uniq > index_urls
+          for i in `cat last_index_urls`; do  grep -q $i index_urls || exit 1 ; done
+          echo "No missing releases detected"
+  update:
+    runs-on: ubuntu-latest
+    needs: checks
+    name: Update
+    steps:
+      - id: checkout-repo
+        name: Checkout repo
+        uses: actions/checkout@v3
+      - id: download-artifact-archive-full-index
+        name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: archive-full-index
+      - id: update-index
+        name: git-add-push
+        run: |
+          cp index.yaml bitnami/index.yaml
+          git config user.name "Bitnami Containers"
+          git config user.email "bitnami-bot@vmware.com"
+          git checkout archive-full-index
+          git add bitnami/index.yaml && git commit -m "[bitnami/index]: Update index.yaml" -s && git push


### PR DESCRIPTION
### Description of the change

This change is a new branch that will not be merged with master. The purpose is to hold file called bitnami/index.yaml which will be the home for the archive of Bitnami Charts full index. The index is built once per day.

The workflow downloads the last 6-months index from charts.bitnami.com and merges it with the last full index available, removes the duplicates and checks that there is not dups remaining or any missing release.

### Benefits

We can offer a full index for everybody so the can use it to access every chart version, not only version from the last six months.

### Additional information

This work is part of the efforts to reduce the impact of cutting off the official Bitnami Charts index to 6-months.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [N/A] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [N/A] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
