### PR TITLE
[bitnami/mongodb-sharded] Use common helper to manage app secrets

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 5.0.17
+version: 5.2.0

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 5.2.0
+version: 5.1.0

--- a/bitnami/mongodb-sharded/templates/secrets.yaml
+++ b/bitnami/mongodb-sharded/templates/secrets.yaml
@@ -15,17 +15,13 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.configsvr.external.rootPassword }}
-  mongodb-root-password: {{ .Values.configsvr.external.rootPassword | b64enc | quote }}
-  {{- else if .Values.auth.rootPassword }}
-  mongodb-root-password: {{ .Values.auth.rootPassword | b64enc | quote }}
+  mongodb-root-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "mongodb-root-password" "providedValues" (list "configsvr.external.rootPassword" ) "context" $) }}
   {{- else }}
-  mongodb-root-password: {{ randAlphaNum 10 | b64enc | quote }}
+  mongodb-root-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "mongodb-root-password" "providedValues" (list "auth.rootPassword" ) "context" $) }}
   {{- end }}
   {{- if .Values.configsvr.external.replicasetKey }}
-  mongodb-replica-set-key: {{ .Values.configsvr.external.replicasetKey | b64enc | quote }}
-  {{- else if .Values.auth.replicaSetKey }}
-  mongodb-replica-set-key: {{ .Values.auth.replicaSetKey | b64enc | quote }}
+  mongodb-replica-set-key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "mongodb-replica-set-key" "providedValues" (list "configsvr.external.replicasetKey" ) "context" $) }}
   {{- else }}
-  mongodb-replica-set-key: {{ randAlphaNum 10 | b64enc | quote }}
+  mongodb-replica-set-key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "mongodb-replica-set-key" "providedValues" (list "auth.replicaSetKey" ) "context" $) }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Use the `common.secrets.passwords.manage` helper to prevent app secrets from being regenerated during an upgrade process.

### Benefits

- Passwords are reused during the upgrade process
- New pods can join the cluster without issues

### Possible drawbacks

None

### Applicable issues

  - fixes #10771 

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
