### PR TITLE
[bitnami/*] Ignoring automated PR (Release activity) from the support flow. 

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -7,12 +7,14 @@ permissions:
   repository-projects: write
   issues: write
 
+# To fix the concurrency when for example more than one label is added
 concurrency:
-  group: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
+  group: ${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
   comments_handler:
+    if: ${{ github.actor != 'bitnami-bot' && github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -11,12 +11,14 @@ permissions:
   issues: write
   repository-projects: write
 
+# To fix the concurrency when for example more than one label is added
 concurrency:
-  group: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
+  group: ${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
   send_to_solved:
+    if: ${{ github.actor != 'bitnami-bot' && github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -9,13 +9,14 @@ permissions:
   repository-projects: read
   issues: write
 
+# To fix the concurrency when for example more than one label is added
 concurrency:
-  # Cards are special
-  group: ${{ github.event.project_card.content_url }}
+  group: ${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
   label-card:
+    if: ${{ github.actor != 'bitnami-bot' && github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout
@@ -52,6 +53,7 @@ jobs:
           add-labels: "solved"
           remove-labels: "in-progress, on-hold, triage"
   assign-assignee-if-needed:
+    if: ${{ github.actor != 'bitnami-bot' && (!contains(github.event.issue.labels.*.name, 'auto-merge')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -13,13 +13,15 @@ permissions:
   repository-projects: write
   issues: write
 
+# To fix the concurrency when for example more than one label is added
 concurrency:
-  group: ${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}
+  group: ${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
   # For any opened or reopened issue, should be sent into Triage
   send_to_board:
+    if: ${{ github.actor != 'bitnami-bot' && github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout
@@ -38,7 +40,6 @@ jobs:
           # creating env variable "on the fly"
           echo "TRIAGE_TEAM_STRING=$TRIAGE_TEAM_STRING" >> $GITHUB_ENV
       - name: Assign to a person to work on it
-        if: ${{ github.actor != 'bitnami-bot' }}
         uses: pozil/auto-assign-issue@v1.7.3
         with:
           numOfAssignee: 1
@@ -47,7 +48,6 @@ jobs:
           # teams: XXX
           repo-token: "${{ secrets.GHPROJECT_TOKEN }}"
       - name: Send to the board
-        if: ${{ github.actor != 'bitnami-bot' }}
         uses: peter-evans/create-or-update-project-card@v2
         with:
           project-name: Support


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Ignoring automated PR (Release activity) from the support flow.

### Benefits

Ensuring the support flow only handles the support and not any flow related to the Release one.

### Possible drawbacks

None detected

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
