### PR TITLE
[bitnami/*] Migrate logic for automated PRs to GitHub's CI

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -25,14 +25,11 @@ jobs:
       # Enables auto-merge and adds necessary labels for automated releases' PRs
       - id: labeling
         name: Label PR
-        run: |
-          curl --request POST \
-          --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
-          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
-          --data '{
-            "labels": ["verify", "auto-merge"]
-            }' \
-          --fail
+        uses: andymckay/labeler@1.0.4
+        with:
+          # We can't use GITHUB_TOKEN because the labeling needs to trigger a new CI pipeline
+          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
+          add-labels: "verify, auto-merge"
       - id: auto-merge
         name: Enable auto-merge
         run: |
@@ -167,14 +164,25 @@ jobs:
             "event": "APPROVE"
             }' \
           --fail
-      # Removes "auto-merge" label and add related agents as reviewers if the 'VIB Verify' job failed
+      - name: Remove auto-merge label
+        if: ${{ needs.vib-verify.result == 'failure' }}
+        uses: andymckay/labeler@1.0.4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          remove-labels: "auto-merge"
+      - name: Disable auto-merge
+        if: ${{ needs.vib-verify.result == 'failure' }}
+        run: |
+          curl --request POST \
+          --url https://api.github.com/graphql \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --data '{
+            "query": "mutation { disablePullRequestAutoMerge(input: {pullRequestId: \"${{ github.event.pull_request.node_id }}\"}) { clientMutationId }}"
+            }' \
+          --fail
       - name: Manual review required
         if: ${{ needs.vib-verify.result == 'failure' }}
         run: |
-          curl --request DELETE \
-          --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/auto-merge \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          --fail
           curl --request POST \
           --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
           --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
@@ -189,12 +197,5 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "team_reviewers": ["build-maintainers"]
-            }' \
-          --fail
-          curl --request POST \
-          --url https://api.github.com/graphql \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          --data '{
-            "query": "mutation { disablePullRequestAutoMerge(input: {pullRequestId: \"${{ github.event.pull_request.node_id }}\"}) { clientMutationId }}"
             }' \
           --fail

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   auto-pr-triage:
     runs-on: ubuntu-latest
-    name: 'Labels and auto-merge'
+    name: Triage for automated PRs
     if: |
       contains(github.event.pull_request.title, 'Release') &&
       github.event.action == 'opened' &&

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -14,6 +14,35 @@ env:
   CSP_API_TOKEN: ${{ secrets.CSP_API_TOKEN }}
   VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
 jobs:
+  auto-pr-triage:
+    runs-on: ubuntu-latest
+    name: 'Labels and auto-merge'
+    if: |
+      contains(github.event.pull_request.title, 'Release') &&
+      github.event.action == 'opened' &&
+      github.actor == 'bitnami-bot'
+    steps:
+      # Enables auto-merge and adds necessary labels for automated releases' PRs
+      - id: labeling
+        name: Label PR
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels \
+          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
+          --data '{
+            "labels": ["verify", "auto-merge"]
+            }' \
+          --fail
+      - id: auto-merge
+        name: Enable auto-merge
+        run: |
+          curl --request POST \
+          --url https://api.github.com/graphql \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --data '{
+            "query": "mutation { enablePullRequestAutoMerge(input: {pullRequestId: \"${{ github.event.pull_request.node_id }}\", mergeMethod: SQUASH}) { clientMutationId }}"
+            }' \
+          --fail
   get-chart:
     runs-on: ubuntu-latest
     name: 'Get modified charts'
@@ -116,7 +145,7 @@ jobs:
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
           # Alternative Target-Platform to be used in case of incompatibilities
           VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}
-  ci-pr-review:
+  auto-pr-review:
     runs-on: ubuntu-latest
     needs: vib-verify
     name: Reviewal for automated PRs
@@ -144,11 +173,11 @@ jobs:
         run: |
           curl --request DELETE \
           --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/auto-merge \
-          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
           --fail
           curl --request POST \
           --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
           --header 'content-type: application/json' \
           --data '{
             "body": "There has been an error during the automated release process. Manual revision is now required."
@@ -160,5 +189,12 @@ jobs:
           --header 'content-type: application/json' \
           --data '{
             "team_reviewers": ["build-maintainers"]
+            }' \
+          --fail
+          curl --request POST \
+          --url https://api.github.com/graphql \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --data '{
+            "query": "mutation { disablePullRequestAutoMerge(input: {pullRequestId: \"${{ github.event.pull_request.node_id }}\"}) { clientMutationId }}"
             }' \
           --fail


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Until now, the initial triage for automated PRs of labeling and enabling auto-merge was performed internally. That is, the same pipeline that created the PR performed the triage. With this PR, we'll leave only the PR creation logic internally and have all the PR lifecycle logic in GH instead of having it divided.

Besides that logic migration, we are also adding the disable of auto-merge when an automated PR fails to run VIB Verify. This is to avoid a specific corner case where an automated PR could be merged without executing the whole CI.

### Benefits

We improve transparency and avoid having part of the PR management logic internally. 

### Possible drawbacks

Users with opened PRs may require a rebase from `master` branch.

### Additional information

This PR is a copy of https://github.com/bitnami/containers/pull/339. Once both of them are approved, the internal logic will be removed and the PRs merged.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
