### PR TITLE
[bitnami/schema-registry] Wrong template name "commons.fullname"

### DIFF
--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: schema-registry
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/schema-registry
-version: 4.0.3
+version: 4.0.4

--- a/bitnami/schema-registry/templates/external-kafka-secrets.yaml
+++ b/bitnami/schema-registry/templates/external-kafka-secrets.yaml
@@ -16,5 +16,5 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  client-passwords: {{ include "common.secrets.passwords.manage" (dict "secret" (include "commons.fullname" .) "key" "client-password" "providedValues" (list "externalKafka.auth.jaas.password" ) "context" $) }}
+  client-passwords: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "client-password" "providedValues" (list "externalKafka.auth.jaas.password" ) "context" $) }}
 {{- end }}


### PR DESCRIPTION
```
"msg": "Failure when executing Helm command. Exited 1.\nstdout: \nstderr: Error: Failed to render chart: exit status 1: Error: template: schema-registry/templates/external-kafka-secrets.yaml:19:81: executing \"schema-registry/templates/external-kafka-secrets.yaml\" at <include \"commons.fullname\" .>: error calling include: template: no template \"commons.fullname\" associated with template
```

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Wrong template name "commons.fullname" in external-kafka-secrets.yaml

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

Signed-off-by: Osmani Sánchez <osmanisanchez@gmail.com>