### PR TITLE
[bitnami/mongodb-sharded] Fixed calls to secretRef and extraEnvVarsSecret

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/bitnami-docker-mongodb-sharded
   - https://mongodb.org
-version: 5.0.12
+version: 5.0.13

--- a/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
+++ b/bitnami/mongodb-sharded/templates/mongos/mongos-dep-sts.yaml
@@ -186,7 +186,7 @@ spec:
                 name: {{ include "common.tplvalues.render" ( dict "value" .Values.mongos.extraEnvVarsCM "context" $ ) }}
             {{- end }}
             {{- if .Values.mongos.extraEnvVarsSecret }}
-            - configMapRef:
+            - secretRef:
                 name: {{ include "common.tplvalues.render" ( dict "value" .Values.mongos.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
           {{- end }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-arbiter-statefulset.yaml
@@ -190,7 +190,7 @@ spec:
                 name: {{ include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVarsCM "context" $ ) }}
             {{- end }}
             {{- if $.Values.shardsvr.arbiter.extraEnvVarsSecret }}
-            - configMapRef:
+            - secretRef:
                 name: {{ include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.arbiter.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
           {{- end }}

--- a/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
+++ b/bitnami/mongodb-sharded/templates/shard/shard-data-statefulset.yaml
@@ -201,19 +201,19 @@ spec:
           envFrom:
             {{- if $.Values.common.extraEnvVarsCM }}
             - configMapRef:
-                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraEnvVarsCM "context" $ ) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.common.extraEnvVarsCM "context" $ ) }}
             {{- end }}
             {{- if $.Values.common.extraEnvVarsSecret }}
             - secretRef:
-                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.common.extraEnvVarsSecret "context" $ ) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.common.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
             {{- if $.Values.shardsvr.dataNode.extraEnvVarsCM }}
             - configMapRef:
-                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.extraEnvVarsCM "context" $ ) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.extraEnvVarsCM "context" $ ) }}
             {{- end }}
             {{- if $.Values.shardsvr.dataNode.extraEnvVarsSecret }}
             - secretRef:
-                name: {{ include "mongodb-sharded.tplValue" ( dict "value" $.Values.shardsvr.dataNode.extraEnvVarsSecret "context" $ ) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" $.Values.shardsvr.dataNode.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
           {{- end }}
           {{- if $.Values.diagnosticMode.enabled }}


### PR DESCRIPTION
### Description of the change

- Fixed call to common render values instead of incorrect mongodb-sharded tplValue
- Fixed extraEnvVarsSecret call to be secretRef instead of configMapRef
- Bumped to newer version

### Benefits

- extraEnvVarsSecret for mongos maps as secrets instead of previous configmap (pod fails to start)
- extraEnvVarsSecret and extraEnvVarsCM have correct calls to include template values, which can pull configuration correctly. Users can set extraEnvVarsSecret and extraEnvVarsCM without error

### Applicable issues

  - fixes #10856
  - fixes #10847

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
