### PR TITLE
[bitnami/dataplatform-bp2] Bump chart version in Chart.yaml

### DIFF
--- a/bitnami/dataplatform-bp2/Chart.yaml
+++ b/bitnami/dataplatform-bp2/Chart.yaml
@@ -57,4 +57,4 @@ sources:
 - https://www.elastic.co/products/logstash
 - https://zookeeper.apache.org/
 - https://github.com/bitnami/bitnami-docker-zookeeper
-version: 12.0.4
+version: 12.0.5


### PR DESCRIPTION
A new version bump is needed, followup of https://github.com/bitnami/charts/pull/11328 and https://github.com/bitnami/charts/pull/11331