### PR TITLE
[bitnami/kube-prometheus] Fix - non consistent nindent on alertmanager secret

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
   - https://github.com/bitnami/containers/tree/main/bitnami/alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 8.0.15
+version: 8.0.16

--- a/bitnami/kube-prometheus/templates/alertmanager/secrets.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/secrets.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
   annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

non consistent nindent on alertmanager secret on kube-prometheus chart
labels were indented to 4 spaces
commonlabels were indented to 10 spaces
this is causing error in helm templating : 
```
  helm.go:88: [debug] error converting YAML to JSON: yaml: line 12: mapping values are not allowed in this context
  YAML parse error on kube-prometheus/templates/alertmanager/secrets.yaml
```
=> commonLabels are unusable in this chart

### Benefits

CommonLabels will be usable in kube-prometheus chart

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
