### PR TITLE
[bitnami/keycloak] Bump chart version accordingly

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 9.3.2
+version: 9.3.3


### PR DESCRIPTION
### Description of the change

Bump chart version to fix https://github.com/bitnami/charts/commit/5e62b53282f56ca55420e96b39f6a7935d449c2a, which was incorrectly merged without a bump.

### Benefits

Correct asset versioning.

### Possible drawbacks

None

### Applicable issues
  - relates to https://github.com/bitnami/charts/pull/10876

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
