### PR TITLE
[bitnami/*] Fix incorrect triggering of VIB

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -46,7 +46,7 @@ jobs:
           num_version_bumps="$(echo "$files_changed_data" | jq -r '[.[] | select(.filename|endswith("Chart.yaml")) | select(.patch|contains("+version")) ] | length' )"
           non_readme_files=$(echo "$files_changed" | grep -vc "\.md" || true)
 
-          if [[ ${{ github.event.action }} = "synchronize" && ${{ github.actor }} = "bitnami-bot" && "$latest_commit_message" == *"readme-generator-for-helm"*  ]]; then
+          if [[ ${{ github.event.action }} == "synchronize" && ${{ github.actor }} == "bitnami-bot" && "$latest_commit_message" == *"readme-generator-for-helm"*  ]]; then
             echo "::set-output name=result::skip"
           elif [[ "$non_readme_files" -le "0" ]]; then
             # The only changes are .md files -> SKIP
@@ -90,13 +90,13 @@ jobs:
     # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
     # -> The 'Get modified charts' job suceededs AND
     # -> The event action is different from opened AND
-    # -> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
-    # -> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one
+    #  ( ---> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
+    #    ---> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one )
     if: |
         needs.get-chart.outputs.result == 'ok' &&
         github.event.action != 'opened' &&
-        github.event.action == 'labeled' && github.event.label.name == 'verify' ||
-        github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify')
+        (github.event.action == 'labeled' && github.event.label.name == 'verify' ||
+        github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify'))
     name: VIB Verify
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### Description of the change

In https://github.com/bitnami/charts/pull/10982, we introduced a new set of logic conditions to prevent `VIB Verify` to be double-triggered. Nevertheless, it seems that the ordering of the logic is not correct and some PRs are now failing due to that:

https://github.com/bitnami/charts/pull/10991
https://github.com/bitnami/charts/pull/10988

https://github.com/bitnami/charts/blob/bec65c1eb1e7c647299f32f11951e4911ca87d6c/.github/workflows/ci-pipeline.yaml#L95-L99

Looking at the logic, we are missing some parentheses between the last two conditions. This opens the possibility for some PRs to skip the first two preconditions (previous step is OK & the event action is not open).

This PR fixes this logic, adding the correct parentheses in place to ensure preconditions are met.

### Benefits

Correct triggering of VIB.

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
