### PR TITLE
Fixing regression when an issue is created by non bitnami-bot

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   comments_handler:
-    if: ${{ github.actor != 'bitnami-bot' && github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge')) }}
+    if: ${{ github.actor != 'bitnami-bot' && ((github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge'))) || github.event_name == 'issues') }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout
@@ -31,21 +31,21 @@ jobs:
         with:
           project-name: Support
           column-name: Pending
-          token: "${{ secrets.GHPROJECT_TOKEN }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Move into In Progress
         uses: peter-evans/create-or-update-project-card@v2
         if: ${{ contains(github.event.issue.labels.*.name, 'in-progress') && (!contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login)) }}
         with:
           project-name: Support
           column-name: In progress
-          token: "${{ secrets.GHPROJECT_TOKEN }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Move into Triage
         uses: peter-evans/create-or-update-project-card@v2
         if: ${{ ((contains(github.event.issue.labels.*.name, 'triage')) || (contains(github.event.issue.labels.*.name, 'solved'))) && (!contains(fromJson(env.BITNAMI_TEAM), github.event.comment.user.login)) }}
         with:
           project-name: Support
           column-name: Triage
-          token: "${{ secrets.GHPROJECT_TOKEN }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Label as triage back
         # Only if commented when solved
         if: ${{ contains(github.event.issue.labels.*.name, 'solved') }}

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   send_to_solved:
-    if: ${{ github.actor != 'bitnami-bot' && github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge')) }}
+    if: ${{ github.actor != 'bitnami-bot' }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   label-card:
-    if: ${{ github.actor != 'bitnami-bot' && github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge')) }}
+    if: ${{ github.actor != 'bitnami-bot' }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   # For any opened or reopened issue, should be sent into Triage
   send_to_board:
-    if: ${{ github.actor != 'bitnami-bot' && github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge')) }}
+    if: ${{ github.actor != 'bitnami-bot' && ((github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge'))) || github.event_name == 'issues') }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

When in the PR #11308 we avoided adding the bitnami-bot PRs action to the support flow, there was a regression that impacted on the issues (are not added into triage). This fixes it.

### Benefits

Issues will be in the support flow as they should.

### Possible drawbacks

None detected.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
