### PR TITLE
Creating a scheduled job to sync labels from bitnami/containers

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,17 @@
+name: 'Synchronize labels from the containers repository'
+on:
+  schedule:
+    # Daily
+    - cron: '0 1 * * *'
+permissions:
+  issues: write
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: EndBug/label-sync@v2
+        with:
+          source-repo: bitnami/containers
+          delete-other-labels: false
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Adding a scheduled daily job to synchronize labels from the bitnami/containers repository.

### Benefits

Ensuring the repositories have the same labels

### Possible drawbacks

If in the bitnami/containers a label is created without thinking in a common way, it maybe will not make sense here.

### Additional information

Now running in the [bitnami/vms](https://github.com/bitnami/vms) repository getting the labels from this repository and working as expected.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
