### PR TITLE
Adding workflows for the support by using the GH board

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: 🐞 Bug
 description: Create a report to help us improve
+labels: ["tech-issues"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: "\U0001F680 Feature request"
 description: Suggest an idea for this project
+labels: ["feature-request"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,5 +1,5 @@
 BITNAMI_TEAM='["bitnami-bot","jotamartos","alemorcuq","agomezmoron","carrodher","dgomezleon","fmulero","FraPazGal","javsalgar","gongomgra","joancafom","marcosbc","aoterolorenzo","CeliaGMqrz","Mauraza","mdhont","migruiz4","rafariossaa"]'
-SUPPORT_TEAM='["jotamartos","alemorcuq","agomezmoron","carrodher","dgomezleon","fmulero","FraPazGal","javsalgar","gongomgra","joancafom","marcosbc","aoterolorenzo","CeliaGMqrz","Mauraza","mdhont","migruiz4","rafariossaa"]'
+SUPPORT_TEAM='["alemorcuq","carrodher","dgomezleon","fmulero","FraPazGal","javsalgar","joancafom","marcosbc","migruiz4","rafariossaa"]'
 TRIAGE_TEAM='["carrodher","fmulero", "javsalgar","rafariossaa"]'
 IN_PROGRESS_COLUMN_ID=19057376
 TRIAGE_COLUMN_ID=19057374

--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,0 +1,9 @@
+BITNAMI_TEAM='["bitnami-bot","jotamartos","alemorcuq","agomezmoron","carrodher","dgomezleon","fmulero","FraPazGal","javsalgar","gongomgra","joancafom","marcosbc","aoterolorenzo","CeliaGMqrz","Mauraza","mdhont","migruiz4","rafariossaa"]'
+SUPPORT_TEAM='["jotamartos","alemorcuq","agomezmoron","carrodher","dgomezleon","fmulero","FraPazGal","javsalgar","gongomgra","joancafom","marcosbc","aoterolorenzo","CeliaGMqrz","Mauraza","mdhont","migruiz4","rafariossaa"]'
+TRIAGE_TEAM='["carrodher","fmulero", "javsalgar","rafariossaa"]'
+IN_PROGRESS_COLUMN_ID=19057376
+TRIAGE_COLUMN_ID=19057374
+SOLVED_COLUMN_ID=19057379
+ON_HOLD_COLUMN_ID=19057378
+BITNAMI_COLUMN_ID=19057375
+PENDING_COLUMN_ID=19057377

--- a/.github/workflows/clossing-issues.yml
+++ b/.github/workflows/clossing-issues.yml
@@ -1,4 +1,4 @@
-name: 'Close Solved issues'
+name: '[Support] Close Solved issues'
 on:
   schedule:
     # Hourly

--- a/.github/workflows/clossing-issues.yml
+++ b/.github/workflows/clossing-issues.yml
@@ -1,0 +1,21 @@
+name: 'Close Solved issues'
+on:
+  schedule:
+    # Hourly
+    - cron: '0 * * * *'
+
+permissions:
+  issues: write
+  repository-projects: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          any-of-labels: 'solved'
+          stale-issue-label: 'solved'
+          days-before-stale: 0
+          days-before-close: 0
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -1,4 +1,4 @@
-name: Organizing cards based on comments
+name: '[Support] Organizing cards based on comments'
 on:
   issue_comment:
     types:

--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -1,0 +1,53 @@
+name: Organizing cards based on comments
+on:
+  issue_comment:
+    types:
+      - created
+permissions:
+  repository-projects: write
+  issues: write
+
+concurrency:
+  group: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  comments_handler:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v1.0.2
+        with:
+          path: .github/workflows/
+      - name: Move into Pending
+        uses: peter-evans/create-or-update-project-card@v2
+        if: ${{ (!contains(github.event.issue.labels.*.name, 'bitnami')) && contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login) }}
+        with:
+          project-name: Support
+          column-name: Pending
+          token: "${{ secrets.GHPROJECT_TOKEN }}"
+      - name: Move into In Progress
+        uses: peter-evans/create-or-update-project-card@v2
+        if: ${{ contains(github.event.issue.labels.*.name, 'in-progress') && (!contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login)) }}
+        with:
+          project-name: Support
+          column-name: In progress
+          token: "${{ secrets.GHPROJECT_TOKEN }}"
+      - name: Move into Triage
+        uses: peter-evans/create-or-update-project-card@v2
+        if: ${{ ((contains(github.event.issue.labels.*.name, 'triage')) || (contains(github.event.issue.labels.*.name, 'solved'))) && (!contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login)) }}
+        with:
+          project-name: Support
+          column-name: Triage
+          token: "${{ secrets.GHPROJECT_TOKEN }}"
+      - name: Label as triage back
+        # Only if commented when solved
+        if: ${{ contains(github.event.issue.labels.*.name, 'solved') }}
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "triage"
+          remove-labels: "solved"

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -1,4 +1,4 @@
-name: 'Move closed issues'
+name: '[Support] Move closed issues'
 on:
   issues:
     types:

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -1,0 +1,50 @@
+name: 'Move closed issues'
+on:
+  issues:
+    types:
+      - closed
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  issues: write
+  repository-projects: write
+
+concurrency:
+  group: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  send_to_solved:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v1.0.2
+        with:
+          path: .github/workflows/
+      - name: Preparing string variables
+        run: |
+          TRIAGE_TEAM_STRING=${TRIAGE_TEAM/[/}
+          TRIAGE_TEAM_STRING=${TRIAGE_TEAM_STRING/]/}
+          TRIAGE_TEAM_STRING=${TRIAGE_TEAM_STRING//'"'/}
+          # creating env variable "on the fly"
+          echo "TRIAGE_TEAM_STRING=$TRIAGE_TEAM_STRING" >> $GITHUB_ENV
+      - name: Send to the Solved column
+        uses: peter-evans/create-or-update-project-card@v2
+        with:
+          project-name: Support
+          # If the author comes from Bitnami, send it to Bitnami. Otherwise, all to Triage
+          column-name: 'Solved'
+          token: "${{ secrets.GHPROJECT_TOKEN }}"
+          issue-number: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
+      - name: Solved labeling
+        # Only if moved into Solved
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "solved"
+          remove-labels: "in-progress, on-hold, triage"

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -69,11 +69,11 @@ jobs:
           echo "SUPPORT_TEAM_STRING=$SUPPORT_TEAM_STRING" >> $GITHUB_ENV
       - name: Assign to a person to work on it
         # Only if moved into In progress FROM Triage
-        if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID && github.event.project_card.changes != null && github.event.project_card.changes.column_id && github.event.project_card.changes.column_id == env.TRIAGE_COLUMN_ID }}
+        if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID && github.event.project_card.changes != null && github.event.project_card.changes.column_id && github.event.project_card.changes.column_id.from == env.TRIAGE_COLUMN_ID }}
         uses: pozil/auto-assign-issue@v1.7.3
         with:
           numOfAssignee: 1
-          assignees: ${{ env.SUPPORTTEAM_STRING }}
+          assignees: ${{ env.SUPPORT_TEAM_STRING }}
           removePreviousAssignees: true
           # teams: XXX
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -68,7 +68,7 @@ jobs:
           echo "SUPPORT_TEAM_STRING=$SUPPORT_TEAM_STRING" >> $GITHUB_ENV
       - name: Assign to a person to work on it
         # Only if moved into In progress FROM Triage
-        if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID && github.event.project_card.changes != null && github.event.project_card.changes.column_id && github.event.project_card.changes.column_id.from == env.TRIAGE_COLUMN_ID }}
+        if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID && github.event.changes != null && github.event.changes.column_id && github.event.changes.column_id.from == env.TRIAGE_COLUMN_ID }}
         uses: pozil/auto-assign-issue@v1.7.3
         with:
           numOfAssignee: 1

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -1,0 +1,79 @@
+# This workflow is built to manage the triage support by using GH issues.
+
+name: Cards movements
+on:
+  project_card:
+    types:
+      - moved
+
+permissions:
+  repository-projects: read
+  issues: write
+
+concurrency:
+  # Cards are special
+  group: ${{ github.event.project_card.content_url }}
+  cancel-in-progress: false
+
+jobs:
+  label-card:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v1.0.2
+        with:
+          path: .github/workflows/
+      # Now handling the needed labeling
+      - name: On hold labeling
+        # Only if moved into on hold
+        if: ${{ github.event.project_card.column_id == env.ON_HOLD_COLUMN_ID  }}
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "on-hold"
+          remove-labels: "triage"
+      - name: In progress labeling
+        # Only if moved into In progress
+        if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID  }}
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "in-progress"
+          remove-labels: "on-hold, triage"
+      - name: Solved labeling
+        # Only if moved into Solved
+        if: ${{ github.event.project_card.column_id == env.SOLVED_COLUMN_ID  }}
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "solved"
+          remove-labels: "in-progress, on-hold, triage"
+  assign-assignee-if-needed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v1.0.2
+        with:
+          path: .github/workflows/
+      - name: Preparing string variables
+        run: |
+          SUPPORT_TEAM_STRING=${SUPPORT_TEAM/[/}
+          SUPPORT_TEAM_STRING=${SUPPORT_TEAM_STRING/]/}
+          SUPPORT_TEAM_STRING=${SUPPORT_TEAM_STRING//'"'/}
+          # creating env variable "on the fly"
+          echo "SUPPORT_TEAM_STRING=$SUPPORT_TEAM_STRING" >> $GITHUB_ENV
+      - name: Assign to a person to work on it
+        # Only if moved into In progress FROM Triage
+        if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID && github.event.project_card.changes != null && github.event.project_card.changes.column_id && github.event.project_card.changes.column_id == env.TRIAGE_COLUMN_ID }}
+        uses: pozil/auto-assign-issue@v1.7.3
+        with:
+          numOfAssignee: 1
+          assignees: ${{ env.SUPPORTTEAM_STRING }}
+          removePreviousAssignees: true
+          # teams: XXX
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -1,6 +1,5 @@
 # This workflow is built to manage the triage support by using GH issues.
-
-name: Cards movements
+name: '[Support] Cards movements'
 on:
   project_card:
     types:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,4 +1,4 @@
-name: 'Synchronize labels from the containers repository'
+name: '[Support] Synchronize labels from the containers repository'
 on:
   schedule:
     # Daily

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,6 +1,5 @@
 # This workflow is built to manage the triage support by using GH issues.
-
-name: Organize triage
+name: '[Support] Organize triage'
 on:
   issues:
     types:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,64 @@
+# This workflow is built to manage the triage support by using GH issues.
+
+name: Organize triage
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+  pull_request_target:
+    types:
+      - reopened
+      - opened
+permissions:
+  repository-projects: write
+  issues: write
+
+concurrency:
+  group: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  # For any opened or reopened issue, should be sent into Triage
+  send_to_board:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repo checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v1.0.2
+        with:
+          path: .github/workflows/
+      - name: Preparing string variables
+        run: |
+          TRIAGE_TEAM_STRING=${TRIAGE_TEAM/[/}
+          TRIAGE_TEAM_STRING=${TRIAGE_TEAM_STRING/]/}
+          TRIAGE_TEAM_STRING=${TRIAGE_TEAM_STRING//'"'/}
+          # creating env variable "on the fly"
+          echo "TRIAGE_TEAM_STRING=$TRIAGE_TEAM_STRING" >> $GITHUB_ENV
+      - name: Assign to a person to work on it
+        uses: pozil/auto-assign-issue@v1.7.3
+        with:
+          numOfAssignee: 1
+          assignees: ${{ env.TRIAGE_TEAM_STRING }}
+          removePreviousAssignees: false
+          # teams: XXX
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Send to the board
+        if: ${{ github.actor != 'bitnami-bot'  }}
+        uses: peter-evans/create-or-update-project-card@v2
+        with:
+          project-name: Support
+          # If the author comes from Bitnami, send it to Bitnami. Otherwise, all to Triage
+          column-name: ${{ (contains(fromJson(env.BITNAMI_TEAM), github.actor)) && 'From Bitnami' || 'Triage' }}
+          token: "${{ secrets.GHPROJECT_TOKEN }}"
+          issue-number: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
+      - name: Triage labeling
+        # Only if moved into Solved
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: ${{ (!contains(fromJson(env.BITNAMI_TEAM), github.actor)) && 'triage' || 'bitnami' }}
+          # For reopened issues
+          remove-labels: "solved"


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Adding GH workflows in order to use GH board.

### Benefits

Using GH board to manage the issues and PRs support.

### Possible drawbacks

When an issue is commented and closed at the same time, depending on how GH performs the actions (order) the issue will appear on the _Solved_ column or in the _Triage_ one (as reopened). That's something out of our control and happens sometimes.

### Additional information

All the issues and PRs will be sent to the Support board.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
