### PR TITLE
[bitnami/external-dns] Fix issue with psp-cluster-role

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/bitnami-docker-external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 6.6.0
+version: 6.6.1

--- a/bitnami/external-dns/templates/psp-clusterrole.yaml
+++ b/bitnami/external-dns/templates/psp-clusterrole.yaml
@@ -17,5 +17,5 @@ rules:
   resources: ['podsecuritypolicies']
   verbs:     ['use']
   resourceNames:
-  - - {{ template "common.names.fullname.namespace" . }}
+  - {{ template "common.names.fullname.namespace" . }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

### Description of the change

Fixes an issue with the psp-clusterrole template caused by a double dash `-`

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #11079

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
