### PR TITLE
[bitnami/*] Temporarily change VIB target-platform

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -108,7 +108,7 @@ jobs:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-publish.json
           config: charts/.vib/
         env:
-          VIB_ENV_TARGET_PLATFORM: 7ddab896-2e4e-4d58-a501-f79897eba3a0
+          VIB_ENV_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
           VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
           VIB_ENV_S3_URL: s3://${{ secrets.AWS_S3_BUCKET }}/bitnami
           VIB_ENV_S3_USERNAME: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/ci-pipeline-extra-redis.yaml
+++ b/.github/workflows/ci-pipeline-extra-redis.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           pipeline: redis/sentinel/vib-verify.json
         env:
-          VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
+          VIB_ENV_TARGET_PLATFORM: 7ddab896-2e4e-4d58-a501-f79897eba3a0
 
   vib-verify-replica:
     if: |
@@ -50,4 +50,4 @@ jobs:
         with:
           pipeline: redis/replicas/vib-verify.json
         env:
-          VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
+          VIB_ENV_TARGET_PLATFORM: 7ddab896-2e4e-4d58-a501-f79897eba3a0

--- a/.github/workflows/ci-pipeline-extra-redis.yaml
+++ b/.github/workflows/ci-pipeline-extra-redis.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           pipeline: redis/sentinel/vib-verify.json
         env:
-          VIB_ENV_TARGET_PLATFORM: 7ddab896-2e4e-4d58-a501-f79897eba3a0
+          VIB_ENV_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
 
   vib-verify-replica:
     if: |
@@ -50,4 +50,4 @@ jobs:
         with:
           pipeline: redis/replicas/vib-verify.json
         env:
-          VIB_ENV_TARGET_PLATFORM: 7ddab896-2e4e-4d58-a501-f79897eba3a0
+          VIB_ENV_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1

--- a/.github/workflows/ci-pipeline-extra-thanos.yaml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yaml
@@ -33,4 +33,4 @@ jobs:
         with:
           pipeline: thanos/bucketweb/vib-verify.json
         env:
-          VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
+          VIB_ENV_TARGET_PLATFORM: 7ddab896-2e4e-4d58-a501-f79897eba3a0

--- a/.github/workflows/ci-pipeline-extra-thanos.yaml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yaml
@@ -33,4 +33,4 @@ jobs:
         with:
           pipeline: thanos/bucketweb/vib-verify.json
         env:
-          VIB_ENV_TARGET_PLATFORM: 7ddab896-2e4e-4d58-a501-f79897eba3a0
+          VIB_ENV_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -110,7 +110,7 @@ jobs:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-verify.json
         env:
           # Target-Platform used by default
-          VIB_ENV_TARGET_PLATFORM: 7ddab896-2e4e-4d58-a501-f79897eba3a0
+          VIB_ENV_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
           # Alternative Target-Platform to be used in case of incompatibilities
           VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
   ci-pr-review:

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -110,9 +110,9 @@ jobs:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-verify.json
         env:
           # Target-Platform used by default
-          VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
+          VIB_ENV_TARGET_PLATFORM: 7ddab896-2e4e-4d58-a501-f79897eba3a0
           # Alternative Target-Platform to be used in case of incompatibilities
-          VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}
+          VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
   ci-pr-review:
     runs-on: ubuntu-latest
     needs: vib-verify


### PR DESCRIPTION
### Description of the change

The team has discovered an issue affecting the creation of some TKG clusters. Temporarily change the default target-platform to avoid pipelines from failing.

Additionally, and as agreed in the past, deprecate the use of GitHub secrets for to set the main and alternative target-platforms.

### Benefits

High-availability: VIB pipelines are not affected by transient errors related to the default platform.

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
