### PR TITLE
[bitnami/argo-cd] Update Redis subchart

### DIFF
--- a/bitnami/argo-cd/Chart.lock
+++ b/bitnami/argo-cd/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.13.2
+  version: 17.0.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.16.0
-digest: sha256:460bf4e4b3247a7947e6c11afbc59bc2762c310746daad286afdfd4b0c277e8a
-generated: "2022-07-08T18:44:31.109263184Z"
+digest: sha256:8ecf3cb0d8774217fc8f8b6a6b6adf46c9bb525e11fb240b320d6ba9d6a765b2
+generated: "2022-07-13T14:17:35.245675+02:00"

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -6,7 +6,7 @@ dependencies:
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 16.x.x
+    version: 17.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/bitnami-docker-dex
   - https://github.com/dexidp/dex
-version: 3.4.6
+version: 4.0.0

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -7,7 +7,7 @@ Argo CD is a continuous delivery tool for Kubernetes based on GitOps.
 [Overview of Argo CD](https://argoproj.github.io/cd)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -705,48 +705,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
-### To 3.0.0
-
-This major update the Redis&reg; subchart to its newest major, 16.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1600) you can find more info about the specific changes.
-
-Additionally, this chart has been standardised adding features from other charts.
-
-### To 2.0.0
-
-This major update the Redis&reg; subchart to its newest major, 15.0.0. [Here](https://github.com/bitnami/charts/tree/master/bitnami/redis#to-1500) you can find more info about the specific changes.
-
-### To 1.0.0
-
-In this version, the `image` block is defined once and is used in the different templates, while in the previous version, the `image` block was duplicated for every component
-
-```yaml
-image:
-  registry: docker.io
-  repository: bitnami/argo-cd
-  tag: 2.0.5
-```
-VS
-```yaml
-controller:
-  image:
-    registry: docker.io
-    repository: bitnami/argo-cd
-    tag: 2.0.5
-...
-server:
-  image:
-    registry: docker.io
-    repository: bitnami/argo-cd
-    tag: 2.0.5
-...
-repoServer:
-  image:
-    registry: docker.io
-    repository: bitnami/argo-cd
-    tag: 2.0.5
-```
-
-See [PR#7113](https://github.com/bitnami/charts/pull/7113) for more info about the implemented changes
+Refer to the [chart documentation for more information about how to upgrade from previous releases](https://docs.bitnami.com/kubernetes/infrastructure/harbor/administration/upgrade/).
 
 ## License
 


### PR DESCRIPTION
### Description of the change

This PR updates the Redis subchart to its latest major `17.0.1`, which updates Redis to its latest version 7.0.

Upgrading notes will be moved to charts-docs: bitnami/charts-docs#120

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)