### PR TITLE
Add [CI/CD] prefix to the GH actions name

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -1,4 +1,4 @@
-name: 'CD Pipeline'
+name: '[CI/CD] CD Pipeline'
 on: # rebuild any PRs and main branch changes
   push:
     branches:

--- a/.github/workflows/ci-pipeline-extra-redis.yaml
+++ b/.github/workflows/ci-pipeline-extra-redis.yaml
@@ -1,5 +1,5 @@
 # Multiple deployments pipelines are custom per asset. All single deployments pipelines are handled by ci-pipeline.yaml
-name: 'CI Pipeline extra Redis'
+name: '[CI/CD] CI Pipeline extra Redis'
 on: # rebuild any PRs and main branch changes
   pull_request_target:
     types:

--- a/.github/workflows/ci-pipeline-extra-thanos.yaml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yaml
@@ -1,5 +1,5 @@
 # Multiple deployments pipelines are custom per asset. All single deployments pipelines are handled by ci-pipeline.yaml
-name: 'CI Pipeline extra Thanos'
+name: '[CI/CD] CI Pipeline extra Thanos'
 on: # rebuild any PRs and main branch changes
   pull_request_target:
     types:

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -1,4 +1,4 @@
-name: 'CI Pipeline'
+name: '[CI/CD] CI Pipeline'
 on: # rebuild any PRs and main branch changes
   pull_request_target:
     types:


### PR DESCRIPTION
### Description of the change

Add the `[CI/CD]` prefix to the GH actions name.

### Benefits

In the [Actions view](https://github.com/bitnami/charts/actions) it would be easy to identify what actions are related to a specific purpose.
In the same way, since actions are alphabetically ordered, all the actions with the same prefix will appear together. This is the approach used for the different actions related to support, see
![Screenshot 2022-07-20 at 13 18 07](https://user-images.githubusercontent.com/13216600/179969366-cd556ad3-ad7a-47f8-a5d5-7201d5b808a7.png)

Related to https://github.com/bitnami/charts/pull/11271