### PR TITLE
Fix CI pipeline to avoid race condition in auto-merge PRs

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -45,7 +45,7 @@ jobs:
           num_charts_changed="$(echo "$charts_dirs_changed" | grep -c "bitnami" || true)"
           num_version_bumps="$(echo "$files_changed_data" | jq -r '[.[] | select(.filename|endswith("Chart.yaml")) | select(.patch|contains("+version")) ] | length' )"
 
-          if [[ ${{ github.actor }} = "bitnami-bot" && "$latest_commit_message" == *"readme-generator-for-helm"*  ]]; then
+          if [[ ${{ github.event.action }} = "synchronize" && ${{ github.actor }} = "bitnami-bot" && "$latest_commit_message" == *"readme-generator-for-helm"*  ]]; then
             echo "::set-output name=result::skip"
           elif [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then
             # Changes done in charts but version not bumped -> ERROR


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The latest changes to the auto-merge feature of automated PRs merged at https://github.com/bitnami/charts/pull/10907 also introduced a race condition that can make every action run skip the `VIB Verify` job. 

This has happened in https://github.com/bitnami/charts/pull/10930, where the action run triggered by labeling the PR with the `verify` label didn't start instantly and only started once the `readme-generator-for-helm` commit was pushed to the PR branch. As the pipeline checks in real-time if the latest branch commit is the one created for the readme-generator, the action run triggered by the `labeled` action saw that there was already said commit present and skipped the `VIB Verify` job.

To avoid this race condition we just need to add an additional condition so the job is skipped if the latest commit is the  `readme-generator-for-helm` one created by `bitnami-bot` and also the action that triggered that run was a `synchronize` one. This action type which is defined in the [documentation](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#webhook-payload-object-35) as:

> synchronize (action): Triggered when a pull request's head branch is updated. For example, when the head branch is updated from the base branch, when new commits are pushed to the head branch, or when the base branch is changed.

### Benefits

Solves existing race condition in automated PRs.

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
