### PR TITLE
[bitnami/*] Bumping the action version to assign PRs

### DIFF
--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Assign to a person to work on it
         # Only if moved into In progress FROM Triage
         if: ${{ github.event.project_card.column_id == env.IN_PROGRESS_COLUMN_ID && github.event.changes != null && github.event.changes.column_id && github.event.changes.column_id.from == env.TRIAGE_COLUMN_ID }}
-        uses: pozil/auto-assign-issue@v1.7.3
+        uses: pozil/auto-assign-issue@v1.9.0
         with:
           numOfAssignee: 1
           removePreviousAssignees: true

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           path: .github/workflows/
       - name: Assign to a person to work on it
-        uses: pozil/auto-assign-issue@v1.7.3
+        uses: pozil/auto-assign-issue@v1.9.0
         with:
           numOfAssignee: 1
           removePreviousAssignees: false


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Bumping the action version after being merged my contribution and being released a [new version](https://github.com/pozil/auto-assign-issue/releases/tag/v1.9.0) of the action.

### Benefits

PRs will be assigned, so in the board will be shown the assignees.

### Possible drawbacks

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
