### PR TITLE
[bitnami/spring-cloud-dataflow] use common tpl function instead of toYaml

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
   - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 12.0.3
+version: 12.0.4

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/deployment.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   replicas: {{ .Values.metrics.replicaCount }}
   {{- if .Values.metrics.updateStrategy }}
-  strategy: {{- toYaml .Values.metrics.updateStrategy | nindent 4 }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.updateStrategy "context" $) | nindent 4 }}
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
@@ -102,7 +102,7 @@ spec:
           volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.metrics.resources }}
-          resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.resources "context" $) | nindent 12 }}
           {{- end }}
       {{- if .Values.metrics.sidecars }}
         {{- include "common.tplvalues.render" (dict "value" .Values.metrics.sidecars "context" $) | trim | nindent 8 }}

--- a/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/prometheus-proxy/service.yaml
@@ -25,7 +25,7 @@ spec:
   externalTrafficPolicy: {{ .Values.metrics.service.externalTrafficPolicy | quote }}
   {{- end }}
   {{- if and (eq .Values.metrics.service.type "LoadBalancer") .Values.metrics.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{- toYaml .Values.metrics.service.loadBalancerSourceRanges | nindent 4 }}
+  loadBalancerSourceRanges: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.service.loadBalancerSourceRanges "context" $) | nindent 4 }}
   {{- end }}
   {{- if (and (eq .Values.metrics.service.type "LoadBalancer") (not (empty .Values.metrics.service.loadBalancerIP))) }}
   loadBalancerIP: {{ .Values.metrics.service.loadBalancerIP }}

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -44,10 +44,10 @@ data:
                     environmentVariables: {{- $environmentVariables | trim | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.resources.limits }}
-                    limits: {{- toYaml .Values.deployer.resources.limits | trim | nindent 22 }}
+                    limits: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.resources.limits "context" $) | trim | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.resources.requests }}
-                    requests: {{- toYaml .Values.deployer.resources.requests | trim | nindent 22 }}
+                    requests: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.resources.requests "context" $) | trim | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.readinessProbe.initialDelaySeconds }}
                     readinessProbeDelay: {{ .Values.deployer.readinessProbe.initialDelaySeconds }}
@@ -59,22 +59,22 @@ data:
                     nodeSelector: {{ .Values.deployer.nodeSelector }}
                     {{- end }}
                     {{- if .Values.deployer.tolerations }}
-                    tolerations: {{- toYaml .Values.deployer.tolerations | nindent 22 }}
+                    tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.tolerations "context" $) | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.volumeMounts }}
-                    volumeMounts: {{- toYaml .Values.deployer.volumeMounts | nindent 22 }}
+                    volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.volumeMounts "context" $) | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.volumes }}
-                    volumes: {{- toYaml .Values.deployer.volumes | nindent 22 }}
+                    volumes: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.volumes "context" $) | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.podSecurityContext.enabled }}
                     podSecurityContext: {{- omit .Values.deployer.podSecurityContext "enabled" | toYaml | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.imagePullSecrets }}
-                    imagePullSecrets: {{- toYaml .Values.deployer.imagePullSecrets | nindent 22 }}
+                    imagePullSecrets: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.imagePullSecrets "context" $) | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.secretRefs }}
-                    secretRefs: {{- toYaml .Values.deployer.secretRefs | nindent 22 }}
+                    secretRefs: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.secretRefs "context" $) | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.entryPointStyle }}
                     entryPointStyle: {{ .Values.deployer.entryPointStyle }}

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -22,7 +22,7 @@ spec:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: server
   {{- if .Values.server.updateStrategy }}
-  strategy: {{- toYaml .Values.server.updateStrategy | nindent 4 }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.server.updateStrategy "context" $) | nindent 4 }}
   {{- end }}
   template:
     metadata:
@@ -81,7 +81,7 @@ spec:
           command:
             - /scripts/wait-for-backends.sh
           {{- if .Values.waitForBackends.resources }}
-          resources: {{- toYaml .Values.waitForBackends.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.waitForBackends.resources "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: scripts
@@ -233,7 +233,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.server.resources }}
-          resources: {{- toYaml .Values.server.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.server.resources "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: database
@@ -243,7 +243,7 @@ spec:
               mountPath: /opt/bitnami/spring-cloud-dataflow/conf
               readOnly: true
             {{- if .Values.server.extraVolumeMounts }}
-            {{- toYaml .Values.server.extraVolumeMounts | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.server.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
         {{- if .Values.server.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.server.sidecars "context" $) | nindent 8 }}
@@ -265,5 +265,5 @@ spec:
             defaultMode: 0755
         {{- end }}
         {{- if .Values.server.extraVolumes }}
-          {{- toYaml .Values.server.extraVolumes | nindent 8 }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.server.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/ingress.yaml
@@ -34,7 +34,7 @@ spec:
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-server" (include "common.names.fullname" .)) "servicePort" "http" "context" $)  | nindent 14 }}
           {{- if .Values.server.ingress.extraPaths }}
-          {{- toYaml .Values.server.ingress.extraPaths | nindent 10 }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.server.ingress.extraPaths "context" $) | nindent 10 }}
           {{- end }}
     {{- end }}
     {{- range .Values.server.ingress.extraHosts }}
@@ -58,7 +58,7 @@ spec:
       secretName: {{ printf "%s-tls" .Values.server.ingress.hostname }}
     {{- end }}
     {{- if .Values.server.ingress.extraTls }}
-    {{- toYaml .Values.server.ingress.extraTls | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.server.ingress.extraTls "context" $) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/server/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/service.yaml
@@ -24,7 +24,7 @@ spec:
   loadBalancerIP: {{ .Values.server.service.loadBalancerIP }}
   {{- end }}
   {{- if and (eq .Values.server.service.type "LoadBalancer") .Values.server.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{- toYaml .Values.server.service.loadBalancerSourceRanges | nindent 4 }}
+  loadBalancerSourceRanges: {{- include "common.tplvalues.render" (dict "value" .Values.server.service.loadBalancerSourceRanges "context" $) | nindent 4 }}
   {{- end }}
   {{- if or (eq .Values.server.service.type "LoadBalancer") (eq .Values.server.service.type "NodePort") }}
   externalTrafficPolicy: {{ .Values.server.service.externalTrafficPolicy | quote }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -70,10 +70,10 @@ data:
                     {{- end }}
                     {{- end }}
                     {{- if .Values.deployer.resources.limits }}
-                    limits: {{- toYaml .Values.deployer.resources.limits | trim | nindent 22 }}
+                    limits: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.resources.limits "context" $) | trim | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.resources.requests }}
-                    requests: {{- toYaml .Values.deployer.resources.requests | trim | nindent 22 }}
+                    requests: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.resources.requests "context" $) | trim | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.readinessProbe.initialDelaySeconds }}
                     readinessProbeDelay: {{ .Values.deployer.readinessProbe.initialDelaySeconds }}
@@ -85,22 +85,22 @@ data:
                     nodeSelector: {{ .Values.deployer.nodeSelector }}
                     {{- end }}
                     {{- if .Values.deployer.tolerations }}
-                    tolerations: {{- toYaml .Values.deployer.tolerations | nindent 22 }}
+                    tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.tolerations "context" $) | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.volumeMounts }}
-                    volumeMounts: {{- toYaml .Values.deployer.volumeMounts | nindent 22 }}
+                    volumeMounts: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.volumeMounts "context" $) | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.volumes }}
-                    volumes: {{- toYaml .Values.deployer.volumes | nindent 22 }}
+                    volumes: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.volumes "context" $) | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.podSecurityContext.enabled }}
                     podSecurityContext: {{- omit .Values.deployer.podSecurityContext "enabled" | toYaml | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.imagePullSecrets }}
-                    imagePullSecrets: {{- toYaml .Values.deployer.imagePullSecrets | nindent 22 }}
+                    imagePullSecrets: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.imagePullSecrets "context" $) | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.secretRefs }}
-                    secretRefs: {{- toYaml .Values.deployer.secretRefs | nindent 22 }}
+                    secretRefs: {{- include "common.tplvalues.render" (dict "value" .Values.deployer.secretRefs "context" $) | nindent 22 }}
                     {{- end }}
                     {{- if .Values.deployer.entryPointStyle }}
                     entryPointStyle: {{ .Values.deployer.entryPointStyle }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: skipper
   {{- if .Values.skipper.updateStrategy }}
-  strategy: {{- toYaml .Values.skipper.updateStrategy | nindent 4 }}
+  strategy: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.updateStrategy "context" $) | nindent 4 }}
   {{- end }}
   template:
     metadata:
@@ -60,7 +60,7 @@ spec:
       schedulerName: {{ .Values.skipper.schedulerName }}
       {{- end }}
       {{- if .Values.skipper.topologySpreadConstraints }}
-      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.topologySpreadConstraints "context" .) | nindent 8 }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.topologySpreadConstraints "context" $) | nindent 8 }}
       {{- end }}
       {{- if .Values.skipper.priorityClassName }}
       priorityClassName: {{ .Values.skipper.priorityClassName | quote }}
@@ -77,7 +77,7 @@ spec:
           command:
             - /scripts/wait-for-backends.sh
           {{- if .Values.waitForBackends.resources }}
-          resources: {{- toYaml .Values.waitForBackends.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.waitForBackends.resources "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: scripts
@@ -191,7 +191,7 @@ spec:
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.skipper.resources }}
-          resources: {{- toYaml .Values.skipper.resources | nindent 12 }}
+          resources: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.resources "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: database
@@ -206,7 +206,7 @@ spec:
               readOnly: true
             {{- end }}
             {{- if .Values.skipper.extraVolumeMounts }}
-            {{- toYaml .Values.skipper.extraVolumeMounts | nindent 12 }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.skipper.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
         {{- if .Values.skipper.sidecars }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.skipper.sidecars "context" $) | nindent 8 }}
@@ -233,6 +233,6 @@ spec:
             defaultMode: 0755
         {{- end }}
         {{- if .Values.skipper.extraVolumes }}
-          {{- toYaml .Values.skipper.extraVolumes | nindent 8 }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.skipper.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/service.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/service.yaml
@@ -25,7 +25,7 @@ spec:
   loadBalancerIP: {{ .Values.skipper.service.loadBalancerIP }}
   {{- end }}
   {{- if and (eq .Values.skipper.service.type "LoadBalancer") .Values.skipper.service.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{- toYaml .Values.skipper.service.loadBalancerSourceRanges | nindent 4 }}
+  loadBalancerSourceRanges: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.service.loadBalancerSourceRanges "context" $) | nindent 4 }}
   {{- end }}
   {{- if or (eq .Values.skipper.service.type "LoadBalancer") (eq .Values.skipper.service.type "NodePort") }}
   externalTrafficPolicy: {{ .Values.skipper.service.externalTrafficPolicy | quote }}


### PR DESCRIPTION
Signed-off-by: umer <umer.anwar@nuance.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Use common `common.tplvalues.render` function instead of just `toYaml`.

### Benefits

<!-- What benefits will be realized by the code change? -->
Allows the usage of templates instead of just outputting the yaml. Also aligns the chart where this function is being used [(example)](https://github.com/bitnami/charts/blob/master/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml#L13).

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
This will allow us to evaluate custom logic and pass it on to the chart as values.

For example:
If we define the following variable:
```yaml
{{- define "common.volumeMount.myVolumeMount" }}
- name: my-volume-mount
  mountPath: {{ .Values.myVolumeMount.containerVolumeMountPath | default "/mnt/foo" }}
  readOnly: true
{{- end }} 
```

Then we want to be able to use it in the spring-cloud-dataflow chart:
```yaml
extraVolumeMounts: '{{ include "common.volumeMount.myVolumeMount" . }}'
```


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
