### PR TITLE
[bitnami/*] Update URLs to point to the new bitnami/containers monorepo

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -30,6 +30,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: airflow
 sources:
-  - https://github.com/bitnami/bitnami-docker-airflow
+  - https://github.com/bitnami/containers/tree/main/bitnami/airflow
   - https://airflow.apache.org/
 version: 13.0.0

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -16,7 +16,7 @@ $ helm install my-release bitnami/airflow
 
 ## Introduction
 
-This chart bootstraps an [Apache Airflow](https://github.com/bitnami/bitnami-docker-airflow) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [Apache Airflow](https://github.com/bitnami/containers/tree/main/bitnami/airflow) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -611,7 +611,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ### Install extra python packages
 
-This chart allows you to mount volumes using `extraVolumes` and `extraVolumeMounts` in all 3 airflow components (web, scheduler, worker). Mounting a requirements.txt using these options to `/bitnami/python/requirements.txt` will execute `pip install -r /bitnami/python/requirements.txt` on container start. [Reference](https://github.com/bitnami/bitnami-docker-airflow/blob/cafc8eab1efddb5efda5a00cc861ef10f35f1d49/1/debian-10/rootfs/run.sh#L14)
+This chart allows you to mount volumes using `extraVolumes` and `extraVolumeMounts` in all 3 airflow components (web, scheduler, worker). Mounting a requirements.txt using these options to `/bitnami/python/requirements.txt` will execute `pip install -r /bitnami/python/requirements.txt` on container start.
 
 ### Enabling network policies
 

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -57,7 +57,7 @@ diagnosticMode:
 ## @section Airflow common parameters
 
 ## Authentication parameters
-## ref: https://github.com/bitnami/bitnami-docker-airflow#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/airflow#environment-variables
 ##
 auth:
   ## @param auth.username Username to access web UI

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: apache
 sources:
-  - https://github.com/bitnami/bitnami-docker-apache
+  - https://github.com/bitnami/containers/tree/main/bitnami/apache
   - https://httpd.apache.org
 version: 9.1.13

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -7,7 +7,7 @@ Apache HTTP Server is an open-source HTTP server. The goal of this project is to
 [Overview of Apache](https://httpd.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -19,7 +19,7 @@ $ helm install my-release bitnami/apache
 
 Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
 
-This chart bootstraps a [Apache](https://github.com/bitnami/bitnami-docker-apache) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Apache](https://github.com/bitnami/containers/tree/main/bitnami/apache) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 The Apache HTTP Server ("httpd") was launched in 1995 and it has been the most popular web server on the Internet since April 1996. It has celebrated its 20th birthday as a project in February 2015.
 
@@ -302,7 +302,7 @@ This release updates the Bitnami Apache container to `2.4.41-debian-9-r40`, whic
 
 ### 6.0.0
 
-This release allows you to use your custom static application. In order to do so, check [this section](#deploying-your-custom-web-application).
+This release allows you to use your custom static application. In order to do so, check [this section](#deploying-a-custom-web-application).
 
 ## Upgrading
 

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -82,13 +82,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
 | `image.registry`                        | Apache image registry                                                                                                    | `docker.io`            |
 | `image.repository`                      | Apache image repository                                                                                                  | `bitnami/apache`       |
-| `image.tag`                             | Apache image tag (immutable tags are recommended)                                                                        | `2.4.53-debian-10-r36` |
+| `image.tag`                             | Apache image tag (immutable tags are recommended)                                                                        | `2.4.54-debian-11-r10` |
 | `image.pullPolicy`                      | Apache image pull policy                                                                                                 | `IfNotPresent`         |
 | `image.pullSecrets`                     | Apache image pull secrets                                                                                                | `[]`                   |
 | `image.debug`                           | Enable image debug mode                                                                                                  | `false`                |
 | `git.registry`                          | Git image registry                                                                                                       | `docker.io`            |
 | `git.repository`                        | Git image name                                                                                                           | `bitnami/git`          |
-| `git.tag`                               | Git image tag                                                                                                            | `2.36.0-debian-10-r1`  |
+| `git.tag`                               | Git image tag                                                                                                            | `2.37.0-debian-11-r2`  |
 | `git.pullPolicy`                        | Git image pull policy                                                                                                    | `IfNotPresent`         |
 | `git.pullSecrets`                       | Specify docker-registry secret names as an array                                                                         | `[]`                   |
 | `replicaCount`                          | Number of replicas of the Apache deployment                                                                              | `1`                    |
@@ -222,7 +222,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                          | Start a sidecar prometheus exporter to expose Apache metrics                                                                              | `false`                   |
 | `metrics.image.registry`                   | Apache Exporter image registry                                                                                                            | `docker.io`               |
 | `metrics.image.repository`                 | Apache Exporter image repository                                                                                                          | `bitnami/apache-exporter` |
-| `metrics.image.tag`                        | Apache Exporter image tag (immutable tags are recommended)                                                                                | `0.11.0-debian-10-r120`   |
+| `metrics.image.tag`                        | Apache Exporter image tag (immutable tags are recommended)                                                                                | `0.11.0-debian-11-r11`    |
 | `metrics.image.pullPolicy`                 | Apache Exporter image pull policy                                                                                                         | `IfNotPresent`            |
 | `metrics.image.pullSecrets`                | Apache Exporter image pull secrets                                                                                                        | `[]`                      |
 | `metrics.image.debug`                      | Apache Exporter image debug mode                                                                                                          | `false`                   |

--- a/bitnami/apache/templates/NOTES.txt
+++ b/bitnami/apache/templates/NOTES.txt
@@ -40,7 +40,7 @@ APP VERSION: {{ .Chart.AppVersion }}
 
 {{/* WARNINGS */}}
 {{- if not (include "apache.useHtdocs" .) }}
-WARNING: You did not provide a custom web application. Apache will be deployed with a default page. Check the README section "Deploying your custom web application" in https://github.com/bitnami/charts/blob/master/bitnami/apache/README.md#deploying-your-custom-web-application.
+WARNING: You did not provide a custom web application. Apache will be deployed with a default page. Check the README section "Deploying your custom web application" in https://github.com/bitnami/charts/blob/master/bitnami/apache/README.md#deploying-a-custom-web-application.
 {{- end }}
 {{- if and (contains "bitnami/" .Values.image.repository) (not (.Values.image.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 WARNING: Rolling tag detected ({{ .Values.image.repository }}:{{ .Values.image.tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -26,8 +26,8 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: argo-cd
 sources:
-  - https://github.com/bitnami/bitnami-docker-argo-cd
+  - https://github.com/bitnami/containers/tree/main/bitnami/argo-cd
   - https://github.com/argoproj/argo-cd/
-  - https://github.com/bitnami/bitnami-docker-dex
+  - https://github.com/bitnami/containers/tree/main/bitnami/dex
   - https://github.com/dexidp/dex
 version: 4.0.2

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -60,6 +60,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
+
 ### Common parameters
 
 | Name                | Description                                        | Value           |
@@ -72,16 +73,18 @@ The command removes all the Kubernetes components associated with the chart and 
 | `clusterDomain`     | Kubernetes cluster domain name                     | `cluster.local` |
 | `extraDeploy`       | Array of extra objects to deploy with the release  | `[]`            |
 
+
 ### Argo CD image parameters
 
 | Name                | Description                                        | Value                |
 | ------------------- | -------------------------------------------------- | -------------------- |
 | `image.registry`    | Argo CD image registry                             | `docker.io`          |
 | `image.repository`  | Argo CD image repository                           | `bitnami/argo-cd`    |
-| `image.tag`         | Argo CD image tag (immutable tags are recommended) | `2.3.4-debian-11-r0` |
+| `image.tag`         | Argo CD image tag (immutable tags are recommended) | `2.4.7-debian-11-r0` |
 | `image.pullPolicy`  | Argo CD image pull policy                          | `IfNotPresent`       |
 | `image.pullSecrets` | Argo CD image pull secrets                         | `[]`                 |
 | `image.debug`       | Enable Argo CD image debug mode                    | `false`              |
+
 
 ### Argo CD application controller parameters
 
@@ -196,6 +199,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Argo CD container(s)                | `[]`            |
 | `controller.sidecars`                                          | Add additional sidecar containers to the Argo CD pod(s)                                              | `[]`            |
 | `controller.initContainers`                                    | Add additional init containers to the Argo CD pod(s)                                                 | `[]`            |
+
 
 ### Argo CD server Parameters
 
@@ -340,6 +344,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `server.serviceAccount.automountServiceAccountToken`       | Automount service account token for the server service account                                                                  | `true`                   |
 | `server.serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                                      | `{}`                     |
 
+
 ### Argo CD repo server Parameters
 
 | Name                                                           | Description                                                                                          | Value           |
@@ -448,115 +453,117 @@ The command removes all the Kubernetes components associated with the chart and 
 | `repoServer.sidecars`                                          | Add additional sidecar containers to the Argo CD repo server pod(s)                                  | `[]`            |
 | `repoServer.initContainers`                                    | Add additional init containers to the Argo CD repo server pod(s)                                     | `[]`            |
 
+
 ### Dex Parameters
 
-| Name                                                    | Description                                                                                   | Value                 |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------- |
-| `dex.image.registry`                                    | Dex image registry                                                                            | `docker.io`           |
-| `dex.image.repository`                                  | Dex image repository                                                                          | `bitnami/dex`         |
-| `dex.image.tag`                                         | Dex image tag (immutable tags are recommended)                                                | `2.31.2-debian-11-r0` |
-| `dex.image.pullPolicy`                                  | Dex image pull policy                                                                         | `IfNotPresent`        |
-| `dex.image.pullSecrets`                                 | Dex image pull secrets                                                                        | `[]`                  |
-| `dex.image.debug`                                       | Enable Dex image debug mode                                                                   | `false`               |
-| `dex.enabled`                                           | Enable the creation of a Dex deployment for SSO                                               | `false`               |
-| `dex.replicaCount`                                      | Number of Dex replicas to deploy                                                              | `1`                   |
-| `dex.startupProbe.enabled`                              | Enable startupProbe on Dex nodes                                                              | `false`               |
-| `dex.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                        | `10`                  |
-| `dex.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                               | `10`                  |
-| `dex.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                              | `1`                   |
-| `dex.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                            | `3`                   |
-| `dex.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                            | `1`                   |
-| `dex.livenessProbe.enabled`                             | Enable livenessProbe on Dex nodes                                                             | `true`                |
-| `dex.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                       | `10`                  |
-| `dex.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                              | `10`                  |
-| `dex.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                             | `1`                   |
-| `dex.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                           | `3`                   |
-| `dex.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                           | `1`                   |
-| `dex.readinessProbe.enabled`                            | Enable readinessProbe on Dex nodes                                                            | `true`                |
-| `dex.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                      | `10`                  |
-| `dex.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                             | `10`                  |
-| `dex.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                            | `1`                   |
-| `dex.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                          | `3`                   |
-| `dex.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                          | `1`                   |
-| `dex.customStartupProbe`                                | Custom startupProbe that overrides the default one                                            | `{}`                  |
-| `dex.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                           | `{}`                  |
-| `dex.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                          | `{}`                  |
-| `dex.resources.limits`                                  | The resources limits for the Dex containers                                                   | `{}`                  |
-| `dex.resources.requests`                                | The requested resources for the Dex containers                                                | `{}`                  |
-| `dex.podSecurityContext.enabled`                        | Enabled Dex pods' Security Context                                                            | `true`                |
-| `dex.podSecurityContext.fsGroup`                        | Set Dex pod's Security Context fsGroup                                                        | `1001`                |
-| `dex.containerSecurityContext.enabled`                  | Enabled Dex containers' Security Context                                                      | `true`                |
-| `dex.containerSecurityContext.runAsUser`                | Set Dex containers' Security Context runAsUser                                                | `1001`                |
-| `dex.containerSecurityContext.allowPrivilegeEscalation` | Set Dex containers' Security Context allowPrivilegeEscalation                                 | `false`               |
-| `dex.containerSecurityContext.readOnlyRootFilesystem`   | Set Dex containers' server Security Context readOnlyRootFilesystem                            | `false`               |
-| `dex.containerSecurityContext.runAsNonRoot`             | Set Dex containers' Security Context runAsNonRoot                                             | `true`                |
-| `dex.service.type`                                      | Dex service type                                                                              | `ClusterIP`           |
-| `dex.service.ports.http`                                | Dex HTTP service port                                                                         | `5556`                |
-| `dex.service.ports.grpc`                                | Dex grpc service port                                                                         | `5557`                |
-| `dex.service.nodePorts.http`                            | HTTP node port for the Dex service                                                            | `""`                  |
-| `dex.service.nodePorts.grpc`                            | gRPC node port for the Dex service                                                            | `""`                  |
-| `dex.service.clusterIP`                                 | Dex service Cluster IP                                                                        | `""`                  |
-| `dex.service.loadBalancerIP`                            | Dex service Load Balancer IP                                                                  | `""`                  |
-| `dex.service.loadBalancerSourceRanges`                  | Dex service Load Balancer sources                                                             | `[]`                  |
-| `dex.service.externalTrafficPolicy`                     | Dex service external traffic policy                                                           | `Cluster`             |
-| `dex.service.annotations`                               | Additional custom annotations for Dex service                                                 | `{}`                  |
-| `dex.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                | `[]`                  |
-| `dex.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                          | `None`                |
-| `dex.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                   | `{}`                  |
-| `dex.containerPorts.http`                               | Dex container HTTP port                                                                       | `5556`                |
-| `dex.containerPorts.grpc`                               | Dex gRPC port                                                                                 | `5557`                |
-| `dex.containerPorts.metrics`                            | Dex metrics port                                                                              | `5558`                |
-| `dex.metrics.enabled`                                   | Enable metrics for Dex                                                                        | `false`               |
-| `dex.metrics.service.type`                              | Dex service type                                                                              | `ClusterIP`           |
-| `dex.metrics.service.port`                              | Dex metrics service port                                                                      | `5558`                |
-| `dex.metrics.service.nodePort`                          | Node port for the Dex service                                                                 | `""`                  |
-| `dex.metrics.service.clusterIP`                         | Dex service metrics service Cluster IP                                                        | `""`                  |
-| `dex.metrics.service.loadBalancerIP`                    | Dex service Load Balancer IP                                                                  | `""`                  |
-| `dex.metrics.service.loadBalancerSourceRanges`          | Dex service Load Balancer sources                                                             | `[]`                  |
-| `dex.metrics.service.externalTrafficPolicy`             | Dex service external traffic policy                                                           | `Cluster`             |
-| `dex.metrics.service.annotations`                       | Additional custom annotations for Dex service                                                 | `{}`                  |
-| `dex.metrics.service.sessionAffinity`                   | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                          | `None`                |
-| `dex.metrics.service.sessionAffinityConfig`             | Additional settings for the sessionAffinity                                                   | `{}`                  |
-| `dex.metrics.serviceMonitor.enabled`                    | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                  | `false`               |
-| `dex.metrics.serviceMonitor.namespace`                  | Namespace which Prometheus is running in                                                      | `""`                  |
-| `dex.metrics.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in prometheus.             | `""`                  |
-| `dex.metrics.serviceMonitor.interval`                   | Interval at which metrics should be scraped                                                   | `30s`                 |
-| `dex.metrics.serviceMonitor.scrapeTimeout`              | Timeout after which the scrape is ended                                                       | `10s`                 |
-| `dex.metrics.serviceMonitor.relabelings`                | RelabelConfigs to apply to samples before scraping                                            | `[]`                  |
-| `dex.metrics.serviceMonitor.metricRelabelings`          | MetricRelabelConfigs to apply to samples before ingestion                                     | `[]`                  |
-| `dex.metrics.serviceMonitor.selector`                   | ServiceMonitor selector labels                                                                | `{}`                  |
-| `dex.metrics.serviceMonitor.honorLabels`                | honorLabels chooses the metric's labels on collisions with target labels                      | `false`               |
-| `dex.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created for Dex                                  | `true`                |
-| `dex.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                        | `""`                  |
-| `dex.serviceAccount.automountServiceAccountToken`       | Automount service account token for the Dex service account                                   | `true`                |
-| `dex.serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.    | `{}`                  |
-| `dex.command`                                           | Override default container command (useful when using custom images)                          | `[]`                  |
-| `dex.args`                                              | Override default container args (useful when using custom images)                             | `[]`                  |
-| `dex.extraArgs`                                         | Add extra args to the default args for Dex                                                    | `[]`                  |
-| `dex.hostAliases`                                       | Dex pods host aliases                                                                         | `[]`                  |
-| `dex.podLabels`                                         | Extra labels for Dex pods                                                                     | `{}`                  |
-| `dex.podAnnotations`                                    | Annotations for Dex pods                                                                      | `{}`                  |
-| `dex.podAffinityPreset`                                 | Pod affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`       | `""`                  |
-| `dex.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                |
-| `dex.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard` | `""`                  |
-| `dex.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `dex.affinity` is set                                     | `""`                  |
-| `dex.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `dex.affinity` is set                                  | `[]`                  |
-| `dex.affinity`                                          | Affinity for Dex pods assignment                                                              | `{}`                  |
-| `dex.nodeSelector`                                      | Node labels for Dex pods assignment                                                           | `{}`                  |
-| `dex.tolerations`                                       | Tolerations for Dex pods assignment                                                           | `[]`                  |
-| `dex.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                | `""`                  |
-| `dex.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                | `[]`                  |
-| `dex.updateStrategy.type`                               | Dex statefulset strategy type                                                                 | `RollingUpdate`       |
-| `dex.priorityClassName`                                 | Dex pods' priorityClassName                                                                   | `""`                  |
-| `dex.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                | `""`                  |
-| `dex.lifecycleHooks`                                    | for the Dex container(s) to automate configuration before or after startup                    | `{}`                  |
-| `dex.extraEnvVars`                                      | Array with extra environment variables to add to Dex nodes                                    | `[]`                  |
-| `dex.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Dex nodes                            | `""`                  |
-| `dex.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Dex nodes                               | `""`                  |
-| `dex.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Dex pod(s)                        | `[]`                  |
-| `dex.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Dex container(s)             | `[]`                  |
-| `dex.sidecars`                                          | Add additional sidecar containers to the Dex pod(s)                                           | `[]`                  |
-| `dex.initContainers`                                    | Add additional init containers to the Dex pod(s)                                              | `[]`                  |
+| Name                                                    | Description                                                                                   | Value                  |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------- |
+| `dex.image.registry`                                    | Dex image registry                                                                            | `docker.io`            |
+| `dex.image.repository`                                  | Dex image repository                                                                          | `bitnami/dex`          |
+| `dex.image.tag`                                         | Dex image tag (immutable tags are recommended)                                                | `2.32.0-debian-11-r13` |
+| `dex.image.pullPolicy`                                  | Dex image pull policy                                                                         | `IfNotPresent`         |
+| `dex.image.pullSecrets`                                 | Dex image pull secrets                                                                        | `[]`                   |
+| `dex.image.debug`                                       | Enable Dex image debug mode                                                                   | `false`                |
+| `dex.enabled`                                           | Enable the creation of a Dex deployment for SSO                                               | `false`                |
+| `dex.replicaCount`                                      | Number of Dex replicas to deploy                                                              | `1`                    |
+| `dex.startupProbe.enabled`                              | Enable startupProbe on Dex nodes                                                              | `false`                |
+| `dex.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                        | `10`                   |
+| `dex.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                               | `10`                   |
+| `dex.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                              | `1`                    |
+| `dex.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                            | `3`                    |
+| `dex.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                            | `1`                    |
+| `dex.livenessProbe.enabled`                             | Enable livenessProbe on Dex nodes                                                             | `true`                 |
+| `dex.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                       | `10`                   |
+| `dex.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                              | `10`                   |
+| `dex.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                             | `1`                    |
+| `dex.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                           | `3`                    |
+| `dex.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                           | `1`                    |
+| `dex.readinessProbe.enabled`                            | Enable readinessProbe on Dex nodes                                                            | `true`                 |
+| `dex.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                      | `10`                   |
+| `dex.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                             | `10`                   |
+| `dex.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                            | `1`                    |
+| `dex.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                          | `3`                    |
+| `dex.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                          | `1`                    |
+| `dex.customStartupProbe`                                | Custom startupProbe that overrides the default one                                            | `{}`                   |
+| `dex.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                           | `{}`                   |
+| `dex.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                          | `{}`                   |
+| `dex.resources.limits`                                  | The resources limits for the Dex containers                                                   | `{}`                   |
+| `dex.resources.requests`                                | The requested resources for the Dex containers                                                | `{}`                   |
+| `dex.podSecurityContext.enabled`                        | Enabled Dex pods' Security Context                                                            | `true`                 |
+| `dex.podSecurityContext.fsGroup`                        | Set Dex pod's Security Context fsGroup                                                        | `1001`                 |
+| `dex.containerSecurityContext.enabled`                  | Enabled Dex containers' Security Context                                                      | `true`                 |
+| `dex.containerSecurityContext.runAsUser`                | Set Dex containers' Security Context runAsUser                                                | `1001`                 |
+| `dex.containerSecurityContext.allowPrivilegeEscalation` | Set Dex containers' Security Context allowPrivilegeEscalation                                 | `false`                |
+| `dex.containerSecurityContext.readOnlyRootFilesystem`   | Set Dex containers' server Security Context readOnlyRootFilesystem                            | `false`                |
+| `dex.containerSecurityContext.runAsNonRoot`             | Set Dex containers' Security Context runAsNonRoot                                             | `true`                 |
+| `dex.service.type`                                      | Dex service type                                                                              | `ClusterIP`            |
+| `dex.service.ports.http`                                | Dex HTTP service port                                                                         | `5556`                 |
+| `dex.service.ports.grpc`                                | Dex grpc service port                                                                         | `5557`                 |
+| `dex.service.nodePorts.http`                            | HTTP node port for the Dex service                                                            | `""`                   |
+| `dex.service.nodePorts.grpc`                            | gRPC node port for the Dex service                                                            | `""`                   |
+| `dex.service.clusterIP`                                 | Dex service Cluster IP                                                                        | `""`                   |
+| `dex.service.loadBalancerIP`                            | Dex service Load Balancer IP                                                                  | `""`                   |
+| `dex.service.loadBalancerSourceRanges`                  | Dex service Load Balancer sources                                                             | `[]`                   |
+| `dex.service.externalTrafficPolicy`                     | Dex service external traffic policy                                                           | `Cluster`              |
+| `dex.service.annotations`                               | Additional custom annotations for Dex service                                                 | `{}`                   |
+| `dex.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                | `[]`                   |
+| `dex.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                          | `None`                 |
+| `dex.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                   | `{}`                   |
+| `dex.containerPorts.http`                               | Dex container HTTP port                                                                       | `5556`                 |
+| `dex.containerPorts.grpc`                               | Dex gRPC port                                                                                 | `5557`                 |
+| `dex.containerPorts.metrics`                            | Dex metrics port                                                                              | `5558`                 |
+| `dex.metrics.enabled`                                   | Enable metrics for Dex                                                                        | `false`                |
+| `dex.metrics.service.type`                              | Dex service type                                                                              | `ClusterIP`            |
+| `dex.metrics.service.port`                              | Dex metrics service port                                                                      | `5558`                 |
+| `dex.metrics.service.nodePort`                          | Node port for the Dex service                                                                 | `""`                   |
+| `dex.metrics.service.clusterIP`                         | Dex service metrics service Cluster IP                                                        | `""`                   |
+| `dex.metrics.service.loadBalancerIP`                    | Dex service Load Balancer IP                                                                  | `""`                   |
+| `dex.metrics.service.loadBalancerSourceRanges`          | Dex service Load Balancer sources                                                             | `[]`                   |
+| `dex.metrics.service.externalTrafficPolicy`             | Dex service external traffic policy                                                           | `Cluster`              |
+| `dex.metrics.service.annotations`                       | Additional custom annotations for Dex service                                                 | `{}`                   |
+| `dex.metrics.service.sessionAffinity`                   | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                          | `None`                 |
+| `dex.metrics.service.sessionAffinityConfig`             | Additional settings for the sessionAffinity                                                   | `{}`                   |
+| `dex.metrics.serviceMonitor.enabled`                    | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                  | `false`                |
+| `dex.metrics.serviceMonitor.namespace`                  | Namespace which Prometheus is running in                                                      | `""`                   |
+| `dex.metrics.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in prometheus.             | `""`                   |
+| `dex.metrics.serviceMonitor.interval`                   | Interval at which metrics should be scraped                                                   | `30s`                  |
+| `dex.metrics.serviceMonitor.scrapeTimeout`              | Timeout after which the scrape is ended                                                       | `10s`                  |
+| `dex.metrics.serviceMonitor.relabelings`                | RelabelConfigs to apply to samples before scraping                                            | `[]`                   |
+| `dex.metrics.serviceMonitor.metricRelabelings`          | MetricRelabelConfigs to apply to samples before ingestion                                     | `[]`                   |
+| `dex.metrics.serviceMonitor.selector`                   | ServiceMonitor selector labels                                                                | `{}`                   |
+| `dex.metrics.serviceMonitor.honorLabels`                | honorLabels chooses the metric's labels on collisions with target labels                      | `false`                |
+| `dex.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created for Dex                                  | `true`                 |
+| `dex.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                        | `""`                   |
+| `dex.serviceAccount.automountServiceAccountToken`       | Automount service account token for the Dex service account                                   | `true`                 |
+| `dex.serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.    | `{}`                   |
+| `dex.command`                                           | Override default container command (useful when using custom images)                          | `[]`                   |
+| `dex.args`                                              | Override default container args (useful when using custom images)                             | `[]`                   |
+| `dex.extraArgs`                                         | Add extra args to the default args for Dex                                                    | `[]`                   |
+| `dex.hostAliases`                                       | Dex pods host aliases                                                                         | `[]`                   |
+| `dex.podLabels`                                         | Extra labels for Dex pods                                                                     | `{}`                   |
+| `dex.podAnnotations`                                    | Annotations for Dex pods                                                                      | `{}`                   |
+| `dex.podAffinityPreset`                                 | Pod affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`       | `""`                   |
+| `dex.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                 |
+| `dex.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard` | `""`                   |
+| `dex.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `dex.affinity` is set                                     | `""`                   |
+| `dex.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `dex.affinity` is set                                  | `[]`                   |
+| `dex.affinity`                                          | Affinity for Dex pods assignment                                                              | `{}`                   |
+| `dex.nodeSelector`                                      | Node labels for Dex pods assignment                                                           | `{}`                   |
+| `dex.tolerations`                                       | Tolerations for Dex pods assignment                                                           | `[]`                   |
+| `dex.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                | `""`                   |
+| `dex.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                | `[]`                   |
+| `dex.updateStrategy.type`                               | Dex statefulset strategy type                                                                 | `RollingUpdate`        |
+| `dex.priorityClassName`                                 | Dex pods' priorityClassName                                                                   | `""`                   |
+| `dex.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                | `""`                   |
+| `dex.lifecycleHooks`                                    | for the Dex container(s) to automate configuration before or after startup                    | `{}`                   |
+| `dex.extraEnvVars`                                      | Array with extra environment variables to add to Dex nodes                                    | `[]`                   |
+| `dex.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Dex nodes                            | `""`                   |
+| `dex.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Dex nodes                               | `""`                   |
+| `dex.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Dex pod(s)                        | `[]`                   |
+| `dex.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Dex container(s)             | `[]`                   |
+| `dex.sidecars`                                          | Add additional sidecar containers to the Dex pod(s)                                           | `[]`                   |
+| `dex.initContainers`                                    | Add additional init containers to the Dex pod(s)                                              | `[]`                   |
+
 
 ### Shared config for Argo CD components
 
@@ -583,6 +590,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `config.secret.repositoryCredentials`          | Repository credentials to add to the Argo CD server confgi secret                                     | `{}`   |
 | `config.clusterCredentials`                    | Configure external cluster credentials                                                                | `[]`   |
 
+
 ### Init Container Parameters
 
 | Name                                                   | Description                                                                                     | Value                   |
@@ -590,12 +598,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                    | `docker.io`             |
 | `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `11-debian-11-r0`       |
+| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `11-debian-11-r16`      |
 | `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                | `[]`                    |
 | `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                    |
 | `volumePermissions.resources.requests`                 | The requested resources for the init container                                                  | `{}`                    |
 | `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                 | `0`                     |
+
 
 ### Other Parameters
 
@@ -604,7 +613,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `rbac.create`                             | Specifies whether RBAC resources should be created                          | `true`               |
 | `redis.image.registry`                    | Argo CD controller image registry                                           | `docker.io`          |
 | `redis.image.repository`                  | Argo CD controller image repository                                         | `bitnami/redis`      |
-| `redis.image.tag`                         | Argo CD controller image tag (immutable tags are recommended)               | `6.2.7-debian-11-r0` |
+| `redis.image.tag`                         | Argo CD controller image tag (immutable tags are recommended)               | `7.0.4-debian-11-r2` |
 | `redis.image.pullPolicy`                  | Argo CD controller image pull policy                                        | `IfNotPresent`       |
 | `redis.image.pullSecrets`                 | Argo CD controller image pull secrets                                       | `[]`                 |
 | `redis.enabled`                           | Enable Redis dependency                                                     | `true`               |
@@ -619,6 +628,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalRedis.password`                  | External Redis password                                                     | `""`                 |
 | `externalRedis.existingSecret`            | Existing secret for the external redis                                      | `""`                 |
 | `externalRedis.existingSecretPasswordKey` | Password key for the existing secret containing the external redis password | `redis-password`     |
+
 
 The above parameters map to the env variables defined in [bitnami/argo-cd](https://github.com/bitnami/containers/tree/main/bitnami/argo-cd). For more information please refer to the [bitnami/argo-cd](https://github.com/bitnami/containers/tree/main/bitnami/argo-cd) image documentation.
 

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -7,7 +7,7 @@ Argo CD is a continuous delivery tool for Kubernetes based on GitOps.
 [Overview of Argo CD](https://argoproj.github.io/cd)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -620,7 +620,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalRedis.existingSecret`            | Existing secret for the external redis                                      | `""`                 |
 | `externalRedis.existingSecretPasswordKey` | Password key for the existing secret containing the external redis password | `redis-password`     |
 
-The above parameters map to the env variables defined in [bitnami/argo-cd](https://github.com/bitnami/bitnami-docker-argo-cd). For more information please refer to the [bitnami/argo-cd](https://github.com/bitnami/bitnami-docker-argo-cd) image documentation.
+The above parameters map to the env variables defined in [bitnami/argo-cd](https://github.com/bitnami/containers/tree/main/bitnami/argo-cd). For more information please refer to the [bitnami/argo-cd](https://github.com/bitnami/containers/tree/main/bitnami/argo-cd) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -31,8 +31,8 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: argo-workflows
 sources:
-  - https://github.com/bitnami/bitnami-docker-argo-workflow-cli
-  - https://github.com/bitnami/bitnami-docker-argo-workflow-controller
-  - https://github.com/bitnami/bitnami-docker-argo-workflow-exec
+  - https://github.com/bitnami/containers/tree/main/bitnami/argo-workflow-cli
+  - https://github.com/bitnami/containers/tree/main/bitnami/argo-workflow-controller
+  - https://github.com/bitnami/containers/tree/main/bitnami/argo-workflow-exec
   - https://argoproj.github.io/workflows/
 version: 2.3.6

--- a/bitnami/argo-workflows/README.md
+++ b/bitnami/argo-workflows/README.md
@@ -7,7 +7,7 @@ Argo Workflows is meant to orchestrate Kubernetes jobs in parallel. It uses DAG 
 [Overview of Argo Workflows](https://argoproj.github.io/workflows)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -371,7 +371,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 See https://github.com/bitnami-labs/readme-generator-for-helm to create the table
 
-The above parameters map to the env variables defined in [bitnami/argo-workflow-cli](https://github.com/bitnami/bitnami-docker-argo-workflow-cli). For more information please refer to the [bitnami/argo-workflow-cli](https://github.com/bitnami/bitnami-docker-argo-workflow-cli) image documentation.
+The above parameters map to the env variables defined in [bitnami/argo-workflow-cli](https://github.com/bitnami/containers/tree/main/bitnami/argo-workflow-cli). For more information please refer to the [bitnami/argo-workflow-cli](https://github.com/bitnami/containers/tree/main/bitnami/argo-workflow-cli) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/argo-workflows/README.md
+++ b/bitnami/argo-workflows/README.md
@@ -82,7 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------- |
 | `server.image.registry`                                  | server image registry                                                                                               | `docker.io`                 |
 | `server.image.repository`                                | server image repository                                                                                             | `bitnami/argo-workflow-cli` |
-| `server.image.tag`                                       | server image tag (immutable tags are recommended)                                                                   | `3.3.6-scratch-r2`          |
+| `server.image.tag`                                       | server image tag (immutable tags are recommended)                                                                   | `3.3.8-scratch-r1`          |
 | `server.image.pullPolicy`                                | server image pull policy                                                                                            | `Always`                    |
 | `server.image.pullSecrets`                               | server image pull secrets                                                                                           | `[]`                        |
 | `server.enabled`                                         | Enable server deployment                                                                                            | `true`                      |
@@ -185,7 +185,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | `controller.image.registry`                                  | controller image registry                                                                                                     | `docker.io`                        |
 | `controller.image.repository`                                | controller image repository                                                                                                   | `bitnami/argo-workflow-controller` |
-| `controller.image.tag`                                       | controller image tag (immutable tags are recommended)                                                                         | `3.3.6-scratch-r0`                 |
+| `controller.image.tag`                                       | controller image tag (immutable tags are recommended)                                                                         | `3.3.8-scratch-r1`                 |
 | `controller.image.pullPolicy`                                | controller image pull policy                                                                                                  | `IfNotPresent`                     |
 | `controller.image.pullSecrets`                               | controller image pull secrets                                                                                                 | `[]`                               |
 | `controller.replicaCount`                                    | Number of controller replicas to deploy                                                                                       | `1`                                |
@@ -291,7 +291,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ---------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------- |
 | `executor.image.registry`                                  | executor image registry                                       | `docker.io`                  |
 | `executor.image.repository`                                | executor image repository                                     | `bitnami/argo-workflow-exec` |
-| `executor.image.tag`                                       | executor image tag (immutable tags are recommended)           | `3.3.6-debian-11-r2`         |
+| `executor.image.tag`                                       | executor image tag (immutable tags are recommended)           | `3.3.8-debian-11-r1`         |
 | `executor.image.pullPolicy`                                | executor image pull policy                                    | `Always`                     |
 | `executor.image.pullSecrets`                               | executor image pull secrets                                   | `[]`                         |
 | `executor.resources.limits`                                | The resources limits for the init container                   | `{}`                         |

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -20,6 +20,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: aspnet-core
 sources:
-  - https://github.com/bitnami/bitnami-docker-aspnet-core
+  - https://github.com/bitnami/containers/tree/main/bitnami/aspnet-core
   - https://dotnet.microsoft.com/apps/aspnet
 version: 3.4.12

--- a/bitnami/aspnet-core/README.md
+++ b/bitnami/aspnet-core/README.md
@@ -7,7 +7,7 @@ ASP.NET Core is an open-source framework for web application development created
 [Overview of ASP.NET](https://github.com/dotnet/aspnetcore)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -19,7 +19,7 @@ Trademarks: This software listing is packaged by Bitnami. The respective tradema
 
 Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
 
-This chart bootstraps an [ASP.NET Core](https://github.com/bitnami/bitnami-docker-aspnet-core) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [ASP.NET Core](https://github.com/bitnami/containers/tree/main/bitnami/aspnet-core) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -289,8 +289,8 @@ Find more information about the process to create your own image in the guide be
 
 This is done using two different init containers:
 
-- `clone-repository`: uses the [Bitnami GIT Image](https://github.com/bitnami/bitnami-docker-git) to download the repository.
-- `dotnet-publish`: uses the [Bitnami .Net SDK Image](https://github.com/bitnami/bitnami-docker-dotnet-sdk) to build/publish the ASP.NET Core application.
+- `clone-repository`: uses the [Bitnami GIT Image](https://github.com/bitnami/containers/tree/main/bitnami/git) to download the repository.
+- `dotnet-publish`: uses the [Bitnami .Net SDK Image](https://github.com/bitnami/containers/tree/main/bitnami/dotnet-sdk) to build/publish the ASP.NET Core application.
 
 To use this feature, set the `appFromExternalRepo.enabled` to `true` and set the repository and branch to use setting the `appFromExternalRepo.clone.repository` and `appFromExternalRepo.clone.revision` parameters. Then, specify the sub folder under the Git repository containing the ASP.NET Core app setting the `appFromExternalRepo.publish.subFolder` parameter. Finally, provide the start command to use setting the `appFromExternalRepo.startCommand`.
 

--- a/bitnami/aspnet-core/README.md
+++ b/bitnami/aspnet-core/README.md
@@ -82,7 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | -------------------- | -------------------------------------------------------------------- | --------------------- |
 | `image.registry`     | ASP.NET Core image registry                                          | `docker.io`           |
 | `image.repository`   | ASP.NET Core image repository                                        | `bitnami/aspnet-core` |
-| `image.tag`          | ASP.NET Core image tag (immutable tags are recommended)              | `6.0.5-debian-10-r9`  |
+| `image.tag`          | ASP.NET Core image tag (immutable tags are recommended)              | `6.0.7-debian-11-r0`  |
 | `image.pullPolicy`   | ASP.NET Core image pull policy                                       | `IfNotPresent`        |
 | `image.pullSecrets`  | ASP.NET Core image pull secrets                                      | `[]`                  |
 | `image.debug`        | Enable image debug mode                                              | `false`               |
@@ -166,7 +166,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `appFromExternalRepo.enabled`                   | Enable to download/build ASP.NET Core app from external git repository | `true`                                                              |
 | `appFromExternalRepo.clone.image.registry`      | Git image registry                                                     | `docker.io`                                                         |
 | `appFromExternalRepo.clone.image.repository`    | Git image repository                                                   | `bitnami/git`                                                       |
-| `appFromExternalRepo.clone.image.tag`           | Git image tag (immutable tags are recommended)                         | `2.36.1-debian-10-r13`                                              |
+| `appFromExternalRepo.clone.image.tag`           | Git image tag (immutable tags are recommended)                         | `2.37.1-debian-11-r0`                                               |
 | `appFromExternalRepo.clone.image.pullPolicy`    | Git image pull policy                                                  | `IfNotPresent`                                                      |
 | `appFromExternalRepo.clone.image.pullSecrets`   | Git image pull secrets                                                 | `[]`                                                                |
 | `appFromExternalRepo.clone.repository`          | Git repository to clone                                                | `https://github.com/dotnet/AspNetCore.Docs.git`                     |
@@ -174,7 +174,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `appFromExternalRepo.clone.extraVolumeMounts`   | Add extra volume mounts for the GIT container                          | `[]`                                                                |
 | `appFromExternalRepo.publish.image.registry`    | .NET SDK image registry                                                | `docker.io`                                                         |
 | `appFromExternalRepo.publish.image.repository`  | .NET SDK image repository                                              | `bitnami/dotnet-sdk`                                                |
-| `appFromExternalRepo.publish.image.tag`         | .NET SDK image tag (immutable tags are recommended)                    | `6.0.300-debian-10-r9`                                              |
+| `appFromExternalRepo.publish.image.tag`         | .NET SDK image tag (immutable tags are recommended)                    | `6.0.301-debian-11-r9`                                              |
 | `appFromExternalRepo.publish.image.pullPolicy`  | .NET SDK image pull policy                                             | `IfNotPresent`                                                      |
 | `appFromExternalRepo.publish.image.pullSecrets` | .NET SDK image pull secrets                                            | `[]`                                                                |
 | `appFromExternalRepo.publish.subFolder`         | Sub folder under the Git repository containing the ASP.NET Core app    | `aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample` |

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -21,6 +21,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: cassandra
 sources:
-  - https://github.com/bitnami/bitnami-docker-cassandra
+  - https://github.com/bitnami/containers/tree/main/bitnami/cassandra
   - http://cassandra.apache.org
 version: 9.2.8

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -83,7 +83,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`              | Cassandra image registry                                                                                               | `docker.io`          |
 | `image.repository`            | Cassandra image repository                                                                                             | `bitnami/cassandra`  |
-| `image.tag`                   | Cassandra image tag (immutable tags are recommended)                                                                   | `4.0.4-debian-11-r0` |
+| `image.tag`                   | Cassandra image tag (immutable tags are recommended)                                                                   | `4.0.5-debian-11-r0` |
 | `image.pullPolicy`            | image pull policy                                                                                                      | `IfNotPresent`       |
 | `image.pullSecrets`           | Cassandra image pull secrets                                                                                           | `[]`                 |
 | `image.debug`                 | Enable image debug mode                                                                                                | `false`              |
@@ -232,7 +232,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                   | Enable init container that changes the owner and group of the persistent volume | `false`                 |
 | `volumePermissions.image.registry`            | Init container volume                                                           | `docker.io`             |
 | `volumePermissions.image.repository`          | Init container volume                                                           | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                 | Init container volume                                                           | `11-debian-11-r0`       |
+| `volumePermissions.image.tag`                 | Init container volume                                                           | `11-debian-11-r16`      |
 | `volumePermissions.image.pullPolicy`          | Init container volume                                                           | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                | `[]`                    |
 | `volumePermissions.resources.limits`          | The resources limits for the container                                          | `{}`                    |
@@ -247,7 +247,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                          | Start a side-car prometheus exporter                                                                   | `false`                      |
 | `metrics.image.registry`                   | Cassandra exporter image registry                                                                      | `docker.io`                  |
 | `metrics.image.repository`                 | Cassandra exporter image name                                                                          | `bitnami/cassandra-exporter` |
-| `metrics.image.tag`                        | Cassandra exporter image tag                                                                           | `2.3.8-debian-11-r0`         |
+| `metrics.image.tag`                        | Cassandra exporter image tag                                                                           | `2.3.8-debian-11-r16`        |
 | `metrics.image.pullPolicy`                 | image pull policy                                                                                      | `IfNotPresent`               |
 | `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                       | `[]`                         |
 | `metrics.resources.limits`                 | The resources limits for the container                                                                 | `{}`                         |

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -7,7 +7,7 @@ Apache Cassandra is an open source distributed database management system design
 [Overview of Apache Cassandra](http://cassandra.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/cassandra
 
 ## Introduction
 
-This chart bootstraps an [Apache Cassandra](https://github.com/bitnami/bitnami-docker-cassandra) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [Apache Cassandra](https://github.com/bitnami/containers/tree/main/bitnami/cassandra) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -284,7 +284,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `tls.tlsEncryptionSecretName` | Secret with the encryption of the TLS certificates                                            | `""`    |
 
 
-The above parameters map to the env variables defined in [bitnami/cassandra](https://github.com/bitnami/bitnami-docker-cassandra). For more information please refer to the [bitnami/cassandra](https://github.com/bitnami/bitnami-docker-cassandra) image documentation.
+The above parameters map to the env variables defined in [bitnami/cassandra](https://github.com/bitnami/containers/tree/main/bitnami/cassandra). For more information please refer to the [bitnami/cassandra](https://github.com/bitnami/containers/tree/main/bitnami/cassandra) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -331,7 +331,7 @@ Refer to the chart documentation for more [information on customizing an Apache 
 
 ### Initialize the database
 
-The [Bitnami Apache Cassandra image](https://github.com/bitnami/bitnami-docker-cassandra) image supports the use of custom scripts to initialize a fresh instance. This may be done by creating a Kubernetes ConfigMap that includes the necessary *sh* or *cql* scripts and passing this ConfigMap to the chart via the *initDBConfigMap* parameter.
+The [Bitnami Apache Cassandra image](https://github.com/bitnami/containers/tree/main/bitnami/cassandra) image supports the use of custom scripts to initialize a fresh instance. This may be done by creating a Kubernetes ConfigMap that includes the necessary *sh* or *cql* scripts and passing this ConfigMap to the chart via the *initDBConfigMap* parameter.
 
 Refer to the chart documentation for more [information on customizing an Apache Cassandra deployment](https://docs.bitnami.com/kubernetes/infrastructure/cassandra/configuration/customize-new-instance/).
 
@@ -343,7 +343,7 @@ As an alternative, you can use the preset configurations for pod affinity, pod a
 
 ## Persistence
 
-The [Bitnami Apache Cassandra](https://github.com/bitnami/bitnami-docker-cassandra) image stores the Apache Cassandra data at the `/bitnami/cassandra` path of the container.
+The [Bitnami Apache Cassandra](https://github.com/bitnami/containers/tree/main/bitnami/cassandra) image stores the Apache Cassandra data at the `/bitnami/cassandra` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -441,7 +441,7 @@ This release make it possible to specify custom initialization scripts in both c
 
 #### Breaking changes
 
-- `startupCQL` has been removed. Instead, for initializing the database, see [this section](#initializing-the-database).
+- `startupCQL` has been removed. Instead, for initializing the database, see [this section](#initialize-the-database).
 
 ## License
 

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -541,7 +541,7 @@ persistence:
   storageClass: ""
   ## @param persistence.commitStorageClass PVC Storage Class for Cassandra Commit Log volume
   ## Storage class to use with CASSANDRA_COMMITLOG_DIR to reduce the concurrence for writing data and commit logs
-  ## ref: https://github.com/bitnami/bitnami-docker-cassandra
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/cassandra
   ## If set to "-", commitStorageClass: "", which disables dynamic provisioning
   ## If undefined (the default) or set to null, no storageClassName spec is
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -22,8 +22,8 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: cert-manager
 sources:
-  - https://github.com/bitnami/bitnami-docker-cert-manager
-  - https://github.com/bitnami/bitnami-docker-cert-manager-webhook
-  - https://github.com/bitnami/bitnami-docker-cainjector
+  - https://github.com/bitnami/containers/tree/main/bitnami/cert-manager
+  - https://github.com/bitnami/containers/tree/main/bitnami/cert-manager-webhook
+  - https://github.com/bitnami/containers/tree/main/bitnami/cainjector
   - https://github.com/jetstack/cert-manager
 version: 0.7.2

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -85,13 +85,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.replicaCount`                                | Number of Controller replicas                                                                        | `1`                    |
 | `controller.image.registry`                              | Controller image registry                                                                            | `docker.io`            |
 | `controller.image.repository`                            | Controller image repository                                                                          | `bitnami/cert-manager` |
-| `controller.image.tag`                                   | Controller image tag (immutable tags are recommended)                                                | `1.8.2-debian-11-r0`   |
+| `controller.image.tag`                                   | Controller image tag (immutable tags are recommended)                                                | `1.9.0-debian-11-r1`   |
 | `controller.image.pullPolicy`                            | Controller image pull policy                                                                         | `IfNotPresent`         |
 | `controller.image.pullSecrets`                           | Controller image pull secrets                                                                        | `[]`                   |
 | `controller.image.debug`                                 | Controller image debug mode                                                                          | `false`                |
 | `controller.acmesolver.image.registry`                   | Controller image registry                                                                            | `docker.io`            |
 | `controller.acmesolver.image.repository`                 | Controller image repository                                                                          | `bitnami/acmesolver`   |
-| `controller.acmesolver.image.tag`                        | Controller image tag (immutable tags are recommended)                                                | `1.8.1-debian-11-r2`   |
+| `controller.acmesolver.image.tag`                        | Controller image tag (immutable tags are recommended)                                                | `1.9.0-debian-11-r0`   |
 | `controller.acmesolver.image.pullPolicy`                 | Controller image pull policy                                                                         | `IfNotPresent`         |
 | `controller.acmesolver.image.pullSecrets`                | Controller image pull secrets                                                                        | `[]`                   |
 | `controller.acmesolver.image.debug`                      | Controller image debug mode                                                                          | `false`                |
@@ -146,7 +146,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `webhook.replicaCount`                                | Number of Webhook replicas                                                                        | `1`                            |
 | `webhook.image.registry`                              | Webhook image registry                                                                            | `docker.io`                    |
 | `webhook.image.repository`                            | Webhook image repository                                                                          | `bitnami/cert-manager-webhook` |
-| `webhook.image.tag`                                   | Webhook image tag (immutable tags are recommended)                                                | `1.8.1-debian-11-r2`           |
+| `webhook.image.tag`                                   | Webhook image tag (immutable tags are recommended)                                                | `1.9.0-debian-11-r0`           |
 | `webhook.image.pullPolicy`                            | Webhook image pull policy                                                                         | `IfNotPresent`                 |
 | `webhook.image.pullSecrets`                           | Webhook image pull secrets                                                                        | `[]`                           |
 | `webhook.image.debug`                                 | Webhook image debug mode                                                                          | `false`                        |
@@ -217,7 +217,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cainjector.replicaCount`                                | Number of CAInjector replicas                                                                        | `1`                  |
 | `cainjector.image.registry`                              | CAInjector image registry                                                                            | `docker.io`          |
 | `cainjector.image.repository`                            | CAInjector image repository                                                                          | `bitnami/cainjector` |
-| `cainjector.image.tag`                                   | CAInjector image tag (immutable tags are recommended)                                                | `1.8.1-debian-11-r2` |
+| `cainjector.image.tag`                                   | CAInjector image tag (immutable tags are recommended)                                                | `1.9.0-debian-11-r0` |
 | `cainjector.image.pullPolicy`                            | CAInjector image pull policy                                                                         | `IfNotPresent`       |
 | `cainjector.image.pullSecrets`                           | CAInjector image pull secrets                                                                        | `[]`                 |
 | `cainjector.image.debug`                                 | CAInjector image debug mode                                                                          | `false`              |

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -28,6 +28,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: concourse
 sources:
-  - https://github.com/bitnami/bitnami-docker-concourse
+  - https://github.com/bitnami/containers/tree/main/bitnami/concourse
   - https://github.com/concourse/concourse
 version: 1.3.8

--- a/bitnami/concourse/README.md
+++ b/bitnami/concourse/README.md
@@ -85,7 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`                | image registry                                                                                                                         | `docker.io`          |
 | `image.repository`              | image repository                                                                                                                       | `bitnami/concourse`  |
-| `image.tag`                     | image tag (immutable tags are recommended)                                                                                             | `7.8.0-debian-11-r0` |
+| `image.tag`                     | image tag (immutable tags are recommended)                                                                                             | `7.8.2-debian-11-r0` |
 | `image.pullPolicy`              | image pull policy                                                                                                                      | `IfNotPresent`       |
 | `image.pullSecrets`             | image pull secrets                                                                                                                     | `[]`                 |
 | `secrets.localAuth.enabled`     | the use of local authentication (basic auth).                                                                                          | `true`               |
@@ -361,7 +361,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume | `false`                 |
 | `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                | `docker.io`             |
 | `volumePermissions.image.repository`                   | Init container volume-permissions image repository                              | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)    | `11-debian-11-r0`       |
+| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)    | `11-debian-11-r15`      |
 | `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                             | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                            | `[]`                    |
 | `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                               | `{}`                    |

--- a/bitnami/concourse/README.md
+++ b/bitnami/concourse/README.md
@@ -7,7 +7,7 @@ Concourse is an automation system written in Go. It is most commonly used for CI
 [Overview of Concourse](https://concourse-ci.org/)
 
 
-                           
+
 ## TL;DR
 
 ```console
@@ -398,7 +398,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 See https://github.com/bitnami-labs/readme-generator-for-helm to create the table
 
-The above parameters map to the env variables defined in [bitnami/concourse](https://github.com/bitnami/bitnami-docker-concourse). For more information please refer to the [bitnami/concourse](https://github.com/bitnami/bitnami-docker-concourse) image documentation.
+The above parameters map to the env variables defined in [bitnami/concourse](https://github.com/bitnami/containers/tree/main/bitnami/concourse). For more information please refer to the [bitnami/concourse](https://github.com/bitnami/containers/tree/main/bitnami/concourse) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -446,7 +446,7 @@ The chart also facilitates the creation of TLS secrets for use with the Ingress 
 
 ## Persistence
 
-The [Bitnami Concourse](https://github.com/bitnami/bitnami-docker-concourse) image stores the concourse data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
+The [Bitnami Concourse](https://github.com/bitnami/containers/tree/main/bitnami/concourse) image stores the concourse data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
 
 ### Configure extra environment variables
 

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -21,6 +21,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: consul
 sources:
-  - https://github.com/bitnami/bitnami-docker-consul
+  - https://github.com/bitnami/containers/tree/main/bitnami/consul
   - https://www.consul.io/
 version: 10.7.7

--- a/bitnami/consul/README.md
+++ b/bitnami/consul/README.md
@@ -7,7 +7,7 @@ HashiCorp Consul is a tool for discovering and configuring services in your infr
 [Overview of HashiCorp Consul](https://consul.io)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/consul
 
 ## Introduction
 
-This chart bootstraps a [HashiCorp Consul](https://github.com/bitnami/bitnami-docker-consul) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [HashiCorp Consul](https://github.com/bitnami/containers/tree/main/bitnami/consul) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -413,7 +413,7 @@ initContainers:
 
 ## Persistence
 
-The [Bitnami HashiCorp Consul](https://github.com/bitnami/bitnami-docker-consul) image stores the HashiCorp Consul data at the `/bitnami` path of the container.
+The [Bitnami HashiCorp Consul](https://github.com/bitnami/containers/tree/main/bitnami/consul) image stores the HashiCorp Consul data at the `/bitnami` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.

--- a/bitnami/contour-operator/Chart.yaml
+++ b/bitnami/contour-operator/Chart.yaml
@@ -24,5 +24,5 @@ maintainers:
 name: contour-operator
 sources:
   - https://github.com/projectcontour/contour-operator
-  - https://github.com/bitnami/bitnami-docker-contour-operator
+  - https://github.com/bitnami/containers/tree/main/bitnami/contour-operator
 version: 1.3.0

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -25,6 +25,6 @@ name: contour
 sources:
   - https://github.com/projectcontour/contour
   - https://github.com/envoyproxy/envoy
-  - https://github.com/bitnami/bitnami-docker-contour
+  - https://github.com/bitnami/containers/tree/main/bitnami/contour
   - https://projectcontour.io
 version: 8.0.5

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -92,7 +92,7 @@ $ helm uninstall my-release
 | `contour.enabled`                                             | Contour Deployment creation.                                                                                                       | `true`                |
 | `contour.image.registry`                                      | Contour image registry                                                                                                             | `docker.io`           |
 | `contour.image.repository`                                    | Contour image name                                                                                                                 | `bitnami/contour`     |
-| `contour.image.tag`                                           | Contour image tag                                                                                                                  | `1.21.1-debian-11-r0` |
+| `contour.image.tag`                                           | Contour image tag                                                                                                                  | `1.21.1-debian-11-r5` |
 | `contour.image.pullPolicy`                                    | Contour Image pull policy                                                                                                          | `IfNotPresent`        |
 | `contour.image.pullSecrets`                                   | Contour Image pull secrets                                                                                                         | `[]`                  |
 | `contour.image.debug`                                         | Enable image debug mode                                                                                                            | `false`               |
@@ -192,7 +192,7 @@ $ helm uninstall my-release
 | `envoy.enabled`                                     | Envoy Proxy creation                                                                                                  | `true`                |
 | `envoy.image.registry`                              | Envoy Proxy image registry                                                                                            | `docker.io`           |
 | `envoy.image.repository`                            | Envoy Proxy image repository                                                                                          | `bitnami/envoy`       |
-| `envoy.image.tag`                                   | Envoy Proxy image tag (immutable tags are recommended)                                                                | `1.22.2-debian-11-r1` |
+| `envoy.image.tag`                                   | Envoy Proxy image tag (immutable tags are recommended)                                                                | `1.22.2-debian-11-r6` |
 | `envoy.image.pullPolicy`                            | Envoy image pull policy                                                                                               | `IfNotPresent`        |
 | `envoy.image.pullSecrets`                           | Envoy image pull secrets                                                                                              | `[]`                  |
 | `envoy.priorityClassName`                           | Priority class assigned to the pods                                                                                   | `""`                  |
@@ -305,7 +305,7 @@ $ helm uninstall my-release
 | `defaultBackend.enabled`                               | Enable a default backend based on NGINX                                                              | `false`                  |
 | `defaultBackend.image.registry`                        | Default backend image registry                                                                       | `docker.io`              |
 | `defaultBackend.image.repository`                      | Default backend image name                                                                           | `bitnami/nginx`          |
-| `defaultBackend.image.tag`                             | Default backend image tag                                                                            | `1.21.6-debian-11-r5`    |
+| `defaultBackend.image.tag`                             | Default backend image tag                                                                            | `1.21.6-debian-11-r10`   |
 | `defaultBackend.image.pullPolicy`                      | Image pull policy                                                                                    | `IfNotPresent`           |
 | `defaultBackend.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                     | `[]`                     |
 | `defaultBackend.extraArgs`                             | Additional command line arguments to pass to NGINX container                                         | `{}`                     |

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -7,7 +7,7 @@ Contour is an open source Kubernetes ingress controller that works by deploying 
 [Overview of Contour](https://github.com/projectcontour/contour)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -38,7 +38,7 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm install my-release bitnami/contour
 ```
 
-These commands deploy contour on the Kubernetes cluster in the default configuration. The [Parameters](##parameters) section lists the parameters that can be configured during installation.
+These commands deploy contour on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list` or `helm ls --all-namespaces`
 

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -32,7 +32,7 @@ maintainers:
     name: lucaprete
 name: discourse
 sources:
-  - https://github.com/bitnami/bitnami-docker-discourse
+  - https://github.com/bitnami/containers/tree/main/bitnami/discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
 version: 8.0.1

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -7,7 +7,7 @@ Discourse is an open source discussion platform with built-in moderation and gov
 [Overview of Discourse&reg;](http://www.discourse.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -333,7 +333,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalRedis.existingSecretPasswordKey` | Name of an existing secret key containing the Redis&trade credentials      | `redis-password` |
 
 
-The above parameters map to the env variables defined in [bitnami/discourse](https://github.com/bitnami/bitnami-docker-discourse). For more information please refer to the [bitnami/discourse](https://github.com/bitnami/bitnami-docker-discourse) image documentation.
+The above parameters map to the env variables defined in [bitnami/discourse](https://github.com/bitnami/containers/tree/main/bitnami/discourse). For more information please refer to the [bitnami/discourse](https://github.com/bitnami/containers/tree/main/bitnami/discourse) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -472,7 +472,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami Discourse](https://github.com/bitnami/bitnami-docker-discourse) image stores the Discourse data and configurations at the `/bitnami` path of the container.
+The [Bitnami Discourse](https://github.com/bitnami/containers/tree/main/bitnami/discourse) image stores the Discourse data and configurations at the `/bitnami` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -86,7 +86,7 @@ image:
   ##
   debug: false
 ## Authentication parameters
-## ref: https://github.com/bitnami/bitnami-docker-discourse#user-and-site-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/discourse#user-and-site-configuration
 ##
 auth:
   ## @param auth.email Discourse admin user email

--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -22,6 +22,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: dokuwiki
 sources:
-  - https://github.com/bitnami/bitnami-docker-dokuwiki
+  - https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki
   - http://www.dokuwiki.org/
 version: 12.5.8

--- a/bitnami/dokuwiki/README.md
+++ b/bitnami/dokuwiki/README.md
@@ -7,7 +7,7 @@ DokuWiki is a standards-compliant wiki optimized for creating documentation. Des
 [Overview of DokuWiki](https://www.splitbrain.org/projects/dokuwiki)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/dokuwiki
 
 ## Introduction
 
-This chart bootstraps a [DokuWiki](https://github.com/bitnami/bitnami-docker-dokuwiki) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [DokuWiki](https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -238,7 +238,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `certificates.image.pullSecrets`                     | Container sidecar image pull secrets                                 | `[]`                                     |
 
 
-The above parameters map to the env variables defined in [bitnami/dokuwiki](https://github.com/bitnami/bitnami-docker-dokuwiki). For more information please refer to the [bitnami/dokuwiki](https://github.com/bitnami/bitnami-docker-dokuwiki) image documentation.
+The above parameters map to the env variables defined in [bitnami/dokuwiki](https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki). For more information please refer to the [bitnami/dokuwiki](https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -276,7 +276,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami DokuWiki](https://github.com/bitnami/bitnami-docker-dokuwiki) image stores the DokuWiki data and configurations at the `/bitnami/dokuwiki` path of the container.
+The [Bitnami DokuWiki](https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki) image stores the DokuWiki data and configurations at the `/bitnami/dokuwiki` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. There is a [known issue](https://github.com/kubernetes/kubernetes/issues/39178) in Kubernetes Clusters with EBS in different availability zones. Ensure your cluster is configured properly to create Volumes in the same availability zone where the nodes are running. Kuberentes 1.12 solved this issue with the [Volume Binding Mode](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode).
 
@@ -381,7 +381,7 @@ This version standardizes the way of defining Ingress rules. When configuring a 
 
 This version also introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
 
-The [Bitnami Dokuwiki](https://github.com/bitnami/bitnami-docker-dokuwiki) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
+The [Bitnami Dokuwiki](https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
 
 Consequences:
 

--- a/bitnami/dokuwiki/values.yaml
+++ b/bitnami/dokuwiki/values.yaml
@@ -85,31 +85,31 @@ hostAliases:
     hostnames:
       - "status.localhost"
 ## @param dokuwikiUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-dokuwiki#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki#environment-variables
 ##
 dokuwikiUsername: user
 ## @param dokuwikiPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-dokuwiki#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki#environment-variables
 ##
 dokuwikiPassword: ""
 ## @param existingSecret Use an existing secret with the dokuwiki password
 ##
 existingSecret: ""
 ## @param dokuwikiEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-dokuwiki#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki#environment-variables
 ##
 dokuwikiEmail: user@example.com
 ## @param dokuwikiFullName User's Full Name
-## ref: https://github.com/bitnami/bitnami-docker-dokuwiki#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki#environment-variables
 ##
 dokuwikiFullName: User Name
 ## @param dokuwikiWikiName Wiki name
-## ref: https://github.com/bitnami/bitnami-docker-dokuwiki#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki#environment-variables
 ##
 dokuwikiWikiName: My Wiki
 ## @param customPostInitScripts Custom post-init.d user scripts
-## ref: https://github.com/bitnami/bitnami-docker-dokuwiki
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki
 ## NOTE: supported formats are `.sh` or `.php`
 ## NOTE: scripts are exclusively executed during the 1st boot of the container
 ## e.g:

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -29,6 +29,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: drupal
 sources:
-  - https://github.com/bitnami/bitnami-docker-drupal
+  - https://github.com/bitnami/containers/tree/main/bitnami/drupal
   - https://www.drupal.org/
 version: 12.3.1

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -82,7 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`                              | Drupal image registry                                                                                                  | `docker.io`          |
 | `image.repository`                            | Drupal Image name                                                                                                      | `bitnami/drupal`     |
-| `image.tag`                                   | Drupal Image tag                                                                                                       | `9.4.2-debian-11-r1` |
+| `image.tag`                                   | Drupal Image tag                                                                                                       | `9.4.3-debian-11-r0` |
 | `image.pullPolicy`                            | Drupal image pull policy                                                                                               | `IfNotPresent`       |
 | `image.pullSecrets`                           | Specify docker-registry secret names as an array                                                                       | `[]`                 |
 | `image.debug`                                 | Specify if debug logs should be enabled                                                                                | `false`              |
@@ -231,7 +231,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                 |
 | `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                                          | `docker.io`             |
 | `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                                                              | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `11-debian-11-r13`      |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `11-debian-11-r16`      |
 | `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                                                       | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                                          | `[]`                    |
 | `volumePermissions.resources.limits`   | The resources limits for the container                                                                                                                    | `{}`                    |
@@ -245,7 +245,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`           | Start a exporter side-car                        | `false`                   |
 | `metrics.image.registry`    | Apache exporter image registry                   | `docker.io`               |
 | `metrics.image.repository`  | Apache exporter image repository                 | `bitnami/apache-exporter` |
-| `metrics.image.tag`         | Apache exporter image tag                        | `0.11.0-debian-11-r13`    |
+| `metrics.image.tag`         | Apache exporter image tag                        | `0.11.0-debian-11-r16`    |
 | `metrics.image.pullPolicy`  | Image pull policy                                | `IfNotPresent`            |
 | `metrics.image.pullSecrets` | Specify docker-registry secret names as an array | `[]`                      |
 | `metrics.resources`         | Metrics exporter resource requests and limits    | `{}`                      |
@@ -270,7 +270,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `certificates.extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)         | `""`                                     |
 | `certificates.image.registry`                        | Container sidecar registry                                           | `docker.io`                              |
 | `certificates.image.repository`                      | Container sidecar image                                              | `bitnami/bitnami-shell`                  |
-| `certificates.image.tag`                             | Container sidecar image tag                                          | `11-debian-11-r13`                       |
+| `certificates.image.tag`                             | Container sidecar image tag                                          | `11-debian-11-r16`                       |
 | `certificates.image.pullPolicy`                      | Container sidecar image pull policy                                  | `IfNotPresent`                           |
 | `certificates.image.pullSecrets`                     | Container sidecar image pull secrets                                 | `[]`                                     |
 

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -7,7 +7,7 @@ Drupal is one of the most versatile open source content management systems in th
 [Overview of Drupal](http://drupal.org)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/drupal
 
 ## Introduction
 
-This chart bootstraps a [Drupal](https://github.com/bitnami/bitnami-docker-drupal) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Drupal](https://github.com/bitnami/containers/tree/main/bitnami/drupal) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment as a database for the Drupal application.
 
@@ -296,7 +296,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                 | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/drupal](https://github.com/bitnami/bitnami-docker-drupal). For more information please refer to the [bitnami/drupal](https://github.com/bitnami/bitnami-docker-drupal) image documentation.
+The above parameters map to the env variables defined in [bitnami/drupal](https://github.com/bitnami/containers/tree/main/bitnami/drupal). For more information please refer to the [bitnami/drupal](https://github.com/bitnami/containers/tree/main/bitnami/drupal) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -352,7 +352,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami Drupal](https://github.com/bitnami/bitnami-docker-drupal) image stores the Drupal data and configurations at the `/bitnami/drupal` path of the container.
+The [Bitnami Drupal](https://github.com/bitnami/containers/tree/main/bitnami/drupal) image stores the Drupal data and configurations at the `/bitnami/drupal` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -474,7 +474,7 @@ mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
 
 ### To 8.0.0
 
-The [Bitnami Drupal](https://github.com/bitnami/bitnami-docker-drupal) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
+The [Bitnami Drupal](https://github.com/bitnami/containers/tree/main/bitnami/drupal) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
 
 Consequences:
 

--- a/bitnami/drupal/values.yaml
+++ b/bitnami/drupal/values.yaml
@@ -76,28 +76,28 @@ image:
 ##
 replicaCount: 1
 ## @param drupalProfile Drupal installation profile
-## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/drupal#configuration
 ##
 drupalProfile: standard
 ## @param drupalSkipInstall Skip Drupal installation wizard. Useful for migrations and restoring from SQL dump
-## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/drupal#configuration
 ##
 drupalSkipInstall: false
 ## @param drupalUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/drupal#configuration
 ##
 drupalUsername: user
 ## @param drupalPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/drupal#configuration
 ##
 drupalPassword: ""
 ## @param drupalEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-drupal#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/drupal#configuration
 ##
 drupalEmail: user@example.com
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-drupal#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/drupal#environment-variables
 ##
 allowEmptyPassword: true
 ## @param command Override default container command (useful when using custom images)
@@ -179,7 +179,7 @@ serviceAccount:
 ##
 existingSecret: ""
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-drupal/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/drupal/#smtp-configuration
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpUser SMTP user
@@ -536,7 +536,7 @@ ingress:
   ## - host: example.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: example-svc
   ##           port:
@@ -564,13 +564,13 @@ mariadb:
   ## @param mariadb.auth.password Password for the database
   ##
   auth:
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_drupal
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_drupal
     password: ""

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -28,6 +28,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: ejbca
 sources:
-  - https://github.com/bitnami/bitnami-docker-ejbca
+  - https://github.com/bitnami/containers/tree/main/bitnami/ejbca
   - https://www.ejbca.org/
 version: 6.2.10

--- a/bitnami/ejbca/README.md
+++ b/bitnami/ejbca/README.md
@@ -7,7 +7,7 @@ EJBCA is an enterprise class PKI Certificate Authority software, built using Jav
 [Overview of EJBCA](http://www.ejbca.org)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -239,7 +239,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/ejbca](https://github.com/bitnami/bitnami-docker-ejbca). For more information please refer to the [bitnami/ejbca](https://github.com/bitnami/bitnami-docker-ejbca) image documentation.
+The above parameters map to the env variables defined in [bitnami/ejbca](https://github.com/bitnami/containers/tree/main/bitnami/ejbca). For more information please refer to the [bitnami/ejbca](https://github.com/bitnami/containers/tree/main/bitnami/ejbca) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -305,7 +305,7 @@ To modify the application version used in this chart, specify a different versio
 
 ## Persistence
 
-The [Bitnami EJBCA](https://github.com/bitnami/bitnami-docker-discourse) image stores the EJBCA data and configurations at the `/bitnami` path of the container.
+The [Bitnami EJBCA](https://github.com/bitnami/containers/tree/main/bitnami/discourse) image stores the EJBCA data and configurations at the `/bitnami` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube. See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
 

--- a/bitnami/ejbca/values.yaml
+++ b/bitnami/ejbca/values.yaml
@@ -242,7 +242,7 @@ schedulerName: ""
 ##
 topologySpreadConstraints: []
 ## @param ejbcaAdminUsername EJBCA administrator username
-## ref: https://github.com/bitnami/bitnami-docker-ejbca#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/ejbca#environment-variables
 ##
 ejbcaAdminUsername: bitnami
 ## @param ejbcaAdminPassword Password for the administrator account
@@ -535,7 +535,7 @@ ingress:
   ## - host: example.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: example-svc
   ##           port:
@@ -563,13 +563,13 @@ mariadb:
   ## @param mariadb.auth.password Password for the database
   ##
   auth:
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_ejbca
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_ejbca
     password: ""

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: elasticsearch
 sources:
-  - https://github.com/bitnami/bitnami-docker-elasticsearch
+  - https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch
   - https://www.elastic.co/products/elasticsearch
 version: 19.1.1

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -7,7 +7,7 @@ Elasticsearch is a distributed search and analytics engine. It is used for web s
 [Overview of Elasticsearch](https://www.elastic.co/products/elasticsearch)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/elasticsearch
 
 ## Introduction
 
-This chart bootstraps a [Elasticsearch](https://github.com/bitnami/bitnami-docker-elasticsearch) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Elasticsearch](https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -793,7 +793,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami Elasticsearch](https://github.com/bitnami/bitnami-docker-elasticsearch) image stores the Elasticsearch data at the `/bitnami/elasticsearch/data` path of the container.
+The [Bitnami Elasticsearch](https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch) image stores the Elasticsearch data at the `/bitnami/elasticsearch/data` path of the container.
 
 By default, the chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning. See the [Parameters](#parameters) section to configure the PVC.
 

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -79,11 +79,11 @@ containerPorts:
   restAPI: 9200
   transport: 9300
 ## @param plugins Comma, semi-colon or space separated list of plugins to install at initialization
-## ref: https://github.com/bitnami/bitnami-docker-elasticsearch#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch#environment-variables
 ##
 plugins: ""
 ## @param snapshotRepoPath File System snapshot repository path
-## ref: https://github.com/bitnami/bitnami-docker-elasticsearch#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch#environment-variables
 ##
 snapshotRepoPath: ""
 ## @param config Override elasticsearch configuration
@@ -202,7 +202,7 @@ security:
   ##
   enabled: false
   ## @param security.elasticPassword Password for 'elastic' user
-  ## Ref: https://github.com/bitnami/bitnami-docker-elasticsearch#security
+  ## Ref: https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch#security
   ##
   elasticPassword: ""
   ## @param security.existingSecret Name of the existing secret containing the Elasticsearch password and
@@ -434,7 +434,7 @@ ingress:
   ## - host: example.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: example-svc
   ##           port:
@@ -1700,7 +1700,7 @@ ingest:
     ## - host: example.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -22,6 +22,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: etcd
 sources:
-  - https://github.com/bitnami/bitnami-docker-etcd
+  - https://github.com/bitnami/containers/tree/main/bitnami/etcd
   - https://coreos.com/etcd/
 version: 8.3.4

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -7,7 +7,7 @@ etcd is a distributed key-value store designed to securely store data across a c
 [Overview of Etcd](https://etcd.io/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/etcd
 
 ## Introduction
 
-This chart bootstraps a [etcd](https://github.com/bitnami/bitnami-docker-etcd) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [etcd](https://github.com/bitnami/containers/tree/main/bitnami/etcd) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -351,7 +351,7 @@ The etcd chart can be configured with Role-based access control and TLS encrypti
 
 ### Persistence
 
-The [Bitnami etcd](https://github.com/bitnami/bitnami-docker-etcd) image stores the etcd data at the `/bitnami/etcd` path of the container. Persistent Volume Claims are used to keep the data across statefulsets.
+The [Bitnami etcd](https://github.com/bitnami/containers/tree/main/bitnami/etcd) image stores the etcd data at the `/bitnami/etcd` path of the container. Persistent Volume Claims are used to keep the data across statefulsets.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning by default. An existing PersistentVolumeClaim can also be defined for this purpose.
 

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -22,6 +22,6 @@ maintainers:
 name: external-dns
 sources:
   - https://github.com/kubernetes-sigs/external-dns
-  - https://github.com/bitnami/bitnami-docker-external-dns
+  - https://github.com/bitnami/containers/tree/main/bitnami/external-dns
   - https://github.com/kubernetes-sigs/external-dns
 version: 6.7.1

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -7,7 +7,7 @@ ExternalDNS is a Kubernetes addon that configures public DNS servers with inform
 [Overview of ExternalDNS](https://github.com/kubernetes-incubator/external-dns)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/external-dns
 
 ## Introduction
 
-This chart bootstraps a [ExternalDNS](https://github.com/bitnami/bitnami-docker-external-dns) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [ExternalDNS](https://github.com/bitnami/containers/tree/main/bitnami/external-dns) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: fluentd
 sources:
-  - https://github.com/bitnami/bitnami-docker-fluentd
+  - https://github.com/bitnami/containers/tree/main/bitnami/fluentd
   - https://www.fluentd.org/
 version: 5.2.2

--- a/bitnami/fluentd/README.md
+++ b/bitnami/fluentd/README.md
@@ -7,7 +7,7 @@ Fluentd collects events from various data sources and writes them to files, RDBM
 [Overview of Fluentd](https://www.fluentd.org)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/fluentd
 
 ## Introduction
 
-This chart bootstraps a [Fluentd](https://github.com/bitnami/bitnami-docker-fluentd) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Fluentd](https://github.com/bitnami/containers/tree/main/bitnami/fluentd) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 

--- a/bitnami/geode/Chart.yaml
+++ b/bitnami/geode/Chart.yaml
@@ -20,6 +20,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: geode
 sources:
-  - https://github.com/bitnami/bitnami-docker-geode
+  - https://github.com/bitnami/containers/tree/main/bitnami/geode
   - https://github.com/apache/geode
 version: 0.6.9

--- a/bitnami/geode/README.md
+++ b/bitnami/geode/README.md
@@ -7,7 +7,7 @@ Apache Geode is a data management platform that provides advanced capabilities f
 [Overview of Apache Geode](https://geode.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/geode
 
 ## Introduction
 
-This chart bootstraps an [Apache Geode](https://github.com/bitnami/bitnami-docker-geode) cluster on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [Apache Geode](https://github.com/bitnami/containers/tree/main/bitnami/geode) cluster on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -370,7 +370,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.allowExternal`                 | Don't require client label for connections                                                                          | `true`  |
 
 
-The above parameters map to the env variables defined in [bitnami/geode](https://github.com/bitnami/bitnami-docker-geode). For more information please refer to the [bitnami/geode](https://github.com/bitnami/bitnami-docker-geode) image documentation.
+The above parameters map to the env variables defined in [bitnami/geode](https://github.com/bitnami/containers/tree/main/bitnami/geode). For more information please refer to the [bitnami/geode](https://github.com/bitnami/containers/tree/main/bitnami/geode) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -481,7 +481,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 
 ## Persistence
 
-The [Bitnami geode](https://github.com/bitnami/bitnami-docker-geode) image stores the geode data and configurations at the `/bitnami/geode` path of the container. Persistent Volume Claims are used to keep the data across deployments.
+The [Bitnami geode](https://github.com/bitnami/containers/tree/main/bitnami/geode) image stores the geode data and configurations at the `/bitnami/geode` path of the container. Persistent Volume Claims are used to keep the data across deployments.
 
 ### Adjust permissions of persistent volume mountpoint
 

--- a/bitnami/geode/values.yaml
+++ b/bitnami/geode/values.yaml
@@ -83,12 +83,12 @@ image:
   ##
   debug: false
 ## @param groups List of Apache Geode member groups to belong to
-## ref: https://github.com/bitnami/bitnami-docker-geode#apache-geode-cluster-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/geode#apache-geode-cluster-configuration
 ## Caveats: it's not possible to indicate different groups for each Apache Geode member
 ##
 groups: []
 ## Authentication parameters
-## ref: https://github.com/bitnami/bitnami-docker-geode#security
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/geode#security
 ##
 auth:
   ## @param auth.enabled Enable Apache Geode security
@@ -150,15 +150,15 @@ auth:
 
 locator:
   ## @param locator.logLevel Log level for Locator nodes
-  ## ref: https://github.com/bitnami/bitnami-docker-geode#apache-geode-configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/geode#apache-geode-configuration
   ##
   logLevel: "info"
   ## @param locator.initialHeapSize Initial size of the heap on Locator nodes
-  ## ref: https://github.com/bitnami/bitnami-docker-geode#apache-geode-configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/geode#apache-geode-configuration
   ##
   initialHeapSize: ""
   ## @param locator.maxHeapSize Maximum size of the heap on Locator nodes
-  ## ref: https://github.com/bitnami/bitnami-docker-geode#apache-geode-configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/geode#apache-geode-configuration
   ##
   maxHeapSize: ""
   ## @param locator.configuration Specify content for gemfire.properties on Locator nodes (auto-generated based on other env. vars otherwise)
@@ -498,15 +498,15 @@ locator:
 
 server:
   ## @param server.logLevel Log level for Cache Server nodes
-  ## ref: https://github.com/bitnami/bitnami-docker-geode#apache-geode-configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/geode#apache-geode-configuration
   ##
   logLevel: "info"
   ## @param server.initialHeapSize Initial size of the heap on Cache Server nodes
-  ## ref: https://github.com/bitnami/bitnami-docker-geode#apache-geode-configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/geode#apache-geode-configuration
   ##
   initialHeapSize: ""
   ## @param server.maxHeapSize Maximum size of the heap on Cache Server nodes
-  ## ref: https://github.com/bitnami/bitnami-docker-geode#apache-geode-configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/geode#apache-geode-configuration
   ##
   maxHeapSize: ""
   ## @param server.configuration Specify content for gemfire.properties on Cache server nodes (auto-generated based on other env. vars otherwise)
@@ -903,7 +903,7 @@ ingress:
   ## - host: example.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: example-svc
   ##           port:

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -31,6 +31,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: ghost
 sources:
-  - https://github.com/bitnami/bitnami-docker-ghost
+  - https://github.com/bitnami/containers/tree/main/bitnami/ghost
   - https://www.ghost.org/
 version: 19.0.10

--- a/bitnami/ghost/README.md
+++ b/bitnami/ghost/README.md
@@ -7,7 +7,7 @@ Ghost is an open source publishing platform designed to create blogs, magazines,
 [Overview of Ghost](https://ghost.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/ghost
 
 ## Introduction
 
-This chart bootstraps a [Ghost](https://github.com/bitnami/bitnami-docker-ghost) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Ghost](https://github.com/bitnami/containers/tree/main/bitnami/ghost) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MySQL chart](https://github.com/bitnami/charts/tree/master/bitnami/mysql) which is required for bootstrapping a MySQL deployment for the database requirements of the Ghost application.
 
@@ -274,7 +274,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.annotations`                                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                                | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/ghost](https://github.com/bitnami/bitnami-docker-ghost). For more information please refer to the [bitnami/ghost](https://github.com/bitnami/bitnami-docker-ghost) image documentation.
+The above parameters map to the env variables defined in [bitnami/ghost](https://github.com/bitnami/containers/tree/main/bitnami/ghost). For more information please refer to the [bitnami/ghost](https://github.com/bitnami/containers/tree/main/bitnami/ghost) image documentation.
 
 > **Note**:
 >
@@ -373,7 +373,7 @@ As an alternative, you can use the preset configurations for pod affinity, pod a
 
 ## Persistence
 
-The [Bitnami Ghost](https://github.com/bitnami/bitnami-docker-ghost) image stores the Ghost data and configurations at the `/bitnami/ghost` and `/bitnami/apache` paths of the container.
+The [Bitnami Ghost](https://github.com/bitnami/containers/tree/main/bitnami/ghost) image stores the Ghost data and configurations at the `/bitnami/ghost` and `/bitnami/apache` paths of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -408,7 +408,7 @@ Affected values:
 
 ### To 14.0.0
 
-Due to recent changes in the container image (see [Notable changes](https://github.com/bitnami/bitnami-docker-ghost#notable-changes)), the major version of the chart has been bumped preemptively.
+Due to recent changes in the container image (see [Notable changes](https://github.com/bitnami/containers/tree/main/bitnami/ghost#notable-changes)), the major version of the chart has been bumped preemptively.
 
 Compatibility is not guaranteed due to the amount of involved changes, however no breaking changes are expected.
 

--- a/bitnami/ghost/values.yaml
+++ b/bitnami/ghost/values.yaml
@@ -74,7 +74,7 @@ image:
 
 ## @section Ghost Configuration parameters
 ## Ghost settings based on environment variables
-## ref: https://github.com/bitnami/bitnami-docker-ghost#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/ghost#configuration
 
 ## @param ghostUsername Ghost user name
 ##
@@ -104,7 +104,7 @@ ghostPath: /
 ##
 ghostEnableHttps: false
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-ghost/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/ghost/#smtp-configuration
 ## @param smtpHost SMTP server host
 ## @param smtpPort SMTP server port
 ## @param smtpUser SMTP username
@@ -611,9 +611,9 @@ mysql:
   ## @param mysql.auth.username MySQL custom user name
   ## @param mysql.auth.password MySQL custom user password
   ## @param mysql.auth.existingSecret Existing secret with MySQL credentials
-  ## ref: https://github.com/bitnami/bitnami-docker-mysql#setting-the-root-password-on-first-run
-  ##      https://github.com/bitnami/bitnami-docker-mysql/blob/master/README.md#creating-a-database-on-first-run
-  ##      https://github.com/bitnami/bitnami-docker-mysql/blob/master/README.md#creating-a-database-user-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mysql#setting-the-root-password-on-first-run
+  ##      https://github.com/bitnami/containers/tree/main/bitnami/mysql/#creating-a-database-on-first-run
+  ##      https://github.com/bitnami/containers/tree/main/bitnami/mysql/#creating-a-database-user-on-first-run
   auth:
     rootPassword: ""
     database: bitnami_ghost

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-description: Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage. 
+description: Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage.
 engine: gotpl
 home: https://github.com/grafana/loki/
 icon: https://bitnami.com/assets/stacks/grafana-loki/img/grafana-loki-stack-220x234.png
@@ -42,6 +42,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: grafana-loki
 sources:
-  - https://github.com/bitnami/bitnami-docker-grafana-loki
+  - https://github.com/bitnami/containers/tree/main/bitnami/grafana-loki
   - https://github.com/grafana/loki/
 version: 2.2.3

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -2,12 +2,12 @@
 
 # Grafana Loki packaged by Bitnami
 
-Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage. 
+Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage.
 
 [Overview of Grafana Loki](https://grafana.com/oss/loki/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -1191,7 +1191,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 See https://github.com/bitnami-labs/readme-generator-for-helm to create the table
 
-The above parameters map to the env variables defined in [bitnami/grafana-loki](https://github.com/bitnami/bitnami-docker-grafana-loki). For more information please refer to the [bitnami/grafana-loki](https://github.com/bitnami/bitnami-docker-grafana-loki) image documentation.
+The above parameters map to the env variables defined in [bitnami/grafana-loki](https://github.com/bitnami/containers/tree/main/bitnami/grafana-loki). For more information please refer to the [bitnami/grafana-loki](https://github.com/bitnami/containers/tree/main/bitnami/grafana-loki) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -1224,7 +1224,7 @@ The loki configuration file `loki.yaml` is shared across the different component
 
 ## Persistence
 
-The [Bitnami grafana-loki](https://github.com/bitnami/bitnami-docker-grafana-loki) image stores the grafana-loki `ingester` data at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
+The [Bitnami grafana-loki](https://github.com/bitnami/containers/tree/main/bitnami/grafana-loki) image stores the grafana-loki `ingester` data at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
 
 ### Additional environment variables
 

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -23,5 +23,5 @@ maintainers:
 name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
-  - https://github.com/bitnami/bitnami-docker-grafana-operator
+  - https://github.com/bitnami/containers/tree/main/bitnami/grafana-operator
 version: 2.6.7

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -26,6 +26,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: grafana-tempo
 sources:
-  - https://github.com/bitnami/bitnami-docker-grafana-tempo
+  - https://github.com/bitnami/containers/tree/main/bitnami/grafana-tempo
   - https://github.com/grafana/tempo/
 version: 1.3.2

--- a/bitnami/grafana-tempo/README.md
+++ b/bitnami/grafana-tempo/README.md
@@ -7,7 +7,7 @@ Grafana Tempo is a distributed tracing system that has out-of-the-box integratio
 [Overview of Grafana Tempo](https://github.com/grafana/tempo)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -795,7 +795,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 See https://github.com/bitnami-labs/readme-generator-for-helm to create the table
 
-The above parameters map to the env variables defined in [bitnami/grafana-tempo](https://github.com/bitnami/bitnami-docker-grafana-tempo). For more information please refer to the [bitnami/grafana-tempo](https://github.com/bitnami/bitnami-docker-grafana-tempo) image documentation.
+The above parameters map to the env variables defined in [bitnami/grafana-tempo](https://github.com/bitnami/containers/tree/main/bitnami/grafana-tempo). For more information please refer to the [bitnami/grafana-tempo](https://github.com/bitnami/containers/tree/main/bitnami/grafana-tempo) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -828,7 +828,7 @@ The tempo configuration file `tempo.yaml` is shared across the different compone
 
 ## Persistence
 
-The [Bitnami grafana-tempo](https://github.com/bitnami/bitnami-docker-grafana-tempo) image stores the grafana-tempo `ingester` data at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
+The [Bitnami grafana-tempo](https://github.com/bitnami/containers/tree/main/bitnami/grafana-tempo) image stores the grafana-tempo `ingester` data at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
 
 ### Additional environment variables
 

--- a/bitnami/grafana-tempo/values.yaml
+++ b/bitnami/grafana-tempo/values.yaml
@@ -2438,7 +2438,7 @@ memcached:
   ##
   enabled: true
   ## Authentication parameters
-  ## ref: https://github.com/bitnami/bitnami-docker-memcached#creating-the-memcached-admin-user
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/memcached#creating-the-memcached-admin-user
   ##
   auth:
     ## @param memcached.auth.enabled Enable Memcached authentication

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -22,6 +22,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: grafana
 sources:
-  - https://github.com/bitnami/bitnami-docker-grafana
+  - https://github.com/bitnami/containers/tree/main/bitnami/grafana
   - https://grafana.com/
 version: 8.0.2

--- a/bitnami/grafana/README.md
+++ b/bitnami/grafana/README.md
@@ -7,7 +7,7 @@ Grafana is an open source metric analytics and visualization suite for visualizi
 [Overview of Grafana](https://grafana.com/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/grafana
 
 ## Introduction
 
-This chart bootstraps a [grafana](https://github.com/bitnami/bitnami-docker-grafana) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [grafana](https://github.com/bitnami/containers/tree/main/bitnami/grafana) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -610,7 +610,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami Grafana](https://github.com/bitnami/bitnami-docker-grafana) image stores the Grafana data and configurations at the `/opt/bitnami/grafana/data` path of the container.
+The [Bitnami Grafana](https://github.com/bitnami/containers/tree/main/bitnami/grafana) image stores the Grafana data and configurations at the `/opt/bitnami/grafana/data` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.

--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: haproxy-intel
 sources:
-  - https://github.com/bitnami/bitnami-docker-haproxy-intel
+  - https://github.com/bitnami/containers/tree/main/bitnami/haproxy-intel
   - https://github.com/haproxytech/haproxy
 version: 0.1.9

--- a/bitnami/haproxy-intel/README.md
+++ b/bitnami/haproxy-intel/README.md
@@ -7,7 +7,7 @@ HAProxy is a high-performance, open-source load balancer and reverse proxy for T
 [Overview of HAProxy for Intel](http://www.haproxy.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -86,7 +86,7 @@ helm install my-release \
 
 The above command sets the HAProxy service type as LoadBalancer.
 
-You can use the `configuration` or `existingConfigmap` parameters to set your own configuration file. You can read more about configuration in the [container's readme](https://github.com/bitnami/bitnami-docker-haproxy-intel#configuration).
+You can use the `configuration` or `existingConfigmap` parameters to set your own configuration file. You can read more about configuration in the [container's readme](https://github.com/bitnami/containers/tree/main/bitnami/haproxy-intel#configuration).
 
 > NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
 

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -21,6 +21,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: haproxy
 sources:
-  - https://github.com/bitnami/bitnami-docker-haproxy
+  - https://github.com/bitnami/containers/tree/main/bitnami/haproxy
   - https://github.com/haproxytech/haproxy
 version: 0.3.30

--- a/bitnami/haproxy/README.md
+++ b/bitnami/haproxy/README.md
@@ -7,7 +7,7 @@ HAProxy is a TCP proxy and a HTTP reverse proxy. It supports SSL termination and
 [Overview of HAProxy](http://www.haproxy.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -183,7 +183,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                              | `""`   |
 
 
-The above parameters map to the env variables defined in [bitnami/haproxy](https://github.com/bitnami/bitnami-docker-haproxy). For more information please refer to the [bitnami/haproxy](https://github.com/bitnami/bitnami-docker-haproxy) image documentation.
+The above parameters map to the env variables defined in [bitnami/haproxy](https://github.com/bitnami/containers/tree/main/bitnami/haproxy). For more information please refer to the [bitnami/haproxy](https://github.com/bitnami/containers/tree/main/bitnami/haproxy) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -28,10 +28,10 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: harbor
 sources:
-  - https://github.com/bitnami/bitnami-docker-harbor-core
-  - https://github.com/bitnami/bitnami-docker-harbor-portal
-  - https://github.com/bitnami/bitnami-docker-harbor-jobservice
-  - https://github.com/bitnami/bitnami-docker-harbor-registry
-  - https://github.com/bitnami/bitnami-docker-harbor-registryctl
+  - https://github.com/bitnami/containers/tree/main/bitnami/harbor-core
+  - https://github.com/bitnami/containers/tree/main/bitnami/harbor-portal
+  - https://github.com/bitnami/containers/tree/main/bitnami/harbor-jobservice
+  - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registry
+  - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registryctl
   - https://goharbor.io/
 version: 15.0.0

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -3595,7 +3595,7 @@ exporter:
 postgresql:
   enabled: true
   ## Override PostgreSQL default image as 14.x is not supported https://goharbor.io/docs/2.4.0/install-config/
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   ## @param postgresql.image.registry PostgreSQL image registry
   ## @param postgresql.image.repository PostgreSQL image repository
   ## @param postgresql.image.tag PostgreSQL image tag (immutable tags are recommended)

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -22,6 +22,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: influxdb
 sources:
-  - https://github.com/bitnami/bitnami-docker-influxdb
+  - https://github.com/bitnami/containers/tree/main/bitnami/influxdb
   - https://www.influxdata.com/products/influxdb-overview/
 version: 5.3.7

--- a/bitnami/influxdb/README.md
+++ b/bitnami/influxdb/README.md
@@ -7,7 +7,7 @@ InfluxDB(TM) is an open source time-series database. It is a core component of t
 [Overview of InfluxDB&trade;](https://www.influxdata.com/products/influxdb-overview)
 
 InfluxDB(TM) is a trademark owned by InfluxData, which is not affiliated with, and does not endorse, this site.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/influxdb
 
 ## Introduction
 
-This chart bootstraps a [influxdb](https://github.com/bitnami/bitnami-docker-influxdb) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [influxdb](https://github.com/bitnami/containers/tree/main/bitnami/influxdb) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -404,7 +404,7 @@ extraEnvVars:
 
 ### Initialize a fresh instance
 
-The [Bitnami InfluxDB&trade;](https://github.com/bitnami/bitnami-docker-influxdb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+The [Bitnami InfluxDB&trade;](https://github.com/bitnami/containers/tree/main/bitnami/influxdb) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
 
 Alternatively, you can specify custom scripts using the `influxdb.initdbScripts` parameter.
 

--- a/bitnami/influxdb/files/conf/README.md
+++ b/bitnami/influxdb/files/conf/README.md
@@ -2,4 +2,4 @@ Place your InfluxDB&trade; configuration file here. These will not be used in ca
 
 More information can be found in the link below:
 
-- [InfluxDB&trade; Configuration File](https://github.com/bitnami/bitnami-docker-influxdb#configuration-file)
+- [InfluxDB&trade; Configuration File](https://github.com/bitnami/containers/tree/main/bitnami/influxdb#configuration-file)

--- a/bitnami/influxdb/files/docker-entrypoint-initdb.d/README.md
+++ b/bitnami/influxdb/files/docker-entrypoint-initdb.d/README.md
@@ -1,3 +1,3 @@
 You can copy here your custom `.sh` or `.txt` files so they are executed during the first boot of the image.
 
-More info in the [bitnami-docker-influxdb](https://github.com/bitnami/bitnami-docker-influxdb#initializing-a-new-instance) repository.
+More info in the [influxdb](https://github.com/bitnami/containers/tree/main/bitnami/influxdb#initializing-a-new-instance) container README.

--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -28,6 +28,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: jasperreports
 sources:
-  - https://github.com/bitnami/bitnami-docker-jasperreports
+  - https://github.com/bitnami/containers/tree/main/bitnami/jasperreports
   - http://community.jaspersoft.com/project/jasperreports-server
 version: 14.1.13

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -7,7 +7,7 @@ JasperReports Server is a stand-alone and embeddable reporting server. It is a c
 [Overview of JasperReports](http://community.jaspersoft.com/project/jasperreports-server)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/jasperreports
 
 ## Introduction
 
-This chart bootstraps a [JasperReports](https://github.com/bitnami/bitnami-docker-jasperreports) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [JasperReports](https://github.com/bitnami/containers/tree/main/bitnami/jasperreports) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which bootstraps a MariaDB deployment required by the JasperReports application.
 
@@ -238,7 +238,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                        | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/jasperreports](https://github.com/bitnami/bitnami-docker-jasperreports). For more information please refer to the [bitnami/jasperreports](https://github.com/bitnami/bitnami-docker-jasperreports) image documentation.
+The above parameters map to the env variables defined in [bitnami/jasperreports](https://github.com/bitnami/containers/tree/main/bitnami/jasperreports). For more information please refer to the [bitnami/jasperreports](https://github.com/bitnami/containers/tree/main/bitnami/jasperreports) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -270,7 +270,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ## Persistence
 
-The [Bitnami JasperReports](https://github.com/bitnami/bitnami-docker-jasperreports) image stores the JasperReports data and configurations at the `/bitnami/jasperreports` path of the container.
+The [Bitnami JasperReports](https://github.com/bitnami/containers/tree/main/bitnami/jasperreports) image stores the JasperReports data and configurations at the `/bitnami/jasperreports` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -343,7 +343,7 @@ Additionally updates the MariaDB subchart to it newest major, 10.0.0, which cont
 
 ### To 11.0.0
 
-The [Bitnami JasperReports](https://github.com/bitnami/bitnami-docker-jasperreports) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Tomcat daemon was started as the `tomcat` user. From now on, both the container and the Tomcat daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
+The [Bitnami JasperReports](https://github.com/bitnami/containers/tree/main/bitnami/jasperreports) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Tomcat daemon was started as the `tomcat` user. From now on, both the container and the Tomcat daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
 
 Consequences:
 
@@ -352,7 +352,7 @@ Consequences:
 
 To upgrade to `11.0.0`, backup JasperReports data and the previous MariaDB databases, install a new JasperReports chart and import the backups and data, ensuring the `1001` user has the appropriate permissions on the migrated volume.
 
-In addition to this, the image was refactored and now the source code is published in GitHub in the [`rootfs`](https://github.com/bitnami/bitnami-docker-jasperreports/tree/master/7/debian-10/rootfs) folder of the container image.
+In addition to this, the image was refactored and now the source code is published in GitHub in the `rootfs` folder of the container image.
 
 We also fixed a regression with readiness and liveness probes. Now the kind of probe cannot be configured under the *readinessProbe/livenessProbe* sections but in the *customReadinessProbe/customLivenessProbe* sections.
 

--- a/bitnami/jasperreports/values.yaml
+++ b/bitnami/jasperreports/values.yaml
@@ -71,24 +71,24 @@ image:
   ##
   pullSecrets: []
 ## @param jasperreportsUsername JasperReports user
-## ref: https://github.com/bitnami/bitnami-docker-jasperreports#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/jasperreports#configuration
 ##
 jasperreportsUsername: jasperadmin
 ## @param jasperreportsPassword JasperReports password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-jasperreports#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/jasperreports#configuration
 ##
 jasperreportsPassword: ""
 ## @param jasperreportsEmail JasperReports user email
-## ref: https://github.com/bitnami/bitnami-docker-jasperreports#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/jasperreports#configuration
 ##
 jasperreportsEmail: user@example.com
 ## @param allowEmptyPassword Set to `yes` to allow the container to be started with blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-jasperreports#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/jasperreports#environment-variables
 ##
 allowEmptyPassword: "no"
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-jasperreports#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/jasperreports#smtp-configuration
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpEmail SMTP email
@@ -508,7 +508,7 @@ ingress:
   ## - host: example.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: example-svc
   ##           port:
@@ -534,15 +534,15 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_jasperreports
     ## @param mariadb.auth.username Database user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_jasperreports
     ## @param mariadb.auth.password Password for the database

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: jenkins
 sources:
-  - https://github.com/bitnami/bitnami-docker-jenkins
+  - https://github.com/bitnami/containers/tree/main/bitnami/jenkins
   - https://jenkins.io/
 version: 10.2.4

--- a/bitnami/jenkins/README.md
+++ b/bitnami/jenkins/README.md
@@ -7,7 +7,7 @@ Jenkins is an open source Continuous Integration and Continuous Delivery (CI/CD)
 [Overview of Jenkins](http://jenkins-ci.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ helm install my-release bitnami/jenkins
 
 ## Introduction
 
-This chart bootstraps a [Jenkins](https://github.com/bitnami/bitnami-docker-jenkins) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Jenkins](https://github.com/bitnami/containers/tree/main/bitnami/jenkins) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -219,7 +219,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.securityContext.runAsUser` | Set init container's Security Context runAsUser                                                 | `0`                     |
 
 
-The above parameters map to the env variables defined in [bitnami/jenkins](https://github.com/bitnami/bitnami-docker-jenkins). For more information please refer to the [bitnami/jenkins](https://github.com/bitnami/bitnami-docker-jenkins) image documentation.
+The above parameters map to the env variables defined in [bitnami/jenkins](https://github.com/bitnami/containers/tree/main/bitnami/jenkins). For more information please refer to the [bitnami/jenkins](https://github.com/bitnami/containers/tree/main/bitnami/jenkins) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -290,7 +290,7 @@ As an alternative, you can use the preset configurations for pod affinity, pod a
 
 ## Persistence
 
-The [Bitnami Jenkins](https://github.com/bitnami/bitnami-docker-jenkins) image stores the Jenkins data and configurations at the `/bitnami/jenkins` path of the container. Persistent Volume Claims (PVCs) are used to keep the data across deployments.
+The [Bitnami Jenkins](https://github.com/bitnami/containers/tree/main/bitnami/jenkins) image stores the Jenkins data and configurations at the `/bitnami/jenkins` path of the container. Persistent Volume Claims (PVCs) are used to keep the data across deployments.
 
 If you encounter errors when working with persistent volumes, refer to our [troubleshooting guide for persistent volumes](https://docs.bitnami.com/kubernetes/faq/troubleshooting/troubleshooting-persistence-volumes/).
 
@@ -315,7 +315,7 @@ Affected values:
 
 ### To 8.0.0
 
-Due to recent changes in the container image (see [Notable changes](https://github.com/bitnami/bitnami-docker-jenkins#notable-changes)), the major version of the chart has been bumped preemptively.
+Due to recent changes in the container image (see [Notable changes](https://github.com/bitnami/containers/tree/main/bitnami/jenkins#notable-changes)), the major version of the chart has been bumped preemptively.
 
 Upgrading from version `7.x.x` should be possible following the workaround below (the following example assumes that the release name is `jenkins`):
 
@@ -360,7 +360,7 @@ This version also introduces `bitnami/common`, a [library chart](https://helm.sh
 
 ### To 5.0.0
 
-The [Bitnami Jenkins](https://github.com/bitnami/bitnami-docker-jenkins) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Jenkins service was started as the `jenkins` user. From now on, both the container and the Jenkins service run as user `jenkins` (`uid=1001`). You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `root`.
+The [Bitnami Jenkins](https://github.com/bitnami/containers/tree/main/bitnami/jenkins) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Jenkins service was started as the `jenkins` user. From now on, both the container and the Jenkins service run as user `jenkins` (`uid=1001`). You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `root`.
 Ingress configuration was also adapted to follow the Helm charts best practices.
 
 Consequences:

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -88,7 +88,7 @@ image:
 
 ## @section Jenkins Configuration parameters
 ## Jenkins settings based on environment variables
-## ref: https://github.com/bitnami/bitnami-docker-jenkins#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/jenkins#configuration
 
 ## @param jenkinsUser Jenkins username
 ##

--- a/bitnami/joomla/Chart.yaml
+++ b/bitnami/joomla/Chart.yaml
@@ -25,6 +25,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: joomla
 sources:
-  - https://github.com/bitnami/bitnami-docker-joomla
+  - https://github.com/bitnami/containers/tree/main/bitnami/joomla
   - https://www.joomla.org/
 version: 13.2.14

--- a/bitnami/joomla/README.md
+++ b/bitnami/joomla/README.md
@@ -7,7 +7,7 @@ Joomla! is an award winning open source CMS platform for building websites and a
 [Overview of Joomla!](http://www.joomla.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/joomla
 
 ## Introduction
 
-This chart bootstraps a [Joomla!](https://github.com/bitnami/bitnami-docker-joomla) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Joomla!](https://github.com/bitnami/containers/tree/main/bitnami/joomla) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the Joomla! application.
 
@@ -252,7 +252,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                 | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/joomla](https://github.com/bitnami/bitnami-docker-joomla). For more information please refer to the [bitnami/joomla](https://github.com/bitnami/bitnami-docker-joomla) image documentation.
+The above parameters map to the env variables defined in [bitnami/joomla](https://github.com/bitnami/containers/tree/main/bitnami/joomla). For more information please refer to the [bitnami/joomla](https://github.com/bitnami/containers/tree/main/bitnami/joomla) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -338,7 +338,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami Joomla!](https://github.com/bitnami/bitnami-docker-joomla) image stores the Joomla! data and configurations at the `/bitnami/joomla` and `/bitnami/apache` paths of the container.
+The [Bitnami Joomla!](https://github.com/bitnami/containers/tree/main/bitnami/joomla) image stores the Joomla! data and configurations at the `/bitnami/joomla` and `/bitnami/apache` paths of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, vpshere, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -447,7 +447,7 @@ mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
 
 ### To 8.0.0
 
-The [Bitnami Joomla!](https://github.com/bitnami/bitnami-docker-joomla) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
+The [Bitnami Joomla!](https://github.com/bitnami/containers/tree/main/bitnami/joomla) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
 
 Consequences:
 

--- a/bitnami/joomla/values.yaml
+++ b/bitnami/joomla/values.yaml
@@ -75,24 +75,24 @@ image:
   ##
   debug: false
 ## @param joomlaSkipInstall Skip Joomla! installation wizard. Useful for migrations and restoring from SQL dump
-## ref: https://github.com/bitnami/bitnami-docker-joomla#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/joomla#configuration
 ##
 joomlaSkipInstall: "no"
 ## @param joomlaUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-joomla#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/joomla#configuration
 ##
 joomlaUsername: user
 ## @param joomlaPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-joomla#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/joomla#configuration
 ##
 joomlaPassword: ""
 ## @param joomlaEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-joomla#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/joomla#configuration
 ##
 joomlaEmail: user@example.com
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-joomla#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/joomla#environment-variables
 ##
 allowEmptyPassword: "no"
 ## @param command Override default container command (useful when using custom images)
@@ -148,7 +148,7 @@ sidecars: []
 ##
 existingSecret: ""
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-joomla/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/joomla/#smtp-configuration
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpUser SMTP user
@@ -508,7 +508,7 @@ ingress:
   ## - host: example.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: example-svc
   ##           port:
@@ -533,15 +533,15 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_joomla
     ## @param mariadb.auth.username Database user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_joomla
     ## @param mariadb.auth.password Password for the database

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: jupyterhub
 sources:
-  - https://github.com/bitnami/bitnami-docker-jupyterhub
+  - https://github.com/bitnami/containers/tree/main/bitnami/jupyterhub
   - https://github.com/jupyterhub/jupyterhub
 version: 1.3.9

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -27,6 +27,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: kafka
 sources:
-  - https://github.com/bitnami/bitnami-docker-kafka
+  - https://github.com/bitnami/containers/tree/main/bitnami/kafka
   - https://kafka.apache.org/
 version: 18.0.3

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -7,7 +7,7 @@ Apache Kafka is a distributed streaming platform designed to build real-time pip
 [Overview of Apache Kafka](http://kafka.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ helm install my-release bitnami/kafka
 
 ## Introduction
 
-This chart bootstraps a [Kafka](https://github.com/bitnami/bitnami-docker-kafka) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Kafka](https://github.com/bitnami/containers/tree/main/bitnami/kafka) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -786,7 +786,7 @@ CMD /opt/bitnami/kafka/bin/connect-standalone.sh /opt/bitnami/kafka/config/conne
 
 ## Persistence
 
-The [Bitnami Kafka](https://github.com/bitnami/bitnami-docker-kafka) image stores the Kafka data at the `/bitnami/kafka` path of the container.
+The [Bitnami Kafka](https://github.com/bitnami/containers/tree/main/bitnami/kafka) image stores the Kafka data at the `/bitnami/kafka` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube. See the [Parameters](#persistence-parameters) section to configure the PVC or to disable persistence.
 

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -213,7 +213,7 @@ allowEveryoneIfNoAclFound: true
 ##
 superUsers: User:admin
 ## Authentication parameters
-## https://github.com/bitnami/bitnami-docker-kafka#security
+## https://github.com/bitnami/containers/tree/main/bitnami/kafka#security
 ##
 auth:
   ## Authentication protocol for client and inter-broker communications
@@ -403,7 +403,7 @@ command:
 ##
 args: []
 ## @param extraEnvVars Extra environment variables to add to Kafka pods
-## ref: https://github.com/bitnami/bitnami-docker-kafka#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/kafka#configuration
 ## e.g:
 ## extraEnvVars:
 ##   - name: KAFKA_CFG_BACKGROUND_THREADS

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: keycloak
 sources:
-  - https://github.com/bitnami/bitnami-docker-keycloak
+  - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
 version: 9.6.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -19,7 +19,7 @@ Trademarks: This software listing is packaged by Bitnami. The respective tradema
 
 Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
 
-This chart bootstraps a [Keycloak](https://github.com/bitnami/bitnami-docker-keycloak) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Keycloak](https://github.com/bitnami/containers/tree/main/bitnami/keycloak) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -385,7 +385,7 @@ Refer to the chart documentation for more information on, and examples of, confi
 
 ### Initialize a fresh instance
 
-The [Bitnami Keycloak](https://github.com/bitnami/bitnami-docker-keycloak) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, you can specify custom scripts using the `initdbScripts` parameter as dict.
+The [Bitnami Keycloak](https://github.com/bitnami/containers/tree/main/bitnami/keycloak) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, you can specify custom scripts using the `initdbScripts` parameter as dict.
 
 In addition to this option, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the `initdbScriptsConfigMap` parameter. Note that this will override the previous option.
 

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -91,7 +91,7 @@ image:
   ##
   debug: false
 ## Keycloak authentication parameters
-## ref: https://github.com/bitnami/bitnami-docker-keycloak#admin-credentials
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/keycloak#admin-credentials
 ##
 auth:
   ## @param auth.adminUser Keycloak administrator user
@@ -139,7 +139,7 @@ auth:
   ##
   existingSecretPerPassword: {}
   ## TLS encryption parameters
-  ## ref: https://github.com/bitnami/bitnami-docker-keycloak#tls-encryption
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/keycloak#tls-encryption
   ##
   tls:
     ## @param auth.tls.enabled Enable TLS encryption. Required for HTTPs traffic.
@@ -210,7 +210,7 @@ proxy: passthrough
 ##
 httpRelativePath: "/"
 ## Keycloak Service Discovery settings
-## ref: https://github.com/bitnami/bitnami-docker-keycloak#cluster-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/keycloak#cluster-configuration
 ##
 ## @param configuration Keycloak Configuration. Auto-generated based on other parameters when not specified
 ## Specify content for keycloak.conf
@@ -232,7 +232,7 @@ existingConfigmap: ""
 extraStartupArgs: ""
 ## @param initdbScripts Dictionary of initdb scripts
 ## Specify dictionary of scripts to be run at first boot
-## ref: https://github.com/bitnami/bitnami-docker-keycloak#initializing-a-new-instance
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/keycloak#initializing-a-new-instance
 ## Example:
 ## initdbScripts:
 ##   my_init_script.sh: |
@@ -727,7 +727,7 @@ autoscaling:
 ##
 metrics:
   ## @param metrics.enabled Enable exposing Keycloak statistics
-  ## ref: https://github.com/bitnami/bitnami-docker-keycloak#enabling-statistics
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/keycloak#enabling-statistics
   ##
   enabled: false
   ## Keycloak metrics service parameters

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -21,6 +21,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: kiam
 sources:
-  - https://github.com/bitnami/bitnami-docker-kiam
+  - https://github.com/bitnami/containers/tree/main/bitnami/kiam
   - https://github.com/uswitch/kiam
 version: 1.0.14

--- a/bitnami/kiam/README.md
+++ b/bitnami/kiam/README.md
@@ -7,7 +7,7 @@ kiam is a proxy that captures AWS Metadata API requests. It allows AWS IAM roles
 [Overview of Kiam](https://github.com/uswitch/kiam)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -21,7 +21,7 @@ Trademarks: This software listing is packaged by Bitnami. The respective tradema
 
 Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
 
-This chart bootstraps a [kiam](https://github.com/bitnami/bitnami-docker-kiam) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [kiam](https://github.com/bitnami/containers/tree/main/bitnami/kiam) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: kibana
 sources:
-  - https://github.com/bitnami/bitnami-docker-kibana
+  - https://github.com/bitnami/containers/tree/main/bitnami/kibana
   - https://www.elastic.co/products/kibana
 version: 10.1.16

--- a/bitnami/kibana/README.md
+++ b/bitnami/kibana/README.md
@@ -7,7 +7,7 @@ Kibana is an open source, browser based analytics and search dashboard for Elast
 [Overview of Kibana](https://www.elastic.co/products/kibana)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/kibana --set elasticsearch.hosts[0]=<Hostname 
 
 ## Introduction
 
-This chart bootstraps a [Kibana](https://github.com/bitnami/bitnami-docker-kibana) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Kibana](https://github.com/bitnami/containers/tree/main/bitnami/kibana) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -367,7 +367,7 @@ As an alternative, you can use one of the preset configurations for pod affinity
 
 ## Persistence
 
-The [Bitnami Kibana](https://github.com/bitnami/bitnami-docker-kibana) image can persist data. If enabled, the persisted path is `/bitnami/kibana` by default.
+The [Bitnami Kibana](https://github.com/bitnami/containers/tree/main/bitnami/kibana) image can persist data. If enabled, the persisted path is `/bitnami/kibana` by default.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
 

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -32,6 +32,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: kong
 sources:
-  - https://github.com/bitnami/bitnami-docker-kong
+  - https://github.com/bitnami/containers/tree/main/bitnami/kong
   - https://konghq.com/
 version: 6.3.23

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -7,7 +7,7 @@ Kong is an open source Microservice API gateway and platform designed for managi
 [Overview of Kong](https://konghq.com/kong-community-edition/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ Trademarks: This software listing is packaged by Bitnami. The respective tradema
 
 ## Introduction
 
-This chart bootstraps a [kong](https://github.com/bitnami/bitnami-docker-kong) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. It also includes the [kong-ingress-controller](https://github.com/bitnami/bitnami-docker-kong-ingress-controller) container for managing Ingress resources using Kong.
+This chart bootstraps a [kong](https://github.com/bitnami/containers/tree/main/bitnami/kong) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. It also includes the [kong-ingress-controller](https://github.com/bitnami/containers/tree/main/bitnami/kong-ingress-controller) container for managing Ingress resources using Kong.
 
 Extra functionalities beyond the Kong core are extended through plugins. Kong is built on top of reliable technologies like NGINX and provides an easy-to-use RESTful API to operate and configure the system.
 

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -765,7 +765,7 @@ migration:
 postgresql:
   enabled: true
   ## Override PostgreSQL default image as 14.x is not supported
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   ## @param postgresql.image.registry PostgreSQL image registry
   ## @param postgresql.image.repository PostgreSQL image repository
   ## @param postgresql.image.tag PostgreSQL image tag (immutable tags are recommended)

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -31,8 +31,8 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: kube-prometheus
 sources:
-  - https://github.com/bitnami/bitnami-docker-prometheus-operator
-  - https://github.com/bitnami/bitnami-docker-prometheus
-  - https://github.com/bitnami/bitnami-docker-alertmanager
+  - https://github.com/bitnami/containers/tree/main/bitnami/prometheus-operator
+  - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
+  - https://github.com/bitnami/containers/tree/main/bitnami/alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
 version: 8.0.11

--- a/bitnami/kube-prometheus/README.md
+++ b/bitnami/kube-prometheus/README.md
@@ -7,7 +7,7 @@ Prometheus Operator provides easy monitoring definitions for Kubernetes services
 [Overview of Prometheus Operator](https://github.com/coreos/prometheus-operator)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/kube-prometheus
 
 ## Introduction
 
-This chart bootstraps [Prometheus Operator](https://github.com/bitnami/bitnami-docker-prometheus-operator) on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+This chart bootstraps [Prometheus Operator](https://github.com/bitnami/containers/tree/main/bitnami/prometheus-operator) on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
 
 In the default configuration the chart deploys the following components on the Kubernetes cluster:
 
@@ -50,7 +50,7 @@ To install the chart with the release name `my-release`:
 $ helm install my-release bitnami/kube-prometheus
 ```
 
-The command deploys kube-prometheus on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys kube-prometheus on the Kubernetes cluster in the default configuration. The [configuration](#configuration-and-installation-details) section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -21,6 +21,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: kube-state-metrics
 sources:
-  - https://github.com/bitnami/bitnami-docker-kube-state-metrics
+  - https://github.com/bitnami/containers/tree/main/bitnami/kube-state-metrics
   - https://github.com/kubernetes/kube-state-metrics
 version: 3.1.1

--- a/bitnami/kube-state-metrics/README.md
+++ b/bitnami/kube-state-metrics/README.md
@@ -7,7 +7,7 @@ kube-state-metrics is a simple service that listens to the Kubernetes API server
 [Overview of Kube State Metrics](https://github.com/kubernetes/kube-state-metrics)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/kube-state-metrics
 
 ## Introduction
 
-This chart bootstraps [kube-state-metrics](https://github.com/bitnami/bitnami-docker-kube-state-metrics) on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+This chart bootstraps [kube-state-metrics](https://github.com/bitnami/containers/tree/main/bitnami/kube-state-metrics) on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -40,7 +40,7 @@ To install the chart with the release name `my-release`:
 $ helm install my-release bitnami/kube-state-metrics
 ```
 
-The command deploys kube-state-metrics on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys kube-state-metrics on the Kubernetes cluster in the default configuration. The [configuration](#configuration-and-installation-details) section lists the parameters that can be configured during installation.
 
 ## Uninstalling the Chart
 

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1730,7 +1730,7 @@ testImage:
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml
 ## @param postgresql.enabled Deploy a PostgreSQL server to satisfy the applications database requirements
 ## @param postgresql.auth.postgresPassword Password for 'postgres' user
-## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#setting-the-root-password-on-first-run
 ## @param postgresql.auth.database Name for a custom database to create
 ## @param postgresql.auth.existingSecret Name of existing secret to use for PostgreSQL credentials
 ##

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: kubernetes-event-exporter
 sources:
-  - https://github.com/bitnami/bitnami-docker-kubernetes-event-exporter
+  - https://github.com/bitnami/containers/tree/main/bitnami/kubernetes-event-exporter
   - https://github.com/opsgenie/kubernetes-event-exporter
 version: 1.4.16

--- a/bitnami/kubernetes-event-exporter/README.md
+++ b/bitnami/kubernetes-event-exporter/README.md
@@ -7,7 +7,7 @@ Kubernetes Event Exporter makes it easy to export Kubernetes events to other too
 [Overview of Kubernetes Event Exporter](https://github.com/opsgenie/kubernetes-event-exporter)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -35,7 +35,7 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm install my-release bitnami/kubernetes-event-exporter
 ```
 
-These commands deploy Kubernetes Event Exporter on the Kubernetes cluster in the default configuration. The [Parameters](##parameters) section lists the parameters that can be configured during installation.
+These commands deploy Kubernetes Event Exporter on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list` or `helm ls --all-namespaces`
 

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -21,6 +21,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: logstash
 sources:
-  - https://github.com/bitnami/bitnami-docker-logstash
+  - https://github.com/bitnami/containers/tree/main/bitnami/logstash
   - https://www.elastic.co/products/logstash
 version: 5.0.13

--- a/bitnami/logstash/README.md
+++ b/bitnami/logstash/README.md
@@ -7,7 +7,7 @@ Logstash is an open source data processing engine. It ingests data from multiple
 [Overview of Logstash](http://logstash.net)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/logstash
 
 ## Introduction
 
-This chart bootstraps a [logstash](https://github.com/bitnami/bitnami-docker-logstash) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [logstash](https://github.com/bitnami/containers/tree/main/bitnami/logstash) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -35,7 +35,7 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm install my-release bitnami/logstash
 ```
 
-These commands deploy logstash on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+These commands deploy logstash on the Kubernetes cluster in the default configuration. The [configuration](#configuration-and-installation-details) section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 
@@ -277,7 +277,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 
 ## Persistence
 
-The [Bitnami Logstash](https://github.com/bitnami/bitnami-docker-logstash) image stores the Logstash data at the `/bitnami/logstash/data` path of the container.
+The [Bitnami Logstash](https://github.com/bitnami/containers/tree/main/bitnami/logstash) image stores the Logstash data at the `/bitnami/logstash/data` path of the container.
 
 Persistent Volume Claims (PVCs) are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -33,6 +33,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: magento
 sources:
-  - https://github.com/bitnami/bitnami-docker-magento
+  - https://github.com/bitnami/containers/tree/main/bitnami/magento
   - https://magento.com/
 version: 21.0.2

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -7,7 +7,7 @@ Magento is a powerful open source e-commerce platform. With easy customizations 
 [Overview of Magento](http://www.magento.com)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/magento
 
 ## Introduction
 
-This chart bootstraps a [Magento](https://github.com/bitnami/bitnami-docker-magento) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Magento](https://github.com/bitnami/containers/tree/main/bitnami/magento) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment as a database for the Magento application.
 
@@ -343,7 +343,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `autoscaling.targetMemory` | Target Memory utilization percentage | `""`    |
 
 
-The above parameters map to the env variables defined in [bitnami/magento](https://github.com/bitnami/bitnami-docker-magento). For more information please refer to the [bitnami/magento](https://github.com/bitnami/bitnami-docker-magento) image documentation.
+The above parameters map to the env variables defined in [bitnami/magento](https://github.com/bitnami/containers/tree/main/bitnami/magento). For more information please refer to the [bitnami/magento](https://github.com/bitnami/containers/tree/main/bitnami/magento) image documentation.
 
 > **Note**:
 >
@@ -455,7 +455,7 @@ If you are going to manage TLS secrets outside of Helm, please know that you can
 
 ## Persistence
 
-The [Bitnami Magento](https://github.com/bitnami/bitnami-docker-magento) image stores the Magento data and configurations at the `/bitnami/magento` and `/bitnami/apache` paths of the container.
+The [Bitnami Magento](https://github.com/bitnami/containers/tree/main/bitnami/magento) image stores the Magento data and configurations at the `/bitnami/magento` and `/bitnami/apache` paths of the container.
 
  Persistent Volume Claims are used to keep the data across deployments. There is a [known issue](https://github.com/kubernetes/kubernetes/issues/39178) in Kubernetes Clusters with EBS in different availability zones. Ensure your cluster is configured properly to create Volumes in the same availability zone where the nodes are running. Kuberentes 1.12 solved this issue with the [Volume Binding Mode](https://kubernetes.io/docs/concepts/storage/storage-classes/#volume-binding-mode).
 
@@ -523,7 +523,7 @@ externalDatabase.port=3306
 
 Note also if you disable MariaDB per above you MUST supply values for the `externalDatabase` connection.
 
-In case the database already contains data from a previous Magento installation, you need to set the `magentoSkipInstall` parameter to _true_. Otherwise, the container would execute the installation wizard and could modify the existing data in the database. This parameter force the container to not execute the Magento installation wizard. This is necessary in case you use a database that already has Magento data [+info](https://github.com/bitnami/bitnami-docker-magento#connect-magento-docker-container-to-an-existing-database).
+In case the database already contains data from a previous Magento installation, you need to set the `magentoSkipInstall` parameter to _true_. Otherwise, the container would execute the installation wizard and could modify the existing data in the database. This parameter force the container to not execute the Magento installation wizard. This is necessary in case you use a database that already has Magento data [+info](https://github.com/bitnami/containers/tree/main/bitnami/magento#connect-magento-docker-container-to-an-existing-database).
 
 ### Deploying extra resources
 
@@ -537,7 +537,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami Magento](https://github.com/bitnami/bitnami-docker-magento) image stores the Magento data and configurations at the `/bitnami/magento` path of the container.
+The [Bitnami Magento](https://github.com/bitnami/containers/tree/main/bitnami/magento) image stores the Magento data and configurations at the `/bitnami/magento` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -625,7 +625,7 @@ This upgrade adapts the chart to the latest Bitnami good practices. Check the Pa
 
 **2. Migration of the Magento image to non-root**
 
-The [Bitnami Magento](https://github.com/bitnami/bitnami-docker-magento) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. Consequences:
+The [Bitnami Magento](https://github.com/bitnami/containers/tree/main/bitnami/magento) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. Consequences:
 
 - The HTTP/HTTPS ports exposed by the container are now `8080/8443` instead of `80/443`.
 - Backwards compatibility is not guaranteed. Uninstall & install the chart again to obtain the latest version.

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -97,63 +97,63 @@ hostAliases:
 ##
 replicaCount: 1
 ## @param magentoSkipInstall Skip Magento installation wizard. Useful for migrations and restoring from SQL dump
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoSkipInstall: false
 ## @param magentoHost Magento host to create application URLs
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoHost: ""
 ## @param magentoUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoUsername: user
 ## @param magentoPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoPassword: ""
 ## @param magentoEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoEmail: user@example.com
 ## @param magentoFirstName Magento Admin First Name
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoFirstName: ""
 ## @param magentoLastName Magento Admin Last Name
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoLastName: ""
 ## @param magentoAdminUri Magento prefix to access Magento Admin
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoAdminUri: ""
 ## @param magentoMode Magento mode
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoMode: ""
 ## @param magentoExtraInstallArgs Magento extra install args
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoExtraInstallArgs: ""
 ## @param magentoDeployStaticContent Deploy static content during the first deployment, to optimize page load time
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoDeployStaticContent: false
 ## @param magentoUseHttps Use SSL to access the Magento Store. Valid values: `true`, `false`
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoUseHttps: false
 ## @param magentoUseSecureAdmin Use SSL to access the Magento Admin. Valid values: `true`, `false`
-## ref: https://github.com/bitnami/bitnami-docker-magento#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#configuration
 ##
 magentoUseSecureAdmin: false
 ## @param magentoSkipReindex Skip Magento Indexer reindex step during the initialization. Valid values: `true`, `false`
 ##
 magentoSkipReindex: false
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-magento#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/magento#environment-variables
 ##
 allowEmptyPassword: false
 ## @param command Override default container command (useful when using custom images)
@@ -480,7 +480,7 @@ mariadb:
   ##
   enabled: true
   ## Override MariaDB default image as 10.6 is not supported https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html#database
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb
   ## @param mariadb.image.registry MariaDB image registry
   ## @param mariadb.image.repository MariaDB image repository
   ## @param mariadb.image.tag MariaDB image tag (immutable tags are recommended)
@@ -496,15 +496,15 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_magento
     ## @param mariadb.auth.username Database user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_magento
     ## @param mariadb.auth.password Password for the database
@@ -572,7 +572,7 @@ elasticsearch:
   ##
   enabled: true
   ## Override Elasticsearch default image as version 8 is not supported https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html#database
-  ## ref: https://github.com/bitnami/bitnami-docker-elasticsearch
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch
   ## @param elasticsearch.image.registry Elasticsearch image registry
   ## @param elasticsearch.image.repository Elasticsearch image repository
   ## @param elasticsearch.image.tag Elasticsearch image tag (immutable tags are recommended)

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -24,7 +24,7 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: mariadb-galera
 sources:
-  - https://github.com/bitnami/bitnami-docker-mariadb-galera
+  - https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
 version: 7.3.6

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -7,7 +7,7 @@ MariaDB Galera is a multi-primary database cluster solution for synchronous repl
 [Overview of MariaDB Galera](https://mariadb.com/kb/en/library/galera-cluster/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/mariadb-galera
 
 ## Introduction
 
-This chart bootstraps a [MariaDB Galera](https://github.com/bitnami/bitnami-docker-mariadb-galera) cluster on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [MariaDB Galera](https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera) cluster on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -261,7 +261,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.prometheusRules.rules`               | PrometheusRule rules to configure                                                                                                                                                             | `{}`                      |
 
 
-The above parameters map to the env variables defined in [bitnami/mariadb-galera](https://github.com/bitnami/bitnami-docker-mariadb-galera). For more information please refer to the [bitnami/mariadb-galera](https://github.com/bitnami/bitnami-docker-mariadb-galera) image documentation.
+The above parameters map to the env variables defined in [bitnami/mariadb-galera](https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera). For more information please refer to the [bitnami/mariadb-galera](https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -380,7 +380,7 @@ tls.certCAFilename="ca.pem"
 
 ### Initialize a fresh instance
 
-The [Bitnami MariaDB Galera](https://github.com/bitnami/bitnami-docker-mariadb-galera) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
+The [Bitnami MariaDB Galera](https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, they must be located inside the chart folder `files/docker-entrypoint-initdb.d` so they can be consumed as a ConfigMap.
 
 Alternatively, you can specify custom scripts using the `initdbScripts` parameter as dict.
 
@@ -550,7 +550,7 @@ helm upgrade my-release bitnami/mariadb-galera \
 
 ## Persistence
 
-The [Bitnami MariaDB Galera](https://github.com/bitnami/bitnami-docker-mariadb-galera) image stores the MariaDB data and configurations at the `/bitnami/mariadb` path of the container.
+The [Bitnami MariaDB Galera](https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera) image stores the MariaDB data and configurations at the `/bitnami/mariadb` path of the container.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning, by default. An existing PersistentVolumeClaim can be defined.
 
@@ -620,7 +620,7 @@ In this version the bootstraping was improved. Now it is possible to indicate a 
 
 ### To 1.0.0
 
-The [Bitnami MariaDB Galera](https://github.com/bitnami/bitnami-docker-mariadb-galera) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the MySQL daemon was started as the `mysql` user. From now on, both the container and the MySQL daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `0`.
+The [Bitnami MariaDB Galera](https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the MySQL daemon was started as the `mysql` user. From now on, both the container and the MySQL daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `0`.
 
 Consequences:
 

--- a/bitnami/mariadb-galera/files/docker-entrypoint-initdb.d/README.md
+++ b/bitnami/mariadb-galera/files/docker-entrypoint-initdb.d/README.md
@@ -1,3 +1,3 @@
 You can copy here your custom .sh, .sql or .sql.gz file so they are executed during the first boot of the image.
 
-More info in the [bitnami-docker-mariadb-galera](https://github.com/bitnami/bitnami-docker-mariadb-galera#initializing-a-new-instance) repository.
+More info in the [mariadb-galera](https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera#initializing-a-new-instance) container README.

--- a/bitnami/mariadb-galera/values.yaml
+++ b/bitnami/mariadb-galera/values.yaml
@@ -238,7 +238,7 @@ rootUser:
   user: root
   ## @param rootUser.password Password for the admin user. Ignored if existing secret is provided.
   ## Password is ignored if existingSecret is specified.
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb-galera#setting-the-root-password-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera#setting-the-root-password-on-first-run
   ##
   password: ""
   ## @param rootUser.forcePassword Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
@@ -264,14 +264,14 @@ customPasswordFiles: {}
 ##
 db:
   ## @param db.user Username of new user to create
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb-galera#creating-a-database-user-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera#creating-a-database-user-on-first-run
   ##
   user: ""
   ## @param db.password Password for the new user. Ignored if existing secret is provided.
   ##
   password: ""
   ## @param db.name Name for new database to create
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb-galera#creating-a-database-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera#creating-a-database-on-first-run
   ##
   name: my_database
   ## @param db.forcePassword Option to force users to specify a password. That is required for 'helm upgrade' to work properly.
@@ -285,7 +285,7 @@ galera:
   ##
   name: galera
   ## Bootstraping options
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb-galera#bootstraping
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera#bootstraping
   ##
   bootstrap:
     ## @param galera.bootstrap.forceBootstrap Option to force the boostraping from the indicated node in `galera.bootstarp.bootstrapFromNode`
@@ -302,7 +302,7 @@ galera:
   ##
   mariabackup:
     ## @param galera.mariabackup.user MariaBackup username
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb-galera#setting-up-a-multi-master-cluster
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera#setting-up-a-multi-master-cluster
     ##
     user: mariabackup
     ## @param galera.mariabackup.password MariaBackup password. Password is ignored if existingSecret is specified.

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -23,7 +23,7 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: mariadb
 sources:
-  - https://github.com/bitnami/bitnami-docker-mariadb
+  - https://github.com/bitnami/containers/tree/main/bitnami/mariadb
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
 version: 11.1.1

--- a/bitnami/mariadb/README.md
+++ b/bitnami/mariadb/README.md
@@ -7,7 +7,7 @@ MariaDB is an open source, community-developed SQL database server that is widel
 [Overview of MariaDB](https://mariadb.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/mariadb
 
 ## Introduction
 
-This chart bootstraps a [MariaDB](https://github.com/bitnami/bitnami-docker-mariadb) replication cluster deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [MariaDB](https://github.com/bitnami/containers/tree/main/bitnami/mariadb) replication cluster deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 MariaDB is developed as open source software and as a relational database it provides an SQL interface for accessing data. The latest versions of MariaDB also include GIS and JSON features.
 
@@ -371,7 +371,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                                | Custom network policy rule                                                                                                             | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/mariadb](https://github.com/bitnami/bitnami-docker-mariadb). For more information please refer to the [bitnami/mariadb](https://github.com/bitnami/bitnami-docker-mariadb) image documentation.
+The above parameters map to the env variables defined in [bitnami/mariadb](https://github.com/bitnami/containers/tree/main/bitnami/mariadb). For more information please refer to the [bitnami/mariadb](https://github.com/bitnami/containers/tree/main/bitnami/mariadb) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -407,7 +407,7 @@ To modify the MariaDB version used in this chart you can specify a [valid image 
 
 ### Initialize a fresh instance
 
-The [Bitnami MariaDB](https://github.com/bitnami/bitnami-docker-mariadb) image allows you to use your custom scripts to initialize a fresh instance. Custom scripts may be specified using the `initdbScripts` parameter. Alternatively, an external ConfigMap may be created with all the initialization scripts and the ConfigMap passed to the chart via the `initdbScriptsConfigMap` parameter. Note that this will override the `initdbScripts` parameter.
+The [Bitnami MariaDB](https://github.com/bitnami/containers/tree/main/bitnami/mariadb) image allows you to use your custom scripts to initialize a fresh instance. Custom scripts may be specified using the `initdbScripts` parameter. Alternatively, an external ConfigMap may be created with all the initialization scripts and the ConfigMap passed to the chart via the `initdbScriptsConfigMap` parameter. Note that this will override the `initdbScripts` parameter.
 
 The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
 
@@ -425,7 +425,7 @@ Similarly, additional containers can be added to MariaDB pods using the `initCon
 
 ## Persistence
 
-The [Bitnami MariaDB](https://github.com/bitnami/bitnami-docker-mariadb) image stores the MariaDB data and configurations at the `/bitnami/mariadb` path of the container.
+The [Bitnami MariaDB](https://github.com/bitnami/containers/tree/main/bitnami/mariadb) image stores the MariaDB data and configurations at the `/bitnami/mariadb` path of the container.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning, by default. An existing PersistentVolumeClaim can also be defined.
 

--- a/bitnami/mariadb/values.yaml
+++ b/bitnami/mariadb/values.yaml
@@ -100,26 +100,26 @@ architecture: standalone
 ##
 auth:
   ## @param auth.rootPassword Password for the `root` user. Ignored if existing secret is provided.
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
   ##
   rootPassword: ""
   ## @param auth.database Name for a custom database to create
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+  ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
   ##
   database: my_database
   ## @param auth.username Name for a custom user to create
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
   ##
   username: ""
   ## @param auth.password Password for the new user. Ignored if existing secret is provided
   ##
   password: ""
   ## @param auth.replicationUser MariaDB replication user
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-up-a-replication-cluster
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-up-a-replication-cluster
   ##
   replicationUser: replicator
   ## @param auth.replicationPassword MariaDB replication user password. Ignored if existing secret is provided
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-up-a-replication-cluster
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-up-a-replication-cluster
   ##
   replicationPassword: ""
   ## @param auth.existingSecret Use existing secret for password details (`auth.rootPassword`, `auth.password`, `auth.replicationPassword` will be ignored and picked up from this secret). The secret has to contain the keys `mariadb-root-password`, `mariadb-replication-password` and `mariadb-password`
@@ -390,7 +390,7 @@ primary:
   ## `bitnami/mariadb` Docker image has built-in startup check mechanism,
   ## which periodically checks if MariaDB service has started up and stops it
   ## if all checks have failed after X tries. Use these to control these checks.
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/pull/240
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb/pull/240
   ## Example (with default options):
   ## startupWaitOptions:
   ##   retries: 300
@@ -772,7 +772,7 @@ secondary:
   ## `bitnami/mariadb` Docker image has built-in startup check mechanism,
   ## which periodically checks if MariaDB service has started up and stops it
   ## if all checks have failed after X tries. Use these to control these checks.
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/pull/240
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb/pull/240
   ## Example (with default options):
   ## startupWaitOptions:
   ##   retries: 300

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -28,6 +28,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: matomo
 sources:
-  - https://github.com/bitnami/bitnami-docker-matomo
+  - https://github.com/bitnami/containers/tree/main/bitnami/matomo
   - https://www.matomo.org/
 version: 0.1.3

--- a/bitnami/matomo/README.md
+++ b/bitnami/matomo/README.md
@@ -7,7 +7,7 @@ Matomo, formerly known as Piwik, is a real time web analytics program. It provid
 [Overview of Matomo](https://matomo.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/matomo
 
 ## Introduction
 
-This chart bootstraps a [Matomo](https://github.com/bitnami/bitnami-docker-matomo) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Matomo](https://github.com/bitnami/containers/tree/main/bitnami/matomo) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment as a database for the Matomo application.
 
@@ -298,7 +298,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                 | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/matomo](https://github.com/bitnami/bitnami-docker-matomo). For more information please refer to the [bitnami/matomo](https://github.com/bitnami/bitnami-docker-matomo) image documentation.
+The above parameters map to the env variables defined in [bitnami/matomo](https://github.com/bitnami/containers/tree/main/bitnami/matomo). For more information please refer to the [bitnami/matomo](https://github.com/bitnami/containers/tree/main/bitnami/matomo) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -354,7 +354,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami Matomo](https://github.com/bitnami/bitnami-docker-matomo) image stores the Matomo data and configurations at the `/bitnami/matomo` path of the container.
+The [Bitnami Matomo](https://github.com/bitnami/containers/tree/main/bitnami/matomo) image stores the Matomo data and configurations at the `/bitnami/matomo` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.

--- a/bitnami/matomo/values.yaml
+++ b/bitnami/matomo/values.yaml
@@ -79,32 +79,32 @@ image:
 ##
 replicaCount: 1
 ## @param matomoUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-matomo#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/matomo#configuration
 ##
 matomoUsername: user
 ## @param matomoPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-matomo#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/matomo#configuration
 ##
 matomoPassword: ""
 ## @param matomoEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-matomo#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/matomo#configuration
 ##
 matomoEmail: user@example.com
 ## @param matomoWebsiteName Matomo application name
-## ref: https://github.com/bitnami/bitnami-docker-matomo#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/matomo#configuration
 ##
 matomoWebsiteName: example
 ## @param matomoWebsiteHost Matomo application host
-## ref: https://github.com/bitnami/bitnami-docker-matomo#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/matomo#configuration
 ##
 matomoWebsiteHost: https://example.org
 ## @param matomoSkipInstall Skip Matomo installation wizard. Useful for migrations and restoring from SQL dump
-## ref: https://github.com/bitnami/bitnami-docker-matomo#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/matomo#configuration
 ##
 matomoSkipInstall: false
 ## @param customPostInitScripts Custom post-init.d user scripts
-## ref: https://github.com/bitnami/bitnami-docker-dokuwiki
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki
 ## NOTE: supported formats are `.sh` or `.php`
 ## NOTE: scripts are exclusively executed during the 1st boot of the container
 ## e.g:
@@ -119,7 +119,7 @@ matomoSkipInstall: false
 ##
 customPostInitScripts: {}
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-matomo#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/matomo#environment-variables
 ##
 allowEmptyPassword: true
 ## @param command Override default container command (useful when using custom images)
@@ -188,7 +188,7 @@ tolerations: []
 ##
 existingSecret: ""
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-matomo/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/matomo/#smtp-configuration
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpUser SMTP user
@@ -591,13 +591,13 @@ mariadb:
   ## @param mariadb.auth.password Password for the database
   ##
   auth:
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_matomo
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_matomo
     password: ""

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -30,6 +30,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: mediawiki
 sources:
-  - https://github.com/bitnami/bitnami-docker-mediawiki
+  - https://github.com/bitnami/containers/tree/main/bitnami/mediawiki
   - https://www.mediawiki.org/
 version: 14.2.12

--- a/bitnami/mediawiki/README.md
+++ b/bitnami/mediawiki/README.md
@@ -7,7 +7,7 @@ MediaWiki is the free and open source wiki software that powers Wikipedia. Used 
 [Overview of MediaWiki](http://www.mediawiki.org/wiki/MediaWiki)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/mediawiki
 
 ## Introduction
 
-This chart bootstraps a [MediaWiki](https://github.com/bitnami/bitnami-docker-mediawiki) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [MediaWiki](https://github.com/bitnami/containers/tree/main/bitnami/mediawiki) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the MediaWiki application.
 
@@ -275,7 +275,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                    | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/mediawiki](https://github.com/bitnami/bitnami-docker-mediawiki). For more information please refer to the [bitnami/mediawiki](https://github.com/bitnami/bitnami-docker-mediawiki) image documentation.
+The above parameters map to the env variables defined in [bitnami/mediawiki](https://github.com/bitnami/containers/tree/main/bitnami/mediawiki). For more information please refer to the [bitnami/mediawiki](https://github.com/bitnami/containers/tree/main/bitnami/mediawiki) image documentation.
 
 > **Note**:
 >
@@ -311,7 +311,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ## Persistence
 
-The [Bitnami MediaWiki](https://github.com/bitnami/bitnami-docker-mediawiki) image stores the MediaWiki data and configurations at the `/bitnami/mediawiki` path of the container.
+The [Bitnami MediaWiki](https://github.com/bitnami/containers/tree/main/bitnami/mediawiki) image stores the MediaWiki data and configurations at the `/bitnami/mediawiki` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -487,7 +487,7 @@ mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
 
 ### To 10.0.0
 
-The [Bitnami MediaWiki](https://github.com/bitnami/bitnami-docker-mediawiki) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
+The [Bitnami MediaWiki](https://github.com/bitnami/containers/tree/main/bitnami/mediawiki) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
 
 Consequences:
 

--- a/bitnami/mediawiki/values.yaml
+++ b/bitnami/mediawiki/values.yaml
@@ -81,12 +81,12 @@ hostAliases:
     hostnames:
       - "status.localhost"
 ## @param mediawikiUser User of the application
-## ref: https://github.com/bitnami/bitnami-docker-mediawiki#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mediawiki#environment-variables
 ##
 mediawikiUser: user
 ## @param mediawikiPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-mediawiki#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mediawiki#environment-variables
 ##
 mediawikiPassword: ""
 ## @param mediawikiSecret Existing `Secret` containing the password for the `mediawikiUser` user; must contain the key `mediawiki-password` and optional key `smtp-password`
@@ -94,23 +94,23 @@ mediawikiPassword: ""
 ##
 mediawikiSecret: ""
 ## @param mediawikiEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-mediawiki#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mediawiki#environment-variables
 ##
 mediawikiEmail: user@example.com
 ## @param mediawikiName Name for the wiki
-## ref: https://github.com/bitnami/bitnami-docker-mediawiki#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mediawiki#environment-variables
 ##
 mediawikiName: My Wiki
 ## @param mediawikiHost Mediawiki host to create application URLs
-## ref: https://github.com/bitnami/bitnami-docker-mediawiki#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mediawiki#configuration
 ##
 mediawikiHost: ""
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-mediawiki#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mediawiki#environment-variables
 ##
 allowEmptyPassword: "yes"
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-mediawiki#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mediawiki#smtp-configuration
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpHostID SMTP host ID
@@ -550,7 +550,7 @@ ingress:
   ## - host: example.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: example-svc
   ##           port:
@@ -575,15 +575,15 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_mediawiki
     ## @param mariadb.auth.username Database user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_mediawiki
     ## @param mariadb.auth.password Password for the database

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -20,6 +20,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: memcached
 sources:
-  - https://github.com/bitnami/bitnami-docker-memcached
+  - https://github.com/bitnami/containers/tree/main/bitnami/memcached
   - http://memcached.org/
 version: 6.1.5

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -7,7 +7,7 @@ Memcached is an high-performance, distributed memory object caching system, gene
 [Overview of Memcached](http://memcached.org)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/memcached
 
 ## Introduction
 
-This chart bootstraps a [Memcached](https://github.com/bitnami/bitnami-docker-memcached) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Memcached](https://github.com/bitnami/containers/tree/main/bitnami/memcached) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -264,7 +264,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.serviceMonitor.jobLabel`                      | The name of the label on the target service to use as the job name in prometheus.     | `""`                         |
 
 
-The above parameters map to the environment variables defined in the [bitnami/memcached](https://github.com/bitnami/bitnami-docker-memcached) container image. For more information please refer to the [bitnami/memcached](https://github.com/bitnami/bitnami-docker-memcached) container image documentation.
+The above parameters map to the environment variables defined in the [bitnami/memcached](https://github.com/bitnami/containers/tree/main/bitnami/memcached) container image. For more information please refer to the [bitnami/memcached](https://github.com/bitnami/containers/tree/main/bitnami/memcached) container image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -306,7 +306,7 @@ As an alternative, you can use the preset configurations for pod affinity, pod a
 
 ## Persistence
 
-When using `architecture: "high-availability"` the [Bitnami Memcached](https://github.com/bitnami/bitnami-docker-memcached) image stores the cache-state at the `/cache-state` path of the container if enabled.
+When using `architecture: "high-availability"` the [Bitnami Memcached](https://github.com/bitnami/containers/tree/main/bitnami/memcached) image stores the cache-state at the `/cache-state` path of the container if enabled.
 
 Persistent Volume Claims (PVCs) are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -90,7 +90,7 @@ image:
 ##
 architecture: standalone
 ## Authentication parameters
-## ref: https://github.com/bitnami/bitnami-docker-memcached#creating-the-memcached-admin-user
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/memcached#creating-the-memcached-admin-user
 ##
 auth:
   ## @param auth.enabled Enable Memcached authentication

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -28,6 +28,6 @@ maintainers:
 name: metallb
 sources:
   - https://github.com/metallb/metallb
-  - https://github.com/bitnami/bitnami-docker-metallb
+  - https://github.com/bitnami/containers/tree/main/bitnami/metallb
   - https://metallb.universe.tf
 version: 3.0.11

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -21,6 +21,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: metrics-server
 sources:
-  - https://github.com/bitnami/bitnami-docker-metrics-server
+  - https://github.com/bitnami/containers/tree/main/bitnami/metrics-server
   - https://github.com/kubernetes-incubator/metrics-server
 version: 6.0.8

--- a/bitnami/metrics-server/README.md
+++ b/bitnami/metrics-server/README.md
@@ -7,7 +7,7 @@ Metrics Server aggregates resource usage data, such as container CPU and memory 
 [Overview of Metrics Server](https://github.com/kubernetes-incubator/metrics-server)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/metrics-server
 
 ## Introduction
 
-This chart bootstraps a [Metrics Server](https://github.com/bitnami/bitnami-docker-metrics-server) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Metrics Server](https://github.com/bitnami/containers/tree/main/bitnami/metrics-server) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 

--- a/bitnami/metrics-server/values.yaml
+++ b/bitnami/metrics-server/values.yaml
@@ -172,7 +172,7 @@ extraEnvVarsCM: ""
 ##
 extraEnvVarsSecret: ""
 ## @param extraArgs Extra arguments to pass to metrics-server on start up
-## ref: https://github.com/kubernetes-incubator/metrics-server/blob/master/README.md#flags
+## ref: https://github.com/kubernetes-incubator/metrics-server#flags
 ##
 ## extraArgs:
 ##   - --kubelet-insecure-tls=true

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: minio
 sources:
-  - https://github.com/bitnami/bitnami-docker-minio
+  - https://github.com/bitnami/containers/tree/main/bitnami/minio
   - https://min.io
 version: 11.7.13

--- a/bitnami/minio/README.md
+++ b/bitnami/minio/README.md
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/minio
 
 ## Introduction
 
-This chart bootstraps a [MinIO&reg;](https://github.com/bitnami/bitnami-docker-minio) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [MinIO&reg;](https://github.com/bitnami/containers/tree/main/bitnami/minio) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -405,7 +405,7 @@ MinIO&reg; exports Prometheus metrics at `/minio/v2/metrics/cluster`. To allow P
 
 ## Persistence
 
-The [Bitnami Object Storage based on MinIO(&reg;)](https://github.com/bitnami/bitnami-docker-minio) image stores data at the `/data` path of the container.
+The [Bitnami Object Storage based on MinIO(&reg;)](https://github.com/bitnami/containers/tree/main/bitnami/minio) image stores data at the `/data` path of the container.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
 

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: mongodb-sharded
 sources:
-  - https://github.com/bitnami/bitnami-docker-mongodb-sharded
+  - https://github.com/bitnami/containers/tree/main/bitnami/mongodb-sharded
   - https://mongodb.org
 version: 5.1.1

--- a/bitnami/mongodb-sharded/README.md
+++ b/bitnami/mongodb-sharded/README.md
@@ -7,7 +7,7 @@ MongoDB(R) is an open source NoSQL database that uses JSON for data storage. Mon
 [Overview of MongoDB&reg; Sharded](http://www.mongodb.org)
 
 Disclaimer: The respective trademarks mentioned in the offering are owned by the respective companies. We do not provide a commercial license for any of these products. This listing has an open-source license. MongoDB(R) is run and maintained by MongoDB, which is a completely separate project from Bitnami.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/mongodb-sharded
 
 ## Introduction
 
-This chart bootstraps a [MongoDB(&reg;) Sharded](https://github.com/bitnami/bitnami-docker-mongodb-sharded) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [MongoDB(&reg;) Sharded](https://github.com/bitnami/containers/tree/main/bitnami/mongodb-sharded) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Classified as a NoSQL database, MongoDB&reg; eschews the traditional table-based relational database structure in favor of JSON-like documents with dynamic schemas, making the integration of data in certain types of applications easier and faster.
 
@@ -555,7 +555,7 @@ This chart deploys a sharded cluster by default. Some characteristics of this ch
 
 ### Initialize a fresh instance
 
-The [Bitnami MongoDB&reg;](https://github.com/bitnami/bitnami-docker-mongodb-sharded) image allows you to use your custom scripts to initialize a fresh instance. You can create a custom config map and give it via `initScriptsCM`(check options for more details).
+The [Bitnami MongoDB&reg;](https://github.com/bitnami/containers/tree/main/bitnami/mongodb-sharded) image allows you to use your custom scripts to initialize a fresh instance. You can create a custom config map and give it via `initScriptsCM`(check options for more details).
 
 The allowed extensions are `.sh`, and `.js`.
 
@@ -603,7 +603,7 @@ It is possible to not deploy any shards or a config server. For example, it is p
 
 ## Persistence
 
-The [Bitnami MongoDB&reg;](https://github.com/bitnami/bitnami-docker-mongodb-sharded) image stores the MongoDB&reg; data and configurations at the `/bitnami/mongodb` path of the container.
+The [Bitnami MongoDB&reg;](https://github.com/bitnami/containers/tree/main/bitnami/mongodb-sharded) image stores the MongoDB&reg; data and configurations at the `/bitnami/mongodb` path of the container.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
 

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -104,7 +104,7 @@ auth:
   ##
   rootUser: root
   ## @param auth.rootPassword MongoDB(&reg;) root password
-  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#setting-the-root-password-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#setting-the-root-user-and-password-on-first-run
   ##
   rootPassword: ""
   ## @param auth.replicaSetKey Key used for authentication in the replicaset (only when `architecture=replicaset`)

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -134,7 +134,7 @@ common:
   ##
   useHostnames: true
   ## @param common.mongodbEnableIPv6 Switch to enable/disable IPv6 on MongoDB&reg;
-  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enabling/disabling-ipv6
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enablingdisabling-ipv6
   ##
   mongodbEnableIPv6: false
   ## @param common.mongodbDirectoryPerDB Switch to enable/disable DirectoryPerDB on MongoDB&reg;

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -138,7 +138,7 @@ common:
   ##
   mongodbEnableIPv6: false
   ## @param common.mongodbDirectoryPerDB Switch to enable/disable DirectoryPerDB on MongoDB&reg;
-  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enabling/disabling-directoryperdb
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enablingdisabling-directoryperdb
   ##
   mongodbDirectoryPerDB: false
   ## @param common.mongodbSystemLogVerbosity MongoDB&reg; system log verbosity level

--- a/bitnami/mongodb-sharded/values.yaml
+++ b/bitnami/mongodb-sharded/values.yaml
@@ -104,7 +104,7 @@ auth:
   ##
   rootUser: root
   ## @param auth.rootPassword MongoDB(&reg;) root password
-  ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#setting-the-root-password-on-first-run
   ##
   rootPassword: ""
   ## @param auth.replicaSetKey Key used for authentication in the replicaset (only when `architecture=replicaset`)
@@ -134,11 +134,11 @@ common:
   ##
   useHostnames: true
   ## @param common.mongodbEnableIPv6 Switch to enable/disable IPv6 on MongoDB&reg;
-  ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enabling/disabling-ipv6
   ##
   mongodbEnableIPv6: false
   ## @param common.mongodbDirectoryPerDB Switch to enable/disable DirectoryPerDB on MongoDB&reg;
-  ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-directoryperdb
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enabling/disabling-directoryperdb
   ##
   mongodbDirectoryPerDB: false
   ## @param common.mongodbSystemLogVerbosity MongoDB&reg; system log verbosity level
@@ -146,7 +146,7 @@ common:
   ##
   mongodbSystemLogVerbosity: 0
   ## @param common.mongodbDisableSystemLog Whether to disable MongoDB&reg; system log or not
-  ## ref: https://github.com/bitnami/bitnami-docker-mongodb#configuring-system-log-verbosity-level
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#configuring-system-log-verbosity-level
   ##
   mongodbDisableSystemLog: false
   ## @param common.mongodbMaxWaitTimeout Maximum time (in seconds) for MongoDB&reg; nodes to wait for another MongoDB&reg; node to be ready

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: mongodb
 sources:
-  - https://github.com/bitnami/bitnami-docker-mongodb
+  - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
 version: 12.1.27

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -7,7 +7,7 @@ MongoDB(R) is a relational open source NoSQL database. Easy to use, it stores da
 [Overview of MongoDB&reg;](http://www.mongodb.org)
 
 Disclaimer: The respective trademarks mentioned in the offering are owned by the respective companies. We do not provide a commercial license for any of these products. This listing has an open-source license. MongoDB(R) is run and maintained by MongoDB, which is a completely separate project from Bitnami.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/mongodb
 
 ## Introduction
 
-This chart bootstraps a [MongoDB(&reg;)](https://github.com/bitnami/bitnami-docker-mongodb) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [MongoDB(&reg;)](https://github.com/bitnami/containers/tree/main/bitnami/mongodb) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -578,7 +578,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ### Customize a new MongoDB instance
 
-The [Bitnami MongoDB(&reg;) image](https://github.com/bitnami/bitnami-docker-mongodb) supports the use of custom scripts to initialize a fresh instance. In order to execute the scripts, two options are available:
+The [Bitnami MongoDB(&reg;) image](https://github.com/bitnami/containers/tree/main/bitnami/mongodb) supports the use of custom scripts to initialize a fresh instance. In order to execute the scripts, two options are available:
 
 * Specify them using the `initdbScripts` parameter as dict.
 * Define an external Kubernetes ConfigMap with all the initialization scripts by setting the `initdbScriptsConfigMap` parameter. Note that this will override the previous option.
@@ -614,7 +614,7 @@ Refer to the chart documentation for more information on, and examples of, confi
 
 ## Persistence
 
-The [Bitnami MongoDB(&reg;)](https://github.com/bitnami/bitnami-docker-mongodb) image stores the MongoDB(&reg;) data and configurations at the `/bitnami/mongodb` path of the container.
+The [Bitnami MongoDB(&reg;)](https://github.com/bitnami/containers/tree/main/bitnami/mongodb) image stores the MongoDB(&reg;) data and configurations at the `/bitnami/mongodb` path of the container.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
 
@@ -720,7 +720,7 @@ ingress:
 ### To 6.0.0
 
 From this version, `mongodbEnableIPv6` is set to `false` by default in order to work properly in most k8s clusters, if you want to use IPv6 support, you need to set this variable to `true` by adding `--set mongodbEnableIPv6=true` to your `helm` command.
-You can find more information in the [`bitnami/mongodb` image README](https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md).
+You can find more information in the [`bitnami/mongodb` image README](https://github.com/bitnami/containers/tree/main/bitnami/mongodb#readme).
 
 ### To 5.0.0
 

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -143,7 +143,7 @@ auth:
   ##
   rootUser: root
   ## @param auth.rootPassword MongoDB(&reg;) root password
-  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#setting-the-root-password-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#setting-the-root-user-and-password-on-first-run
   ##
   rootPassword: ""
   ## MongoDB(&reg;) custom users and databases

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -252,7 +252,7 @@ replicaSetName: rs0
 ##
 replicaSetHostnames: true
 ## @param enableIPv6 Switch to enable/disable IPv6 on MongoDB(&reg;)
-## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enabling/disabling-ipv6
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enablingdisabling-ipv6
 ##
 enableIPv6: false
 ## @param directoryPerDB Switch to enable/disable DirectoryPerDB on MongoDB(&reg;)

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -147,7 +147,7 @@ auth:
   ##
   rootPassword: ""
   ## MongoDB(&reg;) custom users and databases
-  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#creating-users-and-databases-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#creating-a-user-and-database-on-first-run
   ## @param auth.usernames List of custom users to be created during the initialization
   ## @param auth.passwords List of passwords for the custom users set at `auth.usernames`
   ## @param auth.databases List of custom databases to be created during the initialization

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -143,11 +143,11 @@ auth:
   ##
   rootUser: root
   ## @param auth.rootPassword MongoDB(&reg;) root password
-  ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#setting-the-root-password-on-first-run
   ##
   rootPassword: ""
   ## MongoDB(&reg;) custom users and databases
-  ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-users-and-databases-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#creating-users-and-databases-on-first-run
   ## @param auth.usernames List of custom users to be created during the initialization
   ## @param auth.passwords List of passwords for the custom users set at `auth.usernames`
   ## @param auth.databases List of custom databases to be created during the initialization
@@ -252,15 +252,15 @@ replicaSetName: rs0
 ##
 replicaSetHostnames: true
 ## @param enableIPv6 Switch to enable/disable IPv6 on MongoDB(&reg;)
-## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-ipv6
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enabling/disabling-ipv6
 ##
 enableIPv6: false
 ## @param directoryPerDB Switch to enable/disable DirectoryPerDB on MongoDB(&reg;)
-## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#enabling/disabling-directoryperdb
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enabling/disabling-directoryperdb
 ##
 directoryPerDB: false
 ## MongoDB(&reg;) System Log configuration
-## ref: https://github.com/bitnami/bitnami-docker-mongodb#configuring-system-log-verbosity-level
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#configuring-system-log-verbosity-level
 ## @param systemLogVerbosity MongoDB(&reg;) system log verbosity level
 ## @param disableSystemLog Switch to enable/disable MongoDB(&reg;) system log
 ##

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -256,7 +256,7 @@ replicaSetHostnames: true
 ##
 enableIPv6: false
 ## @param directoryPerDB Switch to enable/disable DirectoryPerDB on MongoDB(&reg;)
-## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enabling/disabling-directoryperdb
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#enablingdisabling-directoryperdb
 ##
 directoryPerDB: false
 ## MongoDB(&reg;) System Log configuration

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: moodle
 sources:
-  - https://github.com/bitnami/bitnami-docker-moodle
+  - https://github.com/bitnami/containers/tree/main/bitnami/moodle
   - https://www.moodle.org/
 version: 14.1.12

--- a/bitnami/moodle/README.md
+++ b/bitnami/moodle/README.md
@@ -7,7 +7,7 @@ Moodle(TM) LMS is an open source online Learning Management System widely used a
 [Overview of Bitnami LMS powered by Moodle&trade; LMS](http://moodle.org/)
 
 Disclaimer: The respective trademarks mentioned in the offering are owned by the respective companies. We do not provide commercial license of any of these products. This listing has an open source license. Moodle(TM) LMS is run and maintained by Moodle HQ, that is a completely and separate project from Bitnami.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/moodle
 
 ## Introduction
 
-This chart bootstraps a [Moodle&trade;](https://github.com/bitnami/bitnami-docker-moodle) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Moodle&trade;](https://github.com/bitnami/containers/tree/main/bitnami/moodle) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the Moodle&trade; application.
 
@@ -304,7 +304,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                 | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/moodle](https://github.com/bitnami/bitnami-docker-moodle). For more information please refer to the [bitnami/moodle](https://github.com/bitnami/bitnami-docker-moodle) image documentation.
+The above parameters map to the env variables defined in [bitnami/moodle](https://github.com/bitnami/containers/tree/main/bitnami/moodle). For more information please refer to the [bitnami/moodle](https://github.com/bitnami/containers/tree/main/bitnami/moodle) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -384,7 +384,7 @@ ingress:
 
 ## Persistence
 
-The [Bitnami Container Image for Moodle&trade;](https://github.com/bitnami/bitnami-docker-moodle) stores the Moodle&trade; data and configurations at the `/bitnami/moodle` and `/bitnami/apache` paths of the container.
+The [Bitnami Container Image for Moodle&trade;](https://github.com/bitnami/containers/tree/main/bitnami/moodle) stores the Moodle&trade; data and configurations at the `/bitnami/moodle` and `/bitnami/apache` paths of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, vpshere, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -479,7 +479,7 @@ mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
 
 ### To 8.0.0
 
-The [Bitnami Container Image for Moodle&trade;](https://github.com/bitnami/bitnami-docker-moodle) was updated to support "non-root" user approach, however, **it is not enabled by default**. The container still runs as the `root` user and the Apache daemon is started as the `daemon` user, due to running Cron as a service, which requires running as root.
+The [Bitnami Container Image for Moodle&trade;](https://github.com/bitnami/containers/tree/main/bitnami/moodle) was updated to support "non-root" user approach, however, **it is not enabled by default**. The container still runs as the `root` user and the Apache daemon is started as the `daemon` user, due to running Cron as a service, which requires running as root.
 
 If you want to run with a non-root user, you need to set `podSecurityContext.enabled=true` and `containerSecurity.context.enabled=true`. In addition to that, you will also need to change the default Apache HTTP ports to run as a non-privileged user by setting `containerPorts.http` and `containerPorts.https` to a non-privileged port number (higher than 1024, i.e. 8080 and 8443, respectively). Note that, when running as a non-root user, Cron will not supported and therefore scheduled tasks will not be enabled for Moodle&trade;.
 

--- a/bitnami/moodle/values.yaml
+++ b/bitnami/moodle/values.yaml
@@ -72,28 +72,28 @@ image:
 ##
 replicaCount: 1
 ## @param moodleSkipInstall Skip Moodle&trade; installation wizard. Useful for migrations and restoring from SQL dump
-## ref: https://github.com/bitnami/bitnami-docker-moodle#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/moodle#configuration
 ##
 moodleSkipInstall: false
 ## @param moodleSiteName Site name
-## ref: https://github.com/bitnami/bitnami-docker-moodle#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/moodle#configuration
 ##
 moodleSiteName: ""
 ## @param moodleUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-moodle#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/moodle#configuration
 ##
 moodleUsername: user
 ## @param moodlePassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-moodle#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/moodle#configuration
 ##
 moodlePassword: ""
 ## @param moodleEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-moodle#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/moodle#configuration
 ##
 moodleEmail: user@example.com
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-moodle#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/moodle#environment-variables
 ##
 allowEmptyPassword: true
 ## @param command Override default container command (useful when using custom images)
@@ -157,7 +157,7 @@ topologySpreadConstraints: []
 ##
 existingSecret: ""
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-moodle/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/moodle/#smtp-configuration
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpUser SMTP user
@@ -528,7 +528,7 @@ ingress:
   ## - host: example.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: example-svc
   ##           port:
@@ -553,15 +553,15 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_moodle
     ## @param mariadb.auth.username Database user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_moodle
     ## @param mariadb.auth.password Password for the database

--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -22,6 +22,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: mxnet
 sources:
-  - https://github.com/bitnami/bitnami-docker-mxnet
+  - https://github.com/bitnami/containers/tree/main/bitnami/mxnet
   - https://mxnet.apache.org/
 version: 3.0.17

--- a/bitnami/mxnet/README.md
+++ b/bitnami/mxnet/README.md
@@ -7,7 +7,7 @@ Apache MXNet (Incubating) is a flexible and efficient library for deep learning 
 [Overview of Apache MXNet (Incubating)](https://mxnet.incubator.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/mxnet
 
 ## Introduction
 
-This chart bootstraps an [Apache MXNet (Incubating)](https://github.com/bitnami/bitnami-docker-mxnet) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [Apache MXNet (Incubating)](https://github.com/bitnami/containers/tree/main/bitnami/mxnet) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -524,7 +524,7 @@ initContainers:
 
 ## Persistence
 
-The [Bitnami Apache MXNet (Incubating)](https://github.com/bitnami/bitnami-docker-mxnet) image can persist data. If enabled, the persisted path is `/bitnami/mxnet` by default.
+The [Bitnami Apache MXNet (Incubating)](https://github.com/bitnami/containers/tree/main/bitnami/mxnet) image can persist data. If enabled, the persisted path is `/bitnami/mxnet` by default.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
 

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: mysql
 sources:
-  - https://github.com/bitnami/bitnami-docker-mysql
+  - https://github.com/bitnami/containers/tree/main/bitnami/mysql
   - https://mysql.com
 version: 9.2.1

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -7,7 +7,7 @@ MySQL is a fast, reliable, scalable, and easy to use open source relational data
 [Overview of MySQL](http://www.mysql.com)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/mysql
 
 ## Introduction
 
-This chart bootstraps a [MySQL](https://github.com/bitnami/bitnami-docker-mysql) replication cluster deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [MySQL](https://github.com/bitnami/containers/tree/main/bitnami/mysql) replication cluster deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -355,7 +355,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.prometheusRule.rules`               | Prometheus Rule definitions                                                                                                    | `[]`                      |
 
 
-The above parameters map to the env variables defined in [bitnami/mysql](https://github.com/bitnami/bitnami-docker-mysql). For more information please refer to the [bitnami/mysql](https://github.com/bitnami/bitnami-docker-mysql) image documentation.
+The above parameters map to the env variables defined in [bitnami/mysql](https://github.com/bitnami/containers/tree/main/bitnami/mysql). For more information please refer to the [bitnami/mysql](https://github.com/bitnami/containers/tree/main/bitnami/mysql) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -391,7 +391,7 @@ To modify the application version used in this chart, specify a different versio
 
 ### Customize a new MySQL instance
 
-The [Bitnami MySQL](https://github.com/bitnami/bitnami-docker-mysql) image allows you to use your custom scripts to initialize a fresh instance. Custom scripts may be specified using the `initdbScripts` parameter. Alternatively, an external ConfigMap may be created with all the initialization scripts and the ConfigMap passed to the chart via the `initdbScriptsConfigMap` parameter. Note that this will override the `initdbScripts` parameter.
+The [Bitnami MySQL](https://github.com/bitnami/containers/tree/main/bitnami/mysql) image allows you to use your custom scripts to initialize a fresh instance. Custom scripts may be specified using the `initdbScripts` parameter. Alternatively, an external ConfigMap may be created with all the initialization scripts and the ConfigMap passed to the chart via the `initdbScriptsConfigMap` parameter. Note that this will override the `initdbScripts` parameter.
 
 The allowed extensions are `.sh`, `.sql` and `.sql.gz`.
 
@@ -427,7 +427,7 @@ initContainers:
 
 ## Persistence
 
-The [Bitnami MySQL](https://github.com/bitnami/bitnami-docker-mysql) image stores the MySQL data and configurations at the `/bitnami/mysql` path of the container.
+The [Bitnami MySQL](https://github.com/bitnami/containers/tree/main/bitnami/mysql) image stores the MySQL data and configurations at the `/bitnami/mysql` path of the container.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) volume at this location. The volume is created using dynamic volume provisioning by default. An existing PersistentVolumeClaim can also be defined for this purpose.
 

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -96,26 +96,26 @@ architecture: standalone
 ##
 auth:
   ## @param auth.rootPassword Password for the `root` user. Ignored if existing secret is provided
-  ## ref: https://github.com/bitnami/bitnami-docker-mysql#setting-the-root-password-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mysql#setting-the-root-password-on-first-run
   ##
   rootPassword: ""
   ## @param auth.createDatabase Wheter to create the .Values.auth.database or not
-  ## ref: https://github.com/bitnami/bitnami-docker-mysql/blob/master/README.md#creating-a-database-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mysql#creating-a-database-on-first-run
   ##
   createDatabase: true
   ## @param auth.database Name for a custom database to create
-  ## ref: https://github.com/bitnami/bitnami-docker-mysql/blob/master/README.md#creating-a-database-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mysql#creating-a-database-on-first-run
   ##
   database: "my_database"
   ## @param auth.username Name for a custom user to create
-  ## ref: https://github.com/bitnami/bitnami-docker-mysql/blob/master/README.md#creating-a-database-user-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mysql#creating-a-database-user-on-first-run
   ##
   username: ""
   ## @param auth.password Password for the new user. Ignored if existing secret is provided
   ##
   password: ""
   ## @param auth.replicationUser MySQL replication user
-  ## ref: https://github.com/bitnami/bitnami-docker-mysql#setting-up-a-replication-cluster
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mysql#setting-up-a-replication-cluster
   ##
   replicationUser: replicator
   ## @param auth.replicationPassword MySQL replication user password. Ignored if existing secret is provided
@@ -1145,7 +1145,7 @@ metrics:
     ## @param metrics.serviceMonitor.annotations ServiceMonitor annotations
     ##
     annotations: {}
-  
+
   ## Prometheus Operator prometheusRule configuration
   ##
   prometheusRule:

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -22,6 +22,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: nats
 sources:
-  - https://github.com/bitnami/bitnami-docker-nats
+  - https://github.com/bitnami/containers/tree/main/bitnami/nats
   - https://nats.io/
 version: 7.3.7

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -7,7 +7,7 @@ NATS is an open source, lightweight and high-performance messaging system. It is
 [Overview of NATS](https://nats.io/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/nats
 
 ## Introduction
 
-This chart bootstraps a [NATS](https://github.com/bitnami/bitnami-docker-nats) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [NATS](https://github.com/bitnami/containers/tree/main/bitnami/nats) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -321,7 +321,7 @@ helm install nats-v1 --set natsFilename=gnatsd --set image.tag=1.4.1 bitnami/nat
 
 ### To 7.0.0
 
-This new version updates the NATS image to a [new version that has support to configure NATS based on bash logic](https://github.com/bitnami/bitnami-docker-nats#264-r13), although this chart overwrites the configuration file so that shouldn't affect the functionality. It also adds several standardizations that were missing in the chart:
+This new version updates the NATS image to a [new version that has support to configure NATS based on bash logic](https://github.com/bitnami/containers/tree/main/bitnami/nats#264-r13), although this chart overwrites the configuration file so that shouldn't affect the functionality. It also adds several standardizations that were missing in the chart:
 
 - Add missing parameters such as `existingSecret`, `containerPorts.*`, `startupProbe.*` or `lifecycleHooks`.
 - Add missing parameters to extend the services such as `service.extraPorts` or `service.sessionAffinity`.

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -25,6 +25,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: nginx-ingress-controller
 sources:
-  - https://github.com/bitnami/bitnami-docker-nginx-ingress-controller
+  - https://github.com/bitnami/containers/tree/main/bitnami/nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
 version: 9.2.21

--- a/bitnami/nginx-intel/Chart.yaml
+++ b/bitnami/nginx-intel/Chart.yaml
@@ -22,6 +22,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: nginx-intel
 sources:
-  - https://github.com/bitnami/bitnami-docker-nginx-intel
+  - https://github.com/bitnami/containers/tree/main/bitnami/nginx-intel
   - https://github.com/intel/asynch_mode_nginx
 version: 2.0.12

--- a/bitnami/nginx-intel/README.md
+++ b/bitnami/nginx-intel/README.md
@@ -7,7 +7,7 @@ NGINX Open Source for Intel is a lightweight server, combined with cryptography 
 [Overview of NGINX Open Source for Intel](https://github.com/intel/asynch_mode_nginx)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -19,7 +19,7 @@ $ helm install my-release bitnami/nginx-intel
 
 Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
 
-This chart bootstraps a [NGINX Open Source with Intel Optimizations](https://github.com/bitnami/bitnami-docker-nginx-intel) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [NGINX Open Source with Intel Optimizations](https://github.com/bitnami/containers/tree/main/bitnami/nginx-intel) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -366,7 +366,7 @@ There are cases where you may want to deploy extra objects, such a ConfigMap con
 
 ### Ingress
 
-This chart provides support for ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress-controller](https://github.com/bitnami/charts/tree/master/bitnami/nginx-intel-ingress-controller) or [contour](https://github.com/bitnami/charts/tree/master/bitnami/contour) you can utilize the ingress controller to serve your application.
+This chart provides support for ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress-controller](https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller) or [contour](https://github.com/bitnami/charts/tree/master/bitnami/contour) you can utilize the ingress controller to serve your application.
 
 To enable ingress integration, please set `ingress.enabled` to `true`.
 

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -23,6 +23,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: nginx
 sources:
-  - https://github.com/bitnami/bitnami-docker-nginx
+  - https://github.com/bitnami/containers/tree/main/bitnami/nginx
   - https://www.nginx.org
 version: 13.1.4

--- a/bitnami/nginx/README.md
+++ b/bitnami/nginx/README.md
@@ -7,7 +7,7 @@ NGINX Open Source is a web server that can be also used as a reverse proxy, load
 [Overview of NGINX Open Source](http://nginx.org)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -19,7 +19,7 @@ $ helm install my-release bitnami/nginx
 
 Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
 
-This chart bootstraps a [NGINX Open Source](https://github.com/bitnami/bitnami-docker-nginx) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [NGINX Open Source](https://github.com/bitnami/containers/tree/main/bitnami/nginx) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -21,7 +21,7 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: node-exporter
 sources:
-  - https://github.com/bitnami/bitnami-docker-node-exporter
+  - https://github.com/bitnami/containers/tree/main/bitnami/node-exporter
   - https://github.com/prometheus/node_exporter
   - https://prometheus.io/
 version: 3.0.4

--- a/bitnami/node-exporter/README.md
+++ b/bitnami/node-exporter/README.md
@@ -7,7 +7,7 @@ Prometheus exporter for hardware and OS metrics exposed by UNIX kernels, with pl
 [Overview of Node Exporter](https://prometheus.io/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/node-exporter
 
 ## Introduction
 
-This chart bootstraps [Node Exporter](https://github.com/bitnami/bitnami-docker-node-exporter) on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
+This chart bootstraps [Node Exporter](https://github.com/bitnami/containers/tree/main/bitnami/node-exporter) on [Kubernetes](https://kubernetes.io) using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -40,7 +40,7 @@ To install the chart with the release name `my-release`:
 $ helm install my-release bitnami/node-exporter
 ```
 
-The command deploys Node Exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+The command deploys Node Exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration-and-installation-details) section lists the parameters that can be configured during installation.
 
 ## Uninstalling the Chart
 

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -26,6 +26,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: node
 sources:
-  - https://github.com/bitnami/bitnami-docker-node
+  - https://github.com/bitnami/containers/tree/main/bitnami/node
   - http://nodejs.org/
 version: 18.1.16

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -7,7 +7,7 @@ Node.js is a runtime environment built on V8 JavaScript engine. Its event-driven
 [Overview of Node.js](http://nodejs.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/node
 
 ## Introduction
 
-This chart bootstraps a [Node](https://github.com/bitnami/bitnami-docker-node) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Node](https://github.com/bitnami/containers/tree/main/bitnami/node) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It clones and deploys a Node.js application from a Git repository. Optionally, you can set up an Ingress resource to access your application and provision an external database using the Kubernetes service catalog and the Open Service Broker for Azure.
 
@@ -251,7 +251,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `ingress.extraRules`               | Additional rules to be covered with this ingress record                                                                          | `[]`                     |
 
 
-The above parameters map to the env variables defined in [bitnami/node](https://github.com/bitnami/bitnami-docker-node). For more information please refer to the [bitnami/node](https://github.com/bitnami/bitnami-docker-node) image documentation.
+The above parameters map to the env variables defined in [bitnami/node](https://github.com/bitnami/containers/tree/main/bitnami/node). For more information please refer to the [bitnami/node](https://github.com/bitnami/containers/tree/main/bitnami/node) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -384,7 +384,7 @@ Deploying the helm chart enabling the Azure external database makes the followin
 
 ## Persistence
 
-The [Bitnami Node](https://github.com/bitnami/bitnami-docker-node) image stores the Node application and configurations at the `/app`  path of the container.
+The [Bitnami Node](https://github.com/bitnami/containers/tree/main/bitnami/node) image stores the Node application and configurations at the `/app`  path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -471,7 +471,7 @@ Backwards compatibility is not guaranteed since breaking changes were included i
 
 ### To 7.0.0
 
-This release includes security contexts, so the containers in the chart are run as non-root. More information in [this link](https://github.com/bitnami/bitnami-docker-node#484-r1-6112-r1-7101-r1-and-830-r1).
+This release includes security contexts, so the containers in the chart are run as non-root. More information in [this link](https://github.com/bitnami/containers/tree/main/bitnami/node#484-r1-6112-r1-7101-r1-and-830-r1).
 
 ### To 6.0.0
 

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -81,11 +81,11 @@ mongodb:
     ##
     enabled: true
     ## @param mongodb.auth.rootPassword MongoDB&reg; admin password
-    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mongodb.auth.username MongoDB&reg; custom user
-    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#creating-a-user-and-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#creating-a-user-and-database-on-first-run
     ##
     username: user
     ## @param mongodb.auth.database MongoDB&reg; custom database
@@ -683,7 +683,7 @@ ingress:
   ## - host: example.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: example-svc
   ##           port:

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -28,6 +28,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: oauth2-proxy
 sources:
-  - https://github.com/bitnami/bitnami-docker-oauth2-proxy
+  - https://github.com/bitnami/containers/tree/main/bitnami/oauth2-proxy
   - https://github.com/oauth2-proxy/oauth2-proxy
 version: 3.0.1

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -243,7 +243,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 See https://github.com/bitnami-labs/readmenator to create the table
 
-The above parameters map to the env variables defined in [bitnami/oauth2-proxy](https://github.com/bitnami/bitnami-docker-oauth2-proxy). For more information please refer to the [bitnami/oauth2-proxy](https://github.com/bitnami/bitnami-docker-oauth2-proxy) image documentation.
+The above parameters map to the env variables defined in [bitnami/oauth2-proxy](https://github.com/bitnami/containers/tree/main/bitnami/oauth2-proxy). For more information please refer to the [bitnami/oauth2-proxy](https://github.com/bitnami/containers/tree/main/bitnami/oauth2-proxy) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -285,7 +285,7 @@ The chart also facilitates the creation of TLS secrets for use with the Ingress 
 
 ## Persistence
 
-The [Bitnami OAuth2 Proxy](https://github.com/bitnami/bitnami-docker-oauth2-proxy) image stores the OAuth2 Proxy data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
+The [Bitnami OAuth2 Proxy](https://github.com/bitnami/containers/tree/main/bitnami/oauth2-proxy) image stores the OAuth2 Proxy data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
 
 ### Additional environment variables
 

--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -25,6 +25,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: odoo
 sources:
-  - https://github.com/bitnami/bitnami-docker-odoo
+  - https://github.com/bitnami/containers/tree/main/bitnami/odoo
   - https://www.odoo.com/
 version: 21.5.2

--- a/bitnami/odoo/README.md
+++ b/bitnami/odoo/README.md
@@ -7,7 +7,7 @@ Odoo is an open source ERP and CRM platform, formerly known as OpenERP, that can
 [Overview of Odoo](https://www.odoo.com/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/odoo
 
 ## Introduction
 
-This chart bootstraps a [Odoo](https://github.com/bitnami/bitnami-docker-odoo) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Odoo](https://github.com/bitnami/containers/tree/main/bitnami/odoo) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Odoo Apps can be used as stand-alone applications, but they also integrate seamlessly so you get a full-featured Open Source ERP when you install several Apps.
 
@@ -290,7 +290,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                               | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/odoo](https://github.com/bitnami/bitnami-docker-odoo). For more information please refer to the [bitnami/odoo](https://github.com/bitnami/bitnami-docker-odoo) image documentation.
+The above parameters map to the env variables defined in [bitnami/odoo](https://github.com/bitnami/containers/tree/main/bitnami/odoo). For more information please refer to the [bitnami/odoo](https://github.com/bitnami/containers/tree/main/bitnami/odoo) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -362,7 +362,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami Odoo](https://github.com/bitnami/bitnami-docker-odoo) image stores the Odoo data and configurations at the `/bitnami/odoo` path of the container.
+The [Bitnami Odoo](https://github.com/bitnami/containers/tree/main/bitnami/odoo) image stores the Odoo data and configurations at the `/bitnami/odoo` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.

--- a/bitnami/odoo/values.yaml
+++ b/bitnami/odoo/values.yaml
@@ -88,27 +88,27 @@ image:
 
 ## @section Odoo Configuration parameters
 ## Odoo settings based on environment variables
-## ref: https://github.com/bitnami/bitnami-docker-odoo#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/odoo#environment-variables
 ##
 
 ## @param odooEmail Odoo user email
-## ref: https://github.com/bitnami/bitnami-docker-odoo#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/odoo#configuration
 ##
 odooEmail: user@example.com
 ## @param odooPassword Odoo user password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-odoo#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/odoo#configuration
 ##
 odooPassword: ""
 ## @param odooSkipInstall Skip Odoo installation wizard
 ##
 odooSkipInstall: false
 ## @param loadDemoData Whether to load demo data for all modules during initialization
-## ref: https://github.com/bitnami/bitnami-docker-odoo#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/odoo#configuration
 ##
 loadDemoData: false
 ## @param customPostInitScripts Custom post-init.d user scripts
-## ref: https://github.com/bitnami/bitnami-docker-odoo
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/odoo
 ## NOTE: supported formats are `.sh`, `.sql` or `.php`
 ## NOTE: scripts are exclusively executed during the 1st boot of the container
 ## e.g:
@@ -120,7 +120,7 @@ loadDemoData: false
 ##
 customPostInitScripts: {}
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-odoo/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/odoo/#smtp-configuration
 ## @param smtpHost SMTP server host
 ## @param smtpPort SMTP server port
 ## @param smtpUser SMTP username

--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -27,6 +27,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: opencart
 sources:
-  - https://github.com/bitnami/bitnami-docker-opencart
+  - https://github.com/bitnami/containers/tree/main/bitnami/opencart
   - https://opencart.com/
 version: 12.2.11

--- a/bitnami/opencart/README.md
+++ b/bitnami/opencart/README.md
@@ -7,7 +7,7 @@ OpenCart is free open source ecommerce platform for online merchants. OpenCart p
 [Overview of OpenCart](http://www.opencart.com)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/opencart
 
 ## Introduction
 
-This chart bootstraps an [OpenCart](https://github.com/bitnami/bitnami-docker-opencart) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [OpenCart](https://github.com/bitnami/containers/tree/main/bitnami/opencart) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the OpenCart application.
 
@@ -293,7 +293,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                   | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/opencart](https://github.com/bitnami/bitnami-docker-opencart). For more information please refer to the [bitnami/opencart](https://github.com/bitnami/bitnami-docker-opencart) image documentation.
+The above parameters map to the env variables defined in [bitnami/opencart](https://github.com/bitnami/containers/tree/main/bitnami/opencart). For more information please refer to the [bitnami/opencart](https://github.com/bitnami/containers/tree/main/bitnami/opencart) image documentation.
 
 > **Note**:
 >
@@ -363,7 +363,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami OpenCart](https://github.com/bitnami/bitnami-docker-opencart) image stores the OpenCart data and configurations at the `/bitnami/opencart` path of the container.
+The [Bitnami OpenCart](https://github.com/bitnami/containers/tree/main/bitnami/opencart) image stores the OpenCart data and configurations at the `/bitnami/opencart` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -472,7 +472,7 @@ These folders will be mounted to the respective sub-paths in `/bitnami`. Before,
 
 #### Support for non-root user approach
 
-The [Bitnami OpenCart](https://github.com/bitnami/bitnami-docker-opencart) image was updated to support and enable the "non-root" user approach
+The [Bitnami OpenCart](https://github.com/bitnami/containers/tree/main/bitnami/opencart) image was updated to support and enable the "non-root" user approach
 
 If you want to continue to run the container image as the `root` user, you need to set `podSecurityContext.enabled=false` and `containerSecurity.context.enabled=false`.
 

--- a/bitnami/opencart/values.yaml
+++ b/bitnami/opencart/values.yaml
@@ -84,28 +84,28 @@ hostAliases:
 ##
 replicaCount: 1
 ## @param opencartSkipInstall Skip OpenCart installation wizard. Useful for migrations and restoring from SQL dump
-## ref: https://github.com/bitnami/bitnami-docker-opencart#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/opencart#configuration
 ##
 opencartSkipInstall: false
 ## @param opencartHost OpenCart host to create application URLs
-## ref: https://github.com/bitnami/bitnami-docker-opencart#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/opencart#configuration
 ##
 opencartHost: ""
 ## @param opencartUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-opencart#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/opencart#configuration
 ##
 opencartUsername: user
 ## @param opencartPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-opencart#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/opencart#configuration
 ##
 opencartPassword: ""
 ## @param opencartEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-opencart#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/opencart#configuration
 ##
 opencartEmail: user@example.com
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-opencart#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/opencart#environment-variables
 ##
 allowEmptyPassword: true
 ## @param command Override default container command (useful when using custom images)
@@ -165,7 +165,7 @@ tolerations: []
 ##
 existingSecret: ""
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-opencart/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/opencart/#smtp-configuration
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpUser SMTP user
@@ -517,7 +517,7 @@ ingress:
   ## - host: opencart.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: opencart-svc
   ##           port:
@@ -542,15 +542,15 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_opencart
     ## @param mariadb.auth.username Database user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_opencart
     ## @param mariadb.auth.password Password for the database

--- a/bitnami/osclass/Chart.yaml
+++ b/bitnami/osclass/Chart.yaml
@@ -29,6 +29,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: osclass
 sources:
-  - https://github.com/bitnami/bitnami-docker-osclass
+  - https://github.com/bitnami/containers/tree/main/bitnami/osclass
   - https://osclass.org/
 version: 14.1.15

--- a/bitnami/osclass/README.md
+++ b/bitnami/osclass/README.md
@@ -7,7 +7,7 @@ Osclass allows you to easily create a classifieds site without any technical kno
 [Overview of Osclass](https://osclass-classifieds.com)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/osclass
 
 ## Introduction
 
-This chart bootstraps an [Osclass](https://github.com/bitnami/bitnami-docker-osclass) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [Osclass](https://github.com/bitnami/containers/tree/main/bitnami/osclass) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the Osclass application.
 
@@ -320,7 +320,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                  | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/osclass](https://github.com/bitnami/bitnami-docker-osclass). For more information please refer to the [bitnami/osclass](https://github.com/bitnami/bitnami-docker-osclass) image documentation.
+The above parameters map to the env variables defined in [bitnami/osclass](https://github.com/bitnami/containers/tree/main/bitnami/osclass). For more information please refer to the [bitnami/osclass](https://github.com/bitnami/containers/tree/main/bitnami/osclass) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -352,7 +352,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ## Persistence
 
-The [Bitnami Osclass](https://github.com/bitnami/bitnami-docker-osclass) image stores the Osclass data and configurations at the `/bitnami/osclass` path of the container.
+The [Bitnami Osclass](https://github.com/bitnami/containers/tree/main/bitnami/osclass) image stores the Osclass data and configurations at the `/bitnami/osclass` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube. See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
 
@@ -434,7 +434,7 @@ Additionally updates the MariaDB subchart to it newest major, 10.0.0, which cont
 
 ### To 10.0.0
 
-The [Bitnami Osclass](https://github.com/bitnami/bitnami-docker-osclass) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
+The [Bitnami Osclass](https://github.com/bitnami/containers/tree/main/bitnami/osclass) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
 
 Consequences:
 
@@ -443,7 +443,7 @@ Consequences:
 
 To upgrade to `9.0.0`, backup Osclass data and the previous MariaDB databases, install a new Osclass chart and import the backups and data, ensuring the `1001` user has the appropriate permissions on the migrated volume.
 
-In addition to this, the image was refactored and now the source code is published in GitHub in the [`rootfs`](https://github.com/bitnami/bitnami-docker-osclass/tree/master/4/debian-10/rootfs) folder of the container image.
+In addition to this, the image was refactored and now the source code is published in GitHub in the `rootfs` folder of the container image.
 
 This upgrade also adapts the chart to the latest Bitnami good practices. Check the Parameters section for more information.
 

--- a/bitnami/osclass/values.yaml
+++ b/bitnami/osclass/values.yaml
@@ -75,7 +75,7 @@ image:
 
 ## @param osclassSkipInstall Skip wizard installation
 ## NOTE: useful if you use an external database that already contains Osclass data
-## ref: https://github.com/bitnami/bitnami-docker-osclass#connect-osclass-docker-container-to-an-existing-database
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/osclass#connect-osclass-docker-container-to-an-existing-database
 ##
 osclassSkipInstall: false
 ## @param osclassUsername Osclass username
@@ -100,7 +100,7 @@ existingSecret: ""
 ##
 allowEmptyPassword: true
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-osclass/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/osclass/#smtp-configuration
 ## @param smtpHost SMTP server host
 ## @param smtpPort SMTP server port
 ## @param smtpUser SMTP username
@@ -569,7 +569,7 @@ ingress:
   ## - host: ossclass.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: ossclass-svc
   ##           port:
@@ -621,9 +621,9 @@ mariadb:
   ## @param mariadb.auth.database MariaDB custom database
   ## @param mariadb.auth.username MariaDB custom user name
   ## @param mariadb.auth.password MariaDB custom user password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
-  ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
-  ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
+  ##      https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
+  ##      https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
   ##
   auth:
     rootPassword: ""

--- a/bitnami/owncloud/Chart.yaml
+++ b/bitnami/owncloud/Chart.yaml
@@ -29,6 +29,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: owncloud
 sources:
-  - https://github.com/bitnami/bitnami-docker-owncloud
+  - https://github.com/bitnami/containers/tree/main/bitnami/owncloud
   - https://owncloud.org/
 version: 12.1.12

--- a/bitnami/owncloud/README.md
+++ b/bitnami/owncloud/README.md
@@ -7,7 +7,7 @@ ownCloud is an open source content collaboration platform used to store and shar
 [Overview of ownCloud](http://owncloud.org)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/owncloud
 
 ## Introduction
 
-This chart bootstraps an [ownCloud](https://github.com/bitnami/bitnami-docker-owncloud) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [ownCloud](https://github.com/bitnami/containers/tree/main/bitnami/owncloud) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the ownCloud application.
 
@@ -307,7 +307,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                   | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/owncloud](https://github.com/bitnami/bitnami-docker-owncloud). For more information please refer to the [bitnami/owncloud](https://github.com/bitnami/bitnami-docker-owncloud) image documentation.
+The above parameters map to the env variables defined in [bitnami/owncloud](https://github.com/bitnami/containers/tree/main/bitnami/owncloud). For more information please refer to the [bitnami/owncloud](https://github.com/bitnami/containers/tree/main/bitnami/owncloud) image documentation.
 
 > **Note**:
 >
@@ -377,7 +377,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami ownCloud](https://github.com/bitnami/bitnami-docker-owncloud) image stores the ownCloud data and configurations at the `/bitnami/owncloud` path of the container.
+The [Bitnami ownCloud](https://github.com/bitnami/containers/tree/main/bitnami/owncloud) image stores the ownCloud data and configurations at the `/bitnami/owncloud` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -467,7 +467,7 @@ This upgrade adapts the chart to the latest Bitnami good practices. Check the Pa
 
 **2. Migration of the ownCloud image to non-root**
 
-The [Bitnami ownCloud](https://github.com/bitnami/bitnami-docker-owncloud) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. Consequences:
+The [Bitnami ownCloud](https://github.com/bitnami/containers/tree/main/bitnami/owncloud) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. Consequences:
 
 - The HTTP/HTTPS ports exposed by the container are now `8080/8443` instead of `80/443`.
 - Backwards compatibility is not guaranteed. Uninstall & install the chart again to obtain the latest version.

--- a/bitnami/owncloud/values.yaml
+++ b/bitnami/owncloud/values.yaml
@@ -75,28 +75,28 @@ hostAliases:
 ##
 replicaCount: 1
 ## @param owncloudSkipInstall Skip ownCloud installation wizard. Useful for migrations and restoring from SQL dump
-## ref: https://github.com/bitnami/bitnami-docker-owncloud#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/owncloud#configuration
 ##
 owncloudSkipInstall: false
 ## @param owncloudHost ownCloud host to create application URLs (when ingress, it will be ignored)
-## ref: https://github.com/bitnami/bitnami-docker-owncloud#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/owncloud#configuration
 ##
 owncloudHost: ""
 ## @param owncloudUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-owncloud#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/owncloud#configuration
 ##
 owncloudUsername: user
 ## @param owncloudPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-owncloud#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/owncloud#configuration
 ##
 owncloudPassword: ""
 ## @param owncloudEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-owncloud#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/owncloud#configuration
 ##
 owncloudEmail: user@example.com
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-owncloud#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/owncloud#environment-variables
 ##
 allowEmptyPassword: false
 ## @param command Override default container command (useful when using custom images)
@@ -162,7 +162,7 @@ topologySpreadConstraints: []
 ##
 existingSecret: ""
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-owncloud/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/owncloud/#smtp-configuration
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpUser SMTP user
@@ -340,15 +340,15 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_owncloud
     ## @param mariadb.auth.username Database user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_owncloud
     ## @param mariadb.auth.password Password for the database
@@ -647,7 +647,7 @@ ingress:
   ## - host: owncloud.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: owncloud-svc
   ##           port:

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -27,7 +27,7 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: parse
 sources:
-  - https://github.com/bitnami/bitnami-docker-parse
-  - https://github.com/bitnami/bitnami-docker-parse-dashboard
+  - https://github.com/bitnami/containers/tree/main/bitnami/parse
+  - https://github.com/bitnami/containers/tree/main/bitnami/parse-dashboard
   - https://parse.com/
 version: 18.1.17

--- a/bitnami/parse/README.md
+++ b/bitnami/parse/README.md
@@ -7,7 +7,7 @@ Parse is a platform that enables users to add a scalable and powerful backend to
 [Overview of Parse Server](http://parseplatform.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/parse
 
 ## Introduction
 
-This chart bootstraps a [Parse](https://github.com/bitnami/bitnami-docker-parse) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Parse](https://github.com/bitnami/containers/tree/main/bitnami/parse) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -316,7 +316,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `mongodb.persistence.size`         | PVC Storage Request for MongoDB&reg; volume | `8Gi`           |
 
 
-The above parameters map to the env variables defined in [bitnami/parse](https://github.com/bitnami/bitnami-docker-parse). For more information please refer to the [bitnami/parse](https://github.com/bitnami/bitnami-docker-parse) image documentation.
+The above parameters map to the env variables defined in [bitnami/parse](https://github.com/bitnami/containers/tree/main/bitnami/parse). For more information please refer to the [bitnami/parse](https://github.com/bitnami/containers/tree/main/bitnami/parse) image documentation.
 
 > **Note**:
 >
@@ -362,7 +362,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ### Deploy your Cloud functions with Parse Cloud Code
 
-The [Bitnami Parse](https://github.com/bitnami/bitnami-docker-parse) image allows you to deploy your Cloud functions with Parse Cloud Code (a feature which allows running a piece of code in your Parse Server instead of the user's mobile devices). In order to add your custom scripts, they must be located inside the chart folder `files/cloud` so they can be consumed as a ConfigMap.
+The [Bitnami Parse](https://github.com/bitnami/containers/tree/main/bitnami/parse) image allows you to deploy your Cloud functions with Parse Cloud Code (a feature which allows running a piece of code in your Parse Server instead of the user's mobile devices). In order to add your custom scripts, they must be located inside the chart folder `files/cloud` so they can be consumed as a ConfigMap.
 
 Alternatively, you can specify custom scripts using the `cloudCodeScripts` parameter as dict.
 
@@ -370,7 +370,7 @@ In addition to these options, you can also set an external ConfigMap with all th
 
 ## Persistence
 
-The [Bitnami Parse](https://github.com/bitnami/bitnami-docker-parse) image stores the Parse data and configurations at the `/bitnami/parse` path of the container.
+The [Bitnami Parse](https://github.com/bitnami/containers/tree/main/bitnami/parse) image stores the Parse data and configurations at the `/bitnami/parse` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -460,7 +460,7 @@ Please visit the release notes from the upstream project at https://github.com/p
 
 ### To 15.0.0
 
-The [Bitnami Parse](https://github.com/bitnami/bitnami-docker-parse) and [Bitnami Parse Dashboard](https://github.com/bitnami/bitnami-docker-parse-dashboard) images were refactored and now the source code is published in GitHub in the [`rootfs`](https://github.com/bitnami/bitnami-docker-parse/tree/master/4/debian-10/rootfs) folder of the container images.
+The [Bitnami Parse](https://github.com/bitnami/containers/tree/main/bitnami/parse) and [Bitnami Parse Dashboard](https://github.com/bitnami/containers/tree/main/bitnami/parse-dashboard) images were refactored and now the source code is published in GitHub in the `rootfs` folder of the container images.
 
 Compatibility is not guaranteed due to the amount of involved changes, however no breaking changes are expected.
 

--- a/bitnami/parse/files/cloud/README.md
+++ b/bitnami/parse/files/cloud/README.md
@@ -2,4 +2,4 @@ Place your Cloud Code scripts here. This will not be used in case the value *ser
 
 More information can be found in the link below:
 
-- [How to deploy your Cloud functions with Parse Cloud Code?](https://github.com/bitnami/bitnami-docker-parse#how-to-deploy-your-cloud-functions-with-parse-cloud-code)
+- [How to deploy your Cloud functions with Parse Cloud Code?](https://github.com/bitnami/containers/tree/main/bitnami/parse#how-to-deploy-your-cloud-functions-with-parse-cloud-code)

--- a/bitnami/parse/values.yaml
+++ b/bitnami/parse/values.yaml
@@ -132,20 +132,20 @@ server:
   ##
   args: []
   ## @param server.containerPorts.http Parse server port
-  ## ref: https://github.com/bitnami/bitnami-docker-parse#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/parse#configuration
   ##
   containerPorts:
     http: 1337
   ## @param server.mountPath Parse server API mount path
-  ## ref: https://github.com/bitnami/bitnami-docker-parse#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/parse#configuration
   ##
   mountPath: /parse
   ## @param server.appId Parse server App ID
-  ## ref: https://github.com/bitnami/bitnami-docker-parse#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/parse#configuration
   ##
   appId: myappID
   ## @param server.masterKey Parse server Master Key
-  ## ref: https://github.com/bitnami/bitnami-docker-parse#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/parse#configuration
   ##
   masterKey: ""
   ## @param server.extraEnvVars An array to add extra env vars
@@ -190,7 +190,7 @@ server:
   initContainers: []
 
   ## @param server.enableCloudCode Enable Parse Cloud Code
-  ## ref: https://github.com/bitnami/bitnami-docker-parse#how-to-deploy-your-cloud-functions-with-parse-cloud-code
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/parse#how-to-deploy-your-cloud-functions-with-parse-cloud-code
   ##
   enableCloudCode: false
   ## @param server.cloudCodeScripts Cloud Code scripts
@@ -464,16 +464,16 @@ dashboard:
   ##
   args: []
   ## @param dashboard.username Parse Dashboard application username
-  ## ref: https://github.com/bitnami/bitnami-docker-parse-dashboard#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/parse-dashboard#configuration
   ##
   username: user
   ## @param dashboard.password Parse Dashboard application password
   ## Defaults to a random 10-character alphanumeric string if not set
-  ## ref: https://github.com/bitnami/bitnami-docker-parse-dashboard#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/parse-dashboard#configuration
   ##
   password: ""
   ## @param dashboard.appName Parse Dashboard application name
-  ## ref: https://github.com/bitnami/bitnami-docker-parse-dashboard#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/parse-dashboard#configuration
   ##
   appName: MyDashboard
   ## @param dashboard.resources Parse Dashboard pods' resource requests and limits
@@ -948,7 +948,7 @@ mongodb:
     ##
     enabled: true
     ## @param mongodb.auth.rootPassword MongoDB&reg; admin password
-    ## ref: https://github.com/bitnami/bitnami-docker-mongodb/blob/master/README.md#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mongodb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mongodb.auth.username MongoDB&reg; user

--- a/bitnami/phpbb/Chart.yaml
+++ b/bitnami/phpbb/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: phpbb
 sources:
-  - https://github.com/bitnami/bitnami-docker-phpbb
+  - https://github.com/bitnami/containers/tree/main/bitnami/phpbb
   - https://www.phpbb.com/
 version: 12.2.13

--- a/bitnami/phpbb/README.md
+++ b/bitnami/phpbb/README.md
@@ -7,7 +7,7 @@ phpBB is a popular bulletin board that features robust messaging capabilities su
 [Overview of phpBB](http://www.phpbb.com)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/phpbb
 
 ## Introduction
 
-This chart bootstraps a [phpBB](https://github.com/bitnami/bitnami-docker-phpbb) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [phpBB](https://github.com/bitnami/containers/tree/main/bitnami/phpbb) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the phpBB application.
 
@@ -261,7 +261,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/phpbb](https://github.com/bitnami/bitnami-docker-phpbb). For more information please refer to the [bitnami/phpbb](https://github.com/bitnami/bitnami-docker-phpbb) image documentation.
+The above parameters map to the env variables defined in [bitnami/phpbb](https://github.com/bitnami/containers/tree/main/bitnami/phpbb). For more information please refer to the [bitnami/phpbb](https://github.com/bitnami/containers/tree/main/bitnami/phpbb) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -341,7 +341,7 @@ ingress:
 
 ## Persistence
 
-The [Bitnami phpBB](https://github.com/bitnami/bitnami-docker-phpbb) image stores the phpBB data and configurations at the `/bitnami/phpbb` and `/bitnami/apache` paths of the container.
+The [Bitnami phpBB](https://github.com/bitnami/containers/tree/main/bitnami/phpbb) image stores the phpBB data and configurations at the `/bitnami/phpbb` and `/bitnami/apache` paths of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, vpshere, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -445,7 +445,7 @@ mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
 
 ### To 8.0.0
 
-The [Bitnami phpBB](https://github.com/bitnami/bitnami-docker-phpbb) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
+The [Bitnami phpBB](https://github.com/bitnami/containers/tree/main/bitnami/phpbb) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
 
 Consequences:
 

--- a/bitnami/phpbb/values.yaml
+++ b/bitnami/phpbb/values.yaml
@@ -75,28 +75,28 @@ image:
 ##
 replicaCount: 1
 ## @param phpbbSkipInstall Skip phpBB installation wizard. Useful for migrations and restoring from SQL dump
-## ref: https://github.com/bitnami/bitnami-docker-phpbb#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/phpbb#configuration
 ##
 phpbbSkipInstall: "no"
 ## @param phpbbDisableSessionValidation Disable session validation
-## ref: https://github.com/bitnami/bitnami-docker-phpbb#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/phpbb#configuration
 ##
 phpbbDisableSessionValidation: "yes"
 ## @param phpbbUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-phpbb#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/phpbb#configuration
 ##
 phpbbUsername: user
 ## @param phpbbPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-phpbb#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/phpbb#configuration
 ##
 phpbbPassword: ""
 ## @param phpbbEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-phpbb#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/phpbb#configuration
 ##
 phpbbEmail: user@example.com
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-phpbb#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/phpbb#environment-variables
 ##
 allowEmptyPassword: "no"
 ## @param command Override default container command (useful when using custom images)
@@ -199,7 +199,7 @@ volumePermissions:
     ##    memory: 128Mi
     requests: {}
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-phpbb/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/phpbb/#smtp-configuration
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpUser SMTP user
@@ -555,7 +555,7 @@ ingress:
   ## - host: phpbb.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: phpbb-svc
   ##           port:
@@ -580,15 +580,15 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_phpbb
     ## @param mariadb.auth.username Database user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_phpbb
     ## @param mariadb.auth.password Password for the database

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -27,6 +27,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: phpmyadmin
 sources:
-  - https://github.com/bitnami/bitnami-docker-phpmyadmin
+  - https://github.com/bitnami/containers/tree/main/bitnami/phpmyadmin
   - https://www.phpmyadmin.net/
 version: 10.2.1

--- a/bitnami/phpmyadmin/README.md
+++ b/bitnami/phpmyadmin/README.md
@@ -7,7 +7,7 @@ phpMyAdmin is a free software tool written in PHP, intended to handle the admini
 [Overview of phpMyAdmin](https://www.phpmyadmin.net/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/phpmyadmin
 
 ## Introduction
 
-This chart bootstraps a [phpMyAdmin](https://github.com/bitnami/bitnami-docker-phpmyadmin) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [phpMyAdmin](https://github.com/bitnami/containers/tree/main/bitnami/phpmyadmin) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 As a portable web application written primarily in PHP, phpMyAdmin has become one of the most popular MySQL administration tools, especially for web hosting services.
 
@@ -256,7 +256,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                     | `{}`    |
 
 
-For more information please refer to the [bitnami/phpmyadmin](https://github.com/bitnami/bitnami-docker-Phpmyadmin) image documentation.
+For more information please refer to the [bitnami/phpmyadmin](https://github.com/bitnami/containers/tree/main/bitnami/phpmyadmin) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -496,7 +496,7 @@ mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
 
 ### To 6.0.0
 
-The [Bitnami phpMyAdmin](https://github.com/bitnami/bitnami-docker-phpmyadmin) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
+The [Bitnami phpMyAdmin](https://github.com/bitnami/containers/tree/main/bitnami/phpmyadmin) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `containerSecurityContext.runAsUser` to `root`.
 Chart labels and Ingress configuration were also adapted to follow the Helm charts best practices.
 
 Consequences:

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -20,6 +20,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: pinniped
 sources:
-  - https://github.com/bitnami/bitnami-docker-pinniped
+  - https://github.com/bitnami/containers/tree/main/bitnami/pinniped
   - https://github.com/vmware-tanzu/pinniped/
 version: 0.1.5

--- a/bitnami/pinniped/README.md
+++ b/bitnami/pinniped/README.md
@@ -7,7 +7,7 @@ Pinniped is an identity service provider for Kubernetes. Provides a consistent, 
 [Overview of Pinniped](https://pinniped.dev/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -299,7 +299,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 See https://github.com/bitnami-labs/readme-generator-for-helm to create the table
 
-The above parameters map to the env variables defined in [bitnami/pinniped](http://github.com/bitnami/bitnami-docker-pinniped). For more information please refer to the [bitnami/pinniped](http://github.com/bitnami/bitnami-docker-pinniped) image documentation.
+The above parameters map to the env variables defined in [bitnami/pinniped](https://github.com/bitnami/containers/tree/main/bitnami/pinniped). For more information please refer to the [bitnami/pinniped](https://github.com/bitnami/containers/tree/main/bitnami/pinniped) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -329,7 +329,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ## Persistence
 
-The [Bitnami pinniped](https://github.com/bitnami/bitnami-docker-pinniped) image stores the pinniped data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments. [Learn more about persistence in the chart documentation](https://docs.bitnami.com/kubernetes/apps/pinniped/configuration/chart-persistence/).
+The [Bitnami pinniped](https://github.com/bitnami/containers/tree/main/bitnami/pinniped) image stores the pinniped data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments. [Learn more about persistence in the chart documentation](https://docs.bitnami.com/kubernetes/apps/pinniped/configuration/chart-persistence/).
 
 ### Additional environment variables
 

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -25,6 +25,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: postgresql-ha
 sources:
-  - https://github.com/bitnami/bitnami-docker-postgresql
+  - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
 version: 9.2.5

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -7,7 +7,7 @@ This PostgreSQL cluster solution includes the PostgreSQL replication manager, an
 [Overview of PostgreSQL HA](https://www.postgresql.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -589,7 +589,7 @@ In addition to this option, you can also set an external ConfigMap with all the 
 
 ### Initialize a fresh instance
 
-The [Bitnami PostgreSQL with Repmgr](https://github.com/bitnami/bitnami-docker-postgresql-repmgr) image allows you to use your custom scripts to initialize a fresh instance. You can specify custom scripts using the `initdbScripts` parameter as dict so they can be consumed as a ConfigMap.
+The [Bitnami PostgreSQL with Repmgr](https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr) image allows you to use your custom scripts to initialize a fresh instance. You can specify custom scripts using the `initdbScripts` parameter as dict so they can be consumed as a ConfigMap.
 
 In addition to this option, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the `initdbScriptsCM` parameter. Note that this will override the two previous options. If your initialization scripts contain sensitive information such as credentials or passwords, you can use the `initdbScriptsSecret` parameter.
 
@@ -597,7 +597,7 @@ The above parameters (`initdbScripts`, `initdbScriptsCM`, and `initdbScriptsSecr
 
 The allowed extensions are `.sh`, `.sql` and `.sql.gz` in the **postgresql** container while only `.sh` in the case of the **pgpool** one.
 
-+info: https://github.com/bitnami/bitnami-docker-postgresql#initializing-a-new-instance and https://github.com/bitnami/bitnami-docker-pgpool#initializing-with-custom-scripts
++info: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#initializing-a-new-instance and https://github.com/bitnami/containers/tree/main/bitnami/pgpool#initializing-with-custom-scripts
 
 ### Use of global variables
 
@@ -826,7 +826,7 @@ $ helm upgrade my-release --version 3.0.0 bitnami/postgresql-ha \
 
 ### To 2.0.0
 
-The [Bitnami Pgpool](https://github.com/bitnami/bitnami-docker-pgpool) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Pgpool daemon was started as the `pgpool` user. From now on, both the container and the Pgpool daemon run as user `1001`. You can revert this behavior by setting the parameters `pgpool.containerSecurityContext.runAsUser`, and `pgpool.securityContext.fsGroup` to `0`.
+The [Bitnami Pgpool](https://github.com/bitnami/containers/tree/main/bitnami/pgpool) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Pgpool daemon was started as the `pgpool` user. From now on, both the container and the Pgpool daemon run as user `1001`. You can revert this behavior by setting the parameters `pgpool.containerSecurityContext.runAsUser`, and `pgpool.securityContext.fsGroup` to `0`.
 
 Consequences:
 

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -369,7 +369,7 @@ postgresql:
   ##
   existingSecret: ""
   ## @param postgresql.postgresPassword PostgreSQL password for the `postgres` user when `username` is not `postgres`
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-user-on-first-run (see note!)
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#creating-a-database-user-on-first-run (see note!)
   ##
   postgresPassword: ""
   ## @param postgresql.usePasswordFile Set to `true` to mount PostgreSQL secret as a file instead of passing environment variable
@@ -421,7 +421,7 @@ postgresql:
   ##
   usePgRewind: false
   ## Audit settings
-  ## https://github.com/bitnami/bitnami-docker-postgresql#auditing
+  ## https://github.com/bitnami/containers/tree/main/bitnami/postgresql#auditing
   ##
   audit:
     ## @param postgresql.audit.logHostname Add client hostnames to the log file
@@ -487,8 +487,8 @@ postgresql:
   ## @param postgresql.repmgrConfiguration Repmgr configuration
   ## You can use this parameter to specify the content for repmgr.conf
   ## Otherwise, a repmgr.conf will be generated based on the environment variables
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration-file
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr#configuration-file
   ## Example:
   ## repmgrConfiguration: |-
   ##   ssh_options='-o "StrictHostKeyChecking no" -v'
@@ -499,8 +499,8 @@ postgresql:
   ## @param postgresql.configuration PostgreSQL configuration
   ## You can use this parameter to specify the content for postgresql.conf
   ## Otherwise, a repmgr.conf will be generated based on the environment variables
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration-file
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr#configuration-file
   ## Example:
   ## configuration: |-
   ##   listen_addresses = '*'
@@ -511,8 +511,8 @@ postgresql:
   ## @param postgresql.pgHbaConfiguration PostgreSQL client authentication configuration
   ## You can use this parameter to specify the content for pg_hba.conf
   ## Otherwise, a repmgr.conf will be generated based on the environment variables
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#configuration-file
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr#configuration-file
   ## Example:
   ## pgHbaConfiguration: |-
   ##   host     all            repmgr    0.0.0.0/0    md5
@@ -526,7 +526,7 @@ postgresql:
   configurationCM: ""
   ## @param postgresql.extendedConf Extended PostgreSQL configuration (appended to main or default configuration). Implies `volumePermissions.enabled`.
   ## Similar to postgresql.configuration, but _appended_ to the main configuration
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql-repmgr#allow-settings-to-be-loaded-from-files-other-than-the-default-postgresqlconf
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql-repmgr#allow-settings-to-be-loaded-from-files-other-than-the-default-postgresqlconf
   ## Example:
   ## extendedConf: |-
   ##   deadlock_timeout = 1s
@@ -882,57 +882,57 @@ pgpool:
   ##
   authenticationMethod: scram-sha-256
   ## @param pgpool.logConnections Log all client connections (PGPOOL_ENABLE_LOG_CONNECTIONS)
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   logConnections: false
   ## @param pgpool.logHostname Log the client hostname instead of IP address (PGPOOL_ENABLE_LOG_HOSTNAME)
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   logHostname: true
   ## @param pgpool.logPerNodeStatement Log every SQL statement for each DB node separately (PGPOOL_ENABLE_LOG_PER_NODE_STATEMENT)
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   logPerNodeStatement: false
   ## @param pgpool.logLinePrefix Format of the log entry lines (PGPOOL_LOG_LINE_PREFIX)
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ## ref: https://www.pgpool.net/docs/latest/en/html/runtime-config-logging.html
   ##
   logLinePrefix: ""
   ## @param pgpool.clientMinMessages Log level for clients
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   clientMinMessages: error
   ## @param pgpool.numInitChildren The number of preforked Pgpool-II server processes. It is also the concurrent
   ## connections limit to Pgpool-II from clients. Must be a positive integer. (PGPOOL_NUM_INIT_CHILDREN)
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   numInitChildren: ""
   ## @param pgpool.reservedConnections Number of reserved connections. When zero, excess connection block. When non-zero, excess connections are refused with an error message.
   ## When this parameter is set to 1 or greater, incoming connections from clients are not accepted with error message
   ## "Sorry, too many clients already", rather than blocked if the number of current connections from clients is more than
   ## (num_init_children - reserved_connections).
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   reservedConnections: 1
 
   ## @param pgpool.maxPool The maximum number of cached connections in each child process (PGPOOL_MAX_POOL)
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   maxPool: ""
   ## @param pgpool.childMaxConnections The maximum number of client connections in each child process (PGPOOL_CHILD_MAX_CONNECTIONS)
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   childMaxConnections: ""
   ## @param pgpool.childLifeTime The time in seconds to terminate a Pgpool-II child process if it remains idle (PGPOOL_CHILD_LIFE_TIME)
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   childLifeTime: ""
   ## @param pgpool.clientIdleLimit The time in seconds to disconnect a client if it remains idle since the last query (PGPOOL_CLIENT_IDLE_LIMIT)
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   clientIdleLimit: ""
   ## @param pgpool.connectionLifeTime The time in seconds to terminate the cached connections to the PostgreSQL backend (PGPOOL_CONNECTION_LIFE_TIME)
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
   ##
   connectionLifeTime: ""
   ## @param pgpool.useLoadBalancing Use Pgpool Load-Balancing
@@ -945,8 +945,8 @@ pgpool:
   ## @param pgpool.configuration Pgpool configuration
   ## You can use this parameter to specify the content for pgpool.conf
   ## Otherwise, a repmgr.conf will be generated based on the environment variables
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration
-  ## ref: https://github.com/bitnami/bitnami-docker-pgpool#configuration-file
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/pgpool#configuration-file
   ## Example:
   ## configuration: |-
   ##   listen_addresses = '*'

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     name: desaintmartin
 name: postgresql
 sources:
-  - https://github.com/bitnami/bitnami-docker-postgresql
+  - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
 version: 11.6.19

--- a/bitnami/postgresql/README.md
+++ b/bitnami/postgresql/README.md
@@ -7,7 +7,7 @@ PostgreSQL (Postgres) is an open source object-relational database known for rel
 [Overview of PostgreSQL](http://www.postgresql.org)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ helm install my-release bitnami/postgresql
 
 ## Introduction
 
-This chart bootstraps a [PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [PostgreSQL](https://github.com/bitnami/containers/tree/main/bitnami/postgresql) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 For HA, please see [this repo](https://github.com/bitnami/charts/tree/master/bitnami/postgresql-ha)
 
@@ -465,7 +465,7 @@ The above command sets the PostgreSQL `postgres` account password to `secretpass
 
 > NOTE: Once this chart is deployed, it is not possible to change the application's access credentials, such as usernames or passwords, using Helm. To change these application credentials after deployment, delete any persistent volumes (PVs) used by the chart and re-deploy it, or use the application's built-in administrative tools if available.
 
-> **Warning** Setting a password will be ignored on new installation in case when previous Posgresql release was deleted through the helm command. In that case, old PVC will have an old password, and setting it through helm won't take effect. Deleting persistent volumes (PVs) will solve the issue. Refer to [issue 2061](https://github.com/bitnami/charts/issues/2061) for more details  
+> **Warning** Setting a password will be ignored on new installation in case when previous Posgresql release was deleted through the helm command. In that case, old PVC will have an old password, and setting it through helm won't take effect. Deleting persistent volumes (PVs) will solve the issue. Refer to [issue 2061](https://github.com/bitnami/charts/issues/2061) for more details
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
@@ -501,7 +501,7 @@ In addition to these options, you can also set an external ConfigMap with all th
 
 ### Initialize a fresh instance
 
-The [Bitnami PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, you can specify custom scripts using the `primary.initdb.scripts` parameter as a string.
+The [Bitnami PostgreSQL](https://github.com/bitnami/containers/tree/main/bitnami/postgresql) image allows you to use your custom scripts to initialize a fresh instance. In order to execute the scripts, you can specify custom scripts using the `primary.initdb.scripts` parameter as a string.
 
 In addition, you can also set an external ConfigMap with all the initialization scripts. This is done by setting the `primary.initdb.scriptsConfigMap` parameter. Note that this will override the two previous options. If your initialization scripts contain sensitive information such as credentials or passwords, you can use the `primary.initdb.scriptsSecret` parameter.
 
@@ -615,12 +615,12 @@ This way, the credentials will be available in all of the subcharts.
 
 ## Persistence
 
-The [Bitnami PostgreSQL](https://github.com/bitnami/bitnami-docker-postgresql) image stores the PostgreSQL data and configurations at the `/bitnami/postgresql` path of the container.
+The [Bitnami PostgreSQL](https://github.com/bitnami/containers/tree/main/bitnami/postgresql) image stores the PostgreSQL data and configurations at the `/bitnami/postgresql` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
 
-If you already have data in it, you will fail to sync to standby nodes for all commits, details can refer to [code](https://github.com/bitnami/bitnami-docker-postgresql/blob/8725fe1d7d30ebe8d9a16e9175d05f7ad9260c93/9.6/debian-9/rootfs/libpostgresql.sh#L518-L556). If you need to use those data, please covert them to sql and import after `helm install` finished.
+If you already have data in it, you will fail to sync to standby nodes for all commits, details can refer to the [code present in the container repository](https://github.com/bitnami/containers/tree/main/bitnami/postgresql). If you need to use those data, please covert them to sql and import after `helm install` finished.
 
 ## NetworkPolicy
 

--- a/bitnami/postgresql/values.yaml
+++ b/bitnami/postgresql/values.yaml
@@ -112,9 +112,9 @@ image:
   ##
   debug: false
 ## Authentication parameters
-## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#setting-the-root-password-on-first-run
-## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run
-## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-user-on-first-run
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#setting-the-root-password-on-first-run
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#creating-a-database-on-first-run
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#creating-a-database-user-on-first-run
 ##
 auth:
   ## @param auth.enablePostgresUser Assign a password to the "postgres" admin user. Otherwise, remote access will be blocked for this user
@@ -173,7 +173,7 @@ replication:
 containerPorts:
   postgresql: 5432
 ## Audit settings
-## https://github.com/bitnami/bitnami-docker-postgresql#auditing
+## https://github.com/bitnami/containers/tree/main/bitnami/postgresql#auditing
 ## @param audit.logHostname Log client hostnames
 ## @param audit.logConnections Add client log-in operations to the log file
 ## @param audit.logDisconnections Add client log-outs operations to the log file
@@ -302,7 +302,7 @@ primary:
   ##
   existingConfigmap: ""
   ## @param primary.extendedConfiguration Extended PostgreSQL Primary configuration (appended to main or default configuration)
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql#allow-settings-to-be-loaded-from-files-other-than-the-default-postgresqlconf
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#allow-settings-to-be-loaded-from-files-other-than-the-default-postgresqlconf
   ##
   extendedConfiguration: ""
   ## @param primary.existingExtendedConfigmap Name of an existing ConfigMap with PostgreSQL Primary extended configuration
@@ -310,7 +310,7 @@ primary:
   ##
   existingExtendedConfigmap: ""
   ## Initdb configuration
-  ## ref: https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#specifying-initdb-arguments
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/postgresql#specifying-initdb-arguments
   ##
   initdb:
     ## @param primary.initdb.args PostgreSQL initdb extra arguments

--- a/bitnami/prestashop/Chart.yaml
+++ b/bitnami/prestashop/Chart.yaml
@@ -27,6 +27,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: prestashop
 sources:
-  - https://github.com/bitnami/bitnami-docker-prestashop
+  - https://github.com/bitnami/containers/tree/main/bitnami/prestashop
   - https://prestashop.com/
 version: 15.2.13

--- a/bitnami/prestashop/README.md
+++ b/bitnami/prestashop/README.md
@@ -7,7 +7,7 @@ PrestaShop is a powerful open source eCommerce platform used by over 250,000 onl
 [Overview of PrestaShop](http://www.prestashop.com)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/prestashop
 
 ## Introduction
 
-This chart bootstraps a [PrestaShop](https://github.com/bitnami/bitnami-docker-prestashop) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [PrestaShop](https://github.com/bitnami/containers/tree/main/bitnami/prestashop) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the PrestaShop application.
 
@@ -300,7 +300,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                     | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/prestashop](https://github.com/bitnami/bitnami-docker-prestashop). For more information please refer to the [bitnami/prestashop](https://github.com/bitnami/bitnami-docker-prestashop) image documentation.
+The above parameters map to the env variables defined in [bitnami/prestashop](https://github.com/bitnami/containers/tree/main/bitnami/prestashop). For more information please refer to the [bitnami/prestashop](https://github.com/bitnami/containers/tree/main/bitnami/prestashop) image documentation.
 
 > **Note**:
 >
@@ -370,7 +370,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami PrestaShop](https://github.com/bitnami/bitnami-docker-prestashop) image stores the PrestaShop data and configurations at the `/bitnami/prestashop` path of the container.
+The [Bitnami PrestaShop](https://github.com/bitnami/containers/tree/main/bitnami/prestashop) image stores the PrestaShop data and configurations at the `/bitnami/prestashop` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -510,7 +510,7 @@ mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
 
 ### To 10.0.0
 
-The [Bitnami PrestaShop](https://github.com/bitnami/bitnami-docker-prestashop) image was updated to support and enable the "non-root" user approach
+The [Bitnami PrestaShop](https://github.com/bitnami/containers/tree/main/bitnami/prestashop) image was updated to support and enable the "non-root" user approach
 
 If you want to continue to run the container image as the `root` user, you need to set `podSecurityContext.enabled=false` and `containerSecurity.context.enabled=false`.
 

--- a/bitnami/prestashop/values.yaml
+++ b/bitnami/prestashop/values.yaml
@@ -84,48 +84,48 @@ hostAliases:
 ##
 replicaCount: 1
 ## @param prestashopSkipInstall Skip PrestaShop installation wizard. Useful for migrations and restoring from SQL dump
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#configuration
 ##
 prestashopSkipInstall: false
 ## @param prestashopHost PrestaShop host to create application URLs (when ingress, it will be ignored)
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#configuration
 ##
 prestashopHost: ""
 ## @param prestashopUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#configuration
 ##
 prestashopUsername: user@example.com
 ## @param prestashopPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#configuration
 ##
 prestashopPassword: ""
 ## @param prestashopEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#configuration
 ##
 prestashopEmail: user@example.com
 ## @param prestashopFirstName First Name
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#configuration
 ##
 prestashopFirstName: Bitnami
 ## @param prestashopLastName Last Name
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#configuration
 ##
 prestashopLastName: User
 ## @param prestashopCookieCheckIP Whether to check the cookie's IP address or not
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#configuration
 ##
 prestashopCookieCheckIP: "no"
 ## @param prestashopCountry Default country of the store
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#configuration
 ##
 prestashopCountry: "us"
 ## @param prestashopLanguage Default language of the store (ISO code)
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#configuration
 ##
 prestashopLanguage: "en"
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-prestashop#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop#environment-variables
 ##
 allowEmptyPassword: true
 ## @param command Override default container command (useful when using custom images)
@@ -185,7 +185,7 @@ topologySpreadConstraints: []
 ##
 existingSecret: ""
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-prestashop/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/prestashop/#smtp-configuration
 ## @param smtpHost SMTP host
 ## @param smtpPort SMTP port
 ## @param smtpUser SMTP user
@@ -535,7 +535,7 @@ ingress:
   ## - host: prestashop.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: prestashop-svc
   ##           port:
@@ -560,15 +560,15 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_prestashop
     ## @param mariadb.auth.username Database user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_prestashop
     ## @param mariadb.auth.password Password for the database

--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -22,6 +22,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: pytorch
 sources:
-  - https://github.com/bitnami/bitnami-docker-pytorch
+  - https://github.com/bitnami/containers/tree/main/bitnami/pytorch
   - https://pytorch.org/
 version: 2.4.12

--- a/bitnami/pytorch/README.md
+++ b/bitnami/pytorch/README.md
@@ -7,7 +7,7 @@ PyTorch is a deep learning platform that accelerates the transition from researc
 [Overview of PyTorch](https://pytorch.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/pytorch
 
 ## Introduction
 
-This chart bootstraps a [PyTorch](https://github.com/bitnami/bitnami-docker-pytorch) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [PyTorch](https://github.com/bitnami/containers/tree/main/bitnami/pytorch) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Python is built for full integration into Python that enables you to use it with its libraries and main packages.
 
@@ -260,7 +260,7 @@ cloneFilesFromGit.revision=master
 
 ## Persistence
 
-The [Bitnami PyTorch](https://github.com/bitnami/bitnami-docker-pytorch) image can persist data. If enabled, the persisted path is `/bitnami/pytorch` by default.
+The [Bitnami PyTorch](https://github.com/bitnami/containers/tree/main/bitnami/pytorch) image can persist data. If enabled, the persisted path is `/bitnami/pytorch` by default.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
 

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: rabbitmq-cluster-operator
 sources:
-  - https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator
+  - https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
 version: 2.6.9

--- a/bitnami/rabbitmq-cluster-operator/README.md
+++ b/bitnami/rabbitmq-cluster-operator/README.md
@@ -7,7 +7,7 @@ The RabbitMQ Cluster Kubernetes Operator automates provisioning, management, and
 [Overview of RabbitMQ Cluster Operator](https://github.com/rabbitmq/cluster-operator)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -387,7 +387,7 @@ This solution allows to easily deploy multiple RabbitMQ instances compared to th
 
 See [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm) to create the table.
 
-The above parameters map to the env variables defined in [bitnami/rabbitmq-cluster-operator](https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator). For more information please refer to the [bitnami/rabbitmq-cluster-operator](https://github.com/bitnami/bitnami-docker-rabbitmq-cluster-operator) image documentation.
+The above parameters map to the env variables defined in [bitnami/rabbitmq-cluster-operator](https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq-cluster-operator). For more information please refer to the [bitnami/rabbitmq-cluster-operator](https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq-cluster-operator) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -21,6 +21,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: rabbitmq
 sources:
-  - https://github.com/bitnami/bitnami-docker-rabbitmq
+  - https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq
   - https://www.rabbitmq.com
 version: 10.1.16

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -7,7 +7,7 @@ RabbitMQ is an open source general-purpose message broker that is designed for c
 [Overview of RabbitMQ](https://www.rabbitmq.com)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/rabbitmq
 
 ## Introduction
 
-This chart bootstraps a [RabbitMQ](https://github.com/bitnami/bitnami-docker-rabbitmq) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [RabbitMQ](https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -345,7 +345,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                                                       | `0`                     |
 
 
-The above parameters map to the env variables defined in [bitnami/rabbitmq](https://github.com/bitnami/bitnami-docker-rabbitmq). For more information please refer to the [bitnami/rabbitmq](https://github.com/bitnami/bitnami-docker-rabbitmq) image documentation.
+The above parameters map to the env variables defined in [bitnami/rabbitmq](https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq). For more information please refer to the [bitnami/rabbitmq](https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -522,7 +522,7 @@ More information: [Clustering Guide: Restarting](https://www.rabbitmq.com/cluste
 
 ## Persistence
 
-The [Bitnami RabbitMQ](https://github.com/bitnami/bitnami-docker-rabbitmq) image stores the RabbitMQ data and configurations at the `/opt/bitnami/rabbitmq/var/lib/rabbitmq/` path of the container.
+The [Bitnami RabbitMQ](https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq) image stores the RabbitMQ data and configurations at the `/opt/bitnami/rabbitmq/var/lib/rabbitmq/` path of the container.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) at this location. By default, the volume is created using dynamic volume provisioning. An existing PersistentVolumeClaim can also be defined.
 
@@ -655,7 +655,7 @@ Consequences:
 
 ### To 6.0.0
 
-This new version updates the RabbitMQ image to a [new version based on bash instead of node.js](https://github.com/bitnami/bitnami-docker-rabbitmq#3715-r18-3715-ol-7-r19). However, since this Chart overwrites the container's command, the changes to the container shouldn't affect the Chart. To upgrade, it may be needed to enable the `fastBoot` option, as it is already the case from upgrading from 5.X to 5.Y.
+This new version updates the RabbitMQ image to a [new version based on bash instead of node.js](https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq#3715-r18-3715-ol-7-r19). However, since this Chart overwrites the container's command, the changes to the container shouldn't affect the Chart. To upgrade, it may be needed to enable the `fastBoot` option, as it is already the case from upgrading from 5.X to 5.Y.
 
 ### To 5.0.0
 

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -114,11 +114,11 @@ dnsConfig: {}
 ##
 auth:
   ## @param auth.username RabbitMQ application username
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq#environment-variables
   ##
   username: user
   ## @param auth.password RabbitMQ application password
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq#environment-variables
   ##
   password: ""
   ## @param auth.existingPasswordSecret Existing secret with RabbitMQ credentials (must contain a value for `rabbitmq-password` key)
@@ -127,7 +127,7 @@ auth:
   ##
   existingPasswordSecret: ""
   ## @param auth.erlangCookie Erlang cookie to determine whether different nodes are allowed to communicate with each other
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq#environment-variables
   ##
   erlangCookie: ""
   ## @param auth.existingErlangSecret Existing secret with RabbitMQ Erlang cookie (must contain a value for `rabbitmq-erlang-cookie` key)
@@ -164,7 +164,7 @@ auth:
 ##
 logs: "-"
 ## @param ulimitNofiles RabbitMQ Max File Descriptors
-## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq#environment-variables
 ## ref: https://www.rabbitmq.com/install-debian.html#kernel-resource-limits
 ##
 ulimitNofiles: "65536"
@@ -834,7 +834,7 @@ service:
   ##
   distPortEnabled: true
   ## @param service.managerPortEnabled RabbitMQ Manager port
-  ## ref: https://github.com/bitnami/bitnami-docker-rabbitmq#environment-variables
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq#environment-variables
   ##
   managerPortEnabled: true
   ## @param service.epmdPortEnabled RabbitMQ EPMD Discovery service port

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -21,6 +21,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: redis-cluster
 sources:
-  - https://github.com/bitnami/bitnami-docker-redis
+  - https://github.com/bitnami/containers/tree/main/bitnami/redis
   - http://redis.io/
 version: 8.1.1

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -7,7 +7,7 @@ Redis(R) is an open source, scalable, distributed in-memory cache for applicatio
 [Overview of Redis&reg; Cluster](http://redis.io)
 
 Disclaimer: Redis is a registered trademark of Redis Ltd. Any rights therein are reserved to Redis Ltd. Any use by Bitnami is for referential purposes only and does not indicate any sponsorship, endorsement, or affiliation between Redis Ltd.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/redis-cluster
 
 ## Introduction
 
-This chart bootstraps a [Redis&reg;](https://github.com/bitnami/bitnami-docker-redis) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Redis&reg;](https://github.com/bitnami/containers/tree/main/bitnami/redis) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -70,7 +70,7 @@ image:
   registry: docker.io
   repository: bitnami/redis-cluster
   ## Bitnami Redis&reg; image tag
-  ## ref: https://github.com/bitnami/bitnami-docker-redis#supported-tags-and-respective-dockerfile-links
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/redis#supported-tags-and-respective-dockerfile-links
   ##
   tag: 7.0.4-debian-11-r1
   ## Specify a imagePullPolicy
@@ -179,7 +179,7 @@ containerSecurityContext:
 usePassword: true
 ## @param password Redis&reg; password (ignored if existingSecret set)
 ## Defaults to a random 10-character alphanumeric string if not set and usePassword is true
-## ref: https://github.com/bitnami/bitnami-docker-redis#setting-the-server-password-on-first-run
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run
 ##
 password: ""
 ## @param existingSecret Name of existing secret object (for password authentication)

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -23,5 +23,5 @@ maintainers:
     name: desaintmartin
 name: redis
 sources:
-  - https://github.com/bitnami/bitnami-docker-redis
+  - https://github.com/bitnami/containers/tree/main/bitnami/redis
 version: 17.0.5

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -7,7 +7,7 @@ Redis(R) is an open source, advanced key-value store. It is often referred to as
 [Overview of Redis&reg;](http://redis.io)
 
 Disclaimer: Redis is a registered trademark of Redis Ltd. Any rights therein are reserved to Redis Ltd. Any use by Bitnami is for referential purposes only and does not indicate any sponsorship, endorsement, or affiliation between Redis Ltd.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/redis
 
 ## Introduction
 
-This chart bootstraps a [Redis&reg;](https://github.com/bitnami/bitnami-docker-redis) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Redis&reg;](https://github.com/bitnami/containers/tree/main/bitnami/redis) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -627,7 +627,7 @@ An example of use case is the creation of a redundant set of standalone masters 
 
 One way of achieving this is by setting `master.service.internalTrafficPolicy=Local` in combination with a `master.affinity.podAntiAffinity` spec to never schedule more than one master per Kubernetes node.
 
-It's recommended to only change `master.count` if you know what you are doing.  
+It's recommended to only change `master.count` if you know what you are doing.
 `master.count` greater than `1` is not designed for use when `sentinel.enabled=true`.
 
 ### Using a password file
@@ -797,7 +797,7 @@ The metrics exporter has been changed from a separate deployment to a sidecar co
 
 In order to improve the performance in case of slave failure, we added persistence to the read-only slaves. That means that we moved from Deployment to StatefulSets. This should not affect upgrades from previous versions of the chart, as the deployments did not contain any persistence at all.
 
-This version also allows enabling Redis&reg; Sentinel containers inside of the Redis&reg; Pods (feature disabled by default). In case the master crashes, a new Redis&reg; node will be elected as master. In order to query the current master (no redis master service is exposed), you need to query first the Sentinel cluster. Find more information [in this section](#master-slave-with-sentinel).
+This version also allows enabling Redis&reg; Sentinel containers inside of the Redis&reg; Pods (feature disabled by default). In case the master crashes, a new Redis&reg; node will be elected as master. In order to query the current master (no redis master service is exposed), you need to query first the Sentinel cluster.
 
 ### To 11.0.0
 

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -97,14 +97,14 @@ image:
   debug: false
 
 ## @section Redis&reg; common configuration parameters
-## https://github.com/bitnami/bitnami-docker-redis#configuration
+## https://github.com/bitnami/containers/tree/main/bitnami/redis#configuration
 ##
 
 ## @param architecture Redis&reg; architecture. Allowed values: `standalone` or `replication`
 ##
 architecture: replication
 ## Redis&reg; Authentication parameters
-## ref: https://github.com/bitnami/bitnami-docker-redis#setting-the-server-password-on-first-run
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/redis#setting-the-server-password-on-first-run
 ##
 auth:
   ## @param auth.enabled Enable password authentication

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -34,6 +34,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: redmine
 sources:
-  - https://github.com/bitnami/bitnami-docker-redmine
+  - https://github.com/bitnami/containers/tree/main/bitnami/redmine
   - https://www.redmine.org/
 version: 20.2.14

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -7,7 +7,7 @@ Redmine is an open source management application. It includes a tracking issue s
 [Overview of Redmine](http://www.redmine.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/redmine
 
 ## Introduction
 
-This chart bootstraps a [Redmine](https://github.com/bitnami/bitnami-docker-redmine) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Redmine](https://github.com/bitnami/containers/tree/main/bitnami/redmine) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) and the [PostgreSQL chart](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) which are required for bootstrapping a MariaDB/PostgreSQL deployment for the database requirements of the Redmine application.
 
@@ -370,7 +370,7 @@ helm install my-release bitnami/redmine --set databaseType=postgresql
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                  | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/redmine](https://github.com/bitnami/bitnami-docker-redmine). For more information please refer to the [bitnami/redmine](https://github.com/bitnami/bitnami-docker-redmine) image documentation.
+The above parameters map to the env variables defined in [bitnami/redmine](https://github.com/bitnami/containers/tree/main/bitnami/redmine). For more information please refer to the [bitnami/redmine](https://github.com/bitnami/containers/tree/main/bitnami/redmine) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -415,7 +415,7 @@ Redmine writes uploaded files to a persistent volume. By default that volume can
 
 ### Deploying to a sub-URI
 
-(adapted from https://github.com/bitnami/bitnami-docker-redmine)
+(adapted from https://github.com/bitnami/containers/tree/main/bitnami/redmine)
 
 On certain occasions, you may need that Redmine is available under a specific sub-URI path rather than the root. A common scenario to this problem may arise if you plan to set up your Redmine container behind a reverse proxy. To deploy your Redmine container using a certain sub-URI you just need to follow these steps:
 
@@ -486,7 +486,7 @@ readinessProbe:
 
 ## Persistence
 
-The [Bitnami Redmine](https://github.com/bitnami/bitnami-docker-redmine) image stores the Redmine data and configurations at the `/bitnami/redmine` path of the container.
+The [Bitnami Redmine](https://github.com/bitnami/containers/tree/main/bitnami/redmine) image stores the Redmine data and configurations at the `/bitnami/redmine` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube. The volume is created using dynamic volume provisioning. Clusters configured with NFS mounts require manually managed volumes and claims.
 

--- a/bitnami/redmine/values.yaml
+++ b/bitnami/redmine/values.yaml
@@ -58,7 +58,7 @@ diagnosticMode:
 
 ## @section Redmine Configuration parameters
 ## Redmine settings based on environment variables
-## ref: https://github.com/bitnami/bitnami-docker-redmine#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/redmine#environment-variables
 
 ## Bitnami Redmine image
 ## ref: https://hub.docker.com/r/bitnami/redmine/tags/
@@ -107,7 +107,7 @@ redmineLanguage: en
 ##
 allowEmptyPassword: false
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-redmine/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/redmine/#smtp-configuration
 ## @param smtpHost SMTP server host
 ## @param smtpPort SMTP server port
 ## @param smtpUser SMTP username
@@ -630,7 +630,7 @@ autoscaling:
 ## @section Database Parameters
 
 ## @param databaseType Redmine database type. Allowed values: `mariadb` and `postgresql`
-## ref: https://github.com/bitnami/bitnami-docker-redmine/#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/redmine/#environment-variables
 ##
 databaseType: mariadb
 ## MariaDB chart configuration

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -21,6 +21,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: sealed-secrets
 sources:
-  - https://github.com/bitnami/bitnami-docker-sealed-secrets
+  - https://github.com/bitnami/containers/tree/main/bitnami/sealed-secrets
   - https://github.com/bitnami-labs/sealed-secrets
 version: 1.0.10

--- a/bitnami/sealed-secrets/README.md
+++ b/bitnami/sealed-secrets/README.md
@@ -7,7 +7,7 @@ Sealed Secrets are "one-way" encrypted K8s Secrets that can be created by anyone
 [Overview of Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets)
 
 
-                           
+
 ## TL;DR
 
 ```console

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -25,6 +25,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: solr
 sources:
-  - https://github.com/bitnami/bitnami-docker-solr
+  - https://github.com/bitnami/containers/tree/main/bitnami/solr
   - https://lucene.apache.org/solr/
 version: 6.0.3

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -7,7 +7,7 @@ Apache Solr is an extremely powerful, open source enterprise search platform bui
 [Overview of Apache Solr](http://lucene.apache.org/solr/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/solr
 
 ## Introduction
 
-This chart bootstraps a [Solr](https://github.com/bitnami/bitnami-docker-solr) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Solr](https://github.com/bitnami/containers/tree/main/bitnami/solr) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -400,7 +400,7 @@ As an alternative, you can use the preset configurations for pod affinity, pod a
 
 ## Persistence
 
-The [Bitnami Solr](https://github.com/bitnami/bitnami-docker-solr) image can persist data. If enabled, the persisted path is `/bitnami/solr` by default.
+The [Bitnami Solr](https://github.com/bitnami/containers/tree/main/bitnami/solr) image can persist data. If enabled, the persisted path is `/bitnami/solr` by default.
 
 The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) at this location. The volume is created using dynamic volume provisioning.
 

--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -26,6 +26,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: sonarqube
 sources:
-  - https://github.com/bitnami/bitnami-docker-sonarqube
+  - https://github.com/bitnami/containers/tree/main/bitnami/sonarqube
   - https://github.com/SonarSource/sonarqube
 version: 1.4.7

--- a/bitnami/sonarqube/README.md
+++ b/bitnami/sonarqube/README.md
@@ -7,7 +7,7 @@ SonarQube is an open source quality management platform that analyzes and measur
 [Overview of SonarQube](http://www.sonarqube.org)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/sonarqube
 
 ## Introduction
 
-This chart bootstraps an [SonarQube](https://github.com/bitnami/bitnami-docker-sonarqube) cluster on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [SonarQube](https://github.com/bitnami/containers/tree/main/bitnami/sonarqube) cluster on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -317,7 +317,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalDatabase.port`           | Port of an external PostgreSQL to connect (only if postgresql.enabled=false)                                    | `5432`      |
 
 
-The above parameters map to the env variables defined in [bitnami/sonarqube](https://github.com/bitnami/bitnami-docker-sonarqube). For more information please refer to the [bitnami/sonarqube](https://github.com/bitnami/bitnami-docker-sonarqube) image documentation.
+The above parameters map to the env variables defined in [bitnami/sonarqube](https://github.com/bitnami/containers/tree/main/bitnami/sonarqube). For more information please refer to the [bitnami/sonarqube](https://github.com/bitnami/containers/tree/main/bitnami/sonarqube) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -399,7 +399,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 
 ## Persistence
 
-The [Bitnami SonarQube](https://github.com/bitnami/bitnami-docker-sonarqube) image stores the SonarQube data and configurations at the `/bitnami/sonarqube` path of the container. Persistent Volume Claims are used to keep the data across deployments.
+The [Bitnami SonarQube](https://github.com/bitnami/containers/tree/main/bitnami/sonarqube) image stores the SonarQube data and configurations at the `/bitnami/sonarqube` path of the container. Persistent Volume Claims are used to keep the data across deployments.
 
 ### Adjust permissions of persistent volume mountpoint
 

--- a/bitnami/sonarqube/values.yaml
+++ b/bitnami/sonarqube/values.yaml
@@ -92,7 +92,7 @@ image:
 
 ## @section SonarQube Configuration parameters
 ## SonarQube settings based on environment variables
-## ref: https://github.com/bitnami/bitnami-docker-sonarqube#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/sonarqube#environment-variables
 ## @param sonarqubeUsername SonarQube username
 ##
 sonarqubeUsername: user
@@ -126,11 +126,11 @@ startTimeout: 150
 extraProperties: []
 ## @param sonarqubeSkipInstall Skip wizard installation
 ## NOTE: useful if you use an external database that already contains SonarQube data
-## ref: https://github.com/bitnami/bitnami-docker-sonarqube#connect-sonarqube-container-to-an-existing-database
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/sonarqube#connect-sonarqube-container-to-an-existing-database
 ##
 sonarqubeSkipInstall: false
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-sonarqube/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/sonarqube/#smtp-configuration
 ## @param smtpHost SMTP server host
 ## @param smtpPort SMTP server port
 ## @param smtpUser SMTP username

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -20,6 +20,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: spark
 sources:
-  - https://github.com/bitnami/bitnami-docker-spark
+  - https://github.com/bitnami/containers/tree/main/bitnami/spark
   - https://spark.apache.org/
 version: 6.2.1

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -7,7 +7,7 @@ Apache Spark is a high-performance engine for large-scale computing tasks, such 
 [Overview of Apache Spark](https://spark.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/spark
 
 ## Introduction
 
-This chart bootstraps an [Apache Spark](https://github.com/bitnami/bitnami-docker-spark) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [Apache Spark](https://github.com/bitnami/containers/tree/main/bitnami/spark) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Apache Spark includes APIs for Java, Python, Scala and R.
 
@@ -467,7 +467,7 @@ This version standardizes the way of defining Ingress rules. When configuring a 
 
 - This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
 
-- Spark container images are updated to use Hadoop `3.2.x`: [Notable Changes: 3.0.0-debian-10-r44](https://github.com/bitnami/bitnami-docker-spark#300-debian-10-r44)
+- Spark container images are updated to use Hadoop `3.2.x`: [Notable Changes: 3.0.0-debian-10-r44](https://github.com/bitnami/containers/tree/main/bitnami/spark#300-debian-10-r44)
 
 > Note: Backwards compatibility is not guaranteed due to the above mentioned changes. Please make sure your workloads are compatible with the new version of Hadoop before upgrading. Backups are always recommended before any upgrade operation.
 

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -36,7 +36,7 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: spring-cloud-dataflow
 sources:
-  - https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow
-  - https://github.com/bitnami/bitnami-docker-spring-cloud-skipper
+  - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-dataflow
+  - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-skipper
   - https://dataflow.spring.io/
 version: 12.0.4

--- a/bitnami/spring-cloud-dataflow/README.md
+++ b/bitnami/spring-cloud-dataflow/README.md
@@ -7,7 +7,7 @@ Spring Cloud Data Flow is a microservices-based toolkit for building streaming a
 [Overview of Spring Cloud Data Flow](https://github.com/spring-cloud/spring-cloud-dataflow)
 
 
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ helm install my-release bitnami/spring-cloud-dataflow
 
 ## Introduction
 
-This chart bootstraps a [Spring Cloud Data Flow](https://github.com/bitnami/bitnami-docker-spring-cloud-dataflow) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Spring Cloud Data Flow](https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-dataflow) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -471,7 +471,7 @@ server:
     ## - host: example.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:
@@ -1440,18 +1440,18 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.username Username of new user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     username: dataflow
     ## @param mariadb.auth.password Password for the new user
     ##
     password: change-me
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#creating-a-database-on-first-run
     ##
     database: dataflow
     ## @param mariadb.auth.forcePassword Force users to specify required passwords in the database

--- a/bitnami/suitecrm/Chart.yaml
+++ b/bitnami/suitecrm/Chart.yaml
@@ -27,6 +27,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: suitecrm
 sources:
-  - https://github.com/bitnami/bitnami-docker-suitecrm
+  - https://github.com/bitnami/containers/tree/main/bitnami/suitecrm
   - https://www.suitecrm.com/
 version: 11.1.12

--- a/bitnami/suitecrm/README.md
+++ b/bitnami/suitecrm/README.md
@@ -7,7 +7,7 @@ SuiteCRM is a completely open source, enterprise-grade Customer Relationship Man
 [Overview of SuiteCRM](http://www.suitecrm.com/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/suitecrm
 
 ## Introduction
 
-This chart bootstraps a [SuiteCRM](https://github.com/bitnami/bitnami-docker-suitecrm) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [SuiteCRM](https://github.com/bitnami/containers/tree/main/bitnami/suitecrm) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 SuiteCRM is a software fork of the popular customer relationship management (CRM) system SugarCRM.
 
@@ -312,7 +312,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.egressRules.customRules`                       | Custom network policy rule                                                                                                   | `{}`    |
 
 
-The above parameters map to the env variables defined in [bitnami/suitecrm](https://github.com/bitnami/bitnami-docker-suitecrm). For more information please refer to the [bitnami/suitecrm](https://github.com/bitnami/bitnami-docker-suitecrm) image documentation.
+The above parameters map to the env variables defined in [bitnami/suitecrm](https://github.com/bitnami/containers/tree/main/bitnami/suitecrm). For more information please refer to the [bitnami/suitecrm](https://github.com/bitnami/containers/tree/main/bitnami/suitecrm) image documentation.
 
 > **Note**:
 >
@@ -382,7 +382,7 @@ As an alternative, you can use of the preset configurations for pod affinity, po
 
 ## Persistence
 
-The [Bitnami SuiteCRM](https://github.com/bitnami/bitnami-docker-suitecrm) image stores the SuiteCRM data and configurations at the `/bitnami/suitecrm` path of the container.
+The [Bitnami SuiteCRM](https://github.com/bitnami/containers/tree/main/bitnami/suitecrm) image stores the SuiteCRM data and configurations at the `/bitnami/suitecrm` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -477,7 +477,7 @@ In this major the MariaDB dependency version was also bumped to a new major vers
 
 **3. Migration of the SuiteCRM image to non-root **
 
-The [Bitnami SuiteCRM](https://github.com/bitnami/bitnami-docker-suitecrm) image was updated to support and enable the "non-root" user approach
+The [Bitnami SuiteCRM](https://github.com/bitnami/containers/tree/main/bitnami/suitecrm) image was updated to support and enable the "non-root" user approach
 
 If you want to continue to run the container image as the `root` user, you need to set `podSecurityContext.enabled=false` and `containerSecurity.context.enabled=false`.
 

--- a/bitnami/suitecrm/values.yaml
+++ b/bitnami/suitecrm/values.yaml
@@ -72,32 +72,32 @@ image:
 ##
 replicaCount: 1
 ## @param suitecrmSkipInstall Skip SuiteCRM installation wizard. Useful for migrations and restoring from SQL dump
-## ref: https://github.com/bitnami/bitnami-docker-suitecrm#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/suitecrm#configuration
 ##
 suitecrmSkipInstall: false
 ## @param suitecrmValidateUserIP Whether to validate the user IP address or not
-## ref: https://github.com/bitnami/bitnami-docker-suitecrm#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/suitecrm#configuration
 ##
 suitecrmValidateUserIP: false
 ## @param suitecrmHost SuiteCRM host to create application URLs
-## ref: https://github.com/bitnami/bitnami-docker-suitecrm#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/suitecrm#configuration
 ##
 suitecrmHost: ""
 ## @param suitecrmUsername User of the application
-## ref: https://github.com/bitnami/bitnami-docker-suitecrm#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/suitecrm#configuration
 ##
 suitecrmUsername: user
 ## @param suitecrmPassword Application password
 ## Defaults to a random 10-character alphanumeric string if not set
-## ref: https://github.com/bitnami/bitnami-docker-suitecrm#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/suitecrm#configuration
 ##
 suitecrmPassword: ""
 ## @param suitecrmEmail Admin email
-## ref: https://github.com/bitnami/bitnami-docker-suitecrm#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/suitecrm#configuration
 ##
 suitecrmEmail: user@example.com
 ## @param allowEmptyPassword Allow DB blank passwords
-## ref: https://github.com/bitnami/bitnami-docker-suitecrm#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/suitecrm#environment-variables
 ##
 allowEmptyPassword: false
 ## @param command Override default container command (useful when using custom images)
@@ -166,7 +166,7 @@ topologySpreadConstraints: []
 ##
 existingSecret: ""
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-suitecrm/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/suitecrm/#smtp-configuration
 ## @param suitecrmSmtpHost SMTP host
 ## @param suitecrmSmtpPort SMTP port
 ## @param suitecrmSmtpUser SMTP user
@@ -352,15 +352,15 @@ mariadb:
   ##
   auth:
     ## @param mariadb.auth.rootPassword Password for the MariaDB `root` user
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
+    ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
     ##
     rootPassword: ""
     ## @param mariadb.auth.database Database name to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
     ##
     database: bitnami_suitecrm
     ## @param mariadb.auth.username Database user to create
-    ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+    ## ref: https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
     ##
     username: bn_suitecrm
     ## @param mariadb.auth.password Password for the database
@@ -663,7 +663,7 @@ ingress:
   ## - host: suitecrm.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: suitecrm-svc
   ##           port:

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -24,7 +24,7 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: tensorflow-resnet
 sources:
-  - https://github.com/bitnami/bitnami-docker-tensorflow-serving
-  - https://github.com/bitnami/bitnami-docker-tensorflow-resnet
+  - https://github.com/bitnami/containers/tree/main/bitnami/tensorflow-serving
+  - https://github.com/bitnami/containers/tree/main/bitnami/tensorflow-resnet
   - https://www.tensorflow.org/serving/
 version: 3.5.18

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -26,6 +26,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: thanos
 sources:
-  - https://github.com/bitnami/bitnami-docker-thanos
+  - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
 version: 11.1.2

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -7,7 +7,7 @@ Thanos is a highly available metrics system that can be added on top of existing
 [Overview of Thanos](https://thanos.io/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
@@ -17,7 +17,7 @@ helm install my-release bitnami/thanos
 
 ## Introduction
 
-This chart bootstraps a [Thanos](https://github.com/bitnami/bitnami-docker-thanos) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Thanos](https://github.com/bitnami/containers/tree/main/bitnami/thanos) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -36,7 +36,7 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install my-release bitnami/thanos
 ```
 
-These commands deploy Thanos on the Kubernetes cluster with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+These commands deploy Thanos on the Kubernetes cluster with the default configuration. The [configuration](#configuration-and-installation-details) section lists the parameters that can be configured during installation.
 
 > **Tip**: List all releases using `helm list`
 

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: tomcat
 sources:
-  - https://github.com/bitnami/bitnami-docker-tomcat
+  - https://github.com/bitnami/containers/tree/main/bitnami/tomcat
   - http://tomcat.apache.org
 version: 10.3.10

--- a/bitnami/tomcat/README.md
+++ b/bitnami/tomcat/README.md
@@ -7,7 +7,7 @@ Apache Tomcat is an open-source web server designed to host and run Java-based w
 [Overview of Apache Tomcat](http://tomcat.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/tomcat
 
 ## Introduction
 
-This chart bootstraps a [Tomcat](https://github.com/bitnami/bitnami-docker-tomcat) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Tomcat](https://github.com/bitnami/containers/tree/main/bitnami/tomcat) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Tomcat implements several Java EE specifications including Java Servlet, JavaServer Pages, Java EL, and WebSocket, and provides a "pure Java" HTTP web server environment for Java code to run in.
 
@@ -244,7 +244,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.prometheusRule.rules`            | Create specified [Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) | `[]`                                                                                                                                                                                                                |
 
 
-The above parameters map to the env variables defined in [bitnami/tomcat](https://github.com/bitnami/bitnami-docker-tomcat). For more information please refer to the [bitnami/tomcat](https://github.com/bitnami/bitnami-docker-tomcat) image documentation.
+The above parameters map to the env variables defined in [bitnami/tomcat](https://github.com/bitnami/containers/tree/main/bitnami/tomcat). For more information please refer to the [bitnami/tomcat](https://github.com/bitnami/containers/tree/main/bitnami/tomcat) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -303,7 +303,7 @@ As an alternative, use one of the preset configurations for pod affinity, pod an
 
 ## Persistence
 
-The [Bitnami Tomcat](https://github.com/bitnami/bitnami-docker-tomcat) image stores the Tomcat data and configurations at the `/bitnami/tomcat` path of the container.
+The [Bitnami Tomcat](https://github.com/bitnami/containers/tree/main/bitnami/tomcat) image stores the Tomcat data and configurations at the `/bitnami/tomcat` path of the container.
 
 Persistent Volume Claims (PVCs) are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -79,11 +79,11 @@ image:
 ##
 hostAliases: []
 ## @param tomcatUsername Tomcat admin user
-## ref: https://github.com/bitnami/bitnami-docker-tomcat#creating-a-custom-user
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/tomcat#creating-a-custom-user
 ##
 tomcatUsername: user
 ## @param tomcatPassword Tomcat admin password
-## ref: https://github.com/bitnami/bitnami-docker-tomcat#creating-a-custom-user
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/tomcat#creating-a-custom-user
 ##
 tomcatPassword: ""
 ## @param tomcatAllowRemoteManagement Enable remote access to management interface

--- a/bitnami/wavefront-hpa-adapter/Chart.yaml
+++ b/bitnami/wavefront-hpa-adapter/Chart.yaml
@@ -24,5 +24,5 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: wavefront-hpa-adapter
 sources:
-  - https://github.com/bitnami/bitnami-docker-wavefront-hpa-adapter
+  - https://github.com/bitnami/containers/tree/main/bitnami/wavefront-hpa-adapter
 version: 1.2.4

--- a/bitnami/wavefront-prometheus-storage-adapter/Chart.yaml
+++ b/bitnami/wavefront-prometheus-storage-adapter/Chart.yaml
@@ -28,5 +28,5 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: wavefront-prometheus-storage-adapter
 sources:
-  - https://github.com/bitnami/bitnami-docker-wavefront-prometheus-storage-adapter
+  - https://github.com/bitnami/containers/tree/main/bitnami/wavefront-prometheus-storage-adapter
 version: 2.0.5

--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -26,8 +26,8 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: wavefront
 sources:
-  - https://github.com/bitnami/bitnami-docker-wavefront-kubernetes-collector
-  - https://github.com/bitnami/bitnami-docker-wavefront-proxy
+  - https://github.com/bitnami/containers/tree/main/bitnami/wavefront-kubernetes-collector
+  - https://github.com/bitnami/containers/tree/main/bitnami/wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
 version: 4.0.4

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -24,6 +24,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: wildfly
 sources:
-  - https://github.com/bitnami/bitnami-docker-wildfly
+  - https://github.com/bitnami/containers/tree/main/bitnami/wildfly
   - http://wildfly.org
 version: 13.3.11

--- a/bitnami/wildfly/README.md
+++ b/bitnami/wildfly/README.md
@@ -7,7 +7,7 @@ Wildfly is a lightweight, open source application server, formerly known as JBos
 [Overview of WildFly](http://www.wildfly.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/wildfly
 
 ## Introduction
 
-This chart bootstraps a [WildFly](https://github.com/bitnami/bitnami-docker-wildfly) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [WildFly](https://github.com/bitnami/containers/tree/main/bitnami/wildfly) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 WildFly is written in Java, and implements the Java Platform, Enterprise Edition (Java EE) specification.
 
@@ -226,7 +226,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.securityContext.runAsUser` | Set init container's Security Context runAsUser                                                 | `0`                     |
 
 
-The above parameters map to the env variables defined in [bitnami/wildfly](https://github.com/bitnami/bitnami-docker-wildfly). For more information please refer to the [bitnami/wildfly](https://github.com/bitnami/bitnami-docker-wildfly) image documentation.
+The above parameters map to the env variables defined in [bitnami/wildfly](https://github.com/bitnami/containers/tree/main/bitnami/wildfly). For more information please refer to the [bitnami/wildfly](https://github.com/bitnami/containers/tree/main/bitnami/wildfly) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -258,7 +258,7 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 ## Persistence
 
-The [Bitnami WildFly](https://github.com/bitnami/bitnami-docker-wildfly) image stores the WildFly data and configurations at the `/bitnami/wildfly` path of the container.
+The [Bitnami WildFly](https://github.com/bitnami/containers/tree/main/bitnami/wildfly) image stores the WildFly data and configurations at the `/bitnami/wildfly` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube.
 See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
@@ -304,7 +304,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ### To 10.0.0
 
-Due to recent changes in the container image (see [Notable changes](https://github.com/bitnami/bitnami-docker-apache#notable-changes)), the major version of the chart has been bumped preemptively.
+Due to recent changes in the container image (see [Notable changes](https://github.com/bitnami/containers/tree/main/bitnami/apache#notable-changes)), the major version of the chart has been bumped preemptively.
 
 Upgrading from version `9.x.x` should be possible without any extra required step, but it's highly recommended to backup your custom web apps data before upgrading.
 

--- a/bitnami/wildfly/values.yaml
+++ b/bitnami/wildfly/values.yaml
@@ -88,7 +88,7 @@ image:
 
 ## @section WildFly Configuration parameters
 ## WildFly settings based on environment variables
-## ref: https://github.com/bitnami/bitnami-docker-wildfly#configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wildfly#configuration
 
 ## @param wildflyUsername WildFly username
 ##
@@ -492,7 +492,7 @@ ingress:
   ## - host: wildfly.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: wildfly-svc
   ##           port:

--- a/bitnami/wordpress-intel/Chart.yaml
+++ b/bitnami/wordpress-intel/Chart.yaml
@@ -33,6 +33,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: wordpress-intel
 sources:
-  - https://github.com/bitnami/bitnami-docker-wordpress-intel
+  - https://github.com/bitnami/containers/tree/main/bitnami/wordpress-intel
   - https://wordpress.org/
 version: 2.0.12

--- a/bitnami/wordpress-intel/README.md
+++ b/bitnami/wordpress-intel/README.md
@@ -7,7 +7,7 @@ WordPress for Intel is the most popular blogging application combined with crypt
 [Overview of WordPress for Intel](http://www.wordpress.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/wordpress-intel
 
 ## Introduction
 
-This chart bootstraps a [WordPress Intel](https://github.com/bitnami/bitnami-docker-wordpress-intel) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [WordPress Intel](https://github.com/bitnami/containers/tree/main/bitnami/wordpress-intel) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the WordPress application, and the [Bitnami Memcached chart](https://github.com/bitnami/charts/tree/master/bitnami/memcached) that can be used to cache database queries.
 
@@ -334,7 +334,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalCache.port`                       | External cache server port                                                | `11211`             |
 
 
-The above parameters map to the env variables defined in [bitnami/wordpress-intel](https://github.com/bitnami/bitnami-docker-wordpress-intel). For more information please refer to the [bitnami/wordpress-intel](https://github.com/bitnami/bitnami-docker-wordpress-intel) image documentation.
+The above parameters map to the env variables defined in [bitnami/wordpress-intel](https://github.com/bitnami/containers/tree/main/bitnami/wordpress-intel). For more information please refer to the [bitnami/wordpress-intel](https://github.com/bitnami/containers/tree/main/bitnami/wordpress-intel) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -420,7 +420,7 @@ The chart also facilitates the creation of TLS secrets for use with the Ingress 
 
 ## Persistence
 
-The [Bitnami WordPress Intel](https://github.com/bitnami/bitnami-docker-wordpress-intel) image stores the WordPress data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
+The [Bitnami WordPress Intel](https://github.com/bitnami/containers/tree/main/bitnami/wordpress-intel) image stores the WordPress data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
 
 If you encounter errors when working with persistent volumes, refer to our [troubleshooting guide for persistent volumes](https://docs.bitnami.com/kubernetes/faq/troubleshooting/troubleshooting-persistence-volumes/).
 

--- a/bitnami/wordpress-intel/values.yaml
+++ b/bitnami/wordpress-intel/values.yaml
@@ -89,7 +89,7 @@ image:
 
 ## @section WordPress Configuration parameters
 ## WordPress settings based on environment variables
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#environment-variables
 
 ## @param wordpressUsername WordPress username
 ##
@@ -123,7 +123,7 @@ wordpressTablePrefix: wp_
 wordpressScheme: http
 ## @param wordpressSkipInstall Skip wizard installation
 ## NOTE: useful if you use an external database that already contains WordPress data
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#connect-wordpress-docker-container-to-an-existing-database
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#connect-wordpress-docker-container-to-an-existing-database
 ##
 wordpressSkipInstall: false
 ## @param wordpressExtraConfigContent Add extra content to the default wp-config.php file
@@ -151,13 +151,13 @@ wordpressConfigureCache: false
 ##
 wordpressPlugins: none
 ## @param customPostInitScripts Custom post-init.d user scripts
-## ref: https://github.com/bitnami/bitnami-docker-wordpress
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress
 ## NOTE: supported formats are `.sh`, `.sql` or `.php`
 ## NOTE: scripts are exclusively executed during the 1st boot of the container
 ##
 customPostInitScripts: {}
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress/#smtp-configuration
 ## @param smtpHost SMTP server host
 ## @param smtpPort SMTP server port
 ## @param smtpUser SMTP username
@@ -198,7 +198,7 @@ extraEnvVarsCM: ""
 extraEnvVarsSecret: ""
 
 ## @section WordPress Multisite Configuration parameters
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#multisite-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#multisite-configuration
 
 ## @param multisite.enable Whether to enable WordPress Multisite configuration.
 ## @param multisite.host WordPress Multisite hostname/address. This value is mandatory when enabling Multisite mode.
@@ -894,9 +894,9 @@ mariadb:
   ## @param mariadb.auth.database MariaDB custom database
   ## @param mariadb.auth.username MariaDB custom user name
   ## @param mariadb.auth.password MariaDB custom user password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
-  ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
-  ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
+  ##      https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
+  ##      https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
   auth:
     rootPassword: ""
     database: bitnami_wordpress

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -33,6 +33,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: wordpress
 sources:
-  - https://github.com/bitnami/bitnami-docker-wordpress
+  - https://github.com/bitnami/containers/tree/main/bitnami/wordpress
   - https://wordpress.org/
 version: 15.0.12

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -7,7 +7,7 @@ WordPress is the world's most popular blogging and content management platform. 
 [Overview of WordPress](http://www.wordpress.org)
 
 
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/wordpress
 
 ## Introduction
 
-This chart bootstraps a [WordPress](https://github.com/bitnami/bitnami-docker-wordpress) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [WordPress](https://github.com/bitnami/containers/tree/main/bitnami/wordpress) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 It also packages the [Bitnami MariaDB chart](https://github.com/bitnami/charts/tree/master/bitnami/mariadb) which is required for bootstrapping a MariaDB deployment for the database requirements of the WordPress application, and the [Bitnami Memcached chart](https://github.com/bitnami/charts/tree/master/bitnami/memcached) that can be used to cache database queries.
 
@@ -375,7 +375,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalCache.port`                       | External cache server port                                                        | `11211`             |
 
 
-The above parameters map to the env variables defined in [bitnami/wordpress](https://github.com/bitnami/bitnami-docker-wordpress). For more information please refer to the [bitnami/wordpress](https://github.com/bitnami/bitnami-docker-wordpress) image documentation.
+The above parameters map to the env variables defined in [bitnami/wordpress](https://github.com/bitnami/containers/tree/main/bitnami/wordpress). For more information please refer to the [bitnami/wordpress](https://github.com/bitnami/containers/tree/main/bitnami/wordpress) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -469,7 +469,7 @@ By default, the container image includes all the default `.htaccess` files in Wo
 
 ## Persistence
 
-The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image stores the WordPress data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
+The [Bitnami WordPress](https://github.com/bitnami/containers/tree/main/bitnami/wordpress) image stores the WordPress data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments.
 
 If you encounter errors when working with persistent volumes, refer to our [troubleshooting guide for persistent volumes](https://docs.bitnami.com/kubernetes/faq/troubleshooting/troubleshooting-persistence-volumes/).
 
@@ -508,7 +508,7 @@ Removed support for limiting auto-updates to WordPress core via the `wordpressAu
 
 ### 11.0.0
 
-The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image was refactored and now the source code is published in GitHub in the [`rootfs`](https://github.com/bitnami/bitnami-docker-wordpress/tree/master/5/debian-10/rootfs) folder of the container image.
+The [Bitnami WordPress](https://github.com/bitnami/containers/tree/main/bitnami/wordpress) image was refactored and now the source code is published in GitHub in the `rootfs` folder of the container image.
 
 In addition, several new features have been implemented:
 
@@ -542,7 +542,7 @@ Site backups can be easily performed using tools such as [VaultPress](https://va
 
 ### To 11.0.0
 
-The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image was refactored and now the source code is published in GitHub in the [`rootfs`](https://github.com/bitnami/bitnami-docker-wordpress/tree/master/5/debian-10/rootfs) folder of the container image.
+The [Bitnami WordPress](https://github.com/bitnami/containers/tree/main/bitnami/wordpress) image was refactored and now the source code is published in GitHub in the `rootfs` folder of the container image.
 
 Compatibility is not guaranteed due to the amount of involved changes, however no breaking changes are expected.
 
@@ -594,7 +594,7 @@ mariadb 12:13:25.01 INFO  ==> Running mysql_upgrade
 
 ### To 9.0.0
 
-The [Bitnami WordPress](https://github.com/bitnami/bitnami-docker-wordpress) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `0`.
+The [Bitnami WordPress](https://github.com/bitnami/containers/tree/main/bitnami/wordpress) image was migrated to a "non-root" user approach. Previously the container ran as the `root` user and the Apache daemon was started as the `daemon` user. From now on, both the container and the Apache daemon run as user `1001`. You can revert this behavior by setting the parameters `securityContext.runAsUser`, and `securityContext.fsGroup` to `0`.
 Chart labels and Ingress configuration were also adapted to follow the Helm charts best practices.
 
 Consequences:

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -92,7 +92,7 @@ image:
 
 ## @section WordPress Configuration parameters
 ## WordPress settings based on environment variables
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#environment-variables
 ##
 
 ## @param wordpressUsername WordPress username
@@ -127,7 +127,7 @@ wordpressTablePrefix: wp_
 wordpressScheme: http
 ## @param wordpressSkipInstall Skip wizard installation
 ## NOTE: useful if you use an external database that already contains WordPress data
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#connect-wordpress-docker-container-to-an-existing-database
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#connect-wordpress-docker-container-to-an-existing-database
 ##
 wordpressSkipInstall: false
 ## @param wordpressExtraConfigContent Add extra content to the default wp-config.php file
@@ -162,7 +162,7 @@ apacheConfiguration: ""
 ##
 existingApacheConfigurationConfigMap: ""
 ## @param customPostInitScripts Custom post-init.d user scripts
-## ref: https://github.com/bitnami/bitnami-docker-wordpress
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress
 ## NOTE: supported formats are `.sh`, `.sql` or `.php`
 ## NOTE: scripts are exclusively executed during the 1st boot of the container
 ## e.g:
@@ -180,7 +180,7 @@ existingApacheConfigurationConfigMap: ""
 ##
 customPostInitScripts: {}
 ## SMTP mail delivery configuration
-## ref: https://github.com/bitnami/bitnami-docker-wordpress/#smtp-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress/#smtp-configuration
 ## @param smtpHost SMTP server host
 ## @param smtpPort SMTP server port
 ## @param smtpUser SMTP username
@@ -237,7 +237,7 @@ extraEnvVarsCM: ""
 extraEnvVarsSecret: ""
 
 ## @section WordPress Multisite Configuration parameters
-## ref: https://github.com/bitnami/bitnami-docker-wordpress#multisite-configuration
+## ref: https://github.com/bitnami/containers/tree/main/bitnami/wordpress#multisite-configuration
 ##
 
 ## @param multisite.enable Whether to enable WordPress Multisite configuration.
@@ -1080,9 +1080,9 @@ mariadb:
   ## @param mariadb.auth.database MariaDB custom database
   ## @param mariadb.auth.username MariaDB custom user name
   ## @param mariadb.auth.password MariaDB custom user password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb#setting-the-root-password-on-first-run
-  ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-on-first-run
-  ##      https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/mariadb#setting-the-root-password-on-first-run
+  ##      https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-on-first-run
+  ##      https://github.com/bitnami/containers/blob/main/bitnami/mariadb/README.md#creating-a-database-user-on-first-run
   ##
   auth:
     rootPassword: ""
@@ -1137,7 +1137,7 @@ memcached:
   ##
   enabled: false
   ## Authentication parameters
-  ## ref: https://github.com/bitnami/bitnami-docker-memcached#creating-the-memcached-admin-user
+  ## ref: https://github.com/bitnami/containers/tree/main/bitnami/memcached#creating-the-memcached-admin-user
   ##
   auth:
     ## @param memcached.auth.enabled Enable Memcached authentication

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -19,6 +19,6 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: zookeeper
 sources:
-  - https://github.com/bitnami/bitnami-docker-zookeeper
+  - https://github.com/bitnami/containers/tree/main/bitnami/zookeeper
   - https://zookeeper.apache.org/
 version: 10.0.2

--- a/bitnami/zookeeper/README.md
+++ b/bitnami/zookeeper/README.md
@@ -7,7 +7,7 @@ Apache ZooKeeper provides a reliable, centralized register of configuration data
 [Overview of Apache ZooKeeper](https://zookeeper.apache.org)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -17,7 +17,7 @@ $ helm install my-release bitnami/zookeeper
 
 ## Introduction
 
-This chart bootstraps a [ZooKeeper](https://github.com/bitnami/bitnami-docker-zookeeper) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [ZooKeeper](https://github.com/bitnami/containers/tree/main/bitnami/zookeeper) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
@@ -393,7 +393,7 @@ the available appender is
 
 ## Persistence
 
-The [Bitnami ZooKeeper](https://github.com/bitnami/bitnami-docker-zookeeper) image stores the ZooKeeper data and configurations at the `/bitnami/zookeeper` path of the container.
+The [Bitnami ZooKeeper](https://github.com/bitnami/containers/tree/main/bitnami/zookeeper) image stores the ZooKeeper data and configurations at the `/bitnami/zookeeper` path of the container.
 
 Persistent Volume Claims are used to keep the data across deployments. This is known to work in GCE, AWS, and minikube. See the [Parameters](#parameters) section to configure the PVC or to disable persistence.
 

--- a/template/CHART_NAME/Chart.yaml
+++ b/template/CHART_NAME/Chart.yaml
@@ -25,7 +25,7 @@ maintainers:
     url: https://github.com/bitnami/charts
 name: %%CHART_NAME%%
 sources:
-  - https://github.com/bitnami/bitnami-docker-%%IMAGE_NAME%%
+  - https://github.com/bitnami/containers/tree/main/bitnami/%%IMAGE_NAME%%
   - %%UPSTREAM_PROJECT_SOURCE_CODE_URL%%
   - ...
 version: 0.1.0

--- a/template/CHART_NAME/README.md
+++ b/template/CHART_NAME/README.md
@@ -46,7 +46,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 See https://github.com/bitnami-labs/readme-generator-for-helm to create the table
 
-The above parameters map to the env variables defined in [bitnami/%%CHART_NAME%%](http://github.com/bitnami/bitnami-docker-%%CHART_NAME%%). For more information please refer to the [bitnami/%%CHART_NAME%%](http://github.com/bitnami/bitnami-docker-%%CHART_NAME%%) image documentation.
+The above parameters map to the env variables defined in [bitnami/%%CHART_NAME%%](https://github.com/bitnami/containers/tree/main/bitnami/%%CHART_NAME%%). For more information please refer to the [bitnami/%%CHART_NAME%%](https://github.com/bitnami/containers/tree/main/bitnami/%%CHART_NAME%%) image documentation.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
@@ -109,7 +109,7 @@ The chart also facilitates the creation of TLS secrets for use with the Ingress 
 
 ## Persistence
 
-The [Bitnami %%CHART_NAME%%](https://github.com/bitnami/bitnami-docker-%%CHART_NAME%%) image stores the %%CHART_NAME%% data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments. [Learn more about persistence in the chart documentation](https://docs.bitnami.com/kubernetes/apps/%%CHART_NAME%%/configuration/chart-persistence/).
+The [Bitnami %%CHART_NAME%%](https://github.com/bitnami/containers/tree/main/bitnami/%%CHART_NAME%%) image stores the %%CHART_NAME%% data and configurations at the `/bitnami` path of the container. Persistent Volume Claims are used to keep the data across deployments. [Learn more about persistence in the chart documentation](https://docs.bitnami.com/kubernetes/apps/%%CHART_NAME%%/configuration/chart-persistence/).
 
 ### Additional environment variables
 


### PR DESCRIPTION
### Description of the change

Since we are migrating the different `bitnami/bitnami-docker-foo` repositories to a single `bitnami/containers` repository, the aim of this PR is to replace the different URLs reflecting the new source.

### Benefits

Links are updated pointing to the new source.

### Possible drawbacks

Since changes were done in a batch way maybe some links can be broken, in order to avoid this, I used the [`markdown-link-check` tool](https://www.npmjs.com/package/markdown-link-check) to check the markdown ones

⚠️ We are **not** bumping the Chart version on purpose to avoid triggering a new release of every Helm chart in the catalog. On this way changes will be merged at code level but the release will be done when changes from a different nature trigger it