### PR TITLE
Add [Index] prefix to the GH actions name

### DIFF
--- a/.github/workflows/archive-full-index.yaml
+++ b/.github/workflows/archive-full-index.yaml
@@ -1,4 +1,4 @@
-name: Generate the full index archive for Bitnami Charts
+name: [Index] Generate the full bitnami/charts index.yaml
 on:
   push:
     branches:

--- a/.github/workflows/sync-chart-index.yaml
+++ b/.github/workflows/sync-chart-index.yaml
@@ -1,4 +1,4 @@
-name: Sync bitnami/charts index.yaml to S3
+name: [Index] Sync bitnami/charts index.yaml to S3
 
 on:
   push:


### PR DESCRIPTION
### Description of the change

Add the `[Index]` prefix to the GH actions name.

### Benefits

In the [Actions view](https://github.com/bitnami/charts/actions) it would be easy to identify what actions are related to a specific purpose.
In the same way, since actions are alphabetically ordered, all the actions with the same prefix will appear together. This is the approach used for the different actions related to support, see
![Screenshot 2022-07-20 at 13 18 07](https://user-images.githubusercontent.com/13216600/179969366-cd556ad3-ad7a-47f8-a5d5-7201d5b808a7.png)

Related to https://github.com/bitnami/charts/pull/11270