### PR TITLE
[bitnami/oauth2-proxy] Add DNS parameters to the oauth2 deployment

### DIFF
--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -30,4 +30,4 @@ name: oauth2-proxy
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/oauth2-proxy
   - https://github.com/oauth2-proxy/oauth2-proxy
-version: 3.0.4
+version: 3.1.0

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -117,7 +117,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------- | ------------------------------------------------------- | ---------------------- |
 | `image.registry`    | OAuth2 Proxy image registry                             | `docker.io`            |
 | `image.repository`  | OAuth2 Proxy image repository                           | `bitnami/oauth2-proxy` |
-| `image.tag`         | OAuth2 Proxy image tag (immutable tags are recommended) | `7.3.0-debian-10-r0`   |
+| `image.tag`         | OAuth2 Proxy image tag (immutable tags are recommended) | `7.3.0-debian-11-r23`  |
 | `image.pullPolicy`  | OAuth2 Proxy image pull policy                          | `IfNotPresent`         |
 | `image.pullSecrets` | OAuth2 Proxy image pull secrets                         | `[]`                   |
 
@@ -147,70 +147,72 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### OAuth2 Proxy deployment parameters
 
-| Name                                          | Description                                                                                | Value           |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------ | --------------- |
-| `containerPort`                               | OAuth2 Proxy port number                                                                   | `4180`          |
-| `replicaCount`                                | Number of OAuth2 Proxy replicas to deploy                                                  | `1`             |
-| `extraArgs`                                   | add extra args to the default command                                                      | `[]`            |
-| `startupProbe.enabled`                        | Enable startupProbe on OAuth2 Proxy nodes                                                  | `false`         |
-| `startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                     | `0`             |
-| `startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                            | `10`            |
-| `startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                           | `1`             |
-| `startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                         | `5`             |
-| `startupProbe.successThreshold`               | Success threshold for startupProbe                                                         | `1`             |
-| `livenessProbe.enabled`                       | Enable livenessProbe on OAuth2 Proxy nodes                                                 | `true`          |
-| `livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                    | `0`             |
-| `livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                           | `10`            |
-| `livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                          | `1`             |
-| `livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                        | `5`             |
-| `livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                        | `1`             |
-| `readinessProbe.enabled`                      | Enable readinessProbe on OAuth2 Proxy nodes                                                | `true`          |
-| `readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                   | `0`             |
-| `readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                          | `10`            |
-| `readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                         | `1`             |
-| `readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                       | `5`             |
-| `readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                       | `1`             |
-| `customStartupProbe`                          | Custom startupProbe that overrides the default one                                         | `{}`            |
-| `customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                        | `{}`            |
-| `customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                       | `{}`            |
-| `resources.limits`                            | The resources limits for the OAuth2 Proxy containers                                       | `{}`            |
-| `resources.requests`                          | The requested resources for the OAuth2 Proxy containers                                    | `{}`            |
-| `pdb.create`                                  | Enable a Pod Disruption Budget creation                                                    | `false`         |
-| `pdb.minAvailable`                            | Minimum number/percentage of pods that should remain scheduled                             | `1`             |
-| `pdb.maxUnavailable`                          | Maximum number/percentage of pods that may be made unavailable                             | `1`             |
-| `podSecurityContext.enabled`                  | Enabled OAuth2 Proxy pods' Security Context                                                | `true`          |
-| `podSecurityContext.fsGroup`                  | Set OAuth2 Proxy pod's Security Context fsGroup                                            | `1001`          |
-| `containerSecurityContext.enabled`            | Enabled OAuth2 Proxy containers' Security Context                                          | `true`          |
-| `containerSecurityContext.runAsUser`          | Set OAuth2 Proxy containers' Security Context runAsUser                                    | `1001`          |
-| `command`                                     | Override default container command (useful when using custom images)                       | `[]`            |
-| `args`                                        | Override default container args (useful when using custom images)                          | `[]`            |
-| `hostAliases`                                 | OAuth2 Proxy pods host aliases                                                             | `[]`            |
-| `podLabels`                                   | Extra labels for OAuth2 Proxy pods                                                         | `{}`            |
-| `podAnnotations`                              | Annotations for OAuth2 Proxy pods                                                          | `{}`            |
-| `podAffinityPreset`                           | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`        | `""`            |
-| `podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`   | `soft`          |
-| `nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `""`            |
-| `nodeAffinityPreset.key`                      | Node label key to match. Ignored if `affinity` is set                                      | `""`            |
-| `nodeAffinityPreset.values`                   | Node label values to match. Ignored if `affinity` is set                                   | `[]`            |
-| `affinity`                                    | Affinity for OAuth2 Proxy pods assignment                                                  | `{}`            |
-| `nodeSelector`                                | Node labels for OAuth2 Proxy pods assignment                                               | `{}`            |
-| `tolerations`                                 | Tolerations for OAuth2 Proxy pods assignment                                               | `[]`            |
-| `updateStrategy.type`                         | OAuth2 Proxy statefulset strategy type                                                     | `RollingUpdate` |
-| `priorityClassName`                           | OAuth2 Proxy pods' priorityClassName                                                       | `""`            |
-| `schedulerName`                               | Name of the k8s scheduler (other than default)                                             | `""`            |
-| `topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                             | `[]`            |
-| `lifecycleHooks`                              | for the OAuth2 Proxy container(s) to automate configuration before or after startup        | `{}`            |
-| `extraEnvVars`                                | Array with extra environment variables to add to OAuth2 Proxy nodes                        | `[]`            |
-| `extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for OAuth2 Proxy nodes                | `""`            |
-| `extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for OAuth2 Proxy nodes                   | `""`            |
-| `extraVolumes`                                | Optionally specify extra list of additional volumes for the OAuth2 Proxy pod(s)            | `[]`            |
-| `extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the OAuth2 Proxy container(s) | `[]`            |
-| `sidecars`                                    | Add additional sidecar containers to the OAuth2 Proxy pod(s)                               | `[]`            |
-| `initContainers`                              | Add additional init containers to the OAuth2 Proxy pod(s)                                  | `[]`            |
-| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                       | `true`          |
-| `serviceAccount.name`                         | The name of the ServiceAccount to use                                                      | `""`            |
-| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                             | `true`          |
-| `serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`. | `{}`            |
+| Name                                          | Description                                                                                      | Value           |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------ | --------------- |
+| `containerPort`                               | OAuth2 Proxy port number                                                                         | `4180`          |
+| `replicaCount`                                | Number of OAuth2 Proxy replicas to deploy                                                        | `1`             |
+| `extraArgs`                                   | add extra args to the default command                                                            | `[]`            |
+| `startupProbe.enabled`                        | Enable startupProbe on OAuth2 Proxy nodes                                                        | `false`         |
+| `startupProbe.initialDelaySeconds`            | Initial delay seconds for startupProbe                                                           | `0`             |
+| `startupProbe.periodSeconds`                  | Period seconds for startupProbe                                                                  | `10`            |
+| `startupProbe.timeoutSeconds`                 | Timeout seconds for startupProbe                                                                 | `1`             |
+| `startupProbe.failureThreshold`               | Failure threshold for startupProbe                                                               | `5`             |
+| `startupProbe.successThreshold`               | Success threshold for startupProbe                                                               | `1`             |
+| `livenessProbe.enabled`                       | Enable livenessProbe on OAuth2 Proxy nodes                                                       | `true`          |
+| `livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                          | `0`             |
+| `livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                 | `10`            |
+| `livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                | `1`             |
+| `livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                              | `5`             |
+| `livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                              | `1`             |
+| `readinessProbe.enabled`                      | Enable readinessProbe on OAuth2 Proxy nodes                                                      | `true`          |
+| `readinessProbe.initialDelaySeconds`          | Initial delay seconds for readinessProbe                                                         | `0`             |
+| `readinessProbe.periodSeconds`                | Period seconds for readinessProbe                                                                | `10`            |
+| `readinessProbe.timeoutSeconds`               | Timeout seconds for readinessProbe                                                               | `1`             |
+| `readinessProbe.failureThreshold`             | Failure threshold for readinessProbe                                                             | `5`             |
+| `readinessProbe.successThreshold`             | Success threshold for readinessProbe                                                             | `1`             |
+| `customStartupProbe`                          | Custom startupProbe that overrides the default one                                               | `{}`            |
+| `customLivenessProbe`                         | Custom livenessProbe that overrides the default one                                              | `{}`            |
+| `customReadinessProbe`                        | Custom readinessProbe that overrides the default one                                             | `{}`            |
+| `resources.limits`                            | The resources limits for the OAuth2 Proxy containers                                             | `{}`            |
+| `resources.requests`                          | The requested resources for the OAuth2 Proxy containers                                          | `{}`            |
+| `pdb.create`                                  | Enable a Pod Disruption Budget creation                                                          | `false`         |
+| `pdb.minAvailable`                            | Minimum number/percentage of pods that should remain scheduled                                   | `1`             |
+| `pdb.maxUnavailable`                          | Maximum number/percentage of pods that may be made unavailable                                   | `1`             |
+| `podSecurityContext.enabled`                  | Enabled OAuth2 Proxy pods' Security Context                                                      | `true`          |
+| `podSecurityContext.fsGroup`                  | Set OAuth2 Proxy pod's Security Context fsGroup                                                  | `1001`          |
+| `containerSecurityContext.enabled`            | Enabled OAuth2 Proxy containers' Security Context                                                | `true`          |
+| `containerSecurityContext.runAsUser`          | Set OAuth2 Proxy containers' Security Context runAsUser                                          | `1001`          |
+| `command`                                     | Override default container command (useful when using custom images)                             | `[]`            |
+| `args`                                        | Override default container args (useful when using custom images)                                | `[]`            |
+| `hostAliases`                                 | OAuth2 Proxy pods host aliases                                                                   | `[]`            |
+| `podLabels`                                   | Extra labels for OAuth2 Proxy pods                                                               | `{}`            |
+| `podAnnotations`                              | Annotations for OAuth2 Proxy pods                                                                | `{}`            |
+| `podAffinityPreset`                           | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`              | `""`            |
+| `podAntiAffinityPreset`                       | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`         | `soft`          |
+| `nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`        | `""`            |
+| `nodeAffinityPreset.key`                      | Node label key to match. Ignored if `affinity` is set                                            | `""`            |
+| `nodeAffinityPreset.values`                   | Node label values to match. Ignored if `affinity` is set                                         | `[]`            |
+| `affinity`                                    | Affinity for OAuth2 Proxy pods assignment                                                        | `{}`            |
+| `nodeSelector`                                | Node labels for OAuth2 Proxy pods assignment                                                     | `{}`            |
+| `tolerations`                                 | Tolerations for OAuth2 Proxy pods assignment                                                     | `[]`            |
+| `updateStrategy.type`                         | OAuth2 Proxy statefulset strategy type                                                           | `RollingUpdate` |
+| `priorityClassName`                           | OAuth2 Proxy pods' priorityClassName                                                             | `""`            |
+| `schedulerName`                               | Name of the k8s scheduler (other than default)                                                   | `""`            |
+| `topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                   | `[]`            |
+| `lifecycleHooks`                              | for the OAuth2 Proxy container(s) to automate configuration before or after startup              | `{}`            |
+| `extraEnvVars`                                | Array with extra environment variables to add to OAuth2 Proxy nodes                              | `[]`            |
+| `extraEnvVarsCM`                              | Name of existing ConfigMap containing extra env vars for OAuth2 Proxy nodes                      | `""`            |
+| `extraEnvVarsSecret`                          | Name of existing Secret containing extra env vars for OAuth2 Proxy nodes                         | `""`            |
+| `extraVolumes`                                | Optionally specify extra list of additional volumes for the OAuth2 Proxy pod(s)                  | `[]`            |
+| `extraVolumeMounts`                           | Optionally specify extra list of additional volumeMounts for the OAuth2 Proxy container(s)       | `[]`            |
+| `sidecars`                                    | Add additional sidecar containers to the OAuth2 Proxy pod(s)                                     | `[]`            |
+| `initContainers`                              | Add additional init containers to the OAuth2 Proxy pod(s)                                        | `[]`            |
+| `dnsPolicy`                                   | Pod DNS policy. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. | `""`            |
+| `dnsConfig`                                   | Pod DNS configuration.                                                                           | `{}`            |
+| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                             | `true`          |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use                                                            | `""`            |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                   | `true`          |
+| `serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.       | `{}`            |
 
 
 ### External Redis&reg; parameters

--- a/bitnami/oauth2-proxy/templates/deployment.yaml
+++ b/bitnami/oauth2-proxy/templates/deployment.yaml
@@ -272,3 +272,9 @@ spec:
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | quote }}
+      {{- end }}
+      {{- if .Values.dnsConfig }}
+      dnsConfig: {{- include "common.tplvalues.render" (dict "value" .Values.dnsConfig "context" $) | nindent 8 }}
+      {{- end }}

--- a/bitnami/oauth2-proxy/values.yaml
+++ b/bitnami/oauth2-proxy/values.yaml
@@ -571,6 +571,24 @@ sidecars: []
 ##    command: ['sh', '-c', 'echo "hello world"']
 ##
 initContainers: []
+## @param dnsPolicy Pod DNS policy. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+##
+dnsPolicy: ""
+## @param dnsConfig Pod DNS configuration.
+## ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+## e.g:
+## dnsConfig:
+##   nameservers:
+##   - 8.8.8.8
+##   - 8.8.4.4
+##   options:
+##   - name: ndots
+##     value: "2"
+##   searches:
+##   - example.com
+##
+dnsConfig: {}
 
 ## ServiceAccount configuration
 ##


### PR DESCRIPTION
Signed-off-by: Alexander Evseev <a.evseev@bringo.com>

### Description of the change

Add DNS parameters (dnsPolicy and dnsConfig) to the oauth2 deployment

### Benefits

Allows to configure DNS for ex. to avoid issues with ndots

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
