### PR TITLE
[bitnami/schema-registry] Add schema-registry chart

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -37,6 +37,7 @@ on: # rebuild any PRs and main branch changes
       - 'bitnami/redis-cluster/**'
       - 'bitnami/redis/**'
       - 'bitnami/redmine/**'
+      - 'bitnami/schema-registry/**'
       - 'bitnami/sealed-secrets/**'
       - 'bitnami/solr/**'
       - 'bitnami/spring-cloud-dataflow/**'

--- a/.vib/schema-registry/vib-publish.json
+++ b/.vib/schema-registry/vib-publish.json
@@ -1,0 +1,48 @@
+{
+  "phases": {
+    "package": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/schema-registry"
+        }
+      },
+      "actions": [
+        {
+          "action_id": "helm-package"
+        },
+        {
+          "action_id": "helm-lint"
+        }
+      ]
+    },
+    "verify": {
+      "actions": [
+        {
+          "action_id": "trivy",
+          "params": {
+            "threshold": "CRITICAL",
+            "vuln_type": [
+              "OS"
+            ]
+          }
+        }
+      ]
+    },
+    "publish": {
+      "actions": [
+        {
+          "action_id": "helm-publish",
+          "params": {
+            "repository": {
+              "kind": "S3",
+              "url": "{VIB_ENV_S3_URL}",
+              "username": "{VIB_ENV_S3_USERNAME}",
+              "password": "{VIB_ENV_S3_PASSWORD}"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/.vib/schema-registry/vib-verify.json
+++ b/.vib/schema-registry/vib-verify.json
@@ -1,0 +1,31 @@
+{
+  "phases": {
+    "package": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/schema-registry"
+        }
+      },
+      "actions": [
+        {
+          "action_id": "helm-package"
+        },
+        {
+          "action_id": "helm-lint"
+        }
+      ]
+    },
+    "verify": {
+      "actions": [
+        {
+          "action_id": "trivy",
+          "params": {
+            "threshold": "CRITICAL",
+            "vuln_type": ["OS"]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/bitnami/schema-registry/.helmignore
+++ b/bitnami/schema-registry/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/bitnami/schema-registry/Chart.lock
+++ b/bitnami/schema-registry/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.16.1
+- name: kafka
+  repository: https://charts.bitnami.com/bitnami
+  version: 18.0.3
+digest: sha256:ec6d4fe556e33f3f09745622840efb03ea50591550078d8f01ac4801247c2968
+generated: "2022-07-25T12:38:32.737753+02:00"

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 6.0.1
+appVersion: 7.1.3
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -10,7 +10,7 @@ dependencies:
     name: kafka
     repository: https://charts.bitnami.com/bitnami
     version: 18.x.x
-description: Confluent Schema Registry provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
+description: Schema Registry (Commercial)
 engine: gotpl
 home: https://confluent.io/
 icon: https://bitnami.com/assets/stacks/schema-registry-stac/img/schema-registry-stack-220x234.png

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+appVersion: 6.0.1
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 1.x.x
+  - condition: kafka.enabled
+    name: kafka
+    repository: https://charts.bitnami.com/bitnami
+    version: 18.x.x
+description: Confluent Schema Registry provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
+engine: gotpl
+home: https://confluent.io/
+icon: https://bitnami.com/assets/stacks/schema-registry-stac/img/schema-registry-stack-220x234.png
+keywords:
+  - schema-registry
+  - confluent
+  - kafka
+  - zookeeper
+  - streaming
+maintainers:
+  - email: containers@bitnami.com
+    name: Bitnami
+name: schema-registry
+sources:
+  - https://github.com/bitnami/bitnami-docker-schema-registry
+version: 4.0.0

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     name: kafka
     repository: https://charts.bitnami.com/bitnami
     version: 18.x.x
-description: Schema Registry (Commercial)
+description: Confluent Schema Registry provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
 engine: gotpl
 home: https://confluent.io/
 icon: https://bitnami.com/assets/stacks/schema-registry-stac/img/schema-registry-stack-220x234.png

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -21,8 +21,8 @@ keywords:
   - zookeeper
   - streaming
 maintainers:
-  - email: containers@bitnami.com
-    name: Bitnami
+  - name: Bitnami
+    url: https://github.com/bitnami/charts
 name: schema-registry
 sources:
   - https://github.com/bitnami/bitnami-docker-schema-registry

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -4,7 +4,7 @@
 
 [Confluent Schema Registry](www.confluent.io/schema) provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
 
-## TL;DR;
+## TL;DR
 
 ```bash
 helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -85,7 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------- |
 | `image.registry`                                | Schema Registry image registry                                                                              | `docker.io`               |
 | `image.repository`                              | Schema Registry image repository                                                                            | `bitnami/schema-registry` |
-| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                  | `7.1.3-debian-11-r5`      |
+| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                  | `7.1.3-debian-11-r6`      |
 | `image.pullPolicy`                              | Schema Registry image pull policy                                                                           | `IfNotPresent`            |
 | `image.pullSecrets`                             | Schema Registry image pull secrets                                                                          | `[]`                      |
 | `image.debug`                                   | Enable image debug mode                                                                                     | `false`                   |

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -85,7 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------- |
 | `image.registry`                                | Schema Registry image registry                                                                              | `docker.io`               |
 | `image.repository`                              | Schema Registry image repository                                                                            | `bitnami/schema-registry` |
-| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                  | `7.1.3-debian-11-r4`      |
+| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                  | `7.1.3-debian-11-r5`      |
 | `image.pullPolicy`                              | Schema Registry image pull policy                                                                           | `IfNotPresent`            |
 | `image.pullSecrets`                             | Schema Registry image pull secrets                                                                          | `[]`                      |
 | `image.debug`                                   | Enable image debug mode                                                                                     | `false`                   |

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -1,10 +1,10 @@
-<!--- app-name: Schema Regsitry -->
+<!--- app-name: Confluent Schema Registry -->
 
-# Schema Registry packaged by Bitnami
+# Bitnami Confluent Schema Registry Stack
 
-Schema Registry (Commercial)
+Confluent Schema Registry provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
 
-[Overview of Schema Regsitry](https://change.me)
+[Overview of Confluent Schema Registry](https://www.confluent.io)
 
 
                            

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -85,7 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------- |
 | `image.registry`                                | Schema Registry image registry                                                                              | `docker.io`               |
 | `image.repository`                              | Schema Registry image repository                                                                            | `bitnami/schema-registry` |
-| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                  | `7.1.3-debian-11-r1`      |
+| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                  | `7.1.3-debian-11-r4`      |
 | `image.pullPolicy`                              | Schema Registry image pull policy                                                                           | `IfNotPresent`            |
 | `image.pullSecrets`                             | Schema Registry image pull secrets                                                                          | `[]`                      |
 | `image.debug`                                   | Enable image debug mode                                                                                     | `false`                   |

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -1,9 +1,13 @@
-<!--- app-name: Confluent Schema Registry -->
+<!--- app-name: Schema Regsitry -->
 
-# Confluent Schema Registry packaged by Bitnami
+# Schema Registry packaged by Bitnami
 
-[Confluent Schema Registry](www.confluent.io/schema) provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
+Schema Registry (Commercial)
 
+[Overview of Schema Regsitry](https://change.me)
+
+
+                           
 ## TL;DR
 
 ```bash

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -77,7 +77,7 @@ helm uninstall my-release
 | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------- |
 | `image.registry`                                | Schema Registry image registry                                                                              | `docker.io`               |
 | `image.repository`                              | Schema Registry image repository                                                                            | `bitnami/schema-registry` |
-| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                  | `7.1.1-photon-3-r7`       |
+| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                  | `7.1.3-debian-11-r1`      |
 | `image.pullPolicy`                              | Schema Registry image pull policy                                                                           | `IfNotPresent`            |
 | `image.pullSecrets`                             | Schema Registry image pull secrets                                                                          | `[]`                      |
 | `image.debug`                                   | Enable image debug mode                                                                                     | `false`                   |
@@ -218,30 +218,30 @@ helm uninstall my-release
 
 ### Kafka chart parameters
 
-| Name                                            | Description                                                                                                         | Value                            |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `kafka.enabled`                                 | Enable/disable Kafka chart installation                                                                             | `true`                           |
-| `kafka.replicaCount`                            | Number of Kafka brokers                                                                                             | `1`                              |
-| `kafka.auth.clientProtocol`                     | Authentication protocol for communications with clients. Allowed protocols: plaintext, tls, mtls, sasl and sasl_tls | `plaintext`                      |
-| `kafka.auth.interBrokerProtocol`                | Authentication protocol for inter-broker communications. Allowed protocols: plaintext, tls, mtls, sasl and sasl_tls | `plaintext`                      |
-| `kafka.auth.jksSecret`                          | Name of the existing secret containing the truststore and one keystore per Kafka broker you have in the cluster     | `""`                             |
-| `kafka.auth.jksPassword`                        | Password to access the JKS files when they are password-protected                                                   | `""`                             |
-| `kafka.auth.tlsEndpointIdentificationAlgorithm` | The endpoint identification algorithm to validate server hostname using server certificate                          | `https`                          |
-| `kafka.auth.jaas.clientUsers`                   | Kafka client users for SASL authentication                                                                          | `[]`                             |
-| `kafka.auth.jaas.clientPasswords`               | Kafka client passwords for SASL authentication                                                                      | `[]`                             |
-| `kafka.auth.jaas.interBrokerUser`               | Kafka inter broker communication user for SASL authentication                                                       | `admin`                          |
-| `kafka.auth.jaas.interBrokerPassword`           | Kafka inter broker communication password for SASL authentication                                                   | `""`                             |
-| `kafka.auth.jaas.zookeeperUser`                 | Kafka Zookeeper user for SASL authentication                                                                        | `""`                             |
-| `kafka.auth.jaas.zookeeperPassword`             | Kafka Zookeeper password for SASL authentication                                                                    | `""`                             |
-| `kafka.auth.jaas.existingSecret`                | Name of the existing secret containing credentials for brokerUser, interBrokerUser and zookeeperUser                | `""`                             |
-| `kafka.service.port`                            | Kafka port for client connections                                                                                   | `9092`                           |
-| `kafka.zookeeper.enabled`                       | Enable/disable Zookeeper chart installation                                                                         | `true`                           |
-| `kafka.zookeeper.replicaCount`                  | Number of Zookeeper replicas                                                                                        | `1`                              |
-| `kafka.zookeeper.auth`                          | Zookeeper auth settings                                                                                             | `{}`                             |
-| `externalKafka.brokers`                         | Array of Kafka brokers to connect to. Format: protocol://broker_hostname:port                                       | `["PLAINTEXT://localhost:9092"]` |
-| `externalKafka.auth.protocol`                   | Authentication protocol. Allowed protocols: plaintext, tls, sasl and sasl_tls                                       | `plaintext`                      |
-| `externalKafka.auth.jaas.user`                  | User for SASL authentication                                                                                        | `user`                           |
-| `externalKafka.auth.jaas.password`              | Password for SASL authentication                                                                                    | `""`                             |
+| Name                                             | Description                                                                                                         | Value                            |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `kafka.enabled`                                  | Enable/disable Kafka chart installation                                                                             | `true`                           |
+| `kafka.replicaCount`                             | Number of Kafka brokers                                                                                             | `1`                              |
+| `kafka.auth.clientProtocol`                      | Authentication protocol for communications with clients. Allowed protocols: plaintext, tls, mtls, sasl and sasl_tls | `plaintext`                      |
+| `kafka.auth.interBrokerProtocol`                 | Authentication protocol for inter-broker communications. Allowed protocols: plaintext, tls, mtls, sasl and sasl_tls | `plaintext`                      |
+| `kafka.auth.tls.existingSecrets`                 | Array existing secrets containing the TLS certificates for the Kafka brokers                                        | `[]`                             |
+| `kafka.auth.tls.password`                        | Password to access the JKS files or PEM key when they are password-protected.                                       | `""`                             |
+| `kafka.auth.tls.endpointIdentificationAlgorithm` | The endpoint identification algorithm to validate server hostname using server certificate                          | `https`                          |
+| `kafka.auth.sasl.jaas.clientUsers`               | Kafka client users for SASL authentication                                                                          | `[]`                             |
+| `kafka.auth.sasl.jaas.clientPasswords`           | Kafka client passwords for SASL authentication                                                                      | `[]`                             |
+| `kafka.auth.sasl.jaas.interBrokerUser`           | Kafka inter broker communication user for SASL authentication                                                       | `admin`                          |
+| `kafka.auth.sasl.jaas.interBrokerPassword`       | Kafka inter broker communication password for SASL authentication                                                   | `""`                             |
+| `kafka.auth.sasl.jaas.zookeeperUser`             | Kafka Zookeeper user for SASL authentication                                                                        | `""`                             |
+| `kafka.auth.sasl.jaas.zookeeperPassword`         | Kafka Zookeeper password for SASL authentication                                                                    | `""`                             |
+| `kafka.auth.sasl.jaas.existingSecret`            | Name of the existing secret containing credentials for brokerUser, interBrokerUser and zookeeperUser                | `""`                             |
+| `kafka.service.ports.client`                     | Kafka service port for client connections                                                                           | `9092`                           |
+| `kafka.zookeeper.enabled`                        | Enable/disable Zookeeper chart installation                                                                         | `true`                           |
+| `kafka.zookeeper.replicaCount`                   | Number of Zookeeper replicas                                                                                        | `1`                              |
+| `kafka.zookeeper.auth`                           | Zookeeper auth settings                                                                                             | `{}`                             |
+| `externalKafka.brokers`                          | Array of Kafka brokers to connect to. Format: protocol://broker_hostname:port                                       | `["PLAINTEXT://localhost:9092"]` |
+| `externalKafka.auth.protocol`                    | Authentication protocol. Allowed protocols: plaintext, tls, sasl and sasl_tls                                       | `plaintext`                      |
+| `externalKafka.auth.jaas.user`                   | User for SASL authentication                                                                                        | `user`                           |
+| `externalKafka.auth.jaas.password`               | Password for SASL authentication                                                                                    | `""`                             |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -1,0 +1,439 @@
+# Schema Registry
+
+[Confluent Schema Registry](www.confluent.io/schema) provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
+keywords:
+
+## TL;DR;
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install my-release bitnami/schema-registry
+```
+
+## Introduction
+
+This chart bootstraps a [Schema Registry](https://github.com/bitnami/bitnami-docker-schema-registry) statefulset on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters.
+
+## Prerequisites
+
+- Kubernetes 1.12+
+- Helm 3.0-beta3+
+- PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install my-release bitnami/schema-registry
+```
+
+These commands deploy Schema Registr on the Kubernetes cluster with the default configuration. The [parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` chart:
+
+```bash
+helm uninstall my-release
+```
+
+## Parameters
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `""`  |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
+| `kubeVersion`             | Override Kubernetes version                     | `""`  |
+
+
+### Common parameters
+
+| Name                     | Description                                                                                          | Value           |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | --------------- |
+| `nameOverride`           | String to partially override airflow.fullname template with a string (will prepend the release name) | `""`            |
+| `fullnameOverride`       | String to fully override airflow.fullname template with a string                                     | `""`            |
+| `namespaceOverride`      | String to fully override common.names.namespace                                                      | `""`            |
+| `commonLabels`           | Labels to add to all deployed objects                                                                | `{}`            |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                                           | `{}`            |
+| `clusterDomain`          | Kubernetes cluster domain name                                                                       | `cluster.local` |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                                    | `[]`            |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)              | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the deployment                                                 | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the deployment                                                    | `["infinity"]`  |
+
+
+### Schema Registry parameters
+
+| Name                                            | Description                                                                                                 | Value                     |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `image.registry`                                | Schema Registry image registry                                                                              | `docker.io`               |
+| `image.repository`                              | Schema Registry image repository                                                                            | `bitnami/schema-registry` |
+| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                  | `7.1.1-photon-3-r7`       |
+| `image.pullPolicy`                              | Schema Registry image pull policy                                                                           | `IfNotPresent`            |
+| `image.pullSecrets`                             | Schema Registry image pull secrets                                                                          | `[]`                      |
+| `image.debug`                                   | Enable image debug mode                                                                                     | `false`                   |
+| `command`                                       | Override default container command (useful when using custom images)                                        | `[]`                      |
+| `args`                                          | Override default container args (useful when using custom images)                                           | `[]`                      |
+| `hostAliases`                                   | Schema Registry pods host aliases                                                                           | `[]`                      |
+| `podLabels`                                     | Extra labels for Schema Registry pods                                                                       | `{}`                      |
+| `configuration`                                 | Specify content for schema-registry.properties. Auto-generated based on other parameters when not specified | `{}`                      |
+| `existingConfigmap`                             | Name of existing ConfigMap with Schema Registry configuration                                               | `""`                      |
+| `log4j`                                         | Schema Registry Log4J Configuration (optional)                                                              | `{}`                      |
+| `existingLog4jConfigMap`                        | Name of existing ConfigMap containing a custom log4j.properties file.                                       | `""`                      |
+| `auth.tls.enabled`                              | Enable TLS configuration to provide to be used when a listener uses HTTPS                                   | `false`                   |
+| `auth.tls.jksSecret`                            | Existing secret containing the truststore and one keystore per Schema Registry replica                      | `""`                      |
+| `auth.tls.keystorePassword`                     | Password to access the keystore when it's password-protected                                                | `""`                      |
+| `auth.tls.truststorePassword`                   | Password to access the truststore when it's password-protected                                              | `""`                      |
+| `auth.tls.clientAuthentication`                 | Client authentication configuration.                                                                        | `NONE`                    |
+| `auth.kafka.jksSecret`                          | Existing secret containing the truststore and one keystore per Schema Registry replica                      | `""`                      |
+| `auth.kafka.tlsEndpointIdentificationAlgorithm` | The endpoint identification algorithm used validate brokers hostnames                                       | `https`                   |
+| `auth.kafka.keystorePassword`                   | Password to access the keystore when it's password-protected                                                | `""`                      |
+| `auth.kafka.truststorePassword`                 | Password to access the truststore when it's password-protected                                              | `""`                      |
+| `auth.kafka.saslMechanism`                      | Mechanism that schema registry will use to connect to kafka. Allowed: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512   | `PLAIN`                   |
+| `listeners`                                     | Comma-separated list of listeners that listen for API requests over either HTTP or HTTPS                    | `http://0.0.0.0:8081`     |
+| `avroCompatibilityLevel`                        | Avro compatibility type                                                                                     | `backward`                |
+| `extraEnvVars`                                  | Extra environment variables to be set on Schema Registry container                                          | `[]`                      |
+| `extraEnvVarsCM`                                | Name of existing ConfigMap containing extra env vars                                                        | `""`                      |
+| `extraEnvVarsSecret`                            | Name of existing Secret containing extra env vars                                                           | `""`                      |
+
+
+### Schema Registry statefulset parameters
+
+| Name                                 | Description                                                                                                              | Value           |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ | --------------- |
+| `replicaCount`                       | Number of Schema Registry replicas to deploy.                                                                            | `1`             |
+| `updateStrategy.type`                | Schema Registry statefulset strategy type                                                                                | `RollingUpdate` |
+| `nodeAffinityPreset.type`            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`            |
+| `nodeAffinityPreset.key`             | Node label key to match. Ignored if `affinity` is set                                                                    | `""`            |
+| `nodeAffinityPreset.values`          | Node label values to match. Ignored if `affinity` is set                                                                 | `[]`            |
+| `affinity`                           | Affinity for pod assignment                                                                                              | `{}`            |
+| `nodeSelector`                       | Node labels for pod assignment                                                                                           | `{}`            |
+| `tolerations`                        | Tolerations for pod assignment                                                                                           | `[]`            |
+| `podManagementPolicy`                | Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join                       | `OrderedReady`  |
+| `podAnnotations`                     | Annotations for Schema Registry pods                                                                                     | `{}`            |
+| `podAffinityPreset`                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`            |
+| `podAntiAffinityPreset`              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`          |
+| `priorityClassName`                  | Schema Registry pod priority class name                                                                                  | `""`            |
+| `topologySpreadConstraints`          | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `{}`            |
+| `schedulerName`                      | Name of the k8s scheduler (other than default) for Schema Registry pods                                                  | `""`            |
+| `terminationGracePeriodSeconds`      | Seconds Redmine pod needs to terminate gracefully                                                                        | `""`            |
+| `lifecycleHooks`                     | for the Schema Registry container(s) to automate configuration before or after startup                                   | `{}`            |
+| `podSecurityContext.enabled`         | Enabled Controller pods' Security Context                                                                                | `true`          |
+| `podSecurityContext.fsGroup`         | Set Controller pod's Security Context fsGroup                                                                            | `1001`          |
+| `podSecurityContext.sysctls`         | sysctl settings of the Schema Registry pods                                                                              | `[]`            |
+| `containerSecurityContext.enabled`   | Enable container security context                                                                                        | `true`          |
+| `containerSecurityContext.runAsUser` | User ID for the container                                                                                                | `1001`          |
+| `resources.limits`                   | The resources limits for the container                                                                                   | `{}`            |
+| `resources.requests`                 | The requested resources for the container                                                                                | `{}`            |
+| `livenessProbe.enabled`              | Enable livenessProbe                                                                                                     | `true`          |
+| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                  | `10`            |
+| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                         | `20`            |
+| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                        | `1`             |
+| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                      | `6`             |
+| `livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                      | `1`             |
+| `readinessProbe.enabled`             | Enable readinessProbe                                                                                                    | `true`          |
+| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                 | `10`            |
+| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                        | `20`            |
+| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                       | `1`             |
+| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                     | `6`             |
+| `readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                     | `1`             |
+| `startupProbe.enabled`               | Enable startupProbe                                                                                                      | `false`         |
+| `startupProbe.initialDelaySeconds`   | Initial delay seconds for startupProbe                                                                                   | `10`            |
+| `startupProbe.periodSeconds`         | Period seconds for startupProbe                                                                                          | `5`             |
+| `startupProbe.timeoutSeconds`        | Timeout seconds for startupProbe                                                                                         | `1`             |
+| `startupProbe.failureThreshold`      | Failure threshold for startupProbe                                                                                       | `20`            |
+| `startupProbe.successThreshold`      | Success threshold for startupProbe                                                                                       | `1`             |
+| `customLivenessProbe`                | Custom livenessProbe that overrides the default one                                                                      | `{}`            |
+| `customReadinessProbe`               | Custom readinessProbe that overrides the default one                                                                     | `{}`            |
+| `customStartupProbe`                 | Custom startupProbe that overrides the default one                                                                       | `{}`            |
+| `extraVolumes`                       | Optionally specify extra list of additional volumes for MinIO&reg; pods                                                  | `[]`            |
+| `extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for MinIO&reg; container(s)                                     | `[]`            |
+| `initContainers`                     | Add additional init containers to the Schema Registry pods.                                                              | `[]`            |
+| `sidecars`                           | Add additional sidecar containers to the Schema Registry pods.                                                           | `[]`            |
+| `pdb.create`                         | Enable/disable a Pod Disruption Budget creation                                                                          | `false`         |
+| `pdb.minAvailable`                   | Minimum number/percentage of pods that must still be available after the eviction                                        | `1`             |
+| `pdb.maxUnavailable`                 | Maximum number/percentage of pods that may be made unavailable after the eviction                                        | `""`            |
+| `autoscaling.enabled`                | Enable autoscaling for replicas                                                                                          | `false`         |
+| `autoscaling.minReplicas`            | Minimum number of replicas                                                                                               | `1`             |
+| `autoscaling.maxReplicas`            | Maximum number of replicas                                                                                               | `11`            |
+| `autoscaling.targetCPU`              | Target CPU utilization percentage                                                                                        | `""`            |
+| `autoscaling.targetMemory`           | Target Memory utilization percentage                                                                                     | `""`            |
+
+
+### Exposure Parameters
+
+| Name                               | Description                                                                                           | Value                    |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------ |
+| `service.type`                     | Kubernetes service type                                                                               | `ClusterIP`              |
+| `service.ports.http`               | Service HTTP port                                                                                     | `8081`                   |
+| `service.nodePorts.http`           | Service HTTP node port                                                                                | `""`                     |
+| `service.clusterIP`                | Schema Registry service clusterIP IP                                                                  | `""`                     |
+| `service.externalTrafficPolicy`    | Enable client source IP preservation                                                                  | `Cluster`                |
+| `service.loadBalancerIP`           | loadBalancerIP if service type is LoadBalancer                                                        | `""`                     |
+| `service.loadBalancerSourceRanges` | Address that are allowed when service is LoadBalancer                                                 | `[]`                     |
+| `service.annotations`              | Annotations for Schema Registry service                                                               | `{}`                     |
+| `service.extraPorts`               | Extra ports to expose in Schema Registry service (normally used with the `sidecars` value)            | `[]`                     |
+| `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                      | `None`                   |
+| `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                           | `{}`                     |
+| `ingress.enabled`                  | Enable ingress controller resource                                                                    | `false`                  |
+| `ingress.hostname`                 | Default host for the ingress resource                                                                 | `schema-registry.local`  |
+| `ingress.annotations`              | Ingress annotations                                                                                   | `{}`                     |
+| `ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                            | `[]`                     |
+| `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                   | `[]`                     |
+| `ingress.secrets`                  | Custom TLS certificates as secrets                                                                    | `[]`                     |
+| `ingress.enabled`                  | Enable ingress record generation for Schema Registry                                                  | `false`                  |
+| `ingress.pathType`                 | Ingress path type                                                                                     | `ImplementationSpecific` |
+| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                         | `""`                     |
+| `ingress.hostname`                 | Default host for the ingress record                                                                   | `schema-registry.local`  |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                         | `""`                     |
+| `ingress.path`                     | Default path for the ingress record                                                                   | `/`                      |
+| `ingress.annotations`              | Additional custom annotations for the ingress record                                                  | `{}`                     |
+| `ingress.tls`                      | Enable TLS configuration for the host defined at `ingress.hostname` parameter                         | `false`                  |
+| `ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm          | `false`                  |
+| `ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                            | `[]`                     |
+| `ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host | `[]`                     |
+| `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                   | `[]`                     |
+| `ingress.secrets`                  | Custom TLS certificates as secrets                                                                    | `[]`                     |
+| `ingress.extraRules`               | Additional rules to be covered with this ingress record                                               | `[]`                     |
+
+
+### RBAC parameters
+
+| Name                                          | Description                                                      | Value  |
+| --------------------------------------------- | ---------------------------------------------------------------- | ------ |
+| `serviceAccount.create`                       | Enable the creation of a ServiceAccount for Schema Registry pods | `true` |
+| `serviceAccount.name`                         | Name of the created ServiceAccount to use                        | `""`   |
+| `serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template) | `{}`   |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account   | `true` |
+
+
+### Kafka chart parameters
+
+| Name                                            | Description                                                                                                         | Value                            |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `kafka.enabled`                                 | Enable/disable Kafka chart installation                                                                             | `true`                           |
+| `kafka.replicaCount`                            | Number of Kafka brokers                                                                                             | `1`                              |
+| `kafka.auth.clientProtocol`                     | Authentication protocol for communications with clients. Allowed protocols: plaintext, tls, mtls, sasl and sasl_tls | `plaintext`                      |
+| `kafka.auth.interBrokerProtocol`                | Authentication protocol for inter-broker communications. Allowed protocols: plaintext, tls, mtls, sasl and sasl_tls | `plaintext`                      |
+| `kafka.auth.jksSecret`                          | Name of the existing secret containing the truststore and one keystore per Kafka broker you have in the cluster     | `""`                             |
+| `kafka.auth.jksPassword`                        | Password to access the JKS files when they are password-protected                                                   | `""`                             |
+| `kafka.auth.tlsEndpointIdentificationAlgorithm` | The endpoint identification algorithm to validate server hostname using server certificate                          | `https`                          |
+| `kafka.auth.jaas.clientUsers`                   | Kafka client users for SASL authentication                                                                          | `[]`                             |
+| `kafka.auth.jaas.clientPasswords`               | Kafka client passwords for SASL authentication                                                                      | `[]`                             |
+| `kafka.auth.jaas.interBrokerUser`               | Kafka inter broker communication user for SASL authentication                                                       | `admin`                          |
+| `kafka.auth.jaas.interBrokerPassword`           | Kafka inter broker communication password for SASL authentication                                                   | `""`                             |
+| `kafka.auth.jaas.zookeeperUser`                 | Kafka Zookeeper user for SASL authentication                                                                        | `""`                             |
+| `kafka.auth.jaas.zookeeperPassword`             | Kafka Zookeeper password for SASL authentication                                                                    | `""`                             |
+| `kafka.auth.jaas.existingSecret`                | Name of the existing secret containing credentials for brokerUser, interBrokerUser and zookeeperUser                | `""`                             |
+| `kafka.service.port`                            | Kafka port for client connections                                                                                   | `9092`                           |
+| `kafka.zookeeper.enabled`                       | Enable/disable Zookeeper chart installation                                                                         | `true`                           |
+| `kafka.zookeeper.replicaCount`                  | Number of Zookeeper replicas                                                                                        | `1`                              |
+| `kafka.zookeeper.auth`                          | Zookeeper auth settings                                                                                             | `{}`                             |
+| `externalKafka.brokers`                         | Array of Kafka brokers to connect to. Format: protocol://broker_hostname:port                                       | `["PLAINTEXT://localhost:9092"]` |
+| `externalKafka.auth.protocol`                   | Authentication protocol. Allowed protocols: plaintext, tls, sasl and sasl_tls                                       | `plaintext`                      |
+| `externalKafka.auth.jaas.user`                  | User for SASL authentication                                                                                        | `user`                           |
+| `externalKafka.auth.jaas.password`              | Password for SASL authentication                                                                                    | `""`                             |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+helm install my-release --set replicaCount=2 bitnami/schema-registry
+```
+
+The above command install Schema Registry chart with 2 replicas.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+helm install my-release -f values.yaml bitnami/schema-registry
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Configuration and installation details
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Bitnami will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Enable authentication for Kafka
+
+You can configure different authentication protocols to authenticate with Kafka brokers. This table shows the available protocols and the security they provide:
+
+| Method    | Authentication                | Encryption via TLS |
+|-----------|-------------------------------|--------------------|
+| plaintext | None                          | No                 |
+| tls       | None                          | Yes                |
+| sasl      | Yes (via SASL)                | No                 |
+| sasl_tls  | Yes (via SASL)                | Yes                |
+
+If you enabled SASL authentication for client communication with the Kafka brokers, the following parameters must be provided:
+
+- `kafka.auth.clientProtocol`
+- `kafka.auth.jaas.clientUsers`
+- `kafka.auth.jaas.clientPasswords`
+- `kafka.auth.saslMechanisms`
+- `kafka.auth.saslInterBrokerMechanism`
+
+For instance, you can deploy the chart with the following parameters:
+
+```console
+kafka.auth.clientProtocol=sasl
+kafka.auth.jaas.clientUsers[0]=clientUser
+kafka.auth.jaas.clientPasswords[0]=clientPassword
+```
+
+In order to configure TLS authentication/encryption, you **must** create two secrets containing the Java Key Stores (JKS) files: the truststore (`kafka.truststore.jks`), one keystore (`kafka.keystore.jks`) per Kafka broker you have in the cluster, the truststore (`schema-registry.truststore.jks`) and one keystore (`schema-registry.keystore.jks`) per Schema Registry replica. Then, you need pass the secret names with the `auth.kafka.jksSecret` and `kafka.auth.jksSecret` parameters when deploying the chart.
+
+> **Note**: If the JKS files are password protected (recommended), you will need to provide the password to get access to the keystores. To do so, use the `auth.kafka.keystorePassword`, `auth.kafka.truststorePassword`, and `kafka.auth.jksPassword` parameters to provide your passwords.
+
+For instance, to configure TLS authentication on a cluster with 2 Kafka brokers, and 1 Schema Registry replica use the commands below to create the secrets:
+
+```console
+kubectl create secret generic schema-registry-jks --from-file=/schema-registry.truststore.jks --from-file=./schema-registry-0.keystore.jks
+kubectl create secret generic kafka-jks --from-file=./kafka.truststore.jks --from-file=./kafka-0.keystore.jks --from-file=./kafka-1.keystore.jks
+```
+
+Then, deploy the chart with the following parameters:
+
+```console
+auth.kafka.jksSecret=schema-registry-jks
+auth.kafka.keystorePassword=some-password
+auth.kafka.truststorePassword=some-password
+kafka.auth.clientProtocol=tls
+kafka.auth.jksSecret=kafka-jks
+kafka.auth.jksPassword=some-password
+```
+
+In case you want to ignore hostname verification on Kafka certificates, set the parameter `auth.kafka.tlsEndpointIdentificationAlgorithm` with an empty string `""`. In this case, you can reuse the same truststore and keystore for every Kafka broker and Schema Registry replica. For instance, to configure TLS authentication on a cluster with 2 Kafka brokers, and 1 Schema Registry replica use the commands below to create the secrets:
+
+```console
+kubectl create secret generic schema-registry-jks --from-file=schema-registry.truststore.jks=common.truststore.jks --from-file=schema-registry-0.keystore.jks=common.keystore.jks
+kubectl create secret generic kafka-jks --from-file=kafka.truststore.jks=common.truststore.jks --from-file=kafka-0.keystore.jks=common.keystore.jks --from-file=kafka-1.keystore.jks=common.keystore.jks
+```
+
+### Adding extra flags
+
+In case you want to add extra environment variables to Schema Registry, you can use `extraEnvs` parameter. For instance:
+
+```yaml
+extraEnvs:
+  - name: FOO
+    value: BAR
+```
+
+### Using custom configuration
+
+This helm chart supports using custom configuration for Schema Registry.
+
+You can specify the configuration for Schema Registry using the `configuration` paramater. In addition, you can also set an external configmap with the configuration file. This is done by setting the `existingConfigmap` parameter.
+
+### Sidecars and Init Containers
+
+If you have a need for additional containers to run within the same pod as Schema Registry (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
+
+```yaml
+sidecars:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+       containerPort: 1234
+```
+
+Similarly, you can add extra init containers using the `initContainers` parameter.
+
+```yaml
+initContainers:
+  - name: your-image-name
+    image: your-image
+    imagePullPolicy: Always
+    ports:
+      - name: portname
+        containerPort: 1234
+```
+
+### Using an external Kafka
+
+Sometimes you may want to have Schema Registry connect to an external Kafka cluster rather than installing one as dependency. To do this, the chart allows you to specify credentials for an existing Kafka cluster under the [`externalKafka` parameter](#kafka-chart-parameters). You should also disable the Kafka installation with the `kafka.enabled` option.
+
+For example, use the parameters below to connect Schema Registry with an existing Kafka installation using SASL authentication:
+
+```console
+kafka.enabled=false
+externalKafka.brokers=SASL_PLAINTEXT://kafka-0.kafka-headless.default.svc.cluster.local:9092
+externalKafka.auth.protocol=sasl
+externalKafka.auth.jaas.user=myuser
+externalKafka.auth.jaas.password=mypassword
+```
+
+### Ingress
+
+This chart provides support for ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress](https://kubeapps.com/charts/stable/nginx-ingress) or [traefik](https://kubeapps.com/charts/stable/traefik) you can utilize the ingress controller to serve your Schema Registry.
+
+To enable ingress integration, please set `ingress.enabled` to `true`
+
+#### Hosts
+
+Most likely you will only want to have one hostname that maps to this Schema Registry installation. If that's your case, the property `ingress.hostname` will set it. However, it is possible to have more than one host. To facilitate this, the `ingress.extraHosts` object is can be specified as an array. You can also use `ingress.extraTLS` to add the TLS configuration for extra hosts.
+
+For each host indicated at `ingress.extraHosts`, please indicate a `name`, `path`, and any `annotations` that you may want the ingress controller to know about.
+
+For annotations, please see [this document](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers.
+
+## Upgrading
+
+### To 4.0.0
+
+This version bump the version of charts used as dependency in a major. Kafka from 12.X.X to 18.X.X ([here](https://github.com/bitnami/charts/tree/master/bitnami/kafka#to-1800) you can see the changes introduced in this version).
+
+### To 3.0.0
+
+This major release renames several values and adds new features, in order to be inline with the rest of assets in the Bitnami charts repository.
+
+Affected values:
+
+- `strategyType` is replaced by `updateStrategy`
+- `service.port` is renamed to `service.ports.http`
+- `service.nodePort` is renamed to `service.nodePorts.http`
+- `ingress.certManager` is removed, please use `ingress.annotations`to add any third party feature
+
+### To 2.0.0
+
+This version bump the version of charts used as dependency in a major. Kafka from 11.X.X to 12.X.X ([here](https://github.com/bitnami/charts/tree/master/bitnami/kafka#to-1220) you can see the changes introduced in this version) and common from 0.X.X to 1.X.X ([here](https://github.com/bitnami/charts/tree/master/bitnami/common#to-100) you can find the changes introduced in this version). Mainly the changes in both subcharts are related to the Helm v2 EOL.
+
+### To 1.0.0
+
+[On November 13, 2020, Helm v2 support was formally finished](https://github.com/helm/charts#status-of-the-project), this major version is the result of the required changes applied to the Helm Chart to be able to incorporate the different features added in Helm v3 and to be consistent with the Helm project itself regarding the Helm v2 EOL.
+
+**What changes were introduced in this major version?**
+
+- Previous versions of this Helm Chart use `apiVersion: v1` (installable by both Helm 2 and 3), this Helm Chart was updated to `apiVersion: v2` (installable by Helm 3 only). [Here](https://helm.sh/docs/topics/charts/#the-apiversion-field) you can find more information about the `apiVersion` field.
+- Move dependency information from the *requirements.yaml* to the *Chart.yaml*
+- After running `helm dependency update`, a *Chart.lock* file is generated containing the same structure used in the previous *requirements.lock*
+- The different fields present in the *Chart.yaml* file has been ordered alphabetically in a homogeneous way for all the Bitnami Helm Charts
+
+**Considerations when upgrading to this version**
+
+- If you want to upgrade to this version from a previous one installed with Helm v3, you shouldn't face any issues
+- If you want to upgrade to this version using Helm v2, this scenario is not supported as this version doesn't support Helm v2 anymore
+- If you installed the previous version with Helm v2 and wants to upgrade to this version with Helm v3, please refer to the [official Helm documentation](https://helm.sh/docs/topics/v2_v3_migration/#migration-use-cases) about migrating from Helm v2 to v3
+
+**Useful links**
+
+- https://docs.bitnami.com/tutorials/resolve-helm2-helm3-post-migration-issues/
+- https://helm.sh/docs/topics/v2_v3_migration/
+- https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -1,4 +1,6 @@
-# Schema Registry
+<!--- app-name: Confluent Schema Registry -->
+
+# Confluent Schema Registry packaged by Bitnami
 
 [Confluent Schema Registry](www.confluent.io/schema) provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
 keywords:

--- a/bitnami/schema-registry/templates/NOTES.txt
+++ b/bitnami/schema-registry/templates/NOTES.txt
@@ -1,0 +1,49 @@
+
+** Please be patient while the chart is being deployed **
+
+Schema Registry can be accessed through the following DNS name from within your cluster:
+
+    {{ include "common.names.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }} (port {{ .Values.service.port }})
+
+To access Schema Registry from outside the cluster execute the following commands:
+
+{{- if .Values.ingress.enabled }}
+
+1. Get the Schema Registry URL and associate its hostname to your cluster external IP:
+
+   export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
+   echo "Schema Registry URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}"
+   echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
+
+{{- else }}
+
+1. Get the Schema Registry URL by running these commands:
+
+{{- if contains "NodePort" .Values.service.type }}
+
+    export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "common.names.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo "http://${NODE_IP}:${NODE_PORT}"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "common.names.fullname" . }}'
+
+    export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "common.names.fullname" . }})
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo "http://${SERVICE_IP}:${SERVICE_PORT}"
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+    export SERVICE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].port}" services {{ include "common.names.fullname" . }})
+    kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "common.names.fullname" . }} ${SERVICE_PORT}:${SERVICE_PORT} &
+    echo "http://127.0.0.1:${SERVICE_PORT}"
+
+{{- end }}
+{{- end }}
+
+2. Access Schema Registry using the obtained URL.
+
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "schema-registry.validateValues" . }}

--- a/bitnami/schema-registry/templates/_helpers.tpl
+++ b/bitnami/schema-registry/templates/_helpers.tpl
@@ -1,0 +1,146 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create a default fully qualified app name for Kafka subchart
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "schema-registry.kafka.fullname" -}}
+{{- if .Values.kafka.fullnameOverride -}}
+{{- .Values.kafka.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "kafka" .Values.kafka.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "schema-registry.chart" -}}
+{{- include "common.names.chart" . -}}
+{{- end }}
+
+{{/*
+Return the proper Schema Registry image name
+*/}}
+{{- define "schema-registry.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "schema-registry.imagePullSecrets" -}}
+{{ include "common.images.pullSecrets" (dict "images" (list .Values.image) "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Create the name of the Service Account to use
+*/}}
+{{- define "schema-registry.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+    {{- default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+    {{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the Schema Registry Configuration configmap.
+*/}}
+{{- define "schema-registry.configmapName" -}}
+{{- if .Values.existingConfigmap -}}
+    {{- printf "%s" (tpl .Values.existingConfigmap $) -}}
+{{- else -}}
+    {{- printf "%s" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a configmap object should be created for Schema Registry Configuration
+*/}}
+{{- define "schema-registry.createConfigMap" -}}
+{{- if and .Values.configuration (not .Values.existingConfigmap) }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the Log4J Configuration configmap.
+*/}}
+{{- define "schema-registry.log4j.configmapName" -}}
+{{- if .Values.existingLog4jConfigMap -}}
+    {{- printf "%s" (tpl .Values.existingLog4jConfigMap $) -}}
+{{- else -}}
+    {{- printf "%s-log4j" (include "common.names.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return true if a configmap object should be created for Log4J Configuration
+*/}}
+{{- define "schema-registry.log4j.createConfigMap" -}}
+{{- if and .Values.log4j (not .Values.existingLog4jConfigMap) }}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the type of listener
+Usage:
+{{ include "schema-registry.listenerType" ( dict "protocol" .Values.path.to.the.Value ) }}
+*/}}
+{{- define "schema-registry.listenerType" -}}
+{{- if eq .protocol "plaintext" -}}
+PLAINTEXT
+{{- else if or (eq .protocol "tls") (eq .protocol "mtls") -}}
+SSL
+{{- else if eq .protocol "sasl_tls" -}}
+SASL_SSL
+{{- else if eq .protocol "sasl" -}}
+SASL_PLAINTEXT
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "schema-registry.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := append $messages (include "schema-registry.validateValues.authentication.sasl" .) -}}
+{{- $messages := append $messages (include "schema-registry.validateValues.authentication.tls" .) -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Schema Registry - SASL authentication */}}
+{{- define "schema-registry.validateValues.authentication.sasl" -}}
+{{- $kafkaProtocol := include "schema-registry.listenerType" ( dict "protocol" (ternary .Values.kafka.auth.clientProtocol .Values.externalKafka.auth.protocol .Values.kafka.enabled) ) -}}
+{{- if .Values.kafka.enabled }}
+{{- if and (contains "SASL" $kafkaProtocol) (or (not .Values.kafka.auth.sasl.jaas.clientUsers) (not .Values.kafka.auth.sasl.jaas.clientPasswords)) }}
+schema-registry: kafka.auth.jaas.clientUsers kafka.auth.jaas.clientPasswords
+    It's mandatory to set the SASL credentials when enabling SASL authentication with Kafka brokers.
+    You can specify these credentials setting the parameters below:
+      - kafka.auth.jaas.clientUsers
+      - kafka.auth.jaas.clientPasswords
+{{- end }}
+{{- else if and (contains "SASL" $kafkaProtocol) (or (not .Values.externalKafka.auth.jaas.user) (not .Values.externalKafka.auth.jaas.password)) }}
+schema-registry: externalKafka.auth.jaas.user externalKafka.auth.jaas.password
+    It's mandatory to set the SASL credentials when enabling SASL authentication with Kafka brokers.
+    You can specify these credentials setting the parameters below:
+      - kexternalKafka.auth.jaas.user
+      - externalKafka.auth.jaas.password
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Schema Registry - TLS authentication */}}
+{{- define "schema-registry.validateValues.authentication.tls" -}}
+{{- $kafkaProtocol := include "schema-registry.listenerType" ( dict "protocol" (ternary .Values.kafka.auth.clientProtocol .Values.externalKafka.auth.protocol .Values.kafka.enabled) ) -}}
+{{- if and (contains "SSL" $kafkaProtocol) (not .Values.auth.kafka.jksSecret) }}
+kafka: auth.kafka.jksSecret
+    A secret containing the Schema Registry JKS files is required when TLS encryption in enabled
+{{- end -}}
+{{- end -}}

--- a/bitnami/schema-registry/templates/configmap.yaml
+++ b/bitnami/schema-registry/templates/configmap.yaml
@@ -1,0 +1,20 @@
+{{- if (include "schema-registry.createConfigMap" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+data:
+  schema-registry.properties: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.configuration "context" $) | nindent 4 }}
+{{- end }}

--- a/bitnami/schema-registry/templates/external-kafka-secrets.yaml
+++ b/bitnami/schema-registry/templates/external-kafka-secrets.yaml
@@ -1,0 +1,20 @@
+{{- if not .Values.kafka.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-external-kafka" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+type: Opaque
+data:
+  client-passwords: {{ include "common.secrets.passwords.manage" (dict "secret" (include "commons.fullname" .) "key" "client-password" "providedValues" (list "externalKafka.auth.jaas.password" ) "context" $) }}
+{{- end }}

--- a/bitnami/schema-registry/templates/extra-list.yaml
+++ b/bitnami/schema-registry/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/bitnami/schema-registry/templates/headless-service.yaml
+++ b/bitnami/schema-registry/templates/headless-service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-headless" (include "common.names.fullname" .) }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: {{ .Values.service.ports.http }}
+      targetPort: http
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  selector: {{ include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/schema-registry/templates/hpa.yaml
+++ b/bitnami/schema-registry/templates/hpa.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+    kind: Deployment
+    name: {{ include "common.names.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemory  }}
+    {{- end }}
+{{- end }}

--- a/bitnami/schema-registry/templates/ingress.yaml
+++ b/bitnami/schema-registry/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+  rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" .) "servicePort" "http" "context" $)  | nindent 14 }}
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            backend:
+              serviceName: {{ include "common.names.fullname" . }}
+              servicePort: http
+    {{- end }}
+    {{- if .Values.ingress.extraRules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+  tls:
+    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
+    - hosts:
+        - {{ .Values.ingress.hostname }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/bitnami/schema-registry/templates/log4j-configmap.yaml
+++ b/bitnami/schema-registry/templates/log4j-configmap.yaml
@@ -1,0 +1,17 @@
+{{- if (include "schema-registry.log4j.createConfigMap" .) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-log4j" (include "common.names.fullname" .) }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  log4j.properties: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.log4j "context" $) | nindent 4 }}
+{{- end }}

--- a/bitnami/schema-registry/templates/pdb.yaml
+++ b/bitnami/schema-registry/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.pdb.create }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{ include "common.labels.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/bitnami/schema-registry/templates/service.yaml
+++ b/bitnami/schema-registry/templates/service.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if and .Values.service.loadBalancerIP (eq .Values.service.type "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+  {{- end }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.ports.http }}
+      targetPort: http
+      {{- if (and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (or (not (empty .Values.service.nodePorts.http)) (not (empty .Values.service.nodePort)))) }}
+      nodePort: {{ .Values.service.nodePorts.http }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  selector: {{ include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/schema-registry/templates/serviceaccount.yaml
+++ b/bitnami/schema-registry/templates/serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "schema-registry.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/bitnami/schema-registry/templates/statefulset.yaml
+++ b/bitnami/schema-registry/templates/statefulset.yaml
@@ -1,0 +1,278 @@
+{{- $fullname := include "common.names.fullname" .  }}
+{{- $releaseNamespace := .Release.Namespace }}
+{{- $clusterDomain := .Values.clusterDomain }}
+{{- $kafkaProtocol := include "schema-registry.listenerType" ( dict "protocol" (ternary .Values.kafka.auth.clientProtocol .Values.externalKafka.auth.protocol .Values.kafka.enabled) ) -}}
+{{- $kafkaReplicaCount := int .Values.kafka.replicaCount }}
+{{- $kafkaFullname := include "schema-registry.kafka.fullname" . }}
+{{- $kafkaPort := int .Values.kafka.service.ports.client }}
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" $ }}
+kind: StatefulSet
+metadata:
+  name: {{ $fullname | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  podManagementPolicy: {{ .Values.podManagementPolicy | quote }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+  serviceName: {{ printf "%s-headless" $fullname }}
+  {{- if .Values.updateStrategy }}
+  updateStrategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      {{- if or (include "schema-registry.createConfigMap" .) (include "schema-registry.log4j.createConfigMap" .) .Values.podAnnotations }}
+      annotations:
+        {{- if (include "schema-registry.createConfigMap" .) }}
+        checksum/configuration: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if (include "schema-registry.log4j.createConfigMap" .) }}
+        checksum/log4j-configuration: {{ include (print $.Template.BasePath "/log4j-configmap.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- include "schema-registry.imagePullSecrets" . | indent 6 }}
+      serviceAccountName: {{ include "schema-registry.serviceAccountName" . }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "component" "" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "component" "" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
+       {{- if .Values.initContainers }}
+      initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: schema-registry
+          image: {{ include "schema-registry.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- else }}
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              {{- if contains "SSL" $kafkaProtocol }}
+              ID="${MY_POD_NAME#"{{ $fullname }}-"}"
+              if [[ -f "/certs/schema-registry.truststore.jks" ]] && [[ -f "/certs/schema-registry-${ID}.keystore.jks" ]]; then
+                  mkdir -p /opt/bitnami/schema-registry/certs
+                  cp "/certs/schema-registry.truststore.jks" "/opt/bitnami/schema-registry/certs/schema-registry.truststore.jks"
+                  cp "/certs/schema-registry-${ID}.keystore.jks" "/opt/bitnami/schema-registry/certs/schema-registry.keystore.jks"
+              else
+                  echo "Couldn't find the expected Java Key Stores (JKS) files! They are mandatory when encryption via TLS is enabled with Kafka brokers."
+                  exit 1
+              fi
+              {{- end }}
+              exec /opt/bitnami/scripts/schema-registry/entrypoint.sh /opt/bitnami/scripts/schema-registry/run.sh
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: BITNAMI_DEBUG
+              value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
+            - name: SCHEMA_REGISTRY_DEBUG
+              value: {{ ternary "true" "false" .Values.image.debug | quote }}
+            - name: SCHEMA_REGISTRY_LISTENERS
+              value: {{ .Values.listeners | quote }}
+            {{- if .Values.auth.tls.enabled }}
+            {{- if .Values.auth.tls.keystorePassword }}
+            - name: SCHEMA_REGISTRY_SSL_KEYSTORE_PASSWORD
+              value: {{ .Values.auth.tls.keystorePassword | quote }}
+            {{- end }}
+            {{- if .Values.auth.tls.truststorePassword }}
+            - name: SCHEMA_REGISTRY_SSL_TRUSTSTORE_PASSWORD
+              value: {{ .Values.auth.tls.truststorePassword | quote }}
+            {{- end }}
+            - name: SCHEMA_REGISTRY_CLIENT_AUTHENTICATION
+              value: {{ .Values.auth.tls.clientAuthentication | quote }}
+            {{- end }}
+            - name: SCHEMA_REGISTRY_AVRO_COMPATIBILY_LEVEL
+              value: {{ .Values.avroCompatibilityLevel | quote }}
+            - name: SCHEMA_REGISTRY_ADVERTISED_HOSTNAME
+              value: "$(MY_POD_NAME).{{ $fullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}"
+            - name: SCHEMA_REGISTRY_KAFKA_BROKERS
+              {{- if .Values.kafka.enabled }}
+              {{- $brokers := list }}
+              {{- range $e, $i := until $kafkaReplicaCount }}
+              {{- $brokers = append $brokers (printf "%s://%s-%d.%s-headless.%s.svc.%s:%d" $kafkaProtocol $kafkaFullname $i $kafkaFullname $releaseNamespace $clusterDomain $kafkaPort) }}
+              {{- end }}
+              value: {{ join "," $brokers | quote }}
+              {{- else }}
+              value: {{ join "," .Values.externalKafka.brokers | quote }}
+              {{- end }}
+            {{- if contains "SASL" $kafkaProtocol }}
+            - name : SCHEMA_REGISTRY_KAFKA_SASL_MECHANISM
+              value: {{ .Values.auth.kafka.saslMechanism }}
+            - name: SCHEMA_REGISTRY_KAFKA_SASL_USERS
+              {{- if .Values.kafka.enabled }}
+              value: {{ join "," .Values.kafka.auth.sasl.jaas.clientUsers | quote }}
+              {{- else }}
+              value: {{ .Values.externalKafka.auth.jaas.user | quote }}
+              {{- end }}
+            - name: SCHEMA_REGISTRY_KAFKA_SASL_PASSWORDS
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.kafka.enabled }}
+                  name: {{ printf "%s-jaas" (include "schema-registry.kafka.fullname" .) }}
+                  {{- else }}
+                  name: {{ include "common.names.fullname" . }}-external-kafka
+                  {{- end }}
+                  key: client-passwords
+            {{- end }}
+            {{- if contains "SSL" $kafkaProtocol }}
+            - name: SCHEMA_REGISTRY_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM
+              value: {{ .Values.auth.kafka.tlsEndpointIdentificationAlgorithm | quote }}
+            {{- if .Values.auth.kafka.keystorePassword }}
+            - name: SCHEMA_REGISTRY_KAFKA_KEYSTORE_PASSWORD
+              value: {{ .Values.auth.kafka.keystorePassword | quote }}
+            {{- end }}
+            {{- if .Values.auth.kafka.truststorePassword }}
+            - name: SCHEMA_REGISTRY_KAFKA_TRUSTSTORE_PASSWORD
+              value: {{ .Values.auth.kafka.truststorePassword | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
+            tcpSocket:
+              port: http
+          {{- else if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if or .Values.configuration .Values.existingConfigmap  .Values.log4j .Values.existingLog4jConfigMap (contains "SSL" $kafkaProtocol) .Values.extraVolumes }}
+          volumeMounts:
+            {{- if or .Values.configuration .Values.existingConfigmap }}
+            - name: configuration
+              mountPath: /bitnami/schema-registry/etc/schema-registry/schema-registry.properties
+              subPath: schema-registry.properties
+            {{- end }}
+            {{- if or .Values.log4j .Values.existingLog4jConfigMap }}
+            - name: log4j-configuration
+              mountPath: /bitnami/schema-registry/etc/schema-registry/log4j.properties
+              subPath: log4j.properties
+            {{- end }}
+            {{- if contains "SSL" $kafkaProtocol }}
+            - name: certificates
+              mountPath: /certs
+              readOnly: true
+            {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+          {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.configuration .Values.existingConfigmap  .Values.log4j .Values.existingLog4jConfigMap (contains "SSL" $kafkaProtocol) .Values.extraVolumes }}
+      volumes:
+        {{- if or .Values.configuration .Values.existingConfigmap }}
+        - name: configuration
+          configMap:
+            name: {{ include "schema-registry.configmapName" . }}
+        {{- end }}
+        {{- if or .Values.log4j .Values.existingLog4jConfigMap }}
+        - name: log4j-configuration
+          configMap:
+            name: {{ include "schema-registry.log4j.configmapName" . }}
+        {{ end }}
+        {{- if contains "SSL" $kafkaProtocol }}
+        - name: certificates
+          secret:
+            secretName: {{ printf "%s" (tpl .Values.auth.kafka.jksSecret $) }}
+            defaultMode: 256
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}

--- a/bitnami/schema-registry/templates/tls-secret.yaml
+++ b/bitnami/schema-registry/templates/tls-secret.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ include "common.names.namespace" $ | quote }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- $ca := genCA "schema-registry-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -69,7 +69,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/schema-registry
-  tag: 7.1.3-debian-11-r5
+  tag: 7.1.3-debian-11-r6
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -69,7 +69,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/schema-registry
-  tag: 7.1.3-debian-11-r4
+  tag: 7.1.3-debian-11-r5
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -1,0 +1,756 @@
+
+## @section Global parameters
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry: ""
+  ## e.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass: ""
+
+## @param kubeVersion Override Kubernetes version
+##
+kubeVersion: ""
+## @section Common parameters
+## @param nameOverride String to partially override airflow.fullname template with a string (will prepend the release name)
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override airflow.fullname template with a string
+##
+fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+## @param clusterDomain Kubernetes cluster domain name
+##
+clusterDomain: cluster.local
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
+## Enable diagnostic mode in the deployment
+##
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ##
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the deployment
+  ##
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the deployment
+  ##
+  args:
+    - infinity
+
+## @section Schema Registry parameters
+## Bitnami Schema Registry image
+## ref: https://hub.docker.com/r/bitnami/schema-registry/tags/
+## @param image.registry Schema Registry image registry
+## @param image.repository Schema Registry image repository
+## @param image.tag Schema Registry image tag (immutable tags are recommended)
+## @param image.pullPolicy Schema Registry image pull policy
+## @param image.pullSecrets Schema Registry image pull secrets
+## @param image.debug Enable image debug mode
+##
+image:
+  registry: docker.io
+  repository: bitnami/schema-registry
+  tag: 7.1.3-debian-11-r1
+  ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Set to true if you would like to see extra information on logs
+  ##
+  debug: false
+## @param command Override default container command (useful when using custom images)
+##
+command: []
+## @param args Override default container args (useful when using custom images)
+##
+args: []
+## @param hostAliases Schema Registry pods host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+## @param podLabels Extra labels for Schema Registry pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+## @param configuration Specify content for schema-registry.properties. Auto-generated based on other parameters when not specified
+##
+## e.g:
+## configuration: |-
+##   listeners = http://0.0.0.0:8081
+##   kafkastore.bootstrap.servers = protocol://broker_hostname:port
+##   host.name = schema-registry
+##   kafkastore.topic = _schemas
+##   inter.instance.protocol = http
+##   avro.compatibility.level = backward
+##   debug = false
+##
+configuration: {}
+## @param existingConfigmap Name of existing ConfigMap with Schema Registry configuration
+## NOTE: When it's set the configuration parameter is ignored
+##
+existingConfigmap: ""
+## @param log4j Schema Registry Log4J Configuration (optional)
+## Overwrites default log4j.properties file
+##
+log4j: {}
+## @param existingLog4jConfigMap Name of existing ConfigMap containing a custom log4j.properties file.
+## NOTE: When it's set the log4j is ignored
+##
+existingLog4jConfigMap: ""
+## Authentication parameteres
+## https://github.com/bitnami/bitnami-docker-kafka#security
+##
+auth:
+  ## TLS parameters to be used when a listener uses HTTPS
+  ##
+  tls:
+    ## @param auth.tls.enabled Enable TLS configuration to provide to be used when a listener uses HTTPS
+    ##
+    enabled: false
+    ## @param auth.tls.jksSecret Existing secret containing the truststore and one keystore per Schema Registry replica
+    ##
+    ## Create this secret following the steps below:
+    ## 1) Generate your trustore and keystore files. Helpful script: https://raw.githubusercontent.com/confluentinc/confluent-platform-security-tools/master/kafka-generate-ssl.sh
+    ## 2) Rename your truststore to `schema-registry.truststore.jks`.
+    ## 3) Rename your keystores to `schema-registry-X.keystore.jks` where X is the ID of each Schema Registry replica
+    ## 4) Run the command below where SECRET_NAME is the name of the secret you want to create:
+    ##       kubectl create secret generic SECRET_NAME --from-file=./schema-registry.truststore.jks --from-file=./schema-registry-0.keystore.jks --from-file=./schema-registry-1.keystore.jks ...
+    ##
+    jksSecret: ""
+    ## @param auth.tls.keystorePassword Password to access the keystore when it's password-protected
+    ##
+    keystorePassword: ""
+    ## @param auth.tls.truststorePassword Password to access the truststore when it's password-protected
+    ##
+    truststorePassword: ""
+    ## @param auth.tls.clientAuthentication Client authentication configuration.
+    ## Valid options: NONE, REQUESTED, over REQUIRED
+    ##
+    clientAuthentication: NONE
+  ## Parameters to configure authentication with kafka brokers
+  ##
+  kafka:
+    ## @param auth.kafka.jksSecret Existing secret containing the truststore and one keystore per Schema Registry replica
+    ##
+    ## Create this secret following the steps below:
+    ## 1) Generate your trustore and keystore files. Helpful script: https://raw.githubusercontent.com/confluentinc/confluent-platform-security-tools/master/kafka-generate-ssl.sh
+    ## 2) Rename your truststore to `kafka.truststore.jks`.
+    ## 3) Rename your keystores to `kafka-X.keystore.jks` where X is the ID of each Schema Registry replica
+    ## 4) Run the command below where SECRET_NAME is the name of the secret you want to create:
+    ##       kubectl create secret generic SECRET_NAME --from-file=./kafka.truststore.jks --from-file=./kafka-0.keystore.jks --from-file=./kafka-1.keystore.jks ...
+    ##
+    jksSecret: ""
+    ## @param auth.kafka.tlsEndpointIdentificationAlgorithm The endpoint identification algorithm used validate brokers hostnames
+    ## Disable server hostname verification by setting it to an empty string
+    ## See: https://docs.confluent.io/current/kafka/authentication_ssl.html#optional-settings
+    ##
+    tlsEndpointIdentificationAlgorithm: https
+    ## @param auth.kafka.keystorePassword Password to access the keystore when it's password-protected
+    ##
+    keystorePassword: ""
+    ## @param auth.kafka.truststorePassword Password to access the truststore when it's password-protected
+    ##
+    truststorePassword: ""
+    ## @param auth.kafka.saslMechanism Mechanism that schema registry will use to connect to kafka. Allowed: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512
+    ##
+    saslMechanism: PLAIN
+## @param listeners Comma-separated list of listeners that listen for API requests over either HTTP or HTTPS
+##
+listeners: http://0.0.0.0:8081
+## @param avroCompatibilityLevel Avro compatibility type
+## Valid options: none, backward, backward_transitive, forward, forward_transitive, full, or full_transitive
+##
+avroCompatibilityLevel: backward
+## @param extraEnvVars Extra environment variables to be set on Schema Registry container
+## e.g:
+## extraEnvVars:
+##   - name: FOO
+##     value: BAR
+##
+extraEnvVars: []
+## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars
+##
+extraEnvVarsCM: ""
+## @param extraEnvVarsSecret Name of existing Secret containing extra env vars
+##
+extraEnvVarsSecret: ""
+
+## @section Schema Registry statefulset parameters
+## @param replicaCount Number of Schema Registry replicas to deploy.
+##
+replicaCount: 1
+## @param updateStrategy.type Schema Registry statefulset strategy type
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+##
+updateStrategy:
+  ## StrategyType
+  ## Can be set to RollingUpdate or OnDelete
+  ##
+  type: RollingUpdate
+## Node affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+##
+nodeAffinityPreset:
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ##
+  type: ""
+  ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
+  ##
+  key: ""
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+## @param affinity Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+## @param nodeSelector Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+## @param tolerations Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+## @param podManagementPolicy Statefulset Pod management policy, it needs to be Parallel to be able to complete the cluster join
+## Ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+##
+podManagementPolicy: OrderedReady
+## @param podAnnotations Annotations for Schema Registry pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAffinityPreset: ""
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAntiAffinityPreset: soft
+## @param priorityClassName Schema Registry pod priority class name
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+##
+priorityClassName: ""
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+##
+topologySpreadConstraints: {}
+## @param schedulerName Name of the k8s scheduler (other than default) for Schema Registry pods
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+schedulerName: ""
+## @param terminationGracePeriodSeconds Seconds Redmine pod needs to terminate gracefully
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+##
+terminationGracePeriodSeconds: ""
+## @param lifecycleHooks for the Schema Registry container(s) to automate configuration before or after startup
+##
+lifecycleHooks: {}
+## Schema Registry pods' Security Context.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param podSecurityContext.enabled Enabled Controller pods' Security Context
+## @param podSecurityContext.fsGroup Set Controller pod's Security Context fsGroup
+## @param podSecurityContext.sysctls sysctl settings of the Schema Registry pods
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 1001
+  ## sysctl settings
+  ## Example:
+  ## sysctls:
+  ## - name: net.core.somaxconn
+  ##   value: "10000"
+  ##
+  sysctls: []
+## Schema Registry containers' Security Context (only main container).
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## @param containerSecurityContext.enabled Enable container security context
+## @param containerSecurityContext.runAsUser User ID for the container
+##
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+## Schema Registry containers' resource requests and limits.
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param resources.limits The resources limits for the container
+## @param resources.requests The requested resources for the container
+##
+resources:
+  ## e.g:
+  ## limits:
+  ##   cpu: 100m
+  ##   memory: 128Mi
+  limits: {}
+  ## e.g:
+  ## requests:
+  ##   cpu: 100m
+  ##   memory: 128Mi
+  requests: {}
+## Schema Registry pods' liveness and readiness probes. Evaluated as a template.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+## @param livenessProbe.enabled Enable livenessProbe
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 1
+  periodSeconds: 20
+  failureThreshold: 6
+  successThreshold: 1
+## @param readinessProbe.enabled Enable readinessProbe
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  timeoutSeconds: 1
+  periodSeconds: 20
+  failureThreshold: 6
+  successThreshold: 1
+## @param startupProbe.enabled Enable startupProbe
+## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+## @param startupProbe.periodSeconds Period seconds for startupProbe
+## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.successThreshold Success threshold for startupProbe
+##
+startupProbe:
+  enabled: false
+  initialDelaySeconds: 10
+  timeoutSeconds: 1
+  periodSeconds: 5
+  failureThreshold: 20
+  successThreshold: 1
+## @param customLivenessProbe Custom livenessProbe that overrides the default one
+##
+customLivenessProbe: {}
+## @param customReadinessProbe Custom readinessProbe that overrides the default one
+##
+customReadinessProbe: {}
+## @param customStartupProbe Custom startupProbe that overrides the default one
+##
+customStartupProbe: {}
+## @param extraVolumes Optionally specify extra list of additional volumes for MinIO&reg; pods
+## e.g:
+## extraVolumes:
+##   - name: avro-properties
+##     configMap:
+##       name: avro-properties
+##
+extraVolumes: []
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for MinIO&reg; container(s)
+## e.g:
+## extraVolumeMounts:
+##   - name: avro-properties
+##     mountPath: /bitnami/schema-registry/etc/schema-registry/connect-avro-standalone.properties
+##     subPath: connect-avro-standalone.properties
+##
+extraVolumeMounts: []
+## @param initContainers Add additional init containers to the Schema Registry pods.
+## e.g:
+## initContainers:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+initContainers: []
+## @param sidecars Add additional sidecar containers to the Schema Registry pods.
+## e.g:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: []
+## Schema Registry Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+## @param pdb.create Enable/disable a Pod Disruption Budget creation
+## @param pdb.minAvailable Minimum number/percentage of pods that must still be available after the eviction
+## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable after the eviction
+##
+pdb:
+  create: false
+  minAvailable: 1
+  maxUnavailable: ""
+## Schema Registry Autoscaling parameters.
+## @param autoscaling.enabled Enable autoscaling for replicas
+## @param autoscaling.minReplicas Minimum number of replicas
+## @param autoscaling.maxReplicas Maximum number of replicas
+## @param autoscaling.targetCPU Target CPU utilization percentage
+## @param autoscaling.targetMemory Target Memory utilization percentage
+##
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 11
+  targetCPU: ""
+  targetMemory: ""
+
+## @section Exposure Parameters
+## Schema Registry Service paramaters.
+##
+service:
+  ## @param service.type Kubernetes service type
+  ##
+  type: ClusterIP
+  ## @param service.ports.http Service HTTP port
+  ##
+  ports:
+    http: 8081
+  ## @param service.nodePorts.http Service HTTP node port
+  ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+  ##
+  nodePorts:
+    http: ""
+  ## @param service.clusterIP Schema Registry service clusterIP IP
+  ## e.g:
+  ## clusterIP: None
+  ##
+  clusterIP: ""
+  ## @param service.externalTrafficPolicy Enable client source IP preservation
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+  ## @param service.loadBalancerIP loadBalancerIP if service type is LoadBalancer
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+  ##
+  loadBalancerIP: ""
+  ## @param service.loadBalancerSourceRanges Address that are allowed when service is LoadBalancer
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ## - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## @param service.annotations Annotations for Schema Registry service
+  ##
+  annotations: {}
+  ## @param service.extraPorts Extra ports to expose in Schema Registry service (normally used with the `sidecars` value)
+  ##
+  extraPorts: []
+  ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
+  ## Values: ClientIP or None
+  ## ref: https://kubernetes.io/docs/user-guide/services/
+  ##
+  sessionAffinity: None
+  ## @param service.sessionAffinityConfig Additional settings for the sessionAffinity
+  ## sessionAffinityConfig:
+  ##   clientIP:
+  ##     timeoutSeconds: 300
+  ##
+  sessionAffinityConfig: {}
+## @param ingress.enabled                Enable ingress controller resource
+## @param ingress.hostname               Default host for the ingress resource
+## @param ingress.annotations            Ingress annotations
+## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
+## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+## @param ingress.secrets Custom TLS certificates as secrets
+## Configure the ingress resource that allows you to access Schema Registry
+##
+ingress:
+  ## @param ingress.enabled Enable ingress record generation for Schema Registry
+  ##
+  enabled: false
+  ## @param ingress.pathType Ingress path type
+  ##
+  pathType: ImplementationSpecific
+  ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
+  ##
+  apiVersion: ""
+  ## @param ingress.hostname Default host for the ingress record
+  ##
+  hostname: schema-registry.local
+  ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName: ""
+  ## @param ingress.path Default path for the ingress record
+  ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
+  ##
+  path: /
+  ## @param ingress.annotations Additional custom annotations for the ingress record
+  ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
+  ##
+  ## For a full list of possible ingress annotations, please see
+  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+  ##
+  annotations: {}
+  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.tls=true` and `ingress.certManager=false`
+  ##
+  tls: false
+  ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+  ##
+  selfSigned: false
+  ## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
+  ## e.g:
+  ## extraHosts:
+  ##  - name: schema-registry.local
+  ##    path: /
+  ##
+  extraHosts: []
+  ## @param ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  ## e.g:
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## e.g:
+  ## extraTls:
+  ## - hosts:
+  ##     - schema-registry.local
+  ##   secretName: schema-registry.local-tls
+  ##
+  extraTls: []
+  ## @param ingress.secrets Custom TLS certificates as secrets
+  ## NOTE: 'key' and 'certificate' are expected in PEM format
+  ## NOTE: 'name' should line up with a 'secretName' set further up
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ## e.g:
+  ## secrets:
+  ##   - name: odoo.local-tls
+  ##     key: |-
+  ##       -----BEGIN RSA PRIVATE KEY-----
+  ##       ...
+  ##       -----END RSA PRIVATE KEY-----
+  ##     certificate: |-
+  ##       -----BEGIN CERTIFICATE-----
+  ##       ...
+  ##       -----END CERTIFICATE-----
+  ##
+  secrets: []
+  ## @param ingress.extraRules Additional rules to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+  ## e.g:
+  ## extraRules:
+  ## - host: airflow.local
+  ##     http:
+  ##       path: /
+  ##       backend:
+  ##         service:
+  ##           name: airflow-svc
+  ##           port:
+  ##             name: http
+  ##
+  extraRules: []
+
+## @section RBAC parameters
+## Schema Registry pods ServiceAccount.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable the creation of a ServiceAccount for Schema Registry pods
+  ##
+  create: true
+  ## @param serviceAccount.name Name of the created ServiceAccount to use
+  ## If not set and create is true, a name is generated using the schema-registry.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.annotations Additional Service Account annotations (evaluated as a template)
+  ##
+  annotations: {}
+  ## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
+  ##
+  automountServiceAccountToken: true
+
+## @section Kafka chart parameters
+##
+## Kafka chart configuration
+## For information about these parameters, refer to:
+##   https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml
+##
+kafka:
+  ## @param kafka.enabled Enable/disable Kafka chart installation
+  ##
+  enabled: true
+  ## @param kafka.replicaCount Number of Kafka brokers
+  ##
+  replicaCount: 1
+  auth:
+    ## @param kafka.auth.clientProtocol Authentication protocol for communications with clients. Allowed protocols: plaintext, tls, mtls, sasl and sasl_tls
+    ##
+    clientProtocol: plaintext
+    ## @param kafka.auth.interBrokerProtocol Authentication protocol for inter-broker communications. Allowed protocols: plaintext, tls, mtls, sasl and sasl_tls
+    ##
+    interBrokerProtocol: plaintext
+    ## TLS configuration
+    ##
+    tls:
+      ## @param kafka.auth.tls.existingSecrets Array existing secrets containing the TLS certificates for the Kafka brokers
+      ## When using 'jks' format for certificates, each secret should contain a truststore and a keystore.
+      ## Create these secrets following the steps below:
+      ## 1) Generate your truststore and keystore files. Helpful script: https://raw.githubusercontent.com/confluentinc/confluent-platform-security-tools/master/kafka-generate-ssl.sh
+      ## 2) Rename your truststore to `kafka.truststore.jks`.
+      ## 3) Rename your keystores to `kafka-X.keystore.jks` where X is the ID of each Kafka broker.
+      ## 4) Run the command below one time per broker to create its associated secret (SECRET_NAME_X is the name of the secret you want to create):
+      ##       kubectl create secret generic SECRET_NAME_0 --from-file=kafka.truststore.jks=./kafka.truststore.jks --from-file=kafka.keystore.jks=./kafka-0.keystore.jks
+      ##       kubectl create secret generic SECRET_NAME_1 --from-file=kafka.truststore.jks=./kafka.truststore.jks --from-file=kafka.keystore.jks=./kafka-1.keystore.jks
+      ##       ...
+      ##
+      ## When using 'pem' format for certificates, each secret should contain a public CA certificate, a public certificate and one private key.
+      ## Create these secrets following the steps below:
+      ## 1) Create a certificate key and signing request per Kafka broker, and sign the signing request with your CA
+      ## 2) Rename your CA file to `kafka.ca.crt`.
+      ## 3) Rename your certificates to `kafka-X.tls.crt` where X is the ID of each Kafka broker.
+      ## 3) Rename your keys to `kafka-X.tls.key` where X is the ID of each Kafka broker.
+      ## 4) Run the command below one time per broker to create its associated secret (SECRET_NAME_X is the name of the secret you want to create):
+      ##       kubectl create secret generic SECRET_NAME_0 --from-file=ca.crt=./kafka.ca.crt --from-file=tls.crt=./kafka-0.tls.crt --from-file=tls.key=./kafka-0.tls.key
+      ##       kubectl create secret generic SECRET_NAME_1 --from-file=ca.crt=./kafka.ca.crt --from-file=tls.crt=./kafka-1.tls.crt --from-file=tls.key=./kafka-1.tls.key
+      ##       ...
+      ##
+      existingSecrets: []
+      ## @param kafka.auth.tls.password Password to access the JKS files or PEM key when they are password-protected.
+      ## Note: ignored when using 'existingSecret'.
+      ##
+      password: ""
+      ## @param kafka.auth.tls.endpointIdentificationAlgorithm The endpoint identification algorithm to validate server hostname using server certificate
+      ## Disable server host name verification by setting it to an empty string.
+      ## ref: https://docs.confluent.io/current/kafka/authentication_ssl.html#optional-settings
+      ##
+      endpointIdentificationAlgorithm: https
+    sasl:
+      jaas:
+        ## @param kafka.auth.sasl.jaas.clientUsers [array] Kafka client users for SASL authentication
+        ##
+        clientUsers:
+          - user
+        ## @param kafka.auth.sasl.jaas.clientPasswords Kafka client passwords for SASL authentication
+        ##
+        clientPasswords: []
+        ## @param kafka.auth.sasl.jaas.interBrokerUser Kafka inter broker communication user for SASL authentication
+        ##
+        interBrokerUser: admin
+        ## @param kafka.auth.sasl.jaas.interBrokerPassword Kafka inter broker communication password for SASL authentication
+        ##
+        interBrokerPassword: ""
+        ## @param kafka.auth.sasl.jaas.zookeeperUser Kafka Zookeeper user for SASL authentication
+        ##
+        zookeeperUser: ""
+        ## @param kafka.auth.sasl.jaas.zookeeperPassword Kafka Zookeeper password for SASL authentication
+        ##
+        zookeeperPassword: ""
+        ## @param kafka.auth.sasl.jaas.existingSecret Name of the existing secret containing credentials for brokerUser, interBrokerUser and zookeeperUser
+        ##
+        existingSecret: ""
+  service:
+    ## @param kafka.service.ports.client Kafka service port for client connections
+    ##
+    ports:
+      client: 9092
+  ##
+  ## Zookeeper chart configuration
+  ## For information about these parameters, refer to:
+  ##   https://github.com/bitnami/charts/blob/master/bitnami/zookeeper/values.yaml
+  ##
+  zookeeper:
+    ## @param kafka.zookeeper.enabled Enable/disable Zookeeper chart installation
+    ##
+    enabled: true
+    ## @param kafka.zookeeper.replicaCount Number of Zookeeper replicas
+    ##
+    replicaCount: 1
+    ## @param kafka.zookeeper.auth [object] Zookeeper auth settings
+    auth:
+      client:
+        enabled: false
+        clientUser: zookeeperUser
+        clientPassword: ""
+        serverUsers: zookeeperUser
+        serverPasswords: ""
+        existingSecret: ""
+##
+## External Kafka Configuration
+## All of these values are only used when kafka.enabled is set to false
+##
+externalKafka:
+  ## @param externalKafka.brokers Array of Kafka brokers to connect to. Format: protocol://broker_hostname:port
+  ##
+  brokers:
+    - PLAINTEXT://localhost:9092
+  ## Authentication parameters
+  ## @param externalKafka.auth.protocol                   Authentication protocol. Allowed protocols: plaintext, tls, sasl and sasl_tls
+  ## @param externalKafka.auth.jaas.user                  User for SASL authentication
+  ## @param externalKafka.auth.jaas.password              Password for SASL authentication
+  ##
+  auth:
+    ## Authentication protocol
+    ## Supported values: 'plaintext', 'tls', sasl' and 'sasl_tls'
+    ## This table shows the security provided on each protocol:
+    ## | Method    | Authentication                | Encryption via TLS |
+    ## | plaintext | None                          | No                 |
+    ## | tls       | None                          | Yes                |
+    ## | sasl      | Yes (via SASL)                | No                 |
+    ## | sasl_tls  | Yes (via SASL)                | Yes                |
+    ##
+    protocol: plaintext
+    ## JAAS configuration for SASL authentication
+    ## MANDATORY when protocol is 'sasl' or 'sasl_tls'
+    ##
+    jaas:
+      user: user
+      password: ""

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -69,7 +69,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/schema-registry
-  tag: 7.1.3-debian-11-r1
+  tag: 7.1.3-debian-11-r4
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
### Description of the change

This PR moves the schema-registry chart to the bitnami/charts repository.

The following changes have been added:
- Bumped major version 4.x.x, updating Kafka subchart from version 12 to 18.
- Kafka and Zookeeper subchart values updated.
- Adds VIB files
- Adds `.helmignore`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
