### PR TITLE
[bitnami/*] Make cd-pipeline retryable

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -129,7 +129,7 @@ jobs:
           path: index
           # The token is persisted in the local git config and enables scripts to run authenticated git commands.
           token: ${{ secrets.BITNAMI_BOT_TOKEN }}
-      - name: Install and configure aws-cli, helm and jq
+      - name: Install and configure aws-cli and helm
         run: |
           # AWS CLI
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y awscli
@@ -140,8 +140,6 @@ jobs:
           # helm
           HELM_TARBALL="helm-v3.8.1-linux-amd64.tar.gz"
           curl -SsLfO "https://get.helm.sh/${HELM_TARBALL}" && sudo tar xf "$HELM_TARBALL" --strip-components 1 -C /usr/local/bin
-          # jq
-          sudo curl -SsLf https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
       - id: update-index
         name: Fetch chart and update index
         run: |

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -116,8 +116,6 @@ jobs:
     needs:
       - vib-publish
     name: Update charts index
-    outputs:
-      result: ${{ steps.update-index.outputs.result }}
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -171,10 +169,7 @@ jobs:
             git push && is_index_updated=1 || echo "Failed to push during attempt $attempts"
           done
 
-          if [[ $is_index_updated -eq 1 ]]; then
-            echo "::set-output name=result::ok"
-          else
-            echo "::set-output name=result::fail"
+          if [[ $is_index_updated -ne 1 ]]; then
             echo "Could not update the index after $max_attempts attempts"
             exit 1
           fi
@@ -188,7 +183,7 @@ jobs:
     name: Notify unsuccessful CD run
     steps:
       - name: Notify in Slack channel
-        if: ${{ needs.vib-publish.result != 'success' ||  needs.update-index.outputs.result != 'ok' }}
+        if: ${{ needs.vib-publish.result != 'success' ||  needs.update-index.result != 'success' }}
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: ${{ secrets.CD_SLACK_CHANNEL_ID }}

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -127,6 +127,8 @@ jobs:
         with:
           ref: 'index'
           path: index
+          # The token is persisted in the local git config and enables scripts to run authenticated git commands.
+          token: ${{ secrets.BITNAMI_BOT_TOKEN }}
       - name: Install and configure aws-cli, helm and jq
         run: |
           # AWS CLI

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -90,7 +90,6 @@ jobs:
         with:
           script: |
               core.setFailed('${{ steps.get-chart.outputs.error }}')
-
   vib-publish:
     runs-on: ubuntu-latest
     needs: get-chart
@@ -112,16 +111,14 @@ jobs:
           VIB_ENV_S3_URL: s3://${{ secrets.AWS_S3_BUCKET }}/bitnami
           VIB_ENV_S3_USERNAME: ${{ secrets.AWS_ACCESS_KEY_ID }}
           VIB_ENV_S3_PASSWORD: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
   update-index:
     runs-on: ubuntu-latest
     needs:
-      - get-chart
       - vib-publish
     name: Update charts index
     outputs:
       result: ${{ steps.update-index.outputs.result }}
-    if: ${{ needs.vib-verify.result == 'success' }}
+    if: ${{ needs.vib-publish.result == 'success' }}
     steps:
       - uses: actions/download-artifact@v3
         with:
@@ -131,7 +128,6 @@ jobs:
         with:
           ref: 'index'
           path: index
-          token: ${{ secrets.BITNAMI_BOT_TOKEN }}
       - name: Install and configure aws-cli, helm and jq
         run: |
           # AWS CLI
@@ -145,13 +141,16 @@ jobs:
           curl -SsLfO "https://get.helm.sh/${HELM_TARBALL}" && sudo tar xf "$HELM_TARBALL" --strip-components 1 -C /usr/local/bin
           # jq
           sudo curl -SsLf https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
-      - name: Fetch chart and update index
+      - id: update-index
+        name: Fetch chart and update index
         run: |
+          # Extract chart release metadata from the publish result file
+          vib_publish_result_file=$(find ~/artifacts -name "result.json" -print -quit)
+          chart_name=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.name' $vib_publish_result_file)
+          chart_version=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.version' $vib_publish_result_file)
+          # Download published asset
           mkdir download
-          chart="${{ needs.get-chart.outputs.chart }}"
-          find ~/artifacts -name "*.zip" -exec unzip {} -d ~/artifacts \; -quit
-          chart_version=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.version' ~/artifacts/result.json)
-          aws s3 cp s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/${chart}-${chart_version}.tgz download/
+          aws s3 cp s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/${chart_name}-${chart_version}.tgz download/
 
           cd index
           git config user.name "Bitnami Containers"
@@ -169,7 +168,7 @@ jobs:
             helm repo index --url https://charts.bitnami.com/bitnami --merge bitnami/index.yaml ../download
             cp ../download/index.yaml bitnami/index.yaml
             # Push changes
-            git add bitnami/index.yaml && git commit -m "${chart}-${chart_version}: Update index.yaml" -s
+            git add bitnami/index.yaml && git commit -m "${chart_name}-${chart_version}: Update index.yaml" -s
             git push && is_index_updated=1 || echo "Failed to push during attempt $attempts"
           done
 
@@ -196,7 +195,7 @@ jobs:
     name: Notify unsuccessful CD run
     steps:
       - name: Notify in Slack channel
-        if: ${{ needs.vib-publish.result != 'success' ||  needs.update-index.result != 'ok' }}
+        if: ${{ needs.vib-publish.result != 'success' ||  needs.update-index.outputs.result != 'ok' }}
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: ${{ secrets.CD_SLACK_CHANNEL_ID }}

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -160,7 +160,7 @@ jobs:
           attempts=0
           max_attempts=5
           is_index_updated=0
-          while [[ $attempts -lt $max_attempts ]]; do
+          while [[ $attempts -lt $max_attempts && $is_index_updated -eq 0 ]]; do
             attempts=$((attempts + 1))
             git fetch origin index
             git reset --hard origin/index
@@ -170,18 +170,14 @@ jobs:
             cp ../download/index.yaml bitnami/index.yaml
             # Push changes
             git add bitnami/index.yaml && git commit -m "${chart}-${chart_version}: Update index.yaml" -s
-            git push && is_index_updated=1 || true
-
-            if [[ $is_index_updated -eq 1 ]]; then
-              echo "::set-output name=result::ok"
-              break
-            else
-              echo "Failed to push during attempt $attempts"
-            fi
+            git push && is_index_updated=1 || echo "Failed to push during attempt $attempts"
           done
 
-          # If after $max_attempts attempts changes can't be pushed, the action is considered as failed
-          echo "::set-output name=result::fail"
+          if [[ $is_index_updated -eq 1 ]]; then
+            echo "::set-output name=result::ok"
+          else
+            echo "::set-output name=result::fail"
+          fi
       - id: show-error
         name: 'Show error'
         if: ${{ steps.update-index.outputs.result == 'fail' }}

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -118,7 +118,6 @@ jobs:
     name: Update charts index
     outputs:
       result: ${{ steps.update-index.outputs.result }}
-    if: ${{ needs.vib-publish.result == 'success' }}
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -175,15 +175,9 @@ jobs:
             echo "::set-output name=result::ok"
           else
             echo "::set-output name=result::fail"
+            echo "Could not update the index after $max_attempts attempts"
+            exit 1
           fi
-      - id: show-error
-        name: 'Show error'
-        if: ${{ steps.update-index.outputs.result == 'fail' }}
-        uses: actions/github-script@v3
-        with:
-          script: |
-              core.setFailed('There was a problem updating the index.')
-
   # If the CD Pipeline does not succeed we should notify the interested agents
   slack-notif:
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -123,16 +123,16 @@ jobs:
       result: ${{ steps.update-index.outputs.result }}
     if: ${{ needs.vib-verify.result == 'success' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
         with:
-          path: charts
+          path: ~/artifacts
       # If we perform a checkout of the master branch, we will find conflicts with the submodules
       - uses: actions/checkout@v2
         with:
           ref: 'index'
           path: index
           token: ${{ secrets.BITNAMI_BOT_TOKEN }}
-      - name: Install and configure aws-cli, helm and yq
+      - name: Install and configure aws-cli, helm and jq
         run: |
           # AWS CLI
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y awscli
@@ -140,17 +140,17 @@ jobs:
           aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws configure set source_profile default
-            # helm
+          # helm
           HELM_TARBALL="helm-v3.8.1-linux-amd64.tar.gz"
           curl -SsLfO "https://get.helm.sh/${HELM_TARBALL}" && sudo tar xf "$HELM_TARBALL" --strip-components 1 -C /usr/local/bin
-          # yq
-          sudo curl -SsLf https://github.com/mikefarah/yq/releases/download/v4.23.1/yq_linux_amd64 -o /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq
+          # jq
+          sudo curl -SsLf https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq && sudo chmod +x /usr/local/bin/jq
       - name: Fetch chart and update index
         run: |
           mkdir download
           chart="${{ needs.get-chart.outputs.chart }}"
-          # HACK: Obtain chart tarball out of the latest commit
-          chart_version="$(yq ".version" charts/bitnami/${chart}/Chart.yaml)"
+          find ~/artifacts -name "*.zip" -exec unzip {} -d ~/artifacts \; -quit
+          chart_version=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.version' ~/artifacts/result.json)
           aws s3 cp s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/${chart}-${chart_version}.tgz download/
 
           cd index

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -170,7 +170,7 @@ jobs:
             cp ../download/index.yaml bitnami/index.yaml
             # Push changes
             git add bitnami/index.yaml && git commit -m "${chart}-${chart_version}: Update index.yaml" -s
-            git push && is_index_updated=1
+            git push && is_index_updated=1 || true
 
             if [[ $is_index_updated -eq 1 ]]; then
               echo "::set-output name=result::ok"

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -200,7 +200,7 @@ jobs:
     name: Notify unsuccessful CD run
     steps:
       - name: Notify in Slack channel
-        if: ${{ needs.vib-publish.result != 'success' ||  needs.vib-publish.result != 'ok' }}
+        if: ${{ needs.vib-publish.result != 'success' ||  needs.update-index.result != 'ok' }}
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: ${{ secrets.CD_SLACK_CHANNEL_ID }}

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -183,7 +183,7 @@ jobs:
     name: Notify unsuccessful CD run
     steps:
       - name: Notify in Slack channel
-        if: ${{ needs.vib-publish.result != 'success' ||  needs.update-index.result != 'success' }}
+        if: ${{ needs.vib-publish.result != 'success' || needs.update-index.result != 'success' }}
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: ${{ secrets.CD_SLACK_CHANNEL_ID }}

--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -112,6 +112,20 @@ jobs:
           VIB_ENV_S3_URL: s3://${{ secrets.AWS_S3_BUCKET }}/bitnami
           VIB_ENV_S3_USERNAME: ${{ secrets.AWS_ACCESS_KEY_ID }}
           VIB_ENV_S3_PASSWORD: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  update-index:
+    runs-on: ubuntu-latest
+    needs:
+      - get-chart
+      - vib-publish
+    name: Update charts index
+    outputs:
+      result: ${{ steps.update-index.outputs.result }}
+    if: ${{ needs.vib-verify.result == 'success' }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: charts
       # If we perform a checkout of the master branch, we will find conflicts with the submodules
       - uses: actions/checkout@v2
         with:
@@ -138,24 +152,55 @@ jobs:
           # HACK: Obtain chart tarball out of the latest commit
           chart_version="$(yq ".version" charts/bitnami/${chart}/Chart.yaml)"
           aws s3 cp s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/${chart}-${chart_version}.tgz download/
-          # Rebuild index
-          helm repo index --url https://charts.bitnami.com/bitnami --merge index/bitnami/index.yaml download
-          cp download/index.yaml index/bitnami/index.yaml
+
           cd index
-          # Push changes
           git config user.name "Bitnami Containers"
           git config user.email "bitnami-bot@vmware.com"
-          git add bitnami/index.yaml && git commit -m "${chart}-${chart_version}: Update index.yaml" -s && git push
+
+          attempts=0
+          max_attempts=5
+          is_index_updated=0
+          while [[ $attempts -lt $max_attempts ]]; do
+            attempts=$((attempts + 1))
+            git fetch origin index
+            git reset --hard origin/index
+
+            # Rebuild index
+            helm repo index --url https://charts.bitnami.com/bitnami --merge bitnami/index.yaml ../download
+            cp ../download/index.yaml bitnami/index.yaml
+            # Push changes
+            git add bitnami/index.yaml && git commit -m "${chart}-${chart_version}: Update index.yaml" -s
+            git push && is_index_updated=1
+
+            if [[ $is_index_updated -eq 1 ]]; then
+              echo "::set-output name=result::ok"
+              break
+            else
+              echo "Failed to push during attempt $attempts"
+            fi
+          done
+
+          # If after $max_attempts attempts changes can't be pushed, the action is considered as failed
+          echo "::set-output name=result::fail"
+      - id: show-error
+        name: 'Show error'
+        if: ${{ steps.update-index.outputs.result == 'fail' }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+              core.setFailed('There was a problem updating the index.')
 
   # If the CD Pipeline does not succeed we should notify the interested agents
   slack-notif:
     runs-on: ubuntu-latest
-    needs: vib-publish
+    needs:
+      - vib-publish
+      - update-index
     if: always()
     name: Notify unsuccessful CD run
     steps:
       - name: Notify in Slack channel
-        if: ${{ needs.vib-publish.result != 'success' }}
+        if: ${{ needs.vib-publish.result != 'success' ||  needs.vib-publish.result != 'ok' }}
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: ${{ secrets.CD_SLACK_CHANNEL_ID }}


### PR DESCRIPTION
### Description of the change

This PR makes our CD pipeline more resilient against concurrency failures. It decouples the _VIB Publish_ step from the _Update Index_ one, introducing retry-ability for the latter as well.

### Benefits

* The _Update Index_ step, which can be affected by concurrency errors, is now retried before marking the job as _failed_.
* The _Update Index_ step can be independently retried from the _VIB Publish_ one.
* Less human intervention in failed, automatic releases.

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

NA

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
