### PR TITLE
[bitnami/redis] Fix redis sentinel timeout

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 17.0.8
+version: 17.0.9

--- a/bitnami/redis/templates/scripts-configmap.yaml
+++ b/bitnami/redis/templates/scripts-configmap.yaml
@@ -64,10 +64,15 @@ data:
 
     SENTINEL_SERVICE_PORT=$(get_port "{{ include "common.names.fullname" . }}" "TCP_SENTINEL")
     validate_quorum() {
+        redis_service=${REDIS_SERVICE}
+        if ! timeout 1 bash -c "cat < /dev/null > /dev/tcp/${REDIS_SERVICE}/${SENTINEL_SERVICE_PORT}"; then
+            warn "Timeout when connecting to ${REDIS_SERVICE}, will use ${HEADLESS_SERVICE}"
+            redis_service=${HEADLESS_SERVICE}
+        fi
         if is_boolean_yes "$REDIS_SENTINEL_TLS_ENABLED"; then
-            quorum_info_command="{{- if and .Values.auth.enabled .Values.auth.sentinel }}REDISCLI_AUTH="\$REDIS_PASSWORD" {{ end }}redis-cli -h $REDIS_SERVICE -p $SENTINEL_SERVICE_PORT --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} sentinel master {{ .Values.sentinel.masterSet }}"
+            quorum_info_command="{{- if and .Values.auth.enabled .Values.auth.sentinel }}REDISCLI_AUTH="\$REDIS_PASSWORD" {{ end }}redis-cli -h $redis_service -p $SENTINEL_SERVICE_PORT --tls --cert ${REDIS_SENTINEL_TLS_CERT_FILE} --key ${REDIS_SENTINEL_TLS_KEY_FILE} --cacert ${REDIS_SENTINEL_TLS_CA_FILE} sentinel master {{ .Values.sentinel.masterSet }}"
         else
-            quorum_info_command="{{- if and .Values.auth.enabled .Values.auth.sentinel }}REDISCLI_AUTH="\$REDIS_PASSWORD" {{ end }}redis-cli -h $REDIS_SERVICE -p $SENTINEL_SERVICE_PORT sentinel master {{ .Values.sentinel.masterSet }}"
+            quorum_info_command="{{- if and .Values.auth.enabled .Values.auth.sentinel }}REDISCLI_AUTH="\$REDIS_PASSWORD" {{ end }}redis-cli -h $redis_service -p $SENTINEL_SERVICE_PORT sentinel master {{ .Values.sentinel.masterSet }}"
         fi
         info "about to run the command: $quorum_info_command"
         eval $quorum_info_command | grep -Fq "s_down"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Fixed redis sentinel waiting until timeout and exiting
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
Some CNI will keep connection to service until 1 pods are available
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
None
<!-- Describe any known limitations with your change -->

### Applicable issues
On some CNI (Cilium) it will keep the connection to the Service until timeout, it makes redis sentinel boot longer than usual and is killed by kubernetes
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  <!-- - fixes # -->

### Additional information
On 1 test machine (Created with kind)
```
$ kubectl logs redis-node-0 sentinel 
 02:43:22.99 INFO  ==> about to run the command: REDISCLI_AUTH=$REDIS_PASSWORD redis-cli -h redis.default.svc.cluster.local -p 26379 sentinel get-master-addr-by-name mymaster
Could not connect to Redis at redis.default.svc.cluster.local:26379: Connection refused
1:X 15 Jul 2022 02:43:25.074 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:X 15 Jul 2022 02:43:25.074 # Redis version=7.0.2, bits=64, commit=00000000, modified=0, pid=1, just started
1:X 15 Jul 2022 02:43:25.074 # Configuration loaded
1:X 15 Jul 2022 02:43:25.075 * monotonic clock: POSIX clock_gettime
1:X 15 Jul 2022 02:43:25.076 * Running mode=sentinel, port=26379.
1:X 15 Jul 2022 02:43:25.076 # Sentinel ID is 2a09ba7abbb41ee71e79087310d75f9809c3c815
1:X 15 Jul 2022 02:43:25.076 # +monitor master mymaster redis-node-0.redis-headless.default.svc.cluster.local 6379 quorum 2
```

On my machine (using CNI Cilium)
```
$ kubectl logs -f redis-node-0 sentinel 
 08:08:14.43 INFO  ==> Found previous master redis-node-0.redis-headless.db.svc.cluster.local in /opt/bitnami/redis-sentinel/etc/sentinel.conf
 08:08:14.43 INFO  ==> about to run the command: REDISCLI_AUTH=$REDIS_PASSWORD redis-cli -h redis.db.svc.cluster.local -p 26379 sentinel get-master-addr-by-name mymaster
$ kubectl describe -n db pods redis-node-0 
Events:
  Type     Reason     Age                  From               Message
  ----     ------     ----                 ----               -------
  Normal   Scheduled  12m                  default-scheduler  Successfully assigned db/redis-node-0 to k8s-01
  Normal   Pulled     11m                  kubelet            Container image "[docker.io/bitnami/bitnami-shell:11-debian-11-r14]" already present on machine
  Normal   Created    11m                  kubelet            Created container volume-permissions
  Normal   Started    11m                  kubelet            Started container volume-permissions
  Normal   Pulled     11m                  kubelet            Container image "[docker.io/bitnami/redis:7.0.3-debian-11-r0]" already present on machine
  Normal   Created    11m                  kubelet            Created container redis
  Normal   Started    11m                  kubelet            Started container redis
  Normal   Pulled     11m                  kubelet            Container image "[docker.io/bitnami/redis-sentinel:7.0.2-debian-11-r9]" already present on machine
  Normal   Created    11m                  kubelet            Created container sentinel
  Normal   Started    11m                  kubelet            Started container sentinel
  Warning  Unhealthy  10m (x8 over 11m)    kubelet            Startup probe failed: dial tcp 10.192.0.122:6379: connect: connection refused
  Warning  Unhealthy  112s (x52 over 11m)  kubelet            Startup probe failed: dial tcp 10.192.0.122:26379: connect: connection refused
```
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
