### PR TITLE
[bitnami/rabbitmq] Allow set custom logging

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/bitnami-docker-rabbitmq
   - https://www.rabbitmq.com
-version: 10.1.12
+version: 10.1.13

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -468,6 +468,22 @@ To enable extra plugins, set the `extraPlugins` parameter with the list of plugi
 
 Refer to the chart documentation for [more information on using RabbitMQ plugins](https://docs.bitnami.com/kubernetes/infrastructure/rabbitmq/configuration/use-plugins/).
 
+### Advanced logging
+
+In case you want to configure RabbitMQ logging set `logs` value to false and set the log config in extraConfiguration following the [official documentation](https://www.rabbitmq.com/logging.html#log-file-location).
+
+An example:
+
+```yaml
+logs: false # custom logging
+extraConfiguration: |
+  log.default.level = warning
+  log.file = false
+  log.console = true
+  log.console.level = warning
+  log.console.formatter = json
+```
+
 ### Recover the cluster from complete shutdown
 
 > IMPORTANT: Some of these procedures can lead to data loss. Always make a backup beforehand.

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -189,8 +189,10 @@ spec:
             - name: RABBITMQ_LDAP_USER_DN_PATTERN
               value: {{ .Values.ldap.user_dn_pattern }}
             {{- end }}
+            {{- if .Values.logs }}
             - name: RABBITMQ_LOGS
               value: {{ .Values.logs | quote }}
+            {{- end }}
             - name: RABBITMQ_ULIMIT_NOFILES
               value: {{ .Values.ulimitNofiles | quote }}
             {{- if and .Values.maxAvailableSchedulers }}


### PR DESCRIPTION
### Description of the change

Allow not set RABBITMQ_LOGS env to set custom logging. When RABBITMQ_LOGS is set log parameters in rabbitmq.conf are ignored.

The [official documentation says](https://www.rabbitmq.com/logging.html#log-file-location):

> The environment variable takes precedence over the configuration file. When in doubt, consider overriding log file location via the config file. As a consequence of the environment variable precedence, if the environment variable is set, the configuration key `log.file` will not have any effect.

### Benefits

Allow set `log.*` parameters in `extraConfiguration` value.

### Possible drawbacks

I don't think so.

### Additional information

I have been testing `log.` parameters. When the env `RABBITMQ_LOGS` exists seems like rabbit doesn't read log config. So using the following config:

```yaml
extraConfiguration: |
  log.default.level = warning
  log.file = false
  log.console = true
  log.console.level = warning
  log.console.formatter = json
```

The format output is not JSON. It works fine by removing `RABBITMQ_LOGS` env.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
