### PR TITLE
[bitnami/elasticsearch] Set runAsUser 0 for sysctl containers

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/bitnami-docker-elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 18.2.16
+version: 18.2.17

--- a/bitnami/elasticsearch/templates/coordinating/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/statefulset.yaml
@@ -92,6 +92,7 @@ spec:
               {{- include "elasticsearch.sysctlIfLess" (dict "key" "fs.file-max" "value" "65536") | nindent 14 }}
           securityContext:
             privileged: true
+            runAsUser: 0
           {{- if .Values.sysctlImage.resources }}
           resources: {{- toYaml .Values.sysctlImage.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/elasticsearch/templates/data/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data/statefulset.yaml
@@ -92,6 +92,7 @@ spec:
               {{- include "elasticsearch.sysctlIfLess" (dict "key" "fs.file-max" "value" "65536") | nindent 14 }}
           securityContext:
             privileged: true
+            runAsUser: 0
           {{- if .Values.sysctlImage.resources }}
           resources: {{- toYaml .Values.sysctlImage.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/elasticsearch/templates/ingest/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest/statefulset.yaml
@@ -92,6 +92,7 @@ spec:
               {{- include "elasticsearch.sysctlIfLess" (dict "key" "fs.file-max" "value" "65536") | nindent 14 }}
           securityContext:
             privileged: true
+            runAsUser: 0
           {{- if .Values.sysctlImage.resources }}
           resources: {{- toYaml .Values.sysctlImage.resources | nindent 12 }}
           {{- end }}

--- a/bitnami/elasticsearch/templates/master/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master/statefulset.yaml
@@ -92,6 +92,7 @@ spec:
               {{- include "elasticsearch.sysctlIfLess" (dict "key" "fs.file-max" "value" "65536") | nindent 14 }}
           securityContext:
             privileged: true
+            runAsUser: 0
           {{- if .Values.sysctlImage.resources }}
           resources: {{- toYaml .Values.sysctlImage.resources | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
Signed-off-by: Gonzalo Gomez Gracia <gonzalog@vmware.com>

### Description of the change

`bitnami-shell` is now a non-root container by default, which causes the `sysctl` container in Elasticsearch chart to lack the required permissions to modify kernel parameters.

### Benefits

Pods are properly executed now.

### Possible drawbacks

Not expected.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
