### PR TITLE
[bitnami/zookeeper] Statefulset quorum auth value not set properly

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/zookeeper
   - https://zookeeper.apache.org/
-version: 10.0.7
+version: 10.0.8

--- a/bitnami/zookeeper/templates/statefulset.yaml
+++ b/bitnami/zookeeper/templates/statefulset.yaml
@@ -309,7 +309,7 @@ spec:
             - name: ZOO_TLS_QUORUM_ENABLE
               value: {{ .Values.tls.quorum.enabled | quote }}
             - name: ZOO_TLS_QUORUM_CLIENT_AUTH
-              value: {{ .Values.tls.auth.quorum | quote }}
+              value: {{ .Values.tls.quorum.auth | quote }}
             - name: ZOO_TLS_QUORUM_KEYSTORE_FILE
               value: {{ .Values.tls.quorum.keystorePath | quote }}
             - name: ZOO_TLS_QUORUM_TRUSTSTORE_FILE


### PR DESCRIPTION
quorum auth value not set properly.

Signed-off-by: sachintandon-nexla <93154405+sachintandon-nexla@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

statefulset quorum auth value not set properly

The change was made back on :
https://github.com/bitnami/charts/commit/e4b159ae75f534bf3e951085bd8e2385a26053ca#diff-0ba4ee4bc548e5cbcbb20a833af41af7a75c8fcdd77e63cb7f8a4db2f7007c38

