### PR TITLE
[bitnami/mongodb] Add sessionsAffinity and sessionAffinity to replicaset svc and headless-svc

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.0.1
+version: 13.1.0

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.0.0
+version: 13.0.1

--- a/bitnami/mongodb/templates/replicaset/headless-svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/headless-svc.yaml
@@ -22,6 +22,12 @@ spec:
   type: ClusterIP
   clusterIP: None
   publishNotReadyAddresses: true
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
   ports:
     - name: {{ .Values.service.portName | quote }}
       port: {{ .Values.service.ports.mongodb }}

--- a/bitnami/mongodb/templates/replicaset/svc.yaml
+++ b/bitnami/mongodb/templates/replicaset/svc.yaml
@@ -28,6 +28,12 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
   ports:
     - name: {{ $root.Values.service.portName | quote }}
       port: {{ $root.Values.service.ports.mongodb }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Added the configuration of `sessionAffinity` and `sessionAffinityConfig` within the bitnami/mongodb/templates/replicaset/headless-svc.yaml configuration yaml.

### Benefits

This will allow users to set sessionAffinity for the mongodb services when run as replicaset. This setting allows the pods to be selected by ClientIP, and will solve issues where a different pod is served during a segmented read/write. 
Readme already described the setting of variables and defaults, but did not implement said changes for this svc type.

### Possible drawbacks

None, since defaults will still remain the same.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
