### PR TITLE
[bitnami/spark] Init support scripts for spark chart added

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -22,4 +22,4 @@ name: spark
 sources:
   - https://github.com/bitnami/bitnami-docker-spark
   - https://spark.apache.org/
-version: 6.1.14
+version: 6.2.0

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -64,32 +64,29 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                     | Description                                                                                  | Value           |
-| ------------------------ | -------------------------------------------------------------------------------------------- | --------------- |
-| `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                         | `""`            |
-| `nameOverride`           | String to partially override common.names.fullname template (will maintain the release name) | `""`            |
-| `fullnameOverride`       | String to fully override common.names.fullname template                                      | `""`            |
-| `namespaceOverride`      | String to fully override common.names.namespace                                              | `""`            |
-| `commonLabels`           | Labels to add to all deployed objects                                                        | `{}`            |
-| `commonAnnotations`      | Annotations to add to all deployed objects                                                   | `{}`            |
-| `clusterDomain`          | Kubernetes cluster domain name                                                               | `cluster.local` |
-| `extraDeploy`            | Array of extra objects to deploy with the release                                            | `[]`            |
-| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)      | `false`         |
-| `diagnosticMode.command` | Command to override all containers in the deployment                                         | `["sleep"]`     |
-| `diagnosticMode.args`    | Args to override all containers in the deployment                                            | `["infinity"]`  |
-
-
-### Spark parameters
-
-| Name                | Description                                      | Value                |
-| ------------------- | ------------------------------------------------ | -------------------- |
-| `image.registry`    | Spark image registry                             | `docker.io`          |
-| `image.repository`  | Spark image repository                           | `bitnami/spark`      |
-| `image.tag`         | Spark image tag (immutable tags are recommended) | `3.2.1-debian-11-r3` |
-| `image.pullPolicy`  | Spark image pull policy                          | `IfNotPresent`       |
-| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]`                 |
-| `image.debug`       | Enable image debug mode                          | `false`              |
-| `hostNetwork`       | Enable HOST Network                              | `false`              |
+| Name                     | Description                                                                                                                                         | Value                |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `kubeVersion`            | Force target Kubernetes version (using Helm capabilities if not set)                                                                                | `""`                 |
+| `nameOverride`           | String to partially override common.names.fullname template (will maintain the release name)                                                        | `""`                 |
+| `fullnameOverride`       | String to fully override common.names.fullname template                                                                                             | `""`                 |
+| `namespaceOverride`      | String to fully override common.names.namespace                                                                                                     | `""`                 |
+| `commonLabels`           | Labels to add to all deployed objects                                                                                                               | `{}`                 |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                                                                                          | `{}`                 |
+| `clusterDomain`          | Kubernetes cluster domain name                                                                                                                      | `cluster.local`      |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                                                                                   | `[]`                 |
+| `initScripts`            | Dictionary of init scripts. Evaluated as a template.                                                                                                | `{}`                 |
+| `initScriptsCM`          | ConfigMap with the init scripts. Evaluated as a template.                                                                                           | `""`                 |
+| `initScriptsSecret`      | Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time that contain sensitive data. Evaluated as a template. | `""`                 |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)                                                             | `false`              |
+| `diagnosticMode.command` | Command to override all containers in the deployment                                                                                                | `["sleep"]`          |
+| `diagnosticMode.args`    | Args to override all containers in the deployment                                                                                                   | `["infinity"]`       |
+| `image.registry`         | Spark image registry                                                                                                                                | `docker.io`          |
+| `image.repository`       | Spark image repository                                                                                                                              | `bitnami/spark`      |
+| `image.tag`              | Spark image tag (immutable tags are recommended)                                                                                                    | `3.3.0-debian-11-r2` |
+| `image.pullPolicy`       | Spark image pull policy                                                                                                                             | `IfNotPresent`       |
+| `image.pullSecrets`      | Specify docker-registry secret names as an array                                                                                                    | `[]`                 |
+| `image.debug`            | Enable image debug mode                                                                                                                             | `false`              |
+| `hostNetwork`            | Enable HOST Network                                                                                                                                 | `false`              |
 
 
 ### Spark master parameters

--- a/bitnami/spark/templates/_helpers.tpl
+++ b/bitnami/spark/templates/_helpers.tpl
@@ -104,3 +104,24 @@ Compile all warnings into a single message, and call fail.
 {{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get the initialization scripts volume name.
+*/}}
+{{- define "spark.initScripts" -}}
+{{- printf "%s-init-scripts" (include "common.names.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Get the initialization scripts ConfigMap name.
+*/}}
+{{- define "spark.initScriptsCM" -}}
+{{- printf "%s" .Values.initScriptsCM -}}
+{{- end -}}
+
+{{/*
+Get the initialization scripts Secret name.
+*/}}
+{{- define "spark.initScriptsSecret" -}}
+{{- printf "%s" .Values.initScriptsSecret -}}
+{{- end -}}

--- a/bitnami/spark/templates/init-configmap.yaml
+++ b/bitnami/spark/templates/init-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.initScripts }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  {{ printf "%s-init-scripts" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  {{- include "common.tplvalues.render" ( dict "value" .Values.initScripts "context" $ ) | nindent 4 }}
+{{- end }}

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -188,6 +188,18 @@ spec:
             {{- if .Values.master.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.master.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
+            {{- if .Values.initScripts }}
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d/init-scripts
+            {{- end }}
+            {{- if .Values.initScriptsCM }}
+            - name: custom-init-scripts-cm
+              mountPath: /docker-entrypoint-initdb.d/init-scripts-cm
+            {{- end }}
+            {{- if .Values.initScriptsSecret }}
+            - name: custom-init-scripts-secret
+              mountPath: /docker-entrypoint-initdb.d/init-scripts-secret
+            {{- end }}
           env:
             - name: BITNAMI_DEBUG
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
@@ -315,4 +327,20 @@ spec:
         {{- end }}
         {{- if .Values.master.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.master.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.initScripts }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ template "spark.initScripts" . }}
+        {{- end }}
+        {{- if .Values.initScriptsCM }}
+        - name: custom-init-scripts-cm
+          configMap:
+            name: {{ template ".Values.initScriptsCM" . }}
+        {{- end }}
+        {{- if .Values.initScriptsSecret }}
+        - name: custom-init-scripts-secret
+          secret:
+            secretName: {{ template ".Values.initScriptsSecret" . }}
+            defaultMode: 0755
         {{- end }}

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -194,6 +194,18 @@ spec:
             {{- if .Values.worker.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
+            {{- if .Values.initScripts }}
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d/init-scripts
+            {{- end }}
+            {{- if .Values.initScriptsCM }}
+            - name: custom-init-scripts-cm
+              mountPath: /docker-entrypoint-initdb.d/init-scripts-cm
+            {{- end }}
+            {{- if .Values.initScriptsSecret }}
+            - name: custom-init-scripts-secret
+              mountPath: /docker-entrypoint-initdb.d/init-scripts-secret
+            {{- end }}
           env:
             - name: SPARK_MODE
               value: "worker"
@@ -339,4 +351,20 @@ spec:
         {{- end }}
         {{- if .Values.worker.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.worker.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+        {{- if .Values.initScripts }}
+        - name: custom-init-scripts
+          configMap:
+            name: {{ template "spark.initScripts" . }}
+        {{- end }}
+        {{- if .Values.initScriptsCM }}
+        - name: custom-init-scripts-cm
+          configMap:
+            name: {{ template ".Values.initScriptsCM" . }}
+        {{- end }}
+        {{- if .Values.initScriptsSecret }}
+        - name: custom-init-scripts-secret
+          secret:
+            secretName: {{ template ".Values.initScriptsSecret" . }}
+            defaultMode: 0755
         {{- end }}

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -44,6 +44,23 @@ clusterDomain: cluster.local
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+## @param initScripts Dictionary of init scripts. Evaluated as a template.
+## Specify dictionary of scripts to be run at first boot
+## Alternatively, you can put your scripts under the files/docker-entrypoint-initdb.d directory
+## For example:
+#initScripts:
+  #my_init_script.sh: |
+    #  #!/bin/sh
+   #   touch test
+#echo "Do something." >> test.txt
+initScripts: {}
+## @param initScriptsCM ConfigMap with the init scripts. Evaluated as a template.
+## Note: This will override initScripts
+##
+initScriptsCM: ""
+## @param initScriptsSecret Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time that contain sensitive data. Evaluated as a template.
+##
+initScriptsSecret: ""
 ## Enable diagnostic mode in the deployment
 ##
 diagnosticMode:


### PR DESCRIPTION
### Description of the change

Add init scripts support to the Spark chart

### Benefits

Users can to add custom init scripts to Spark so they can, for example, add custom plugins.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
