### PR TITLE
Add runAsGroup to apache chart.

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -26,4 +26,4 @@ name: apache
 sources:
   - https://github.com/bitnami/bitnami-docker-apache
   - https://httpd.apache.org
-version: 9.1.11
+version: 9.1.12

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -122,6 +122,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `podSecurityContext.fsGroup`            | Set Apache Server pod's Security Context fsGroup                                                                         | `1001`                 |
 | `containerSecurityContext.enabled`      | Enabled Apache Server containers' Security Context                                                                       | `true`                 |
 | `containerSecurityContext.runAsUser`    | Set Apache Server containers' Security Context runAsUser                                                                 | `1001`                 |
+| `containerSecurityContext.runAsGroup`    | Set Apache Server containers' Security Context runAsGroup                                                                 | `1001`                 |
 | `containerSecurityContext.runAsNonRoot` | Set Controller container's Security Context runAsNonRoot                                                                 | `true`                 |
 | `command`                               | Override default container command (useful when using custom images)                                                     | `[]`                   |
 | `args`                                  | Override default container args (useful when using custom images)                                                        | `[]`                   |

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -208,11 +208,13 @@ podSecurityContext:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param containerSecurityContext.enabled Enabled Apache Server containers' Security Context
 ## @param containerSecurityContext.runAsUser Set Apache Server containers' Security Context runAsUser
+## @param containerSecurityContext.runAsGroup Set Apache Server containers' Security Context runAsGroup
 ## @param containerSecurityContext.runAsNonRoot Set Controller container's Security Context runAsNonRoot
 ##
 containerSecurityContext:
   enabled: true
   runAsUser: 1001
+  runAsGroup: 1001
   runAsNonRoot: true
 ## @param command Override default container command (useful when using custom images)
 ##


### PR DESCRIPTION
### Description of the change

Allows customization of the apache container GID.

**CHANGES THE DEFAULT** so that it’s no longer root.

### Benefits

Better security:
1) Pods will no longer run as a privileged group by default.
2) Pods _can_ run as whatever group is desired.

### Possible drawbacks

Deployments that may depend on privileged-by-default may break if they upgrade the chart.

### Applicable issues

(None.)

### Additional information

(none)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
