### PR TITLE
[bitnami/matomo] Fix Cypress test for version 4.11.0

### DIFF
--- a/.vib/matomo/cypress/cypress/integration/matomo_spec.js
+++ b/.vib/matomo/cypress/cypress/integration/matomo_spec.js
@@ -12,11 +12,9 @@ it('allows to create user', () => {
   cy.visit('/?module=UsersManager&showadduser=1');
   cy.fixture('users').then((user) => {
     cy.get('#user_login').type(`${user.newUser.username}-${random}`);
-    cy.get('#user_password').type(`${user.newUser.password}-${random}`);
-    cy.get('#user_password').type(`${user.newUser.password}-${random}`);
     cy.get('#user_email').type(`${random}_${user.newUser.email}`);
-    cy.get('input[value*="Create user"]').click();
-    cy.contains('changes have been saved');
+    cy.get('input[value*="Invite user"]').click();
+    cy.contains('Success!');
     cy.visit('/index.php?module=UsersManager');
     cy.contains('#userLogin', `${user.newUser.username}-${random}`);
   });


### PR DESCRIPTION
Signed-off-by: Michiel <michield@vmware.com>

### Description of the change

A few selectors changed with the new version, this fix uses the correct ones.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

### Successful test run

https://github.com/mdhont/charts/runs/7860775592