### PR TITLE
[bitnami/*]  Fixing the race condition only to exclude bitnami-bot ON auto-merge PRs

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   comments_handler:
-    if: ${{ github.actor != 'bitnami-bot' && ((github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge'))) || github.event_name == 'issues') }}
+    if: ${{ github.actor != 'bitnami-bot' && ((github.event.pull_request && (!contains(github.event.pull_request.labels.*.name, 'auto-merge'))) || (github.event.issue && (!contains(github.event.issue.labels.*.name, 'auto-merge')))) }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixing the race condition only to exclude bitnami-bot ON auto-merge PRs

### Benefits

When an user comment on a non release PR/issue the cards are properly moved.

### Possible drawbacks

None detected.

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
