### PR TITLE
Mark Wavefront Adapter for Istio as deprecated

### DIFF
--- a/bitnami/wavefront-adapter-for-istio/Chart.yaml
+++ b/bitnami/wavefront-adapter-for-istio/Chart.yaml
@@ -12,7 +12,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: Wavefront Adapter for Istio is an adapter for Istio to expose Istio metrics to Wavefront. It is a lightweight tool written in Go. It supports Istio v1.4+ and Kubernetes v1.15+.
+description: DEPRECATED Wavefront Adapter for Istio is an adapter for Istio to expose Istio metrics to Wavefront. It is a lightweight tool written in Go. It supports Istio v1.4+ and Kubernetes v1.15+.
 engine: gotpl
 home: https://github.com/vmware/wavefront-adapter-for-istio/
 icon: https://bitnami.com/assets/stacks/wavefront-adapter-for-istio/img/wavefront-adapter-for-istio-stack-220x234.png
@@ -25,9 +25,7 @@ keywords:
   - observability
   - wavefront
 maintainers:
-  - name: Bitnami
-    url: https://github.com/bitnami/charts
 name: wavefront-adapter-for-istio
 sources:
   - https://github.com/bitnami/bitnami-docker-wavefront-adapter-for-istio
-version: 2.0.5
+version: 2.0.6


### PR DESCRIPTION
Signed-off-by: michield <michield@vmware.com>

### Description of the change

Marking Wavefront Adapter for Istio as deprecated