### PR TITLE
[bitnami/nginx] Fix TLS setup for externally provided TLS certificates

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -25,4 +25,4 @@ name: nginx
 sources:
   - https://github.com/bitnami/bitnami-docker-nginx
   - https://www.nginx.org
-version: 13.1.3
+version: 13.1.4

--- a/bitnami/nginx/templates/health-ingress.yaml
+++ b/bitnami/nginx/templates/health-ingress.yaml
@@ -46,9 +46,9 @@ spec:
     {{- if .Values.healthIngress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.healthIngress.extraRules "context" $) | nindent 4 }}
     {{- end }}
-  {{- if or (and .Values.healthIngress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.healthIngress.annotations )) .Values.healthIngress.selfSigned)) .Values.healthIngress.extraTls }}
+  {{- if or (and .Values.healthIngress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.healthIngress.annotations )) .Values.healthIngress.selfSigned (not (empty .Values.healthIngress.secrets)))) .Values.healthIngress.extraTls }}
   tls:
-    {{- if and .Values.healthIngress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.healthIngress.annotations )) .Values.healthIngress.selfSigned) }}
+    {{- if and .Values.healthIngress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.healthIngress.annotations )) .Values.healthIngress.selfSigned (not (empty .Values.healthIngress.secrets))) }}
     - hosts:
         - {{ .Values.healthIngress.hostname | quote }}
       secretName: {{ printf "%s-health-tls" .Values.healthIngress.hostname }}

--- a/bitnami/nginx/templates/ingress.yaml
+++ b/bitnami/nginx/templates/ingress.yaml
@@ -46,9 +46,9 @@ spec:
     {{- if .Values.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}
     {{- end }}
-  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned (not (empty .Values.ingress.secrets)))) .Values.ingress.extraTls }}
   tls:
-    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
+    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned (not (empty .Values.ingress.secrets))) }}
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}


### PR DESCRIPTION
Signed-off-by: Ferdinand Hübner <mail@ferdi.codes>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Commit f48790b465021af15620f08d40fec2d065535e14 (PR #10048) breaks support for externally provided TLS certificates that are specified through the `ingress.secrets` and `healthIngress.secrets` parameters. This change fixes the TLS block rendering for configurations of the chart that supply TLS certificates externally. 

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

TLS certificats can be provided externally again.

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

N/A

<!-- Describe any known limitations with your change -->

### Applicable issues

N/A

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
