### PR TITLE
[bitnami/kubeapps] Update Redis subchart

### DIFF
--- a/bitnami/kubeapps/Chart.lock
+++ b/bitnami/kubeapps/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 16.13.1
+  version: 17.0.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.12
+  version: 11.6.16
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 1.16.0
-digest: sha256:280e8b6072e8285d9ffaa1af864f1c9d7a87fe847742fdd75482f5a2b60674e0
-generated: "2022-07-01T03:30:28.134505552Z"
+digest: sha256:026544156c432b63fea1b34c28c2eb1dc0c21ad73628551d31edcbd05ee86431
+generated: "2022-07-13T14:34:16.901427+02:00"

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -5,7 +5,7 @@ appVersion: 2.4.6
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 16.x.x
+    version: 17.x.x
     condition: packaging.flux.enabled
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +30,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 9.0.3
+version: 10.0.0


### PR DESCRIPTION
### Description of the change

This PR updates the Redis subchart to its latest major `17.0.1`, which updates Redis to its latest version 7.0.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
