### PR TITLE
[bitnami/keycloak] make metrics scrape target configurable

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/bitnami-docker-keycloak
   - https://github.com/keycloak/keycloak
-version: 9.4.3
+version: 9.5.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -244,21 +244,22 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics parameters
 
-| Name                                       | Description                                                                           | Value   |
-| ------------------------------------------ | ------------------------------------------------------------------------------------- | ------- |
-| `metrics.enabled`                          | Enable exposing Keycloak statistics                                                   | `false` |
-| `metrics.service.ports.http`               | Metrics service HTTP port                                                             | `8080`  |
-| `metrics.service.annotations`              | Annotations for enabling prometheus to access the metrics endpoints                   | `{}`    |
-| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator          | `false` |
-| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                              | `""`    |
-| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                           | `30s`   |
-| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                   | `""`    |
-| `metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`    |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                   | `{}`    |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                    | `[]`    |
-| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                             | `[]`    |
-| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels              | `false` |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.     | `""`    |
+| Name                                       | Description                                                                           | Value      |
+| ------------------------------------------ | ------------------------------------------------------------------------------------- | ---------- |
+| `metrics.enabled`                          | Enable exposing Keycloak statistics                                                   | `false`    |
+| `metrics.service.ports.http`               | Metrics service HTTP port                                                             | `8080`     |
+| `metrics.service.annotations`              | Annotations for enabling prometheus to access the metrics endpoints                   | `{}`       |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator          | `false`    |
+| `metrics.serviceMonitor.path`              | Metrics service HTTP path                                                             | `/metrics` |
+| `metrics.serviceMonitor.namespace`         | Namespace which Prometheus is running in                                              | `""`       |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped                                           | `30s`      |
+| `metrics.serviceMonitor.scrapeTimeout`     | Specify the timeout after which the scrape is ended                                   | `""`       |
+| `metrics.serviceMonitor.labels`            | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`       |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                   | `{}`       |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                    | `[]`       |
+| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                             | `[]`       |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels              | `false`    |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.     | `""`       |
 
 
 ### keycloak-config-cli parameters

--- a/bitnami/keycloak/templates/servicemonitor.yaml
+++ b/bitnami/keycloak/templates/servicemonitor.yaml
@@ -21,6 +21,9 @@ spec:
   {{- end }}
   endpoints:
     - port: http
+      {{- if .Values.metrics.serviceMonitor.path }}
+      path: {{ .Values.metrics.serviceMonitor.path }}
+      {{- end }}
       {{- if .Values.metrics.serviceMonitor.interval }}
       interval: {{ .Values.metrics.serviceMonitor.interval }}
       {{- end }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -745,6 +745,9 @@ metrics:
     ## @param metrics.serviceMonitor.enabled Create ServiceMonitor Resource for scraping metrics using PrometheusOperator
     ##
     enabled: false
+    ## @param metrics.serviceMonitor.path Metrics service HTTP path
+    ##
+    path: /metrics
     ## @param metrics.serviceMonitor.namespace Namespace which Prometheus is running in
     ##
     namespace: ""


### PR DESCRIPTION
### Description of the change

This change will allow the scrape path to be configurable, as `/metrics` will only work, if `httpRelativePath` is set to `/`

### Benefits

Monitoring will work if `httpRelativePath` set to a non-default value.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

```
keycloak@keycloak-2:/$ curl -s http://localhost:8080/metrics; echo
<html><body><h1>Resource not found</h1></body></html>

keycloak@keycloak-2:/$ curl -s http://localhost:8080/auth/metrics | head -n1; echo
# HELP base_classloader_loadedClasses_count Displays the number of classes that are currently loaded in the Java virtual machine.

```
### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
