### PR TITLE
[bitnami/*] Unify Cypress' command delays

### DIFF
--- a/.vib/airflow/cypress/cypress/support/commands.js
+++ b/.vib/airflow/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 800;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {

--- a/.vib/discourse/cypress/cypress/support/commands.js
+++ b/.vib/discourse/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const CLICK_DELAY = 500;
+const COMMAND_DELAY = 2000;
 const BASE_URL = 'http://bitnami-discourse.my';
 
 for (const command of ['click']) {
@@ -8,7 +8,7 @@ for (const command of ['click']) {
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(origVal);
-      }, CLICK_DELAY);
+      }, COMMAND_DELAY);
     });
   });
 }

--- a/.vib/dokuwiki/cypress/cypress/support/commands.js
+++ b/.vib/dokuwiki/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 500;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {

--- a/.vib/ghost/cypress/cypress/support/commands.js
+++ b/.vib/ghost/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 500;
+const COMMAND_DELAY = 2000;
 const BASE_URL = 'http://bitnami-ghost.my';
 
 for (const command of ['click']) {

--- a/.vib/grafana/cypress/cypress/support/commands.js
+++ b/.vib/grafana/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const CLICK_DELAY = 1300;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
@@ -7,7 +7,7 @@ for (const command of ['click']) {
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(origVal);
-      }, CLICK_DELAY);
+      }, COMMAND_DELAY);
     });
   });
 }

--- a/.vib/harbor/cypress/cypress/support/commands.js
+++ b/.vib/harbor/cypress/cypress/support/commands.js
@@ -1,6 +1,6 @@
-const COMMAND_DELAY = 500;
+const COMMAND_DELAY = 2000;
 
-for (const command of ["click"]) {
+for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
     const origVal = originalFn(...args);
 
@@ -13,11 +13,11 @@ for (const command of ["click"]) {
 }
 
 Cypress.Commands.add(
-  "login",
-  (username = Cypress.env("username"), password = Cypress.env("password")) => {
-    cy.visit("/account/sign-in");
-    cy.get("#login_username").type(username);
-    cy.get("#login_password").type(password);
-    cy.get('button[type="submit"]').should("not.be.disabled").click();
+  'login',
+  (username = Cypress.env('username'), password = Cypress.env('password')) => {
+    cy.visit('/account/sign-in');
+    cy.get('#login_username').type(username);
+    cy.get('#login_password').type(password);
+    cy.get('button[type="submit"]').should('not.be.disabled').click();
   }
 );

--- a/.vib/jenkins/cypress/cypress/support/commands.js
+++ b/.vib/jenkins/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 800;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {

--- a/.vib/joomla/cypress/cypress/support/commands.js
+++ b/.vib/joomla/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const CLICK_DELAY = 500;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
@@ -7,7 +7,7 @@ for (const command of ['click']) {
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(origVal);
-      }, CLICK_DELAY);
+      }, COMMAND_DELAY);
     });
   });
 }

--- a/.vib/keycloak/cypress/cypress/support/commands.js
+++ b/.vib/keycloak/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 1100;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {

--- a/.vib/keycloak/cypress/cypress/support/commands.js
+++ b/.vib/keycloak/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 2000;
+const COMMAND_DELAY = 1100;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {

--- a/.vib/magento/cypress/cypress/support/commands.js
+++ b/.vib/magento/cypress/cypress/support/commands.js
@@ -1,27 +1,14 @@
-const CLICK_DELAY = 1000;
-const GET_DELAY = 1000;
+const COMMAND_DELAY = 2000;
 const BASE_URL = 'http://vmware-magento.my';
 
-for (const command of ['click']) {
+for (const command of ['click', 'get']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
     const origVal = originalFn(...args);
 
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(origVal);
-      }, CLICK_DELAY);
-    });
-  });
-}
-
-for (const command of ['get']) {
-  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-    const origVal = originalFn(...args);
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(origVal);
-      }, GET_DELAY);
+      }, COMMAND_DELAY);
     });
   });
 }

--- a/.vib/matomo/cypress/cypress/support/commands.js
+++ b/.vib/matomo/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 500;
+const COMMAND_DELAY = 2000;
 const BASE_URL = 'http://bitnami-matomo.my';
 
 for (const command of ['click']) {

--- a/.vib/mediawiki/cypress/cypress/support/commands.js
+++ b/.vib/mediawiki/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 500;
+const COMMAND_DELAY = 2000;
 const BASE_URL = 'http://bitnami-mediawiki.my';
 
 for (const command of ['click']) {

--- a/.vib/minio/cypress/cypress/support/commands.js
+++ b/.vib/minio/cypress/cypress/support/commands.js
@@ -1,39 +1,13 @@
-const CLICK_DELAY = 1300;
-const TYPE_DELAY = 300;
-const FILE_UPLOAD_DELAY = 300;
+const COMMAND_DELAY = 2000;
 
-for (const command of ['click']) {
+for (const command of ['click', 'type', 'selectFile']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
     const origVal = originalFn(...args);
 
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(origVal);
-      }, CLICK_DELAY);
-    });
-  });
-}
-
-for (const command of ['type']) {
-  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-    const origVal = originalFn(...args);
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(origVal);
-      }, TYPE_DELAY);
-    });
-  });
-}
-
-for (const command of ['selectFile']) {
-  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-    const origVal = originalFn(...args);
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(origVal);
-      }, FILE_UPLOAD_DELAY);
+      }, COMMAND_DELAY);
     });
   });
 }

--- a/.vib/odoo/cypress/cypress/support/commands.js
+++ b/.vib/odoo/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const CLICK_DELAY = 800;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
@@ -7,7 +7,7 @@ for (const command of ['click']) {
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(origVal);
-      }, CLICK_DELAY);
+      }, COMMAND_DELAY);
     });
   });
 }

--- a/.vib/opencart/cypress/cypress/support/commands.js
+++ b/.vib/opencart/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 500;
+const COMMAND_DELAY = 2000;
 const BASE_URL = 'http://vmware-opencart.my';
 
 for (const command of ['click']) {

--- a/.vib/owncloud/cypress/cypress/support/commands.js
+++ b/.vib/owncloud/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 800;
+const COMMAND_DELAY = 2000;
 const BASE_URL = 'http://vmware-owncloud.my';
 
 for (const command of ['click']) {

--- a/.vib/phpmyadmin/cypress/cypress/support/commands.js
+++ b/.vib/phpmyadmin/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 1000;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {

--- a/.vib/prestashop/cypress/cypress/support/commands.js
+++ b/.vib/prestashop/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 500;
+const COMMAND_DELAY = 2000;
 const BASE_URL = 'http://vmware-prestashop.my';
 
 for (const command of ['click']) {
@@ -32,7 +32,9 @@ Cypress.Commands.add(
     cy.get('div#error').should('not.exist');
     cy.contains('Dashboard');
     cy.get('body').then(($body) => {
-      if ($body.find('button[class*="onboarding-button-shut-down"]').length > 0) {
+      if (
+        $body.find('button[class*="onboarding-button-shut-down"]').length > 0
+      ) {
         cy.get('button[class*="onboarding-button-shut-down"]').click();
       }
     });

--- a/.vib/rabbitmq/cypress/cypress/support/commands.js
+++ b/.vib/rabbitmq/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 900;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {

--- a/.vib/redmine/cypress/cypress/support/commands.js
+++ b/.vib/redmine/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 800;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {

--- a/.vib/solr/cypress/cypress/support/commands.js
+++ b/.vib/solr/cypress/cypress/support/commands.js
@@ -1,6 +1,6 @@
-const COMMAND_DELAY = 500;
+const COMMAND_DELAY = 2000;
 
-for (const command of ["click"]) {
+for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
     const origVal = originalFn(...args);
 
@@ -13,16 +13,16 @@ for (const command of ["click"]) {
 }
 
 Cypress.Commands.add(
-  "login",
-  (username = Cypress.env("username"), password = Cypress.env("password")) => {
+  'login',
+  (username = Cypress.env('username'), password = Cypress.env('password')) => {
     // SolR stores user and session info in the Session Storage
     cy.window().then((win) => {
       win.sessionStorage.clear();
     });
-    cy.visit("/solr/#/");
-    cy.contains("Basic Authentication");
-    cy.get("input#username").type(username);
-    cy.get("input#password").type(password);
-    cy.contains("button", "Login").click();
+    cy.visit('/solr/#/');
+    cy.contains('Basic Authentication');
+    cy.get('input#username').type(username);
+    cy.get('input#password').type(password);
+    cy.contains('button', 'Login').click();
   }
 );

--- a/.vib/spring-cloud-dataflow/cypress/cypress/support/commands.js
+++ b/.vib/spring-cloud-dataflow/cypress/cypress/support/commands.js
@@ -1,26 +1,13 @@
-const CLICK_DELAY = 800;
-const TYPE_DELAY = 200;
+const COMMAND_DELAY = 2000;
 
-for (const command of ['click']) {
+for (const command of ['click', 'type']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
     const origVal = originalFn(...args);
 
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(origVal);
-      }, CLICK_DELAY);
-    });
-  });
-}
-
-for (const command of ['type']) {
-  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-    const origVal = originalFn(...args);
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(origVal);
-      }, TYPE_DELAY);
+      }, COMMAND_DELAY);
     });
   });
 }

--- a/.vib/suitecrm/cypress/cypress/support/commands.js
+++ b/.vib/suitecrm/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 800;
+const COMMAND_DELAY = 2000;
 const BASE_URL = 'http://vmware-suitecrm.my/';
 
 for (const command of ['click']) {

--- a/.vib/thanos/bucketweb/cypress/cypress/support/commands.js
+++ b/.vib/thanos/bucketweb/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 1300;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {

--- a/.vib/thanos/queryfrontend/cypress/cypress/support/commands.js
+++ b/.vib/thanos/queryfrontend/cypress/cypress/support/commands.js
@@ -1,26 +1,13 @@
-const CLICK_DELAY = 1300;
-const TYPE_DELAY = 300;
+const COMMAND_DELAY = 1300;
 
-for (const command of ['click']) {
+for (const command of ['click', 'type']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
     const origVal = originalFn(...args);
 
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(origVal);
-      }, CLICK_DELAY);
-    });
-  });
-}
-
-for (const command of ['type']) {
-  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-    const origVal = originalFn(...args);
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(origVal);
-      }, TYPE_DELAY);
+      }, COMMAND_DELAY);
     });
   });
 }

--- a/.vib/thanos/queryfrontend/cypress/cypress/support/commands.js
+++ b/.vib/thanos/queryfrontend/cypress/cypress/support/commands.js
@@ -1,4 +1,4 @@
-const COMMAND_DELAY = 1300;
+const COMMAND_DELAY = 2000;
 
 for (const command of ['click', 'type']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {

--- a/.vib/wordpress/cypress/cypress/support/commands.js
+++ b/.vib/wordpress/cypress/cypress/support/commands.js
@@ -1,8 +1,8 @@
 // Added to slow down Cypress test execution without using hardcoded waits. If removed, there will be false positives.
 
-const COMMAND_DELAY = 1000;
+const COMMAND_DELAY = 2000;
 
-for (const command of ['click']) {
+for (const command of ['click', 'type']) {
   Cypress.Commands.overwrite(command, (originalFn, ...args) => {
     const origVal = originalFn(...args);
 
@@ -10,20 +10,6 @@ for (const command of ['click']) {
       setTimeout(() => {
         resolve(origVal);
       }, COMMAND_DELAY);
-    });
-  });
-}
-
-const TYPE_DELAY = 100;
-
-for (const command of ['type']) {
-  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
-    const origVal = originalFn(...args);
-
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(origVal);
-      }, TYPE_DELAY);
     });
   });
 }


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR unifies the delays used in Cypress for specific types of commands (click/type/etc) to a single duration across the catalog. Besides using the same interval for every asset, it also unifies the different delays (COMMAND_DELAY, TYPE_DELAY, etc.) into a single `COMMAND_DELAY` const. This further reduced the involved logic.

This duration is equal to the largest time interval used by any of our tested assets, which means the majority of our tests now have bigger command delays. Even though this will translate into a (slightly) slower test execution, we are gaining in test stability and readability.

Having said that, given the current effort to reduce the number of strictly necessary tests, the added delayed time will be negligible.

### Benefits

Better readability of tests and reduced possible flakiness due to performance issues. 

### Possible drawbacks

Slower execution of Cypress tests.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
