### PR TITLE
[bitnami/*] Use secrets to define target-platforms

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -108,8 +108,8 @@ jobs:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-publish.json
           config: charts/.vib/
         env:
-          VIB_ENV_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
-          VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
+          VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
+          VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}
           VIB_ENV_S3_URL: s3://${{ secrets.AWS_S3_BUCKET }}/bitnami
           VIB_ENV_S3_USERNAME: ${{ secrets.AWS_ACCESS_KEY_ID }}
           VIB_ENV_S3_PASSWORD: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci-pipeline-extra-redis.yaml
+++ b/.github/workflows/ci-pipeline-extra-redis.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           pipeline: redis/sentinel/vib-verify.json
         env:
-          VIB_ENV_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
+          VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
 
   vib-verify-replica:
     if: |
@@ -50,4 +50,4 @@ jobs:
         with:
           pipeline: redis/replicas/vib-verify.json
         env:
-          VIB_ENV_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
+          VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}

--- a/.github/workflows/ci-pipeline-extra-thanos.yaml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yaml
@@ -33,4 +33,4 @@ jobs:
         with:
           pipeline: thanos/bucketweb/vib-verify.json
         env:
-          VIB_ENV_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
+          VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -110,9 +110,9 @@ jobs:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-verify.json
         env:
           # Target-Platform used by default
-          VIB_ENV_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
+          VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
           # Alternative Target-Platform to be used in case of incompatibilities
-          VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: 91d398a2-25c4-4cda-8732-75a3cfc179a1
+          VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}
   ci-pr-review:
     runs-on: ubuntu-latest
     needs: vib-verify


### PR DESCRIPTION
### Description of the change

Use a secret to define the `target-platform` instead of hardcoding the value. This also allows failed jobs to use updated values.

### Benefits

The `target-platform` can be modified dynamically, without having to explicitly alter the workflow file every time.

### Possible drawbacks

Traceability is lost, but failed jobs can be retried using a new `target-platform`.

### Applicable issues

None

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
