### PR TITLE
Skip VIB verification pipeline for update-readme-metadata changes

### DIFF
--- a/.github/workflows/vib-verify.yaml
+++ b/.github/workflows/vib-verify.yaml
@@ -45,7 +45,7 @@ jobs:
           num_charts_changed="$(echo "$charts_dirs_changed" | grep -c "bitnami" || true)"
           num_version_bumps="$(echo "$files_changed_data" | jq -r '[.[] | select(.filename|endswith("Chart.yaml")) | select(.patch|contains("+version")) ] | length' )"
 
-          if [[ ${{ github.actor }} = "bitnami-bot" && "$latest_commit_message" == *"update-readme-metadata"*  ]]; then
+          if [[ ${{ github.actor }} = "bitnami-bot" && "$latest_commit_message" == *"readme-generator-for-helm"*  ]]; then
             echo "::set-output name=result::skip"
           elif [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then
             # Changes done in charts but version not bumped -> ERROR


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR was caused by a use case detected after landing #10734 where the commit from the `update-readme-metadata` done by the `bitnami-bot` user will trigger the `vib-verify` job from the `VIB` workflow. Besides the increased costs, this produced confusing UX in the automated CI PRs (see #10840).

With this change, the `vib-verify` job will be skipped for those specific commits. Before going for this solution, I explored a couple of them related to `.md` files that had to be discarded at the end:

- Implement the [paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) directive. This could be useful for specific cases but only works when there is no file different from `.md` as explained in their doc:

  > When all the path names match patterns in paths-ignore, the workflow will not run. If any path names do not match patterns in paths-ignore, even if some path names match the patterns, the workflow will run.
- Skip the job when the latest changes only include `.md` file modifications. Although ideal, I haven't been able to check the changes done between the previously pushed changes (already tested) and the newest ones. As far as I investigated, the most similar thing is to check the changes in the latest commit, but that is not a viable solution. Two commits pushed together where the first changes `.yaml` files and the second only `.md` ones will skip the `vib-verify` job.

As there is no easy implementation for the second option and the first one can be avoided by just not adding the `verify` label, I decided to go with this solution. 

Lastly, as we are using the `on.pull_request_target` trigger instead of `on.pull_request`, we cannot skip specific commits by adding `[skip ci]` to the commit message. Ref: [Skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs)

### Benefits

Avoids unnecessary VIB runs.

### Possible drawbacks

None, only specific commits from `bitnami-bot` will be affected.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
