### PR TITLE
[bitnami/matomo] Fix category case

### DIFF
--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -1,5 +1,5 @@
 annotations:
-  category: analytics
+  category: Analytics
 apiVersion: v2
 appVersion: 4.10.1
 dependencies:
@@ -30,4 +30,4 @@ name: matomo
 sources:
   - https://github.com/bitnami/bitnami-docker-matomo
   - https://www.matomo.org/
-version: 0.1.2
+version: 0.1.3


### PR DESCRIPTION
### Description of the change

This PR just changes the case in the `category` field, as the rest of the chart capitalizes the first letter. So, `analytics` becomes `Analytics`.

### Benefits

For case-sensitive consumers (like Kubeapps)  this field will be processed properly

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
