### PR TITLE
[bitnami/mariadb] fix missing volumeMounts key for metrics container

### DIFF
--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 11.1.3
+version: 11.1.4

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -318,7 +318,6 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
-          {{- if or (and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles)) .Values.metrics.extraVolumeMounts.primary }}
           volumeMounts:
           {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
             - name: mariadb-credentials
@@ -326,7 +325,6 @@ spec:
           {{- end }}
           {{- if .Values.metrics.extraVolumeMounts.primary }}
           {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraVolumeMounts.primary "context" $) | nindent 12 }}
-          {{- end }}
           {{- end }}
         {{- end }}
         {{- if .Values.primary.sidecars }}

--- a/bitnami/mariadb/templates/primary/statefulset.yaml
+++ b/bitnami/mariadb/templates/primary/statefulset.yaml
@@ -318,13 +318,15 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
-          {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
+          {{- if or (and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles)) .Values.metrics.extraVolumeMounts.primary }}
           volumeMounts:
+          {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
             - name: mariadb-credentials
               mountPath: /opt/bitnami/mysqld-exporter/secrets/
           {{- end }}
           {{- if .Values.metrics.extraVolumeMounts.primary }}
           {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraVolumeMounts.primary "context" $) | nindent 12 }}
+          {{- end }}
           {{- end }}
         {{- end }}
         {{- if .Values.primary.sidecars }}

--- a/bitnami/mariadb/templates/secondary/statefulset.yaml
+++ b/bitnami/mariadb/templates/secondary/statefulset.yaml
@@ -301,8 +301,8 @@ spec:
           {{- if .Values.metrics.resources }}
           resources: {{- toYaml .Values.metrics.resources | nindent 12 }}
           {{- end }}
-          {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
           volumeMounts:
+          {{- if and .Values.auth.usePasswordFiles (not .Values.auth.customPasswordFiles) }}
             - name: mariadb-credentials
               mountPath: /opt/bitnami/mysqld-exporter/secrets/
           {{- end }}


### PR DESCRIPTION
Signed-off-by: Stollin, Thomas <thomas.stollin@interhyp.de>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This change fixes a templating error caused by adding extraVolumeMounts to the mariadb metrics container when customPasswordFiles are used. This combination of configurations results in a missing ```volumeMounts``` key for the metrics container and dangling list entries. 
The problem was introduced with https://github.com/bitnami/charts/pull/11142. 

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
