### PR TITLE
[bitnami/redis] Remove 'slave-read-only yes' test for replicas

### DIFF
--- a/.vib/redis/replicas/goss/goss-replica/goss.yaml
+++ b/.vib/redis/replicas/goss/goss-replica/goss.yaml
@@ -84,6 +84,5 @@ file:
     mode: "0777"
     filetype: symlink
     contains:
-      - slave-read-only yes
       - rename-command FLUSHDB ""
       - rename-command FLUSHALL ""


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

In #10655 `slave-read-only yes` was removed because that configuration was removed in 2.6 and the new `replica-read-only` is `yes` by default

### Benefits

Keep tests aligned with latest redis version

### Additional information

#10655 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
