### PR TITLE
[bitnami/common] quote secret value when lookup

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.0.2
+appVersion: 2.0.3
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - https://www.bitnami.com/
 type: library
-version: 2.0.2
+version: 2.0.3

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -93,7 +93,7 @@ The order in which this function returns a secret password:
 {{- $secretData := (lookup "v1" "Secret" $.context.Release.Namespace .secret).data }}
 {{- if $secretData }}
   {{- if hasKey $secretData .key }}
-    {{- $password = index $secretData .key }}
+    {{- $password = index $secretData .key | quote }}
   {{- else }}
     {{- printf "\nPASSWORDS ERROR: The secret \"%s\" does not contain the key \"%s\"\n" .secret .key | fail -}}
   {{- end -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Add quotes to password values when using `lookup`.

### Benefits

<!-- What benefits will be realized by the code change? -->

Helm release revisions >1 will keep quotes in secret values so checksum are consistent.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None known.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes helm/helm#11144
  - fixes #10985

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

Tested with a chart depending on `bitnami/rabbitmq` in version 10.1.14 (including `bitnami/common` in version 1.16.1).

First release revision contains the quotes in secrets (eg. `<release>-rabbitmq`) because the `lookup` is not done on first revision (the secret does not exist yet).

When creating a second revision, the quotes are gone because the secret value is fetch by `lookup` which return no quote as `kubectl` does.

Before this PR:

```bash
diff <(helm -n rabbitmq get manifest rabbitmq-test --revision 1) <(helm -n rabbitmq get manifest rabbitmq-test --revision 2)
```

```diff
<   rabbitmq-password: "WTVEdW1hNW9qZUpEeTVHaQ=="
---
>   rabbitmq-password: WTVEdW1hNW9qZUpEeTVHaQ==
145c145
<   rabbitmq-erlang-cookie: "eUxCVFZadXZERUJTeGZ1WA=="
---
>   rabbitmq-erlang-cookie: eUxCVFZadXZERUJTeGZ1WA==
3918c3918
<         checksum/secret: a7546955ba77379ed477532c18c438a31567c5f98949f95a9235e9cd53b0769d
---
>         checksum/secret: 194149074b29f06e1e69cc8bea381ffdc595455a91fb1af717af405f4dc96217
```

This will re-deploy components as secret checksum has changed.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
