### PR TITLE
[bitnami/phpmyadmin] Fix PhpMyAdmin cypress tests

### DIFF
--- a/.vib/phpmyadmin/cypress/cypress/integration/phpmyadmin_spec.js
+++ b/.vib/phpmyadmin/cypress/cypress/integration/phpmyadmin_spec.js
@@ -12,11 +12,11 @@ it('allows creating a database and a table', () => {
   cy.login();
   cy.visit('index.php?route=/server/databases');
   cy.fixture('testdata').then((td) => {
-    cy.get('#text_create_db').type(`${td.databaseName}.${random}`);
-    cy.get('#buttonGo').click();
+    cy.get('#text_create_db').type(`${td.databaseName}.${random}`, { force: true });
+    cy.get('#buttonGo').click({ force: true });
     cy.get('.lock-page [type="text"]').type(`${td.tableName}.${random}`);
     cy.get('.lock-page [type="number"]').clear().type(td.columnNumber);
-    cy.contains('[type="submit"]', 'Go').click();
+    cy.contains('[type="submit"]', 'Create').click();
     cy.get('#field_0_1').type(`${td.columnName}.${random}`);
     cy.get('.btn-primary').click();
     cy.visit('index.php');
@@ -58,8 +58,8 @@ it('allows adding a user', () => {
   cy.get('#add_user_anchor').click();
   cy.fixture('testdata').then((td) => {
     cy.get('#pma_username').type(`${td.username}.${random}`);
-    cy.get('#text_pma_pw').type(td.password);
-    cy.get('#text_pma_pw2').type(td.password);
+    cy.get('#text_pma_pw').type(td.password, { force: true });
+    cy.get('#text_pma_pw2').type(td.password, { force: true });
     cy.get('#adduser_submit').click();
   });
   cy.contains('You have added a new user.');


### PR DESCRIPTION
### Description of the change

This PR adapts tests to the new version of PhpMyAdmin, which includes some minor changes in the UI:

- A floating menu that covers some actionable elements (hence, use `force: true`)
- Renaming of some buttons (`Go` -> `Create`)

### Benefits

Working, up-to-date tests.

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

This PR will unblock https://github.com/bitnami/charts/pull/10946

Associated Graph ID used to test: ff12a94e-39d6-45fd-871d-43d2441defc6 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
