### PR TITLE
[bitnami/pinniped] add support for hostNetwork

### DIFF
--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -22,4 +22,4 @@ name: pinniped
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/pinniped
   - https://github.com/vmware-tanzu/pinniped/
-version: 0.2.2
+version: 0.3.0

--- a/bitnami/pinniped/README.md
+++ b/bitnami/pinniped/README.md
@@ -91,6 +91,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `concierge.replicaCount`                                    | Number of Concierge replicas to deploy                                                                                   | `1`             |
 | `concierge.containerPorts.api`                              | Concierge API container port                                                                                             | `10250`         |
 | `concierge.containerPorts.proxy`                            | Concierge Proxy container port                                                                                           | `8443`          |
+| `concierge.configurationPorts.aggregatedAPIServerPort`      | Concierge API configuration port                                                                                         | `10250`         |
+| `concierge.configurationPorts.impersonationProxyServerPort` | Concierge Proxy configuration port                                                                                       | `8444`          |
+| `concierge.hostNetwork`                                     | Concierge API and Proxy container hostNetwork                                                                            | `false`         |
+| `concierge.dnsPolicy`                                       | Concierge API and Proxy container dnsPolicy                                                                              | `ClusterFirst`  |
 | `concierge.configuration`                                   | Concierge pinniped.yaml configuration file                                                                               | `""`            |
 | `concierge.credentialIssuerConfig`                          | Configuration for the credential issuer                                                                                  | `""`            |
 | `concierge.livenessProbe.enabled`                           | Enable livenessProbe on Concierge containers                                                                             | `true`          |

--- a/bitnami/pinniped/README.md
+++ b/bitnami/pinniped/README.md
@@ -91,10 +91,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `concierge.replicaCount`                                    | Number of Concierge replicas to deploy                                                                                   | `1`             |
 | `concierge.containerPorts.api`                              | Concierge API container port                                                                                             | `10250`         |
 | `concierge.containerPorts.proxy`                            | Concierge Proxy container port                                                                                           | `8443`          |
-| `concierge.configurationPorts.aggregatedAPIServerPort`      | Concierge API configuration port                                                                                         | `10250`         |
-| `concierge.configurationPorts.impersonationProxyServerPort` | Concierge Proxy configuration port                                                                                       | `8444`          |
+| `concierge.configurationPorts.aggregatedAPIServerPort`      | Concierge API configuration port                                                                                         | `""`            |
+| `concierge.configurationPorts.impersonationProxyServerPort` | Concierge Proxy configuration port                                                                                       | `""`            |
 | `concierge.hostNetwork`                                     | Concierge API and Proxy container hostNetwork                                                                            | `false`         |
-| `concierge.dnsPolicy`                                       | Concierge API and Proxy container dnsPolicy                                                                              | `ClusterFirst`  |
+| `concierge.dnsPolicy`                                       | Concierge API and Proxy container dnsPolicy                                                                              | `""`            |
 | `concierge.configuration`                                   | Concierge pinniped.yaml configuration file                                                                               | `""`            |
 | `concierge.credentialIssuerConfig`                          | Configuration for the credential issuer                                                                                  | `""`            |
 | `concierge.livenessProbe.enabled`                           | Enable livenessProbe on Concierge containers                                                                             | `true`          |

--- a/bitnami/pinniped/templates/concierge/deployment.yaml
+++ b/bitnami/pinniped/templates/concierge/deployment.yaml
@@ -71,6 +71,12 @@ spec:
         {{- if .Values.concierge.initContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.concierge.initContainers "context" $) | nindent 8 }}
         {{- end }}
+      {{- if .Values.concierge.hostNetwork }}
+      hostNetwork: {{ .Values.concierge.hostNetwork }}
+      {{- end }}
+      {{- if .Values.concierge.dnsPolicy }}
+      dnsPolicy: {{ .Values.concierge.dnsPolicy }}
+      {{- end }}
       containers:
         - name: concierge
           image: {{ template "pinniped.image" . }}

--- a/bitnami/pinniped/values.yaml
+++ b/bitnami/pinniped/values.yaml
@@ -90,6 +90,25 @@ concierge:
     api: 10250
     proxy: 8443
 
+  ## @param concierge.configurationPorts.aggregatedAPIServerPort Concierge API configuration port
+  ## @param concierge.configurationPorts.impersonationProxyServerPort Concierge Proxy configuration port
+  ##
+  ## Changes to concierge.configuration overwrites this param.
+  ##
+  ## If changed, other YAML references to the default ports may also need to be updated
+  ##
+  configurationPorts:
+    aggregatedAPIServerPort: ""
+    impersonationProxyServerPort: ""
+
+  ## @param concierge.hostNetwork Concierge API and Proxy container hostNetwork
+  ##
+  hostNetwork: false
+
+  ## @param concierge.dnsPolicy Concierge API and Proxy container dnsPolicy
+  ##
+  dnsPolicy: ""
+
   ## @param concierge.configuration [string] Concierge pinniped.yaml configuration file
   ##
   configuration: |
@@ -100,8 +119,12 @@ concierge:
         durationSeconds: 2592000
         renewBeforeSeconds: 2160000
     apiGroupSuffix: pinniped.dev
-    # aggregatedAPIServerPort may be set here, although other YAML references to the default port (10250) may also need to be updated
-    # impersonationProxyServerPort may be set here, although other YAML references to the default port (8444) may also need to be updated
+    {{- if .Values.concierge.configurationPorts.aggregatedAPIServerPort }}
+    aggregatedAPIServerPort: {{ .Values.concierge.configurationPorts.aggregatedAPIServerPort }}
+    {{- end }}
+    {{- if .Values.concierge.configurationPorts.impersonationProxyServerPort }}
+    impersonationProxyServerPort: {{ .Values.concierge.configurationPorts.impersonationProxyServerPort }}
+    {{- end }}
     names:
       servingCertificateSecret: {{ printf "%s-%s" (include "pinniped.concierge.api.fullname" .) "tls-serving-certificate" | trunc 63 | trimSuffix "-" }}
       credentialIssuer: {{ template "pinniped.concierge.fullname" . }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR enables deployment of Pinniped on setups requiring host network mode e.g. An EKS cluster using a custom CNI plugin like Cilium in overlay network mode.

### Benefits

* Without `hostNetwork: true` Pinniped will not be able to talk to the EKS control plane with a custom CNI in overlay network mode.
* `dnsPolicy: "ClusterFirstWithHostNet"` might be needed if the cluster relies on a in-cluster DNS service that is not reachable by the nodes directly.
* It will be easier to configure the `aggregatedAPIServerPort` and `impersonationProxyServerPort` in the concierge `configMap` if needed without having to replicate the whole config file in Helm values.

### Possible drawbacks

If you somehow hacked the changes yourself they might clash with the Helm Chart although the custom implementation will most likely overwrite this change.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
