### PR TITLE
[bitnami/wildfly] Allow appVersion as image tag

### DIFF
--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -26,4 +26,4 @@ name: wildfly
 sources:
   - https://github.com/bitnami/bitnami-docker-wildfly
   - http://wildfly.org
-version: 13.3.11
+version: 13.4.0

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -75,7 +75,13 @@ spec:
         {{- end }}
       containers:
         - name: wildfly
-          image: {{ template "wildfly.image" . }}
+          image:
+            registry: {{ .Values.image.registry }}
+            repository: {{ .Values.image.repository }}
+            tag: {{ .Values.image.tag | default .Chart.AppVersion }}
+            pullPolicy: {{ .Values.image.pullPolicy }}
+            pullSecrets: {{ .Values.image.pullSecrets }}
+            debug: {{ .Values.image.debug }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -75,13 +75,7 @@ spec:
         {{- end }}
       containers:
         - name: wildfly
-          image:
-            registry: {{ .Values.image.registry }}
-            repository: {{ .Values.image.repository }}
-            tag: {{ .Values.image.tag | default .Chart.AppVersion }}
-            pullPolicy: {{ .Values.image.pullPolicy }}
-            pullSecrets: {{ .Values.image.pullSecrets }}
-            debug: {{ .Values.image.debug }}
+          image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}


### PR DESCRIPTION

### Description of the change

This change allows users - that use bitnami/wildfly as a dependency to their main chart - to use its appVersion as docker image tag.
### Benefits

Before, you had to explicitly set the image.tag, especially when you build your own wildfly docker images. With this change you can maintain your appVersion directly in the Chart.yaml. This also makes sense, since the Chart.yaml of bitnami/wildfly always corresponds to a version of the bitnami/wildfly docker image.

To have this flexibility seems to be a "best practice" to some of us.
source: https://jfrog.com/blog/helm-charts-best-practices/
### Possible drawbacks

- none
### Applicable issues

- none

### Additional information

- none
### Checklist


- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
