### PR TITLE
[bitnami/kubeapps] Allow prereleases in `kubeVersion`

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -24,11 +24,11 @@ keywords:
   - dashboard
   - service catalog
   - deployment
-kubeVersion: ">=1.21"
+kubeVersion: ">=1.21.0-0"
 maintainers:
   - name: Bitnami
     url: https://github.com/bitnami/charts
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 10.1.0
+version: 10.1.1


### PR DESCRIPTION
### Description of the change

In a recent PR we added the `kubeVersion` constraint in the chart. However, some clouds are using suffixes to identify their k8s version. For instance, 1.21.1-gke. In semver, this is technically a prerelease, so it is less than 1.21.1, for instance. Adding ' -0` makes the trick. This PR is just updating this constraint to allow prereleases and therefore supporting k8s cluster version using suffixes.

### Benefits

The chart will work again in clouds using k8s version names with suffixes.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
