### PR TITLE
[bitnami/*] Ensuring all developers are properly added to bitnami-team

### DIFF
--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,4 +1,4 @@
-BITNAMI_TEAM='["Javirln","agarcia-oss","agomezmoron","alvneiayu","andresbono","andresiglesias","aruiz14","beltran-rubo","carlossm","cscazorla","dani8art","dariver","fjagugar","gongomgra","hmoragrega","javsalgar","jiparis","jorgelzpz","josvazg","jotadrilo","juamedgod","marcosbc","mpermar","pablogalegoc","ppbaena","randradas","recena","rogelio-o","tompizmor","xoanteis"]'
+BITNAMI_TEAM='["Akinorev","Alienah","CeliaGMqrz","ClaaudiaGarcia","FraPazGal","Javirln","Mauraza","agarcia-oss","agomezmoron","alemorcuq","alvneiayu","andresbono","andresiglesias","antgamdia","aoterolorenzo","aruiz14","awca22","beltran-rubo","bitnami-bot","carlossm","carrodher","castelblanque","corico44","cscazorla","dani8art","dariver","dgomezleon","fevisera","fjagugar","fmulero","gdelgadot","gongomgra","hmoragrega","javsalgar","jbianquetti-nami","jiparis","joancafom","jorgelzpz","josvazg","jotadrilo","jotamartos","juamedgod","kaysavps","marcosbc","mdhont","migruiz4","mpermar","pablogalegoc","paleloser","ppbaena","rafariossaa","randradas","recena","rloporp","rogelio-o","ruospalo","tompizmor","xoanteis","zubero"]'
 IN_PROGRESS_COLUMN_ID=19057376
 TRIAGE_COLUMN_ID=19057374
 SOLVED_COLUMN_ID=19057379

--- a/.github/workflows/sync-teams.yml
+++ b/.github/workflows/sync-teams.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Updating members of the Bitnami team
         run: |
           TEAM_MEMBERS=$(curl --request GET \
-          --url https://api.github.com/orgs/bitnami/teams/developers/members \
+          --url https://api.github.com/orgs/bitnami/teams/developers/members?per_page=100 \
           --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
           --header 'content-type: application/json' \
           | jq 'sort_by(.login)|map(.login)|join(",")')


### PR DESCRIPTION
Signed-off-by: Alejandro Gómez <morona@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The request done to the GH API didn't add the per_page parameters and only 30 members were retrieved.
The workflow is executed once a day, that's why I run it locally and fix it for today.

### Benefits

All the Bitnami members are properly set.

### Possible drawbacks

None detected

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
