### PR TITLE
[bitnami/fluentd] Add GOSS tests and publish using VIB

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -10,6 +10,7 @@ on: # rebuild any PRs and main branch changes
       - 'bitnami/dokuwiki/**'
       - 'bitnami/elasticsearch/**'
       - 'bitnami/external-dns/**'
+      - 'bitnami/fluentd/**'
       - 'bitnami/ghost/**'
       - 'bitnami/grafana-loki/**'
       - 'bitnami/grafana/**'

--- a/.vib/fluentd/goss/goss.yaml
+++ b/.vib/fluentd/goss/goss.yaml
@@ -1,0 +1,34 @@
+file:
+  /opt/bitnami/fluentd/conf/fluentd-inputs.conf:
+    exists: true
+    filetype: symlink
+    contains:
+      - "type http"
+      - "type kubernetes_metadata"
+      - "path /var/log/containers/*.log"
+  /var/log:
+    exists: true
+    filetype: directory
+    mode: "0755"
+    owner: root
+    group: root
+  /var/lib/docker/containers:
+    exists: true
+    filetype: directory
+    mode: "0701"
+    owner: root
+    group: root
+command:
+  # The Chart is configured to keep track of the logs in the /var/log/containers directory. Creating a log file
+  # should trigger the Forwarder to send the contents to the Aggregator.
+  #
+  # The integration can be verified as the Forwarder pods have access to the logs of every pod in the cluster, so
+  # we check that the Aggregator is aware of the newly created file.
+  {{ with (printf "test-%s.log" (randAlpha 5)) }}
+  forward-aggregator-integration:
+    exec: "cd /var/log/containers && echo '{\"time\": \"2022-07-29T11:33:47.408955753Z\", \"data\": \"zwiebel\"}' > {{.}} && sleep 65 && find . -name \"*fluentd-0*\" -exec tail {} \\;"
+    exit-status: 0
+    stdout:
+      - {{.}}
+    timeout: 75000
+  {{end}}

--- a/.vib/fluentd/vib-publish.json
+++ b/.vib/fluentd/vib-publish.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/fluentd"
         },
-        "runtime_parameters": "ImFnZ3JlZ2F0b3IiOgogICJjb250YWluZXJTZWN1cml0eUNvbnRleHQiOgogICAgImNhcGFiaWxpdGllcyI6CiAgICAgICJkcm9wIjogbnVsbAoiZm9yd2FyZGVyIjoKICAiY29udGFpbmVyU2VjdXJpdHlDb250ZXh0IjoKICAgICJjYXBhYmlsaXRpZXMiOgogICAgICAiZHJvcCI6IG51bGwKICAic2VydmljZSI6CiAgICAicG9ydHMiOgogICAgICAiaHR0cCI6CiAgICAgICAgInBvcnQiOiA4MAogICAgInR5cGUiOiAiTG9hZEJhbGFuY2VyIg==",
+        "runtime_parameters": "YWdncmVnYXRvcjoKICBlbmFibGVkOiB0cnVlCmZvcndhcmRlcjoKICBlbmFibGVkOiB0cnVlCiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6CiAgICAgICAgcG9ydDogODA=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
           "size": {
@@ -45,6 +45,17 @@
           "params": {
             "endpoint": "lb-fluentd-forwarder-http",
             "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/fluentd/goss"
+            },
+            "remote": {
+              "workload": "ds-fluentd"
+            }
           }
         }
       ]

--- a/.vib/fluentd/vib-verify.json
+++ b/.vib/fluentd/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/fluentd"
         },
-        "runtime_parameters": "ImFnZ3JlZ2F0b3IiOgogICJjb250YWluZXJTZWN1cml0eUNvbnRleHQiOgogICAgImNhcGFiaWxpdGllcyI6CiAgICAgICJkcm9wIjogbnVsbAoiZm9yd2FyZGVyIjoKICAiY29udGFpbmVyU2VjdXJpdHlDb250ZXh0IjoKICAgICJjYXBhYmlsaXRpZXMiOgogICAgICAiZHJvcCI6IG51bGwKICAic2VydmljZSI6CiAgICAicG9ydHMiOgogICAgICAiaHR0cCI6CiAgICAgICAgInBvcnQiOiA4MAogICAgInR5cGUiOiAiTG9hZEJhbGFuY2VyIg==",
+        "runtime_parameters": "YWdncmVnYXRvcjoKICBlbmFibGVkOiB0cnVlCmZvcndhcmRlcjoKICBlbmFibGVkOiB0cnVlCiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6CiAgICAgICAgcG9ydDogODA=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
           "size": {
@@ -43,6 +43,17 @@
           "params": {
             "endpoint": "lb-fluentd-forwarder-http",
             "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/fluentd/goss"
+            },
+            "remote": {
+              "workload": "ds-fluentd"
+            }
           }
         }
       ]

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/fluentd
   - https://www.fluentd.org/
-version: 5.2.4
+version: 5.3.0

--- a/bitnami/fluentd/templates/forwarder-clusterrole.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "common.names.fullname.namespace" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -28,7 +28,7 @@ rules:
     resources:
       - "podsecuritypolicies"
     resourceNames:
-      - {{ include "common.names.fullname" . }}-forwarder
+      - {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "forwarder" }}
     verbs:
       - "use"
   {{- end }}

--- a/bitnami/fluentd/templates/forwarder-clusterrolebinding.yaml
+++ b/bitnami/fluentd/templates/forwarder-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRoleBinding
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "common.names.fullname.namespace" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -14,7 +14,7 @@ metadata:
 roleRef:
   kind: ClusterRole
   apiGroup: rbac.authorization.k8s.io
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname.namespace" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "fluentd.forwarder.serviceAccountName" . }}

--- a/bitnami/fluentd/templates/forwarder-psp.yaml
+++ b/bitnami/fluentd/templates/forwarder-psp.yaml
@@ -3,7 +3,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ include "common.names.fullname" . }}-forwarder
+  name: {{ printf "%s-%s" (include "common.names.fullname.namespace" .) "forwarder" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: forwarder


### PR DESCRIPTION
**Description of the change**
The main objective of this PR is to publish our Bitnami Fluentd Helm Chart using VMware Image Builder. In order to do that, several changes are included:

- Adding the asset to the publishing workflow
- Increasing the existing test coverage of the asset by adding GOSS tests.
- Adapting the chart to use `common.names.fullname.namespace`, which allows deploying several releases under the same K8s cluster but in different namespaces.

**Benefits**

- Ensuring higher quality of the Helm charts.
- Increased pool of assets completely handled by VMware Image Builder.


**Possible drawbacks**
Automated tests could show to be potentially flaky. 

**Test results**

Tested in https://github.com/joancafom/charts/pull/60

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in the agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
