### PR TITLE
[bitnami/discourse] Update Redis subchart

### DIFF
--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 16.13.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.15
+  version: 11.6.16
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.16.0
-digest: sha256:c9a64bc0866b174f1940e502f5365e0663d527eb5a2c83419d419444aaba63c1
-generated: "2022-07-09T08:44:20.932513126Z"
+digest: sha256:143d69f00809efd8c7dc2342e0f44264b159a6352f2b456cdd35762dff9e1c8c
+generated: "2022-07-13T14:17:42.588027+02:00"

--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.13.2
+  version: 17.0.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 11.6.16
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.16.0
-digest: sha256:143d69f00809efd8c7dc2342e0f44264b159a6352f2b456cdd35762dff9e1c8c
-generated: "2022-07-13T14:17:42.588027+02:00"
+digest: sha256:4045b6ff34a7f25652bd8412107798b26fb2c3c8de316d9d054b5f350152a573
+generated: "2022-07-13T17:21:55.237481+02:00"

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 7.3.13
+version: 8.0.0

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 16.X.X
+    version: 17.X.X
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
### Description of the change

This PR updates the Redis subchart to its latest major `17.0.1`, which updates Redis to its latest version 7.0.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)