### PR TITLE
[bitnami/wildfly]: add serviceAccountName property

### DIFF
--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -26,4 +26,4 @@ name: wildfly
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wildfly
   - http://wildfly.org
-version: 13.3.15
+version: 13.4.0

--- a/bitnami/wildfly/README.md
+++ b/bitnami/wildfly/README.md
@@ -82,14 +82,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### WildFly Image parameters
 
-| Name                | Description                                        | Value                 |
-| ------------------- | -------------------------------------------------- | --------------------- |
-| `image.registry`    | WildFly image registry                             | `docker.io`           |
-| `image.repository`  | WildFly image repository                           | `bitnami/wildfly`     |
-| `image.tag`         | WildFly image tag (immutable tags are recommended) | `26.1.1-debian-11-r0` |
-| `image.pullPolicy`  | WildFly image pull policy                          | `IfNotPresent`        |
-| `image.pullSecrets` | WildFly image pull secrets                         | `[]`                  |
-| `image.debug`       | Enable image debug mode                            | `false`               |
+| Name                | Description                                        | Value                  |
+| ------------------- | -------------------------------------------------- | ---------------------- |
+| `image.registry`    | WildFly image registry                             | `docker.io`            |
+| `image.repository`  | WildFly image repository                           | `bitnami/wildfly`      |
+| `image.tag`         | WildFly image tag (immutable tags are recommended) | `26.1.1-debian-11-r26` |
+| `image.pullPolicy`  | WildFly image pull policy                          | `IfNotPresent`         |
+| `image.pullSecrets` | WildFly image pull secrets                         | `[]`                   |
+| `image.debug`       | Enable image debug mode                            | `false`                |
 
 
 ### WildFly Configuration parameters
@@ -116,7 +116,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `hostAliases`                           | WildFly pod host aliases                                                                  | `[]`            |
 | `extraVolumes`                          | Optionally specify extra list of additional volumes for WildFly pods                      | `[]`            |
 | `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for WildFly container(s)         | `[]`            |
-| `serviceAccountName`                    | Add a serviceAccount to the pod                                                           | `""`            |
+| `serviceAccountName`                    | Name of existing ServiceAccount to be connected                                           | `""`            |
 | `sidecars`                              | Add additional sidecar containers to the WildFly pod                                      | `[]`            |
 | `initContainers`                        | Add additional init containers to the WildFly pods                                        | `[]`            |
 | `podLabels`                             | Extra labels for WildFly pods                                                             | `{}`            |
@@ -219,7 +219,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                   | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
 | `volumePermissions.image.registry`            | Bitnami Shell image registry                                                                    | `docker.io`             |
 | `volumePermissions.image.repository`          | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                        | `11-debian-11-r0`       |
+| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                        | `11-debian-11-r23`      |
 | `volumePermissions.image.pullPolicy`          | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`         | Bitnami Shell image pull secrets                                                                | `[]`                    |
 | `volumePermissions.resources.limits`          | The resources limits for the init container                                                     | `{}`                    |

--- a/bitnami/wildfly/README.md
+++ b/bitnami/wildfly/README.md
@@ -116,6 +116,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `hostAliases`                           | WildFly pod host aliases                                                                  | `[]`            |
 | `extraVolumes`                          | Optionally specify extra list of additional volumes for WildFly pods                      | `[]`            |
 | `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for WildFly container(s)         | `[]`            |
+| `serviceAccountName`                    | Add a serviceAccount to the pod                                                           | `""`            |
 | `sidecars`                              | Add additional sidecar containers to the WildFly pod                                      | `[]`            |
 | `initContainers`                        | Add additional init containers to the WildFly pods                                        | `[]`            |
 | `podLabels`                             | Extra labels for WildFly pods                                                             | `{}`            |

--- a/bitnami/wildfly/templates/deployment.yaml
+++ b/bitnami/wildfly/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
       {{- if .Values.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}
       {{- else }}

--- a/bitnami/wildfly/values.yaml
+++ b/bitnami/wildfly/values.yaml
@@ -150,6 +150,8 @@ extraVolumes: []
 ## @param extraVolumeMounts [array] Optionally specify extra list of additional volumeMounts for WildFly container(s)
 ##
 extraVolumeMounts: []
+## @param serviceAccountName Name of existing ServiceAccount to be connected
+serviceAccountName: ""
 ## @param sidecars [array] Add additional sidecar containers to the WildFly pod
 ## e.g:
 ## sidecars:


### PR DESCRIPTION

### Description of the change

This change enables the user to add a serviceAccount to the deployment

### Benefits

It is possible to connect your deployment to a k8s ServiceAccount object

### Possible drawbacks

- none

### Applicable issues

- none

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist


- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
