### PR TITLE
[bitnami/schema-registry] Bump version to 4.0.5

### DIFF
--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: schema-registry
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/schema-registry
-version: 4.0.4
+version: 4.0.5


### PR DESCRIPTION
### Description of the change

Bump the version of the schema-registry chart to 4.0.5 so that #11431 can make it into a build. The chart version had been bumped to 4.0.4 by both #11431 and #11664 in parallel, but the latter went in first. Git didn't see it as a conflict, but [the build for the former PR failed](https://github.com/bitnami/charts/actions/runs/2838925682) since 4.0.4 had already been built.

### Benefits

Produces a build of the schema-registry chart that supports the use of an external Kafka.

### Possible drawbacks

None known

### Applicable issues

Fixes #11630

### Additional information

None

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
