### PR TITLE
[bitnami/rabbitmq] Document persistent volume layout change in 7.0.0

### DIFF
--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -647,6 +647,12 @@ See the [Upgrading guide](https://www.rabbitmq.com/upgrade.html) and the [Rabbit
 - Chart labels and Ingress configuration were adapted to follow the Helm charts best practices.
 - Initialization logic now relies on the container.
 - This version introduces `bitnami/common`, a [library chart](https://helm.sh/docs/topics/library_charts/#helm) as a dependency. More documentation about this new utility could be found [here](https://github.com/bitnami/charts/tree/master/bitnami/common#bitnami-common-library-chart). Please, make sure that you have updated the chart dependencies before executing any upgrade.
+- The layout of the persistent volumes has changed (if using persistence). Action is required if preserving data through the upgrade is desired:
+  - The data has moved from `mnesia/` within the persistent volume to the root of the persistent volume
+  - The `config/` and `schema/` directories within the persistent volume are no longer used
+  - An init container can be used to move and clean up the peristent volumes. An example can be found [here](https://github.com/bitnami/charts/issues/10913#issuecomment-1169619513).
+  - Alternately the value `persistence.subPath` can be overridden to be `mnesia` so that the directory layout is consistent with what it was previously.
+    - Note however that this will leave the unused `config/` and `schema/` directories within the peristent volume forever.
 
 Consequences:
 


### PR DESCRIPTION
### Description of the change

This adds documentation on a previously undocumented breaking change in the RabbitMQ chart version 7.0.0 - if persistence is enabled, the structure of the persistent volumes is changed under the default values - previously the RabbitMQ data was stored under `mnesia/` in the persistent volume but now it is stored at the root of the peristent volume and the previous `config/` and `schema/` directories are no longer used.  If using persistence it is desirable to know about this change and address it appropriately.

### Benefits

Anyone upgrading from a chart version below 7.0.0 to a newer one (7.0.0 or above) can read these notes and know to address this before they accidentally loose data currently in their RabitMQ cluster.

### Possible drawbacks

- Specific, bulletproof instructions for addressing this are not provided.  A link is provided to a solution that worked in one case but it has not been extensively tested.  This could induce some confusion.

### Applicable issues

- Addresses #10913

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
  - not applicable (only changing readme)
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
  - not applicable (only changing readme)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
