### PR TITLE
[bitnami/keycloak] remove Wildfly management port and secret key

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 9.6.2
+version: 9.6.3

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -91,8 +91,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.debug`                    | Specify if debug logs should be enabled                                                                                      | `false`                |
 | `auth.adminUser`                 | Keycloak administrator user                                                                                                  | `user`                 |
 | `auth.adminPassword`             | Keycloak administrator password for the new user                                                                             | `""`                   |
-| `auth.managementUser`            | Wildfly management user                                                                                                      | `manager`              |
-| `auth.managementPassword`        | Wildfly management password                                                                                                  | `""`                   |
 | `auth.existingSecret`            | An already existing secret containing auth info                                                                              | `""`                   |
 | `auth.existingSecretPerPassword` | Override `existingSecret` and other secret values                                                                            | `{}`                   |
 | `auth.tls.enabled`               | Enable TLS encryption. Required for HTTPs traffic.                                                                           | `false`                |
@@ -127,7 +125,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replicaCount`                          | Number of Keycloak replicas to deploy                                                                                    | `1`             |
 | `containerPorts.http`                   | Keycloak HTTP container port                                                                                             | `8080`          |
 | `containerPorts.https`                  | Keycloak HTTPS container port                                                                                            | `8443`          |
-| `containerPorts.management`             | Keycloak management HTTP container port                                                                                  | `9990`          |
 | `podSecurityContext.enabled`            | Enabled Keycloak pods' Security Context                                                                                  | `true`          |
 | `podSecurityContext.fsGroup`            | Set Keycloak pod's Security Context fsGroup                                                                              | `1001`          |
 | `containerSecurityContext.enabled`      | Enabled Keycloak containers' Security Context                                                                            | `true`          |

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -13,7 +13,6 @@ metadata:
   {{- end }}
 data:
   KEYCLOAK_ADMIN_USER: {{ .Values.auth.adminUser | quote }}
-  KEYCLOAK_MANAGEMENT_USER: {{ .Values.auth.managementUser | quote }}
   KEYCLOAK_HTTP_PORT: {{ .Values.containerPorts.http | quote }}
   KEYCLOAK_PROXY: {{ .Values.proxy }}
   KEYCLOAK_ENABLE_STATISTICS: {{ ternary "true" "false" .Values.metrics.enabled | quote }}

--- a/bitnami/keycloak/templates/networkpolicy.yaml
+++ b/bitnami/keycloak/templates/networkpolicy.yaml
@@ -21,9 +21,6 @@ spec:
         {{- if .Values.auth.tls.enabled }}
         - port: {{ .Values.containerPorts.https }}
         {{- end }}
-        {{- if .Values.metrics.enabled }}
-        - port: {{ .Values.containerPorts.management }}
-        {{- end }}
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:

--- a/bitnami/keycloak/templates/secrets.yaml
+++ b/bitnami/keycloak/templates/secrets.yaml
@@ -16,7 +16,6 @@ metadata:
 type: Opaque
 data:
   admin-password: {{ include "common.secrets.passwords.manage" (dict "secret" $secretName "key" "admin-password" "length" 10 "providedValues" (list "auth.adminPassword") "context" $) }}
-  management-password: {{ include "common.secrets.passwords.manage" (dict "secret" $secretName "key" "management-password" "providedValues" (list "auth.managementPassword") "context" $) }}
   {{- if and (not .Values.postgresql.enabled) (not .Values.externalDatabase.existingSecret) }}
   password: {{ include "common.secrets.passwords.manage" (dict "secret" $secretName "key" "password" "length" 10 "providedValues" (list "externalDatabase.password") "context" $) }}
   {{- end }}

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -220,16 +220,6 @@ spec:
                   name: {{ $globalSecretName }}
                   key: {{ include "common.secrets.key" (dict "existingSecret" .Values.auth.existingSecret "key" "admin-password") }}
                 {{- end }}
-            - name: KEYCLOAK_MANAGEMENT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                {{- if .Values.auth.existingSecretPerPassword }}
-                  name: {{ tpl (include "common.secrets.name" (dict "existingSecret" .Values.auth.existingSecretPerPassword.managementPassword "context" $)) $ }}
-                  key: {{ include "common.secrets.key" (dict "existingSecret" .Values.auth.existingSecretPerPassword "key" "managementPassword") }}
-                {{- else }}
-                  name: {{ $globalSecretName }}
-                  key: {{ include "common.secrets.key" (dict "existingSecret" .Values.auth.existingSecret "key" "management-password") }}
-                {{- end }}
             - name: KEYCLOAK_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -302,9 +292,6 @@ spec:
               containerPort: {{ .Values.containerPorts.https }}
               protocol: TCP
             {{- end }}
-            - name: http-management
-              containerPort: {{ .Values.containerPorts.management }}
-              protocol: TCP
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe: {{- omit .Values.startupProbe "enabled" | toYaml | nindent 12 }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -100,19 +100,12 @@ auth:
   ## @param auth.adminPassword Keycloak administrator password for the new user
   ##
   adminPassword: ""
-  ## @param auth.managementUser Wildfly management user
-  ##
-  managementUser: manager
-  ## @param auth.managementPassword Wildfly management password
-  ##
-  managementPassword: ""
   ## @param auth.existingSecret An already existing secret containing auth info
   ## e.g:
   ## existingSecret:
   ##   name: mySecret
   ##   keyMapping:
   ##     admin-password: myPasswordKey
-  ##     management-password: myManagementPasswordKey
   ##     tls-keystore-password: myTlsKeystorePasswordKey
   ##     tls-truststore-password: myTlsTruststorePasswordKey
   ##
@@ -122,14 +115,11 @@ auth:
   ## existingSecretPerPassword:
   ##   keyMapping:
   ##     adminPassword: KEYCLOAK_ADMIN_PASSWORD
-  ##     managementPassword: KEYCLOAK_MANAGEMENT_PASSWORD
   ##     databasePassword: password
   ##     tlsKeystorePassword: JKS_KEYSTORE_TRUSTSTORE_PASSWORD
   ##     tlsTruststorePassword: JKS_KEYSTORE_TRUSTSTORE_PASSWORD
   ##   adminPassword:
   ##     name: keycloak-test2.credentials ## release-name
-  ##   managementPassword:
-  ##     name: keycloak-test2.credentials
   ##   databasePassword:
   ##     name: keycloak.pocwatt-keycloak-cluster.credentials
   ##   tlsKeystorePassword:
@@ -270,12 +260,10 @@ extraEnvVarsSecret: ""
 replicaCount: 1
 ## @param containerPorts.http Keycloak HTTP container port
 ## @param containerPorts.https Keycloak HTTPS container port
-## @param containerPorts.management Keycloak management HTTP container port
 ##
 containerPorts:
   http: 8080
   https: 8443
-  management: 9990
 ## Keycloak pods' SecurityContext
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Keycloak pods' Security Context


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Since Keycloak 17, there isn't any listener bound to port 9990, and the management password passed to the image isn't used. This PR removes all references to these obsoleted features.

### Benefits

<!-- What benefits will be realized by the code change? -->
See #11129

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - Closes #11129

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
