### PR TITLE
[bitnami/minio] allow empty s3 creds when using iam role for sa

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,8 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
-<<<<<<< Updated upstream
-version: 11.7.12
-=======
 version: 11.7.13
->>>>>>> Stashed changes

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,8 @@ name: minio
 sources:
   - https://github.com/bitnami/bitnami-docker-minio
   - https://min.io
+<<<<<<< Updated upstream
 version: 11.7.12
+=======
+version: 11.7.13
+>>>>>>> Stashed changes

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -7,7 +7,7 @@ MinIO(R) is an object storage server, compatible with Amazon S3 cloud storage se
 [Overview of Bitnami Object Storage based on MinIO&reg;](https://min.io/)
 
 Disclaimer: All software products, projects and company names are trademark(TM) or registered(R) trademarks of their respective holders, and use of them does not imply any affiliation or endorsement. This software is licensed to you subject to one or more open source licenses and VMware provides the software on an AS-IS basis. MinIO(R) is a registered trademark of the MinIO Inc. in the US and other countries. Bitnami is not affiliated, associated, authorized, endorsed by, or in any way officially connected with MinIO Inc. MinIO(R) is licensed under GNU AGPL v3.0.
-                           
+
 ## TL;DR
 
 ```console
@@ -334,6 +334,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `gateway.auth.gcs.projectID`                             | GCP Project ID to use                                                                              | `""`                       |
 | `gateway.auth.nas.accessKey`                             | Access key to access MinIO&reg; using NAS Gateway                                                  | `""`                       |
 | `gateway.auth.nas.secretKey`                             | Secret key to access MinIO&reg; using NAS Gateway                                                  | `""`                       |
+| `gateway.auth.s3.useIRSA`                                | Use IAM roles for service accounts to access AWS S3                                                | `false`                    |
 | `gateway.auth.s3.accessKey`                              | Access key to use to access AWS S3                                                                 | `""`                       |
 | `gateway.auth.s3.secretKey`                              | Secret key to use to access AWS S3                                                                 | `""`                       |
 | `gateway.auth.s3.serviceEndpoint`                        | AWS S3 endpoint                                                                                    | `https://s3.amazonaws.com` |

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Get the user to use to access MinIO&reg;
         {{- else -}}
             {{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (include "common.names.fullname" .) "Length" 10 "Key" "root-user")  -}}
         {{- end -}}
-    {{- else if eq .Values.gateway.type "s3" }}
+    {{- else if and (eq .Values.gateway.type "s3") (not .Values.gateway.auth.s3.useIRSA ) }}
         {{- .Values.gateway.auth.s3.accessKey -}}
     {{- end -}}
 {{- else }}
@@ -103,7 +103,7 @@ Get the password to use to access MinIO&reg;
         {{- else -}}
             {{- include "getValueFromSecret" (dict "Namespace" .Release.Namespace "Name" (include "common.names.fullname" .) "Length" 10 "Key" "root-password")  -}}
         {{- end -}}
-    {{- else if eq .Values.gateway.type "s3" }}
+    {{- else if and (eq .Values.gateway.type "s3") (not .Values.gateway.auth.s3.useIRSA ) }}
         {{- .Values.gateway.auth.s3.secretKey -}}
     {{- end -}}
 {{- else }}
@@ -288,7 +288,7 @@ minio: persistence.accessModes
 Validate values of MinIO&reg; - when using MinIO&reg; as a S3 Gateway, the Access & Secret keys are required
 */}}
 {{- define "minio.validateValues.gateway.s3.credentials" -}}
-{{- if and .Values.gateway.enabled (eq .Values.gateway.type "s3") (or (empty .Values.gateway.auth.s3.accessKey) (empty .Values.gateway.auth.s3.secretKey)) }}
+{{- if and .Values.gateway.enabled (eq .Values.gateway.type "s3") (not .Values.gateway.auth.s3.useIRSA ) (or (empty .Values.gateway.auth.s3.accessKey) (empty .Values.gateway.auth.s3.secretKey)) }}
 minio: gateway.auth.s3
     The Access & Secret keys are required to use MinIO&reg; as a S3 Gateway.
     Please set valid keys (--set gateway.auth.s3.accessKey="xxxx",gateway.auth.s3.secretKey="yyyy")


### PR DESCRIPTION
Signed-off-by: kyue1005 <kyue1005@gmail.com>

### Description of the change

Remove empty values check for s3 creds when using IRSA

### Benefits

Allow empty s3 creds when using IRSA for accessing s3 in EKS

### Possible drawbacks

No drawbacks.

### Applicable issues

N/A

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
