### PR TITLE
[bitnami/mariadb] add app labels

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 7.3.6
+version: 7.3.7

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
+    ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+    app: mariadb-galera
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
@@ -28,6 +30,8 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       {{- end }}
       labels: {{- include "common.labels.matchLabels" . | nindent 8 }}
+        ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+        app: mariadb-galera
         {{- if .Values.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 11.1.0
+version: 11.1.1

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: primary
+    ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+    app: mariadb-primary
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -32,6 +34,8 @@ spec:
         {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: primary
+        ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+        app: mariadb-primary
         {{- if .Values.primary.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.primary.podLabels "context" $) | nindent 8 }}
         {{- end }}

--- a/bitnami/mariadb/templates/secondary/statefulset.yaml
+++ b/bitnami/mariadb/templates/secondary/statefulset.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: secondary
+    ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+    app: mariadb-secondary
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -34,6 +36,8 @@ spec:
         {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: secondary
+        ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+        app: mariadb-secondary
         {{- if .Values.secondary.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.secondary.podLabels "context" $) | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
mariadb  chart add app label, Meet the requirements of Istio labels
https://istio.io/docs/ops/deployment/requirements/
The app label is used to add contextual information in distributed tracing (in Istio).

### Description of the change

mariadb chart
mariadb-galera chart

### Benefits

The app label is used to add contextual information in distributed tracing (in Istio).

### Possible drawbacks
no

### Applicable issues
no

### Additional information
no


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
