### PR TITLE
[bitnami/kubernetes-event-exporter] Replace upstream repo

### DIFF
--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -25,5 +25,5 @@ maintainers:
 name: kubernetes-event-exporter
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kubernetes-event-exporter
-  - https://github.com/opsgenie/kubernetes-event-exporter
-version: 1.4.20
+  - https://github.com/resmoio/kubernetes-event-exporter
+version: 1.4.21

--- a/bitnami/kubernetes-event-exporter/README.md
+++ b/bitnami/kubernetes-event-exporter/README.md
@@ -4,10 +4,10 @@
 
 Kubernetes Event Exporter makes it easy to export Kubernetes events to other tools, thereby enabling better event observability, custom alerts and aggregation.
 
-[Overview of Kubernetes Event Exporter](https://github.com/opsgenie/kubernetes-event-exporter)
+[Overview of Kubernetes Event Exporter](https://github.com/resmoio/kubernetes-event-exporter)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console


### PR DESCRIPTION
The repo used in the past containing the source code (https://github.com/opsgenie/kubernetes-event-exporter) is not being maintained. At this moment, the source code can be found at https://github.com/resmoio/kubernetes-event-exporter.

We updated the URL in our internal track, test & release pipeline to reflect this change. In this PR, we are updating the README and some chart metadata.

- Fixes #11412