### PR TITLE
[bitnami/kubeapps] Disable redis persistence by default

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 10.1.1
+version: 10.2.0

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -623,10 +623,10 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `redis.auth.password`           | Redis&reg; password                                              | `""`                                                     |
 | `redis.auth.existingSecret`     | The name of an existing secret with Redis&reg; credentials       | `""`                                                     |
 | `redis.master.extraFlags`       | Array with additional command line flags for Redis&reg; master   | `["--maxmemory 200mb","--maxmemory-policy allkeys-lru"]` |
-| `redis.master.disableCommands`  | Array with commands to deactivate on Redis&trade                 | `[]`                                                     |
+| `redis.master.disableCommands`  | Array with commands to deactivate on Redis&reg;                  | `[]`                                                     |
 | `redis.replica.replicaCount`    | Number of Redis&reg; replicas to deploy                          | `1`                                                      |
 | `redis.replica.extraFlags`      | Array with additional command line flags for Redis&reg; replicas | `["--maxmemory 200mb","--maxmemory-policy allkeys-lru"]` |
-| `redis.replica.disableCommands` | Array with commands to deactivate on Redis&trade                 | `[]`                                                     |
+| `redis.replica.disableCommands` | Array with commands to deactivate on Redis&reg;                  | `[]`                                                     |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -617,16 +617,18 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 
 ### Redis&reg; chart configuration
 
-| Name                            | Description                                                      | Value                                                    |
-| ------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------- |
-| `redis.auth.enabled`            | Enable password authentication                                   | `true`                                                   |
-| `redis.auth.password`           | Redis&reg; password                                              | `""`                                                     |
-| `redis.auth.existingSecret`     | The name of an existing secret with Redis&reg; credentials       | `""`                                                     |
-| `redis.master.extraFlags`       | Array with additional command line flags for Redis&reg; master   | `["--maxmemory 200mb","--maxmemory-policy allkeys-lru"]` |
-| `redis.master.disableCommands`  | Array with commands to deactivate on Redis&reg;                  | `[]`                                                     |
-| `redis.replica.replicaCount`    | Number of Redis&reg; replicas to deploy                          | `1`                                                      |
-| `redis.replica.extraFlags`      | Array with additional command line flags for Redis&reg; replicas | `["--maxmemory 200mb","--maxmemory-policy allkeys-lru"]` |
-| `redis.replica.disableCommands` | Array with commands to deactivate on Redis&reg;                  | `[]`                                                     |
+| Name                                | Description                                                      | Value                                                    |
+| ----------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------- |
+| `redis.auth.enabled`                | Enable password authentication                                   | `true`                                                   |
+| `redis.auth.password`               | Redis&reg; password                                              | `""`                                                     |
+| `redis.auth.existingSecret`         | The name of an existing secret with Redis&reg; credentials       | `""`                                                     |
+| `redis.master.extraFlags`           | Array with additional command line flags for Redis&reg; master   | `["--maxmemory 200mb","--maxmemory-policy allkeys-lru"]` |
+| `redis.master.disableCommands`      | Array with commands to deactivate on Redis&reg;                  | `[]`                                                     |
+| `redis.master.persistence.enabled`  | Enable Redis&reg; master data persistence using PVC              | `false`                                                  |
+| `redis.replica.replicaCount`        | Number of Redis&reg; replicas to deploy                          | `1`                                                      |
+| `redis.replica.extraFlags`          | Array with additional command line flags for Redis&reg; replicas | `["--maxmemory 200mb","--maxmemory-policy allkeys-lru"]` |
+| `redis.replica.disableCommands`     | Array with commands to deactivate on Redis&reg;                  | `[]`                                                     |
+| `redis.replica.persistence.enabled` | Enable Redis&reg; replica data persistence using PVC             | `false`                                                  |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -514,17 +514,18 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 
 ### Database Parameters
 
-| Name                                     | Description                                                                  | Value    |
-| ---------------------------------------- | ---------------------------------------------------------------------------- | -------- |
-| `postgresql.enabled`                     | Deploy a PostgreSQL server to satisfy the applications database requirements | `true`   |
-| `postgresql.auth.postgresPassword`       | Password for 'postgres' user                                                 | `""`     |
-| `postgresql.auth.database`               | Name for a custom database to create                                         | `assets` |
-| `postgresql.auth.existingSecret`         | Name of existing secret to use for PostgreSQL credentials                    | `""`     |
-| `postgresql.primary.persistence.enabled` | Enable PostgreSQL Primary data persistence using PVC                         | `false`  |
-| `postgresql.securityContext.enabled`     | Enabled PostgreSQL replicas pods' Security Context                           | `false`  |
-| `postgresql.resources.limits`            | The resources limits for the PostreSQL container                             | `{}`     |
-| `postgresql.resources.requests.cpu`      | The requested CPU for the PostreSQL container                                | `250m`   |
-| `postgresql.resources.requests.memory`   | The requested memory for the PostreSQL container                             | `256Mi`  |
+| Name                                     | Description                                                                  | Value        |
+| ---------------------------------------- | ---------------------------------------------------------------------------- | ------------ |
+| `postgresql.enabled`                     | Deploy a PostgreSQL server to satisfy the applications database requirements | `true`       |
+| `postgresql.auth.postgresPassword`       | Password for 'postgres' user                                                 | `""`         |
+| `postgresql.auth.database`               | Name for a custom database to create                                         | `assets`     |
+| `postgresql.auth.existingSecret`         | Name of existing secret to use for PostgreSQL credentials                    | `""`         |
+| `postgresql.primary.persistence.enabled` | Enable PostgreSQL Primary data persistence using PVC                         | `false`      |
+| `postgresql.architecture`                | PostgreSQL architecture (`standalone` or `replication`)                      | `standalone` |
+| `postgresql.securityContext.enabled`     | Enabled PostgreSQL replicas pods' Security Context                           | `false`      |
+| `postgresql.resources.limits`            | The resources limits for the PostreSQL container                             | `{}`         |
+| `postgresql.resources.requests.cpu`      | The requested CPU for the PostreSQL container                                | `250m`       |
+| `postgresql.resources.requests.memory`   | The requested memory for the PostreSQL container                             | `256Mi`      |
 
 
 ### kubeappsapis parameters
@@ -622,6 +623,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `redis.auth.enabled`                | Enable password authentication                                   | `true`                                                   |
 | `redis.auth.password`               | Redis&reg; password                                              | `""`                                                     |
 | `redis.auth.existingSecret`         | The name of an existing secret with Redis&reg; credentials       | `""`                                                     |
+| `redis.architecture`                | Redis(R) architecture (`standalone` or `replication`)            | `standalone`                                             |
 | `redis.master.extraFlags`           | Array with additional command line flags for Redis&reg; master   | `["--maxmemory 200mb","--maxmemory-policy allkeys-lru"]` |
 | `redis.master.disableCommands`      | Array with commands to deactivate on Redis&reg;                  | `[]`                                                     |
 | `redis.master.persistence.enabled`  | Enable Redis&reg; master data persistence using PVC              | `false`                                                  |

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -2104,45 +2104,55 @@ kubeappsapis:
 ## @section Redis&reg; chart configuration
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/redis/values.yaml
 ##
-## Redis will be enabled and installed if `packages.flux.enabled` is true.
+## Redis(R) will be enabled and installed if `packages.flux.enabled` is true.
 redis:
   ## @param redis.auth.enabled Enable password authentication
   ## @param redis.auth.password Redis&reg; password
   ## @param redis.auth.existingSecret The name of an existing secret with Redis&reg; credentials
+  ##
   auth:
     enabled: true
     password: ""
     existingSecret: ""
   master:
     ## @param redis.master.extraFlags Array with additional command line flags for Redis&reg; master
+    ##
     extraFlags:
-      ## The maxmemory configuration directive is used in order to configure Redis to use a specified
+      ## The maxmemory configuration directive is used in order to configure Redis(R) to use a specified
       ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits
       ## see https://redis.io/topics/lru-cache for more details
+      ##
       - "--maxmemory 200mb"
-      ## The exact behavior Redis follows when the maxmemory limit is reached is configured using the
+      ## The exact behavior Redis(R) follows when the maxmemory limit is reached is configured using the
       ## maxmemory-policy configuration directive
       ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order
       ## to make space for the new data added
+      ##
       - "--maxmemory-policy allkeys-lru"
       ## ref https://stackoverflow.com/questions/22815364/flushall-and-flushdb-commands-on-redis-return-unk-command
       ## Redis official Helm chart by default disables FLUSHDB and FLUSHALL commands
-    ## @param redis.master.disableCommands Array with commands to deactivate on Redis&trade
+      ##
+    ## @param redis.master.disableCommands Array with commands to deactivate on Redis&reg;
     disableCommands: []
   replica:
     ## @param redis.replica.replicaCount Number of Redis&reg; replicas to deploy
+    ##
     replicaCount: 1
     ## @param redis.replica.extraFlags Array with additional command line flags for Redis&reg; replicas
+    ##
     extraFlags:
-      ## The maxmemory configuration directive is used in order to configure Redis to use a specified
+      ## The maxmemory configuration directive is used in order to configure Redis(R) to use a specified
       ## amount of memory for the data set. Setting maxmemory to zero results into no memory limits
+      ##
       - "--maxmemory 200mb"
-      ## The exact behavior Redis follows when the maxmemory limit is reached is configured using the
+      ## The exact behavior Redis(R) follows when the maxmemory limit is reached is configured using the
       ## maxmemory-policy configuration directive
       ## allkeys-lru: evict keys by trying to remove the less recently used (LRU) keys first, in order
       ## to make space for the new data added
+      ##
       - "--maxmemory-policy allkeys-lru"
     ## ref https://stackoverflow.com/questions/22815364/flushall-and-flushdb-commands-on-redis-return-unk-command
-    ## Redis official Helm chart by default disables FLUSHDB and FLUSHALL commands
-    ## @param redis.replica.disableCommands Array with commands to deactivate on Redis&trade
+    ## Redis(R) official Helm chart by default disables FLUSHDB and FLUSHALL commands
+    ## @param redis.replica.disableCommands Array with commands to deactivate on Redis&reg;
+    ##
     disableCommands: []

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1761,6 +1761,9 @@ postgresql:
   primary:
     persistence:
       enabled: false
+  ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
+  ##
+  architecture: standalone
   ## @param postgresql.securityContext.enabled Enabled PostgreSQL replicas pods' Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
@@ -2114,6 +2117,9 @@ redis:
     enabled: true
     password: ""
     existingSecret: ""
+  ## @param architecture Redis(R) architecture (`standalone` or `replication`)
+  ##
+  architecture: standalone
   master:
     ## @param redis.master.extraFlags Array with additional command line flags for Redis&reg; master
     ##

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1761,7 +1761,7 @@ postgresql:
   primary:
     persistence:
       enabled: false
-  ## @param architecture PostgreSQL architecture (`standalone` or `replication`)
+  ## @param postgresql.architecture PostgreSQL architecture (`standalone` or `replication`)
   ##
   architecture: standalone
   ## @param postgresql.securityContext.enabled Enabled PostgreSQL replicas pods' Security Context
@@ -2117,7 +2117,7 @@ redis:
     enabled: true
     password: ""
     existingSecret: ""
-  ## @param architecture Redis(R) architecture (`standalone` or `replication`)
+  ## @param redis.architecture Redis(R) architecture (`standalone` or `replication`)
   ##
   architecture: standalone
   master:

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -2134,6 +2134,12 @@ redis:
       ##
     ## @param redis.master.disableCommands Array with commands to deactivate on Redis&reg;
     disableCommands: []
+    ## Redis(R) Master persistence configuration
+    #
+    persistence:
+      ## @param redis.master.persistence.enabled Enable Redis&reg; master data persistence using PVC
+      ##
+      enabled: false
   replica:
     ## @param redis.replica.replicaCount Number of Redis&reg; replicas to deploy
     ##
@@ -2156,3 +2162,9 @@ redis:
     ## @param redis.replica.disableCommands Array with commands to deactivate on Redis&reg;
     ##
     disableCommands: []
+    ## Redis(R) Replica persistence configuration
+    ##
+    persistence:
+      ## @param redis.replica.persistence.enabled Enable Redis&reg; replica data persistence using PVC
+      ##
+      enabled: false


### PR DESCRIPTION
### Description of the change

Some time ago we disabled the persistence of the cached data for the PostgreSQL database, meaning no PVC are created by default. This simply implies that cached repos in Kubeapps will get erased when deleting kubeapps.
However, this behavior wasn't replicated for the Flux plugin, which uses Redis. This PR is to disable by default the creation of PVCs for the Flux cache.

### Benefits

No persistent cache by default + allowing users to enable this functionality if they want via chart.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

Squeezing some fixes in the usage of the Redis trademark.

Requiring @gfichtenholt's before merging.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
