### PR TITLE
[bitnami/drupal] Add ServiceAccount

### DIFF
--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -31,4 +31,4 @@ name: drupal
 sources:
   - https://github.com/bitnami/bitnami-docker-drupal
   - https://www.drupal.org/
-version: 12.2.14
+version: 12.3.0

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -82,7 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`                              | Drupal image registry                                                                                                  | `docker.io`          |
 | `image.repository`                            | Drupal Image name                                                                                                      | `bitnami/drupal`     |
-| `image.tag`                                   | Drupal Image tag                                                                                                       | `9.4.1-debian-11-r0` |
+| `image.tag`                                   | Drupal Image tag                                                                                                       | `9.4.2-debian-11-r1` |
 | `image.pullPolicy`                            | Drupal image pull policy                                                                                               | `IfNotPresent`       |
 | `image.pullSecrets`                           | Specify docker-registry secret names as an array                                                                       | `[]`                 |
 | `image.debug`                                 | Specify if debug logs should be enabled                                                                                | `false`              |
@@ -231,7 +231,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                 |
 | `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                                          | `docker.io`             |
 | `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                                                              | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `11-debian-11-r10`      |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `11-debian-11-r13`      |
 | `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                                                       | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                                          | `[]`                    |
 | `volumePermissions.resources.limits`   | The resources limits for the container                                                                                                                    | `{}`                    |
@@ -245,7 +245,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`           | Start a exporter side-car                        | `false`                   |
 | `metrics.image.registry`    | Apache exporter image registry                   | `docker.io`               |
 | `metrics.image.repository`  | Apache exporter image repository                 | `bitnami/apache-exporter` |
-| `metrics.image.tag`         | Apache exporter image tag                        | `0.11.0-debian-11-r10`    |
+| `metrics.image.tag`         | Apache exporter image tag                        | `0.11.0-debian-11-r13`    |
 | `metrics.image.pullPolicy`  | Image pull policy                                | `IfNotPresent`            |
 | `metrics.image.pullSecrets` | Specify docker-registry secret names as an array | `[]`                      |
 | `metrics.resources`         | Metrics exporter resource requests and limits    | `{}`                      |
@@ -270,7 +270,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `certificates.extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)         | `""`                                     |
 | `certificates.image.registry`                        | Container sidecar registry                                           | `docker.io`                              |
 | `certificates.image.repository`                      | Container sidecar image                                              | `bitnami/bitnami-shell`                  |
-| `certificates.image.tag`                             | Container sidecar image tag                                          | `11-debian-11-r10`                       |
+| `certificates.image.tag`                             | Container sidecar image tag                                          | `11-debian-11-r13`                       |
 | `certificates.image.pullPolicy`                      | Container sidecar image pull policy                                  | `IfNotPresent`                           |
 | `certificates.image.pullSecrets`                     | Container sidecar image pull secrets                                 | `[]`                                     |
 

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -78,92 +78,96 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Drupal parameters
 
-| Name                                    | Description                                                                                                           | Value                  |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `image.registry`                        | Drupal image registry                                                                                                 | `docker.io`            |
-| `image.repository`                      | Drupal Image name                                                                                                     | `bitnami/drupal`       |
-| `image.tag`                             | Drupal Image tag                                                                                                      | `9.3.12-debian-10-r20` |
-| `image.pullPolicy`                      | Drupal image pull policy                                                                                              | `IfNotPresent`         |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                      | `[]`                   |
-| `image.debug`                           | Specify if debug logs should be enabled                                                                               | `false`                |
-| `replicaCount`                          | Number of Drupal Pods to run (requires ReadWriteMany PVC support)                                                     | `1`                    |
-| `drupalProfile`                         | Drupal installation profile                                                                                           | `standard`             |
-| `drupalSkipInstall`                     | Skip Drupal installation wizard. Useful for migrations and restoring from SQL dump                                    | `false`                |
-| `drupalUsername`                        | User of the application                                                                                               | `user`                 |
-| `drupalPassword`                        | Application password                                                                                                  | `""`                   |
-| `drupalEmail`                           | Admin email                                                                                                           | `user@example.com`     |
-| `allowEmptyPassword`                    | Allow DB blank passwords                                                                                              | `true`                 |
-| `command`                               | Override default container command (useful when using custom images)                                                  | `[]`                   |
-| `args`                                  | Override default container args (useful when using custom images)                                                     | `[]`                   |
-| `updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                        | `RollingUpdate`        |
-| `priorityClassName`                     | Drupal pods' priorityClassName                                                                                        | `""`                   |
-| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                                        | `""`                   |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                        | `[]`                   |
-| `hostAliases`                           | Add deployment host aliases                                                                                           | `[]`                   |
-| `extraEnvVars`                          | Extra environment variables                                                                                           | `[]`                   |
-| `extraEnvVarsCM`                        | ConfigMap containing extra env vars                                                                                   | `""`                   |
-| `extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)                                                          | `""`                   |
-| `extraVolumes`                          | Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`    | `[]`                   |
-| `extraVolumeMounts`                     | Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`. | `[]`                   |
-| `initContainers`                        | Add additional init containers to the pod (evaluated as a template)                                                   | `[]`                   |
-| `sidecars`                              | Attach additional containers to the pod (evaluated as a template)                                                     | `[]`                   |
-| `tolerations`                           | Tolerations for pod assignment                                                                                        | `[]`                   |
-| `existingSecret`                        | Name of a secret with the application password                                                                        | `""`                   |
-| `smtpHost`                              | SMTP host                                                                                                             | `""`                   |
-| `smtpPort`                              | SMTP port                                                                                                             | `""`                   |
-| `smtpUser`                              | SMTP user                                                                                                             | `""`                   |
-| `smtpPassword`                          | SMTP password                                                                                                         | `""`                   |
-| `smtpProtocol`                          | SMTP Protocol (options: ssl,tls, nil)                                                                                 | `""`                   |
-| `containerPorts`                        | Container ports                                                                                                       | `{}`                   |
-| `sessionAffinity`                       | Control where client requests go, to the same pod or round-robin. Values: ClientIP or None                            | `None`                 |
-| `persistence.enabled`                   | Enable persistence using PVC                                                                                          | `true`                 |
-| `persistence.storageClass`              | PVC Storage Class for Drupal volume                                                                                   | `""`                   |
-| `persistence.accessModes`               | PVC Access Mode for Drupal volume                                                                                     | `["ReadWriteOnce"]`    |
-| `persistence.size`                      | PVC Storage Request for Drupal volume                                                                                 | `8Gi`                  |
-| `persistence.existingClaim`             | A manually managed Persistent Volume Claim                                                                            | `""`                   |
-| `persistence.hostPath`                  | If defined, the drupal-data volume will mount to the specified hostPath.                                              | `""`                   |
-| `persistence.annotations`               | Persistent Volume Claim annotations                                                                                   | `{}`                   |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                   | `""`                   |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `soft`                 |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                   |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                                 | `""`                   |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                             | `[]`                   |
-| `affinity`                              | Affinity for pod assignment                                                                                           | `{}`                   |
-| `nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                                              | `{}`                   |
-| `resources.requests`                    | The requested resources for the init container                                                                        | `{}`                   |
-| `resources.limits`                      | The resources limits for the init container                                                                           | `{}`                   |
-| `podSecurityContext.enabled`            | Enable Drupal pods' Security Context                                                                                  | `true`                 |
-| `podSecurityContext.fsGroup`            | Drupal pods' group ID                                                                                                 | `1001`                 |
-| `containerSecurityContext.enabled`      | Enable Drupal containers' Security Context                                                                            | `true`                 |
-| `containerSecurityContext.runAsUser`    | Drupal containers' Security Context                                                                                   | `1001`                 |
-| `containerSecurityContext.runAsNonRoot` | Set Controller container's Security Context runAsNonRoot                                                              | `true`                 |
-| `startupProbe.enabled`                  | Enable startupProbe                                                                                                   | `false`                |
-| `startupProbe.path`                     | Request path for startupProbe                                                                                         | `/user/login`          |
-| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                | `600`                  |
-| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                       | `10`                   |
-| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                      | `5`                    |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                    | `5`                    |
-| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                    | `1`                    |
-| `livenessProbe.enabled`                 | Enable livenessProbe                                                                                                  | `true`                 |
-| `livenessProbe.path`                    | Request path for livenessProbe                                                                                        | `/user/login`          |
-| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                               | `600`                  |
-| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                      | `10`                   |
-| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                     | `5`                    |
-| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                   | `5`                    |
-| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                   | `1`                    |
-| `readinessProbe.enabled`                | Enable readinessProbe                                                                                                 | `true`                 |
-| `readinessProbe.path`                   | Request path for readinessProbe                                                                                       | `/user/login`          |
-| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                              | `30`                   |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                     | `5`                    |
-| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                    | `1`                    |
-| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                  | `5`                    |
-| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                  | `1`                    |
-| `customStartupProbe`                    | Override default startup probe                                                                                        | `{}`                   |
-| `customLivenessProbe`                   | Override default liveness probe                                                                                       | `{}`                   |
-| `customReadinessProbe`                  | Override default readiness probe                                                                                      | `{}`                   |
-| `lifecycleHooks`                        | LifecycleHook to set additional configuration at startup Evaluated as a template                                      | `{}`                   |
-| `podAnnotations`                        | Pod annotations                                                                                                       | `{}`                   |
-| `podLabels`                             | Add additional labels to the pod (evaluated as a template)                                                            | `{}`                   |
+| Name                                          | Description                                                                                                            | Value                |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `image.registry`                              | Drupal image registry                                                                                                  | `docker.io`          |
+| `image.repository`                            | Drupal Image name                                                                                                      | `bitnami/drupal`     |
+| `image.tag`                                   | Drupal Image tag                                                                                                       | `9.4.1-debian-11-r0` |
+| `image.pullPolicy`                            | Drupal image pull policy                                                                                               | `IfNotPresent`       |
+| `image.pullSecrets`                           | Specify docker-registry secret names as an array                                                                       | `[]`                 |
+| `image.debug`                                 | Specify if debug logs should be enabled                                                                                | `false`              |
+| `replicaCount`                                | Number of Drupal Pods to run (requires ReadWriteMany PVC support)                                                      | `1`                  |
+| `drupalProfile`                               | Drupal installation profile                                                                                            | `standard`           |
+| `drupalSkipInstall`                           | Skip Drupal installation wizard. Useful for migrations and restoring from SQL dump                                     | `false`              |
+| `drupalUsername`                              | User of the application                                                                                                | `user`               |
+| `drupalPassword`                              | Application password                                                                                                   | `""`                 |
+| `drupalEmail`                                 | Admin email                                                                                                            | `user@example.com`   |
+| `allowEmptyPassword`                          | Allow DB blank passwords                                                                                               | `true`               |
+| `command`                                     | Override default container command (useful when using custom images)                                                   | `[]`                 |
+| `args`                                        | Override default container args (useful when using custom images)                                                      | `[]`                 |
+| `updateStrategy.type`                         | Update strategy - only really applicable for deployments with RWO PVs attached                                         | `RollingUpdate`      |
+| `priorityClassName`                           | Drupal pods' priorityClassName                                                                                         | `""`                 |
+| `schedulerName`                               | Name of the k8s scheduler (other than default)                                                                         | `""`                 |
+| `topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                                         | `[]`                 |
+| `hostAliases`                                 | Add deployment host aliases                                                                                            | `[]`                 |
+| `extraEnvVars`                                | Extra environment variables                                                                                            | `[]`                 |
+| `extraEnvVarsCM`                              | ConfigMap containing extra env vars                                                                                    | `""`                 |
+| `extraEnvVarsSecret`                          | Secret containing extra env vars (in case of sensitive data)                                                           | `""`                 |
+| `extraVolumes`                                | Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`     | `[]`                 |
+| `extraVolumeMounts`                           | Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes`.  | `[]`                 |
+| `initContainers`                              | Add additional init containers to the pod (evaluated as a template)                                                    | `[]`                 |
+| `sidecars`                                    | Attach additional containers to the pod (evaluated as a template)                                                      | `[]`                 |
+| `tolerations`                                 | Tolerations for pod assignment                                                                                         | `[]`                 |
+| `serviceAccount.create`                       | Specifies whether a service account should be created                                                                  | `true`               |
+| `serviceAccount.name`                         | The name of the service account to use. If not set and create is true, a name is generated using the fullname template | `""`                 |
+| `serviceAccount.annotations`                  | Add annotations                                                                                                        | `{}`                 |
+| `serviceAccount.automountServiceAccountToken` | Automount API credentials for a service account.                                                                       | `true`               |
+| `existingSecret`                              | Name of a secret with the application password                                                                         | `""`                 |
+| `smtpHost`                                    | SMTP host                                                                                                              | `""`                 |
+| `smtpPort`                                    | SMTP port                                                                                                              | `""`                 |
+| `smtpUser`                                    | SMTP user                                                                                                              | `""`                 |
+| `smtpPassword`                                | SMTP password                                                                                                          | `""`                 |
+| `smtpProtocol`                                | SMTP Protocol (options: ssl,tls, nil)                                                                                  | `""`                 |
+| `containerPorts`                              | Container ports                                                                                                        | `{}`                 |
+| `sessionAffinity`                             | Control where client requests go, to the same pod or round-robin. Values: ClientIP or None                             | `None`               |
+| `persistence.enabled`                         | Enable persistence using PVC                                                                                           | `true`               |
+| `persistence.storageClass`                    | PVC Storage Class for Drupal volume                                                                                    | `""`                 |
+| `persistence.accessModes`                     | PVC Access Mode for Drupal volume                                                                                      | `["ReadWriteOnce"]`  |
+| `persistence.size`                            | PVC Storage Request for Drupal volume                                                                                  | `8Gi`                |
+| `persistence.existingClaim`                   | A manually managed Persistent Volume Claim                                                                             | `""`                 |
+| `persistence.hostPath`                        | If defined, the drupal-data volume will mount to the specified hostPath.                                               | `""`                 |
+| `persistence.annotations`                     | Persistent Volume Claim annotations                                                                                    | `{}`                 |
+| `podAffinityPreset`                           | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                    | `""`                 |
+| `podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                               | `soft`               |
+| `nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                              | `""`                 |
+| `nodeAffinityPreset.key`                      | Node label key to match Ignored if `affinity` is set.                                                                  | `""`                 |
+| `nodeAffinityPreset.values`                   | Node label values to match. Ignored if `affinity` is set.                                                              | `[]`                 |
+| `affinity`                                    | Affinity for pod assignment                                                                                            | `{}`                 |
+| `nodeSelector`                                | Node labels for pod assignment. Evaluated as a template.                                                               | `{}`                 |
+| `resources.requests`                          | The requested resources for the init container                                                                         | `{}`                 |
+| `resources.limits`                            | The resources limits for the init container                                                                            | `{}`                 |
+| `podSecurityContext.enabled`                  | Enable Drupal pods' Security Context                                                                                   | `true`               |
+| `podSecurityContext.fsGroup`                  | Drupal pods' group ID                                                                                                  | `1001`               |
+| `containerSecurityContext.enabled`            | Enable Drupal containers' Security Context                                                                             | `true`               |
+| `containerSecurityContext.runAsUser`          | Drupal containers' Security Context                                                                                    | `1001`               |
+| `containerSecurityContext.runAsNonRoot`       | Set Controller container's Security Context runAsNonRoot                                                               | `true`               |
+| `startupProbe.enabled`                        | Enable startupProbe                                                                                                    | `false`              |
+| `startupProbe.path`                           | Request path for startupProbe                                                                                          | `/user/login`        |
+| `startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                                                 | `600`                |
+| `startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                                        | `10`                 |
+| `startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                                       | `5`                  |
+| `startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                                                     | `5`                  |
+| `startupProbe.successThreshold`               | Success threshold for startupProbe                                                                                     | `1`                  |
+| `livenessProbe.enabled`                       | Enable livenessProbe                                                                                                   | `true`               |
+| `livenessProbe.path`                          | Request path for livenessProbe                                                                                         | `/user/login`        |
+| `livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                                | `600`                |
+| `livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                                       | `10`                 |
+| `livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                                      | `5`                  |
+| `livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                                    | `5`                  |
+| `livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                                    | `1`                  |
+| `readinessProbe.enabled`                      | Enable readinessProbe                                                                                                  | `true`               |
+| `readinessProbe.path`                         | Request path for readinessProbe                                                                                        | `/user/login`        |
+| `readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                                               | `30`                 |
+| `readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                                      | `5`                  |
+| `readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                                                     | `1`                  |
+| `readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                                                   | `5`                  |
+| `readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                                                   | `1`                  |
+| `customStartupProbe`                          | Override default startup probe                                                                                         | `{}`                 |
+| `customLivenessProbe`                         | Override default liveness probe                                                                                        | `{}`                 |
+| `customReadinessProbe`                        | Override default readiness probe                                                                                       | `{}`                 |
+| `lifecycleHooks`                              | LifecycleHook to set additional configuration at startup Evaluated as a template                                       | `{}`                 |
+| `podAnnotations`                              | Pod annotations                                                                                                        | `{}`                 |
+| `podLabels`                                   | Add additional labels to the pod (evaluated as a template)                                                             | `{}`                 |
 
 
 ### Traffic Exposure Parameters
@@ -227,7 +231,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                 |
 | `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                                          | `docker.io`             |
 | `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                                                              | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `10-debian-10-r422`     |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `11-debian-11-r10`      |
 | `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                                                       | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                                          | `[]`                    |
 | `volumePermissions.resources.limits`   | The resources limits for the container                                                                                                                    | `{}`                    |
@@ -241,7 +245,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`           | Start a exporter side-car                        | `false`                   |
 | `metrics.image.registry`    | Apache exporter image registry                   | `docker.io`               |
 | `metrics.image.repository`  | Apache exporter image repository                 | `bitnami/apache-exporter` |
-| `metrics.image.tag`         | Apache exporter image tag                        | `0.11.0-debian-10-r141`   |
+| `metrics.image.tag`         | Apache exporter image tag                        | `0.11.0-debian-11-r10`    |
 | `metrics.image.pullPolicy`  | Image pull policy                                | `IfNotPresent`            |
 | `metrics.image.pullSecrets` | Specify docker-registry secret names as an array | `[]`                      |
 | `metrics.resources`         | Metrics exporter resource requests and limits    | `{}`                      |
@@ -266,7 +270,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `certificates.extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)         | `""`                                     |
 | `certificates.image.registry`                        | Container sidecar registry                                           | `docker.io`                              |
 | `certificates.image.repository`                      | Container sidecar image                                              | `bitnami/bitnami-shell`                  |
-| `certificates.image.tag`                             | Container sidecar image tag                                          | `10-debian-10-r422`                      |
+| `certificates.image.tag`                             | Container sidecar image tag                                          | `11-debian-11-r10`                       |
 | `certificates.image.pullPolicy`                      | Container sidecar image pull policy                                  | `IfNotPresent`                           |
 | `certificates.image.pullSecrets`                     | Container sidecar image pull secrets                                 | `[]`                                     |
 

--- a/bitnami/drupal/templates/_helpers.tpl
+++ b/bitnami/drupal/templates/_helpers.tpl
@@ -126,3 +126,14 @@ mariadb-password
 db-password
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "drupal.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/bitnami/drupal/templates/deployment.yaml
+++ b/bitnami/drupal/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
         podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "context" $) | nindent 10 }}
         nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
       {{- end }}
+      serviceAccountName: {{ include "drupal.serviceAccountName" . }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName }}
       {{- end }}

--- a/bitnami/drupal/templates/serviceaccount.yaml
+++ b/bitnami/drupal/templates/serviceaccount.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "drupal.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/bitnami/drupal/values.schema.json
+++ b/bitnami/drupal/values.schema.json
@@ -183,6 +183,36 @@
           "form": true
         }
       }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "drupal": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "string",
+              "title": "Specifies whether a service account should be created",
+              "form": true
+            },
+            "name": {
+              "type": "string",
+              "title": "The name of the service account to use",
+              "form": true
+            },
+            "annotations": {
+              "type": "string",
+              "title": "Add annotations",
+              "form": true
+            },
+            "automountServiceAccountToken": {
+              "type": "string",
+              "title": "Automount API credentials for a service account",
+              "form": true
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/bitnami/drupal/values.yaml
+++ b/bitnami/drupal/values.yaml
@@ -162,6 +162,19 @@ sidecars: []
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a service account should be created
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the service account to use. If not set and create is true, a name is generated using the fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.annotations Add annotations
+  ##
+  annotations: {}
+  ## @param serviceAccount.automountServiceAccountToken Automount API credentials for a service account.
+  ##
+  automountServiceAccountToken: true
 ## @param existingSecret Name of a secret with the application password
 ##
 existingSecret: ""


### PR DESCRIPTION
### Description of the change
This PR adds a configurable ServiceAccount to Drupal

### Benefits
It is Best Practice to use ServiceAccounts per Namespace/Deploment for security reasons

### Possible drawbacks
No drawbacks because a default ServiceAccount will be used as fallback

### Checklist

- [x]  Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is not necessary when the changes only affect README.md files.
- [x]  Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x]  Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x]  All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)