### PR TITLE
[bitnami/thanos] fix Deprecation Warning of thanos

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/bitnami-docker-thanos
   - https://thanos.io
-version: 11.1.0
+version: 11.1.1

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -110,7 +110,7 @@ spec:
             - --store.sd-files=/conf/servicediscovery.yml
             {{- end }}
             {{- if and .Values.query.dnsDiscovery.enabled .Values.query.dnsDiscovery.sidecarsService .Values.query.dnsDiscovery.sidecarsNamespace }}
-            - --store=dnssrv+_grpc._tcp.{{- include "common.tplvalues.render" ( dict "value" .Values.query.dnsDiscovery.sidecarsService "context" $) -}}.{{- include "common.tplvalues.render"  ( dict "value" .Values.query.dnsDiscovery.sidecarsNamespace "context" $) -}}.svc.{{ .Values.clusterDomain }}
+            - --endpoint=dnssrv+_grpc._tcp.{{- include "common.tplvalues.render" ( dict "value" .Values.query.dnsDiscovery.sidecarsService "context" $) -}}.{{- include "common.tplvalues.render"  ( dict "value" .Values.query.dnsDiscovery.sidecarsNamespace "context" $) -}}.svc.{{ .Values.clusterDomain }}
             {{- end }}
             {{- if and .Values.storegateway.enabled .Values.storegateway.sharded.enabled }}
             {{- $shards := int 0 }}
@@ -120,20 +120,20 @@ spec:
             {{- $shards = len .Values.storegateway.sharded.timePartitioning }}
             {{- end }}
             {{- range $index, $_ := until $shards }}
-            - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "common.names.fullname" $ }}-storegateway-{{ toString $index }}.{{ $.Release.Namespace }}.svc.{{ $.Values.clusterDomain }}
             {{- end }}
             {{- end }}
             {{- if and .Values.storegateway.enabled .Values.query.dnsDiscovery.enabled (not .Values.storegateway.sharded.enabled ) }}
-            - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-storegateway{{ if .Values.storegateway.service.additionalHeadless }}-headless{{ end }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-storegateway{{ if .Values.storegateway.service.additionalHeadless }}-headless{{ end }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
             {{- end }}
             {{- if and .Values.ruler.enabled .Values.query.dnsDiscovery.enabled }}
-            - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-ruler{{ if .Values.ruler.service.additionalHeadless }}-headless{{ end }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-ruler{{ if .Values.ruler.service.additionalHeadless }}-headless{{ end }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
             {{- end }}
             {{- if and .Values.receive.enabled .Values.query.dnsDiscovery.enabled }}
-            - --store=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-receive{{ if .Values.receive.service.additionalHeadless }}-headless{{ end }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+            - --endpoint=dnssrv+_grpc._tcp.{{ include "common.names.fullname" . }}-receive{{ if .Values.receive.service.additionalHeadless }}-headless{{ end }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
             {{- end }}
             {{- range .Values.query.stores }}
-            - --store={{ . }}
+            - --endpoint={{ . }}
             {{- end }}
             {{- if .Values.query.grpc.server.tls.enabled }}
             - --grpc-server-tls-cert=/certs/server/{{ include "common.secrets.key" (dict "existingSecret" .Values.query.grpc.server.tls.existingSecret "key" "tls-cert") }}


### PR DESCRIPTION
 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.


### Description of the change

Replaced `--store=` with `--endpoint=`

### Benefits

Users will not have to worry when the "deprecation" happens.

### Possible drawbacks

Older versions (before adding `--endpoint` flag might not work

### Applicable issues

fixes:
```
      --store=<store> ...        Deprecation Warning - This flag is deprecated
                                 and replaced with `endpoint`. Addresses of
                                 statically configured store API servers
                                 (repeatable). The scheme may be prefixed with
                                 'dns+' or 'dnssrv+' to detect store API servers
                                 through respective DNS lookups.
      --store-strict=<staticstore> ...
                                 Deprecation Warning - This flag is deprecated
                                 and replaced with `endpoint-strict`. Addresses
                                 of only statically configured store API servers
                                 that are always used, even if the health check
                                 fails. Useful if you have a caching layer on
                                 top.
```

### Additional information

https://thanos.io/tip/components/query.md/#flags

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)]
