### PR TITLE
[bitnami/argo-cd] Persistent autogenerated admin password on upgrade

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/bitnami-docker-dex
   - https://github.com/dexidp/dex
-version: 3.4.4
+version: 3.4.5

--- a/bitnami/argo-cd/templates/argocd-secret.yaml
+++ b/bitnami/argo-cd/templates/argocd-secret.yaml
@@ -43,8 +43,9 @@ data:
   tls.key: {{ .Values.config.secret.argocdServerTlsConfig.key | b64enc }}
   tls.crt: {{ .Values.config.secret.argocdServerTlsConfig.crt | b64enc }}
   {{- end }}
-  {{- $password := default (randAlphaNum 10) .Values.config.secret.argocdServerAdminPassword }}
-  clearPassword: {{ $password | b64enc }}
+  {{- $password := include "common.secrets.passwords.manage" (dict "secret" "argocd-secret" "key" "clearPassword" "providedValues" (list "config.secret.argocdServerAdminPassword") "context" $) }}
+  clearPassword: {{ $password }}
+  {{- $password = (trimAll "\"" $password) | b64dec }}
   # The password needs to be bcrypt hashed
   admin.password: {{ (split ":" (htpasswd "" $password))._1 | b64enc }}
   admin.passwordMtime: {{ default (dateInZone "2006-01-02T15:04:05Z" (now) "UTC") .Values.config.secret.argocdServerAdminPasswordMtime | b64enc }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

do not change autogenerated admin password during upgrade.

### Benefits



### Possible drawbacks



### Applicable issues

  - fixes #10974 

### Additional information

 
### Checklist
 
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
