### PR TITLE
[bitnami/elasticsearch] Fix alt names in generated TLS certs

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 19.1.9
+version: 19.1.10

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -701,7 +701,7 @@ kibana:
         # Instruct kibana to connect to elastic over https
         enabled: true
         # Bit of a catch 22, as you will need to know the name upfront of your release
-        existingSecret: RELEASENAME-elasticsearch-coordinating-only-crt
+        existingSecret: RELEASENAME-elasticsearch-coordinating-crt # or just 'elasticsearch-coordinating-crt' if the release name happens to be 'elasticsearch'
         # As the certs are auto-generated, they are pemCerts so set to true
         usePemCerts: true
 ```

--- a/bitnami/elasticsearch/templates/tls-secret.yaml
+++ b/bitnami/elasticsearch/templates/tls-secret.yaml
@@ -9,7 +9,7 @@
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) $fullname "127.0.0.1" "localhost" }}
 {{- if not (include "elasticsearch.coordinating.enabled" .) }}
 {{- $altNames = append $altNames (include "elasticsearch.service.name" .) }}
-{{- $altNames = append $altNames (printf "%s.%s.svc.%s" (include "elasticsearch.service.name" .)) }}
+{{- $altNames = append $altNames (printf "%s.%s.svc.%s" (include "elasticsearch.service.name" .) $releaseNamespace $clusterDomain) }}
 {{- end }}
 {{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
 apiVersion: v1
@@ -59,7 +59,7 @@ data:
 {{- if and (include "elasticsearch.coordinating.enabled" .) (not .Values.security.tls.coordinating.existingSecret) }}
 {{- $fullname := include "elasticsearch.coordinating.fullname" . }}
 {{- $serviceName := printf "%s-hl" (include "elasticsearch.coordinating.fullname" .) | trunc 63 | trimSuffix "-" }}
-{{- $altNames := list (include "elasticsearch.service.name" .) (printf "%s.%s.svc.%s" (include "elasticsearch.service.name" .)) (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) $fullname "127.0.0.1" "localhost" }}
+{{- $altNames := list (include "elasticsearch.service.name" .) (printf "%s.%s.svc.%s" (include "elasticsearch.service.name" .) $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) $fullname "127.0.0.1" "localhost" }}
 {{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
 ---
 apiVersion: v1
@@ -87,7 +87,7 @@ data:
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) $fullname "127.0.0.1" "localhost" }}
 {{- if .Values.ingest.service.enabled }}
 {{- $altNames = append $altNames (include "elasticsearch.ingest.fullname" .) }}
-{{- $altNames = append $altNames (printf "%s.%s.svc.%s" (include "elasticsearch.ingest.fullname" .)) }}
+{{- $altNames = append $altNames (printf "%s.%s.svc.%s" (include "elasticsearch.ingest.fullname" .) $releaseNamespace $clusterDomain) }}
 {{- end }}
 {{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
 ---


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
Minor fix in the generated Elasticsearch TLS certs, specifically one of the alternative DNS names.
Before this change, the name would be generated like this: `DNS:elasticsearch.%!s(MISSING).svc.%!s(MISSING)`.

### Benefits
Those fixed alt names are now usable.

### Possible drawbacks
Can't think of any.

### Applicable issues
I haven't created an issue for this, since it is a very simple fix. If preferred I can also file GitHub issue and link it here.

### Additional information
One additional (super minor) fix in the README.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
