### PR TITLE
[bitnami/redis] Fix OutOfSync HPAs with ArgoCD

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -24,4 +24,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/bitnami-docker-redis
-version: 17.0.5
+version: 17.0.6

--- a/bitnami/redis/templates/replicas/hpa.yaml
+++ b/bitnami/redis/templates/replicas/hpa.yaml
@@ -20,18 +20,6 @@ spec:
   minReplicas: {{ .Values.replica.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.replica.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.replica.autoscaling.targetCPU }}
-    - type: Resource
-      resource:
-        name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.replica.autoscaling.targetCPU }}
-        {{- else }}
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.replica.autoscaling.targetCPU }}
-        {{- end }}
-    {{- end }}
     {{- if .Values.replica.autoscaling.targetMemory }}
     - type: Resource
       resource:
@@ -42,6 +30,18 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.replica.autoscaling.targetMemory }}
+        {{- end }}
+    {{- end }}
+    {{- if .Values.replica.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.replica.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.replica.autoscaling.targetCPU }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/bitnami/redis/templates/sentinel/hpa.yaml
+++ b/bitnami/redis/templates/sentinel/hpa.yaml
@@ -20,18 +20,6 @@ spec:
   minReplicas: {{ .Values.replica.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.replica.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.replica.autoscaling.targetCPU }}
-    - type: Resource
-      resource:
-        name: cpu
-        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
-        targetAverageUtilization: {{ .Values.replica.autoscaling.targetCPU }}
-        {{- else }}
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.replica.autoscaling.targetCPU }}
-        {{- end }}
-    {{- end }}
     {{- if .Values.replica.autoscaling.targetMemory }}
     - type: Resource
       resource:
@@ -42,6 +30,18 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.replica.autoscaling.targetMemory }}
+        {{- end }}
+    {{- end }}
+    {{- if .Values.replica.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.replica.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.replica.autoscaling.targetCPU }}
         {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Minor change that prevents the bitnami/redis helm chart to produce OutOfSync applications when deployed with ArgoCD

### Benefits

Chart can be used with or without ArgoCD

### Possible drawbacks

None

### Applicable issues

  - fixes #11312

### Additional information

It is a known limitation of ArgoCD and Kubernetes as stated in ArgoCD's documentation: https://argo-cd.readthedocs.io/en/stable/user-guide/diffing

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
