### PR TITLE
[bitnami/redis-cluster] Allow specifying metrics container security context

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
   - http://redis.io/
-version: 8.0.0
+version: 8.1.0

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -277,38 +277,40 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics sidecar parameters
 
-| Name                                       | Description                                                                                                                        | Value                    |
-| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                                               | `false`                  |
-| `metrics.image.registry`                   | Redis&reg; exporter image registry                                                                                                 | `docker.io`              |
-| `metrics.image.repository`                 | Redis&reg; exporter image name                                                                                                     | `bitnami/redis-exporter` |
-| `metrics.image.tag`                        | Redis&reg; exporter image tag                                                                                                      | `1.43.0-debian-11-r7`    |
-| `metrics.image.pullPolicy`                 | Redis&reg; exporter image pull policy                                                                                              | `IfNotPresent`           |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                                                   | `[]`                     |
-| `metrics.resources`                        | Metrics exporter resource requests and limits                                                                                      | `{}`                     |
-| `metrics.extraArgs`                        | Extra arguments for the binary; possible values [here](https://github.com/oliver006/redis_exporter                                 | `{}`                     |
-| `metrics.podAnnotations`                   | Additional annotations for Metrics exporter pod                                                                                    | `{}`                     |
-| `metrics.podLabels`                        | Additional labels for Metrics exporter pod                                                                                         | `{}`                     |
-| `metrics.serviceMonitor.enabled`           | If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                             | `false`                  |
-| `metrics.serviceMonitor.namespace`         | Optional namespace which Prometheus is running in                                                                                  | `""`                     |
-| `metrics.serviceMonitor.interval`          | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                                             | `""`                     |
-| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                                            | `""`                     |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                                                | `{}`                     |
-| `metrics.serviceMonitor.labels`            | ServiceMonitor extra labels                                                                                                        | `{}`                     |
-| `metrics.serviceMonitor.annotations`       | ServiceMonitor annotations                                                                                                         | `{}`                     |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                                                  | `""`                     |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                                                 | `[]`                     |
-| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                                                          | `[]`                     |
-| `metrics.prometheusRule.enabled`           | Set this to true to create prometheusRules for Prometheus operator                                                                 | `false`                  |
-| `metrics.prometheusRule.additionalLabels`  | Additional labels that can be used so prometheusRules will be discovered by Prometheus                                             | `{}`                     |
-| `metrics.prometheusRule.namespace`         | namespace where prometheusRules resource should be created                                                                         | `""`                     |
-| `metrics.prometheusRule.rules`             | Create specified [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/), check values for an example. | `[]`                     |
-| `metrics.priorityClassName`                | Metrics exporter pod priorityClassName                                                                                             | `""`                     |
-| `metrics.service.type`                     | Kubernetes Service type (redis metrics)                                                                                            | `ClusterIP`              |
-| `metrics.service.loadBalancerIP`           | Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank                                                   | `""`                     |
-| `metrics.service.annotations`              | Annotations for the services to monitor.                                                                                           | `{}`                     |
-| `metrics.service.labels`                   | Additional labels for the metrics service                                                                                          | `{}`                     |
-| `metrics.service.clusterIP`                | Service Cluster IP                                                                                                                 | `""`                     |
+| Name                                                        | Description                                                                                                                        | Value                    |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `metrics.enabled`                                           | Start a side-car prometheus exporter                                                                                               | `false`                  |
+| `metrics.image.registry`                                    | Redis&reg; exporter image registry                                                                                                 | `docker.io`              |
+| `metrics.image.repository`                                  | Redis&reg; exporter image name                                                                                                     | `bitnami/redis-exporter` |
+| `metrics.image.tag`                                         | Redis&reg; exporter image tag                                                                                                      | `1.43.0-debian-11-r7`    |
+| `metrics.image.pullPolicy`                                  | Redis&reg; exporter image pull policy                                                                                              | `IfNotPresent`           |
+| `metrics.image.pullSecrets`                                 | Specify docker-registry secret names as an array                                                                                   | `[]`                     |
+| `metrics.resources`                                         | Metrics exporter resource requests and limits                                                                                      | `{}`                     |
+| `metrics.extraArgs`                                         | Extra arguments for the binary; possible values [here](https://github.com/oliver006/redis_exporter                                 | `{}`                     |
+| `metrics.podAnnotations`                                    | Additional annotations for Metrics exporter pod                                                                                    | `{}`                     |
+| `metrics.podLabels`                                         | Additional labels for Metrics exporter pod                                                                                         | `{}`                     |
+| `metrics.containerSecurityContext.enabled`                  | Enable Metrics Containers' Security Context                                                                                        | `false`                  |
+| `metrics.containerSecurityContext.allowPrivilegeEscalation` | Allow Privilege Escalation for metrics container                                                                                   | `false`                  |
+| `metrics.serviceMonitor.enabled`                            | If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                             | `false`                  |
+| `metrics.serviceMonitor.namespace`                          | Optional namespace which Prometheus is running in                                                                                  | `""`                     |
+| `metrics.serviceMonitor.interval`                           | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                                             | `""`                     |
+| `metrics.serviceMonitor.scrapeTimeout`                      | Timeout after which the scrape is ended                                                                                            | `""`                     |
+| `metrics.serviceMonitor.selector`                           | Prometheus instance selector labels                                                                                                | `{}`                     |
+| `metrics.serviceMonitor.labels`                             | ServiceMonitor extra labels                                                                                                        | `{}`                     |
+| `metrics.serviceMonitor.annotations`                        | ServiceMonitor annotations                                                                                                         | `{}`                     |
+| `metrics.serviceMonitor.jobLabel`                           | The name of the label on the target service to use as the job name in prometheus.                                                  | `""`                     |
+| `metrics.serviceMonitor.relabelings`                        | RelabelConfigs to apply to samples before scraping                                                                                 | `[]`                     |
+| `metrics.serviceMonitor.metricRelabelings`                  | MetricRelabelConfigs to apply to samples before ingestion                                                                          | `[]`                     |
+| `metrics.prometheusRule.enabled`                            | Set this to true to create prometheusRules for Prometheus operator                                                                 | `false`                  |
+| `metrics.prometheusRule.additionalLabels`                   | Additional labels that can be used so prometheusRules will be discovered by Prometheus                                             | `{}`                     |
+| `metrics.prometheusRule.namespace`                          | namespace where prometheusRules resource should be created                                                                         | `""`                     |
+| `metrics.prometheusRule.rules`                              | Create specified [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/), check values for an example. | `[]`                     |
+| `metrics.priorityClassName`                                 | Metrics exporter pod priorityClassName                                                                                             | `""`                     |
+| `metrics.service.type`                                      | Kubernetes Service type (redis metrics)                                                                                            | `ClusterIP`              |
+| `metrics.service.loadBalancerIP`                            | Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank                                                   | `""`                     |
+| `metrics.service.annotations`                               | Annotations for the services to monitor.                                                                                           | `{}`                     |
+| `metrics.service.labels`                                    | Additional labels for the metrics service                                                                                          | `{}`                     |
+| `metrics.service.clusterIP`                                 | Service Cluster IP                                                                                                                 | `""`                     |
 
 
 ### Sysctl Image parameters

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -289,6 +289,9 @@ spec:
         - name: metrics
           image: {{ template "redis-cluster.metrics.image" . }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+          {{- if .Values.metrics.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.metrics.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.diagnosticMode.enabled }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -821,6 +821,13 @@ metrics:
   ## @param metrics.podLabels Additional labels for Metrics exporter pod
   ##
   podLabels: {}
+  ## Containers' Security Context - All fields other than `enabled` get added to the metrics container's security context
+  ## @param metrics.containerSecurityContext.enabled Enable Metrics Containers' Security Context
+  ## @param metrics.containerSecurityContext.allowPrivilegeEscalation Allow Privilege Escalation for metrics container
+  ##
+  containerSecurityContext:
+    enabled: false
+    allowPrivilegeEscalation: false
   ## Enable this if you're using https://github.com/coreos/prometheus-operator
   ##
   serviceMonitor:


### PR DESCRIPTION
Signed-off-by: Muhammad Hamza Zaib <hamzazaib3202@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This pull request adds the ability to specify container security context for the metrics container. Even though the change introduced does not break anything, it is still disabled by default i.e the default behavior is to not set container security context for the metrics container.

### Benefits

<!-- What benefits will be realized by the code change? -->

It will be possible to set the container security context for the metrics container. If a cluster doesn't allow privilege escalation then it is not possible to deploy redis with metrics currently.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None that I am aware of

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
N/A
### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
