### PR TITLE
[bitnami/*] Disable CI in closed PRs

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -17,17 +17,7 @@ jobs:
   get-chart:
     runs-on: ubuntu-latest
     name: 'Get modified charts'
-    # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
-    # -> The 'Get modified charts' job suceededs AND
-    # -> The event is performed over an open PR  AND
-    #  ( ---> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
-    #    ---> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one )
-    if: |
-        github.event.pull_request.state != 'closed' &&
-        (
-          (github.event.action == 'labeled' && github.event.label.name == 'verify') ||
-          (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify'))
-        )
+    if: github.event.pull_request.state != 'closed'
     outputs:
       chart: ${{ steps.get-chart.outputs.chart }}
       result: ${{ steps.get-chart.outputs.result }}
@@ -98,7 +88,18 @@ jobs:
   vib-verify:
     runs-on: ubuntu-latest
     needs: get-chart
-    if: needs.get-chart.outputs.result == 'ok'
+    # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
+    # -> The 'Get modified charts' job suceededs AND
+    # -> It isn't an opened action (it avoids very running twice on consecutive opened and labeled events)  AND
+    #  ( ---> The pipeline was triggered due to a label addition and said label was the 'verify' one) OR
+    #  ( ---> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one )
+    if: |
+        needs.get-chart.outputs.result == 'ok' &&
+        github.event.action != 'opened' &&
+        (
+          (github.event.action == 'labeled' && github.event.label.name == 'verify') ||
+          (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify'))
+        )
     name: VIB Verify
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -17,7 +17,7 @@ jobs:
   get-chart:
     runs-on: ubuntu-latest
     name: 'Get modified charts'
-    if: github.event.pull_request.state != 'closed'
+    if: ${{ github.event.pull_request.state != 'closed' }}
     outputs:
       chart: ${{ steps.get-chart.outputs.chart }}
       result: ${{ steps.get-chart.outputs.result }}

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -91,8 +91,8 @@ jobs:
     # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
     # -> The 'Get modified charts' job suceededs AND
     # -> The event is not opened (avoids running twice on consecutive opened and labeled events)  AND
-    #  ( ---> The pipeline was triggered due to a label addition and said label was the 'verify' one) OR
-    #  ( ---> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one )
+    #  ( ---> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
+    #    ---> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one )
     if: |
         needs.get-chart.outputs.result == 'ok' &&
         github.event.action != 'opened' &&

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -17,6 +17,17 @@ jobs:
   get-chart:
     runs-on: ubuntu-latest
     name: 'Get modified charts'
+    # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
+    # -> The 'Get modified charts' job suceededs AND
+    # -> The event is performed over an open PR  AND
+    #  ( ---> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
+    #    ---> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one )
+    if: |
+        github.event.pull_request.state != 'closed' &&
+        (
+          (github.event.action == 'labeled' && github.event.label.name == 'verify') ||
+          (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify'))
+        )
     outputs:
       chart: ${{ steps.get-chart.outputs.chart }}
       result: ${{ steps.get-chart.outputs.result }}
@@ -87,16 +98,7 @@ jobs:
   vib-verify:
     runs-on: ubuntu-latest
     needs: get-chart
-    # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
-    # -> The 'Get modified charts' job suceededs AND
-    # -> The event action is different from opened AND
-    #  ( ---> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
-    #    ---> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one )
-    if: |
-        needs.get-chart.outputs.result == 'ok' &&
-        github.event.action != 'opened' &&
-        (github.event.action == 'labeled' && github.event.label.name == 'verify' ||
-        github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify'))
+    if: needs.get-chart.outputs.result == 'ok'
     name: VIB Verify
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -90,7 +90,7 @@ jobs:
     needs: get-chart
     # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
     # -> The 'Get modified charts' job suceededs AND
-    # -> It isn't an opened action (it avoids very running twice on consecutive opened and labeled events)  AND
+    # -> The event is not opened (avoids running twice on consecutive opened and labeled events)  AND
     #  ( ---> The pipeline was triggered due to a label addition and said label was the 'verify' one) OR
     #  ( ---> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one )
     if: |


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Disable CI in closed PRs. Also on 'labeled' events we take care only about 'verify' label

### Benefits

Don't run CI on unexpected events. For example automated [PRs are failing](https://github.com/bitnami/charts/pulls?q=is%3Apr+is%3Aclosed+is%3Amerged+author%3Abitnami-bot) after closing it


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
