### PR TITLE
Added sessionAffinity setting to headless-svc configuration

### DIFF
--- a/bitnami/mongodb/templates/replicaset/headless-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/headless-svc.yaml
@@ -21,7 +21,13 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
-  publishNotReadyAddresses: true
+  publishNotReadyAddresses: true  
+  {{- if $root.Values.service.sessionAffinity }}
+  sessionAffinity: {{ $root.Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if $root.Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" $root.Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
   ports:
     - name: {{ .Values.service.portName | quote }}
       port: {{ .Values.service.ports.mongodb }}


### PR DESCRIPTION
Signed-off-by: Anders Bea <91246428+swimand@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Added the configuration of sessionAffinity and sessionAffinityConfig within the `bitnami/mongodb/templates/replicaset/headless-svc.yaml` configuration yaml. 

### Benefits

Readme already described the setting of variables and defaults, but did not implement said changes for this svc type.

### Possible drawbacks

None, since defaults will still remain the same.

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
