### PR TITLE
[bitnami/nginx-ingress-controller] fix name of electionID in RBAC

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -27,4 +27,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 9.2.27
+version: 9.2.28

--- a/bitnami/nginx-ingress-controller/templates/role.yaml
+++ b/bitnami/nginx-ingress-controller/templates/role.yaml
@@ -97,7 +97,7 @@ rules:
   - apiGroups:
     - coordination.k8s.io
     resourceNames:
-      - ingress-controller-leader
+      - {{ .Values.electionID }}
     resources:
       - leases
     verbs:


### PR DESCRIPTION
### Description of the change
https://github.com/bitnami/charts/pull/11454 introduced changes for nginx ingress 1.3.x but hardcoded values that are actually configurable within the chart. this fixes that
### Benefits

You can specify your own electionID again, without the chart breaking
### Possible drawbacks


### Applicable issues


### Additional information


### Checklist


- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
