### PR TITLE
[bitnami/elasticsearch]fix master statefulset envFrom

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 19.1.9
+version: 19.1.10

--- a/bitnami/elasticsearch/templates/master/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master/statefulset.yaml
@@ -202,9 +202,9 @@ spec:
             {{- end }}
           {{- if or .Values.extraEnvVarsCM .Values.extraEnvVarsSecret .Values.master.extraEnvVarsCM .Values.master.extraEnvVarsSecret }}
           envFrom:
-            {{- if .Values.master.extraEnvVarsCM }}
+            {{- if .Values.extraEnvVarsCM }}
             - configMapRef:
-                name: {{ include "common.tplvalues.render" ( dict "value" .Values.master.extraEnvVarsCM "context" $ ) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" .Values.extraEnvVarsCM "context" $ ) }}
             {{- end }}
             {{- if .Values.master.extraEnvVarsCM }}
             - configMapRef:
@@ -214,9 +214,9 @@ spec:
             - secretRef:
                 name: {{ include "common.tplvalues.render" ( dict "value" .Values.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
-            {{- if .Values.extraEnvVarsSecret }}
+            {{- if .Values.master.extraEnvVarsSecret }}
             - secretRef:
-                name: {{ include "common.tplvalues.render" ( dict "value" .Values.extraEnvVarsSecret "context" $ ) }}
+                name: {{ include "common.tplvalues.render" ( dict "value" .Values.master.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
           {{- end }}
           ports:


### PR DESCRIPTION
Signed-off-by: wanggy <717338097@qq.com>

### Description of the change
`Values.master.extraEnvVarsCM` and `Values.extraEnvVarsSecret` is repeat effective for master statefulset envFrom 
`Values.extraEnvVarsCM` and `Values.master.extraEnvVarsSecret` is not effective for master statefulset envFrom
replace one of `Values.master.extraEnvVarsCM` with `Values.extraEnvVarsCM` on master statefulset
replace one of `Values.extraEnvVarsSecret`  with `Values.master.extraEnvVarsSecret` on master statefulset

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
`Values.extraEnvVarsCM` and `Values.master.extraEnvVarsSecret`  effect for master statefulset

### Possible drawbacks
none

### Additional information
none

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)