### PR TITLE
[bitnami/postgresql] Fix postgresql read servicemonitor scraping metrics on primary pod

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/bitnami-docker-postgresql
   - https://www.postgresql.org/
-version: 11.6.13
+version: 11.6.14

--- a/bitnami/postgresql/templates/read/metrics-configmap.yaml
+++ b/bitnami/postgresql/templates/read/metrics-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.metrics.enabled .Values.metrics.customMetrics }}
+{{- if and .Values.metrics.enabled .Values.metrics.customMetrics (eq .Values.architecture "replication") }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bitnami/postgresql/templates/read/metrics-svc.yaml
+++ b/bitnami/postgresql/templates/read/metrics-svc.yaml
@@ -1,11 +1,11 @@
-{{- if .Values.metrics.enabled }}
+{{- if and .Values.metrics.enabled (eq .Values.architecture "replication") }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ printf "%s-metrics" (include "postgresql.readReplica.fullname" .) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: metrics
+    app.kubernetes.io/component: metrics-read
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/bitnami/postgresql/templates/read/servicemonitor.yaml
+++ b/bitnami/postgresql/templates/read/servicemonitor.yaml
@@ -1,11 +1,11 @@
-{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled (eq .Values.architecture "replication") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "postgresql.readReplica.fullname" . }}
   namespace: {{ default .Release.Namespace .Values.metrics.serviceMonitor.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: metrics
+    app.kubernetes.io/component: metrics-read
     {{- if .Values.metrics.serviceMonitor.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -24,7 +24,7 @@ spec:
       {{- if .Values.metrics.serviceMonitor.selector }}
       {{- include "common.tplvalues.render" (dict "value" .Values.metrics.serviceMonitor.selector "context" $) | nindent 6 }}
       {{- end }}
-      app.kubernetes.io/component: metrics
+      app.kubernetes.io/component: metrics-read
   endpoints:
     - port: http-metrics
       {{- if .Values.metrics.serviceMonitor.interval }}


### PR DESCRIPTION
Signed-off-by: Aurélien Pasteau <aurelien.pasteau@illuin.tech>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change adds the condition that the replication architecture must be enabled to create the following templates in the postgresql chart:
* read/metrics-configmap.yaml
* read/metrics-svc.yaml
* read/servicemonitor.yaml
It also changes the selectors in the read/servicemonitor.yaml and the labels in read/metrics-svc.yaml to scrape the metrics from the correct pod.

### Benefits
This PR solves 2 different bugs:
1. When standalone architecture is enabled, the read servicemonitor is created (which is not normal) and exports metrics from the primary pod.
2. When replication architecture is enabled, the read servicemonitor is created (so far all good) but it exports the metrics from the primary pod instead of the replication pod

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
