### PR TITLE
[bitnami/mysql] Revisit tests

### DIFF
--- a/.vib/mysql/goss/goss.yaml
+++ b/.vib/mysql/goss/goss.yaml
@@ -1,34 +1,25 @@
 command:
-  mysql-env:
-    exec: env
+  create-table-root-test:
+    exec: mysql -h mysql-primary -u root -P {{ .Vars.primary.service.ports.mysql }} -p'{{ .Vars.auth.rootPassword }}' {{ .Vars.auth.database }} -e 'DROP TABLE IF EXISTS TEST; create table TEST(test_id int auto_increment, test_value int, primary key(test_id)); INSERT INTO TEST (TEST_VALUE) VALUES (1993);SELECT * FROM TEST'
     exit-status: 0
     stdout:
-      - "MYSQL_DATABASE=important_db"
-    stderr: [ ]
-    timeout: 40000  
-  mysql-create:
-    exec: mysql -h localhost -u root -p"$MYSQL_ROOT_PASSWORD" "$MYSQL_DATABASE" -e 'DROP TABLE IF EXISTS TEST; create table TEST( test_id int auto_increment, test_value int, primary key(test_id)); INSERT INTO TEST (TEST_VALUE) VALUES (1993);SELECT * FROM TEST'
+    - 1993
+  replication-test:
+    exec: mysql -h mysql-primary -u {{ .Vars.auth.username }} -P {{ .Vars.primary.service.ports.mysql }} -p'{{ .Vars.auth.password }}' {{ .Vars.auth.database }} -e 'DROP TABLE IF EXISTS TEST_REP; create table TEST_REP(test_id int auto_increment, test_value varchar(4), primary key(test_id)); INSERT INTO TEST_REP (TEST_VALUE) VALUES (2022)' && sleep 2 && mysql -h mysql-secondary -u {{ .Vars.auth.username }} -P {{ .Vars.secondary.service.ports.mysql }} -p'{{ .Vars.auth.password }}' {{ .Vars.auth.database }} -e 'SELECT * FROM TEST_REP'
     exit-status: 0
     stdout:
-      - "test_id"
-      - "test_value"
-      - "1993"
-    stderr: [ ]
-    timeout: 40000    
-  user-id-test:
-    exec: if [ "$(id -u)" -eq 0 ]; then exit 1; fi
-    exit-status: 0
-    stdout: []
-    stderr: []   
+    - 2022
+    timeout: 9000
 file:
-  {{ printf "/bitnami/mysql/data/%s" .Env.MYSQL_DATABASE }}:
+  /bitnami/mysql/data/{{ .Vars.auth.database }}:
     mode: "2750"
     filetype: directory
     exists: true
   /opt/bitnami/mysql/conf/my.cnf:
     mode: "0644"
     filetype: file
-    contains: 
+    contains:
+    - "[mysqld]"
     - "datadir=/bitnami/mysql/data"
     - "socket=/opt/bitnami/mysql/tmp/mysql.sock"
     exists: true

--- a/.vib/mysql/goss/vars.yaml
+++ b/.vib/mysql/goss/vars.yaml
@@ -1,0 +1,13 @@
+auth:
+  database: test_database
+  username: "user"
+  password: "ComplicatedPassword123!4"
+  rootPassword: "R0ot)Password"
+primary:
+  service:
+    ports:
+      mysql: 80
+secondary:
+  service:
+    ports:
+      mysql: 3306

--- a/.vib/mysql/vib-publish.json
+++ b/.vib/mysql/vib-publish.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/mysql"
         },
-        "runtime_parameters": "YXV0aDogCiAgcm9vdFBhc3N3b3JkOiBDb21wbGljYXRlZFBhc3N3b3JkMTIzNAogIGRhdGFiYXNlOiBpbXBvcnRhbnRfZGIKcHJpbWFyeToKICBzZXJ2aWNlOgogICAgdHlwZTogTG9hZEJhbGFuY2VyCiAgICBwb3J0czogCiAgICAgIG15c3FsOiA4MAo=",
+        "runtime_parameters": "YXJjaGl0ZWN0dXJlOiByZXBsaWNhdGlvbgphdXRoOgogIGRhdGFiYXNlOiB0ZXN0X2RhdGFiYXNlCiAgdXNlcm5hbWU6ICJ1c2VyIgogIHBhc3N3b3JkOiAiQ29tcGxpY2F0ZWRQYXNzd29yZDEyMyE0IgogIHJvb3RQYXNzd29yZDogIlIwb3QpUGFzc3dvcmQiCnByaW1hcnk6CiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIG15c3FsOiA4MApzZWNvbmRhcnk6CiAgc2VydmljZToKICAgIHR5cGU6IENsdXN0ZXJJUAogICAgcG9ydHM6CiAgICAgIG15c3FsOiAzMzA2",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -34,7 +34,7 @@
         {
           "action_id": "health-check",
           "params": {
-            "endpoint": "lb-mysql-mysql"
+            "endpoint": "lb-mysql-primary-mysql"
           }
         },
         {
@@ -44,8 +44,9 @@
               "path": "/.vib/mysql/goss"
             },
             "remote": {
-              "workload": "sts-mysql"
-            }
+              "workload": "sts-mysql-primary"
+            },
+            "vars_file": "vars.yaml"
           }
         }
       ]

--- a/.vib/mysql/vib-verify.json
+++ b/.vib/mysql/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/mysql"
         },
-        "runtime_parameters": "YXV0aDogCiAgcm9vdFBhc3N3b3JkOiBDb21wbGljYXRlZFBhc3N3b3JkMTIzNAogIGRhdGFiYXNlOiBpbXBvcnRhbnRfZGIKcHJpbWFyeToKICBzZXJ2aWNlOgogICAgdHlwZTogTG9hZEJhbGFuY2VyCiAgICBwb3J0czogCiAgICAgIG15c3FsOiA4MAo=",
+        "runtime_parameters": "YXJjaGl0ZWN0dXJlOiByZXBsaWNhdGlvbgphdXRoOgogIGRhdGFiYXNlOiB0ZXN0X2RhdGFiYXNlCiAgdXNlcm5hbWU6ICJ1c2VyIgogIHBhc3N3b3JkOiAiQ29tcGxpY2F0ZWRQYXNzd29yZDEyMyE0IgogIHJvb3RQYXNzd29yZDogIlIwb3QpUGFzc3dvcmQiCnByaW1hcnk6CiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIG15c3FsOiA4MApzZWNvbmRhcnk6CiAgc2VydmljZToKICAgIHR5cGU6IENsdXN0ZXJJUAogICAgcG9ydHM6CiAgICAgIG15c3FsOiAzMzA2",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -34,7 +34,7 @@
         {
           "action_id": "health-check",
           "params": {
-            "endpoint": "lb-mysql-mysql"
+            "endpoint": "lb-mysql-primary-mysql"
           }
         },
         {
@@ -44,8 +44,9 @@
               "path": "/.vib/mysql/goss"
             },
             "remote": {
-              "workload": "sts-mysql"
-            }
+              "workload": "sts-mysql-primary"
+            },
+            "vars_file": "vars.yaml"
           }
         }
       ]


### PR DESCRIPTION
### Description of the change

After reviewing the existing tests and the general testing strategy we have been following until now, we saw there was a need to revisit them. The main objective that our chart testing strategy should aim for is asserting that the Chart deliverable works. As such, the focus should not be on the application itself or the container, which are regarded as trustful components (that is, they should have been tested at a previous stage).

As charts usually pack a number of different components, it is essential to test that their integrations and the application itself work as expected.

Consequently, we have updated the tests so they are related to the chart deliverable and left only a couple of basic tests to verify that the application functions correctly. Besides that, an effort has been made to reduce future tests' flakiness improving some existing selectors and checks.

Tested in https://github.com/joancafom/charts/pull/68

### Benefits

Improved, revisited test strategy.

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
