### PR TITLE
Improve trigger restrictions for the CI/VIB Verify job

### DIFF
--- a/.github/workflows/ci-pipeline-extra-redis.yaml
+++ b/.github/workflows/ci-pipeline-extra-redis.yaml
@@ -16,7 +16,7 @@ env:
   VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
 jobs:
   vib-verify-sentinel:
-    # Given permormance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
+    # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
     # -> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
     # -> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one
     if: |

--- a/.github/workflows/ci-pipeline-extra-redis.yaml
+++ b/.github/workflows/ci-pipeline-extra-redis.yaml
@@ -3,7 +3,6 @@ name: 'CI Pipeline extra Redis'
 on: # rebuild any PRs and main branch changes
   pull_request_target:
     types:
-      - opened
       - reopened
       - synchronize
       - labeled
@@ -17,7 +16,12 @@ env:
   VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
 jobs:
   vib-verify-sentinel:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'verify') }}
+    # Given permormance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
+    # -> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
+    # -> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one
+    if: |
+        github.event.action == 'labeled' && github.event.label.name == 'verify' ||
+        github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify')
     runs-on: ubuntu-latest
     name: Verify Redis Sentinel on Tanzu Kubernetes Grid
     steps:
@@ -32,7 +36,9 @@ jobs:
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
 
   vib-verify-replica:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'verify') }}
+    if: |
+        github.event.action == 'labeled' && github.event.label.name == 'verify' ||
+        github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify')
     runs-on: ubuntu-latest
     name: Verify Redis Replica on Tanzu Kubernetes Grid
     steps:

--- a/.github/workflows/ci-pipeline-extra-thanos.yaml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yaml
@@ -16,7 +16,7 @@ env:
   VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
 jobs:
   vib-verify-bucketweb:
-    # Given permormance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
+    # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
     # -> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
     # -> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one
     if: |

--- a/.github/workflows/ci-pipeline-extra-thanos.yaml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yaml
@@ -3,7 +3,6 @@ name: 'CI Pipeline extra Thanos'
 on: # rebuild any PRs and main branch changes
   pull_request_target:
     types:
-      - opened
       - reopened
       - synchronize
       - labeled
@@ -17,7 +16,12 @@ env:
   VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
 jobs:
   vib-verify-bucketweb:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'verify') }}
+    # Given permormance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
+    # -> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
+    # -> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one
+    if: |
+        github.event.action == 'labeled' && github.event.label.name == 'verify' ||
+        github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify')
     runs-on: ubuntu-latest
     name: Verify BucketWeb on Tanzu Kubernetes Grid
     steps:

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -87,8 +87,16 @@ jobs:
   vib-verify:
     runs-on: ubuntu-latest
     needs: get-chart
-    if: ${{ needs.get-chart.outputs.result == 'ok' && contains(github.event.pull_request.labels.*.name, 'verify') }}
-    name: VIB Verify
+    # Given permormance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
+    # -> The 'Get modified charts' job suceededs AND
+    # -> The event action is different from opened AND
+    # -> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
+    # -> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one
+    if: |
+        needs.get-chart.outputs.result == 'ok' &&
+        github.event.action != 'opened' &&
+        github.event.action == 'labeled' && github.event.label.name == 'verify' ||
+        github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify')    name: VIB Verify
     steps:
       - uses: actions/checkout@v2
         name: 'Checkout Repository'
@@ -114,6 +122,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'auto-merge')
     steps:
       # Approves the CI's PR if the 'VIB Verify' job succeeded
+      # Approved by the 'github-actions' user. A PR can't be approved by its author
       - name: Approval
         if: ${{ needs.vib-verify.result == 'success' }}
         run: |
@@ -131,11 +140,11 @@ jobs:
         run: |
           curl --request DELETE \
           --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/auto-merge \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
           --fail
           curl --request POST \
           --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
           --header 'content-type: application/json' \
           --data '{
             "body": "There has been an error during the automated release process. Manual revision is now required."
@@ -143,7 +152,7 @@ jobs:
           --fail
           curl --request POST \
           --url https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
           --header 'content-type: application/json' \
           --data '{
             "team_reviewers": ["build-maintainers"]

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -87,7 +87,7 @@ jobs:
   vib-verify:
     runs-on: ubuntu-latest
     needs: get-chart
-    # Given permormance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
+    # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
     # -> The 'Get modified charts' job suceededs AND
     # -> The event action is different from opened AND
     # -> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
@@ -96,7 +96,8 @@ jobs:
         needs.get-chart.outputs.result == 'ok' &&
         github.event.action != 'opened' &&
         github.event.action == 'labeled' && github.event.label.name == 'verify' ||
-        github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify')    name: VIB Verify
+        github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify')
+    name: VIB Verify
     steps:
       - uses: actions/checkout@v2
         name: 'Checkout Repository'


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Today our internal tools created 30 automated PRs in the span of ~45 min. Given the high number of action runs triggered, the GitHub's service that manages actions couldn't process so many of them simultaneously and queued them. Unfortunately, some of them were queued incorrectly. In [this example](https://github.com/bitnami/charts/actions?query=branch%3Aautomated%2Fairflow-12.5.11), the run triggered by labeling the PR was executed after the execution of the run triggered by opening the PR.

As seen above, this caused instances where the execution order was mixed and thus some of the actions that should have skipped the `VIB Verify` job executed it. This would normally cause only a PR to have double approval but because the VIB service was at full-load, we received some false negatives. Some PRs where the service was executed 2 times received one success and one failure. Example: https://github.com/bitnami/charts/pull/10949

To avoid future double-executions independently of GH's performance, we are going to further restrict the trigger conditions for the `VIB Verify` job.

Additionally, this PR adds some permissions changes to avoid issues with GH API and replicates the changes for the `ci-pipeline-extra-*` workflows.

### Benefits

Greater restrictions will reduce the number of calls to the VIB service in the future, so it would take longer to overload the service.

### Additional information

Changes tested in personal fork -> https://github.com/FraPazGal/charts/pull/49

### Checklist

- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
