### PR TITLE
[bitnami/etcd] Add support for image digest apart from tag

### DIFF
--- a/bitnami/etcd/Chart.lock
+++ b/bitnami/etcd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-30T10:28:21.079114234Z"
+  version: 1.17.0
+digest: sha256:523580f5b251bf14ae6b0c7c5728ed0cd057760270583b8f919d318527257559
+generated: "2022-08-18T07:11:58.645895717Z"

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -24,4 +24,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/etcd
   - https://coreos.com/etcd/
-version: 8.3.8
+version: 8.4.0

--- a/bitnami/etcd/README.md
+++ b/bitnami/etcd/README.md
@@ -79,50 +79,51 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### etcd parameters
 
-| Name                                   | Description                                                                                     | Value                |
-| -------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------- |
-| `image.registry`                       | etcd image registry                                                                             | `docker.io`          |
-| `image.repository`                     | etcd image name                                                                                 | `bitnami/etcd`       |
-| `image.tag`                            | etcd image tag                                                                                  | `3.5.4-debian-11-r3` |
-| `image.pullPolicy`                     | etcd image pull policy                                                                          | `IfNotPresent`       |
-| `image.pullSecrets`                    | etcd image pull secrets                                                                         | `[]`                 |
-| `image.debug`                          | Enable image debug mode                                                                         | `false`              |
-| `auth.rbac.create`                     | Switch to enable RBAC authentication                                                            | `true`               |
-| `auth.rbac.allowNoneAuthentication`    | Allow to use etcd without configuring RBAC authentication                                       | `true`               |
-| `auth.rbac.rootPassword`               | Root user password. The root user is always `root`                                              | `""`                 |
-| `auth.rbac.existingSecret`             | Name of the existing secret containing credentials for the root user                            | `""`                 |
-| `auth.rbac.existingSecretPasswordKey`  | Name of key containing password to be retrieved from the existing secret                        | `""`                 |
-| `auth.token.type`                      | Authentication token type. Allowed values: 'simple' or 'jwt'                                    | `jwt`                |
-| `auth.token.privateKey.filename`       | Name of the file containing the private key for signing the JWT token                           | `jwt-token.pem`      |
-| `auth.token.privateKey.existingSecret` | Name of the existing secret containing the private key for signing the JWT token                | `""`                 |
-| `auth.token.signMethod`                | JWT token sign method                                                                           | `RS256`              |
-| `auth.token.ttl`                       | JWT token TTL                                                                                   | `10m`                |
-| `auth.client.secureTransport`          | Switch to encrypt client-to-server communications using TLS certificates                        | `false`              |
-| `auth.client.useAutoTLS`               | Switch to automatically create the TLS certificates                                             | `false`              |
-| `auth.client.existingSecret`           | Name of the existing secret containing the TLS certificates for client-to-server communications | `""`                 |
-| `auth.client.enableAuthentication`     | Switch to enable host authentication using TLS certificates. Requires existing secret           | `false`              |
-| `auth.client.certFilename`             | Name of the file containing the client certificate                                              | `cert.pem`           |
-| `auth.client.certKeyFilename`          | Name of the file containing the client certificate private key                                  | `key.pem`            |
-| `auth.client.caFilename`               | Name of the file containing the client CA certificate                                           | `""`                 |
-| `auth.peer.secureTransport`            | Switch to encrypt server-to-server communications using TLS certificates                        | `false`              |
-| `auth.peer.useAutoTLS`                 | Switch to automatically create the TLS certificates                                             | `false`              |
-| `auth.peer.existingSecret`             | Name of the existing secret containing the TLS certificates for server-to-server communications | `""`                 |
-| `auth.peer.enableAuthentication`       | Switch to enable host authentication using TLS certificates. Requires existing secret           | `false`              |
-| `auth.peer.certFilename`               | Name of the file containing the peer certificate                                                | `cert.pem`           |
-| `auth.peer.certKeyFilename`            | Name of the file containing the peer certificate private key                                    | `key.pem`            |
-| `auth.peer.caFilename`                 | Name of the file containing the peer CA certificate                                             | `""`                 |
-| `autoCompactionMode`                   | Auto compaction mode, by default periodic. Valid values: "periodic", "revision".                | `""`                 |
-| `autoCompactionRetention`              | Auto compaction retention for mvcc key value store in hour, by default 0, means disabled        | `""`                 |
-| `initialClusterState`                  | Initial cluster state. Allowed values: 'new' or 'existing'                                      | `""`                 |
-| `maxProcs`                             | Limits the number of operating system threads that can execute user-level                       | `""`                 |
-| `removeMemberOnContainerTermination`   | Use a PreStop hook to remove the etcd members from the etcd cluster on container termination    | `true`               |
-| `configuration`                        | etcd configuration. Specify content for etcd.conf.yml                                           | `""`                 |
-| `existingConfigmap`                    | Existing ConfigMap with etcd configuration                                                      | `""`                 |
-| `extraEnvVars`                         | Extra environment variables to be set on etcd container                                         | `[]`                 |
-| `extraEnvVarsCM`                       | Name of existing ConfigMap containing extra env vars                                            | `""`                 |
-| `extraEnvVarsSecret`                   | Name of existing Secret containing extra env vars                                               | `""`                 |
-| `command`                              | Default container command (useful when using custom images)                                     | `[]`                 |
-| `args`                                 | Default container args (useful when using custom images)                                        | `[]`                 |
+| Name                                   | Description                                                                                          | Value                 |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`                       | etcd image registry                                                                                  | `docker.io`           |
+| `image.repository`                     | etcd image name                                                                                      | `bitnami/etcd`        |
+| `image.tag`                            | etcd image tag                                                                                       | `3.5.4-debian-11-r22` |
+| `image.digest`                         | etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `image.pullPolicy`                     | etcd image pull policy                                                                               | `IfNotPresent`        |
+| `image.pullSecrets`                    | etcd image pull secrets                                                                              | `[]`                  |
+| `image.debug`                          | Enable image debug mode                                                                              | `false`               |
+| `auth.rbac.create`                     | Switch to enable RBAC authentication                                                                 | `true`                |
+| `auth.rbac.allowNoneAuthentication`    | Allow to use etcd without configuring RBAC authentication                                            | `true`                |
+| `auth.rbac.rootPassword`               | Root user password. The root user is always `root`                                                   | `""`                  |
+| `auth.rbac.existingSecret`             | Name of the existing secret containing credentials for the root user                                 | `""`                  |
+| `auth.rbac.existingSecretPasswordKey`  | Name of key containing password to be retrieved from the existing secret                             | `""`                  |
+| `auth.token.type`                      | Authentication token type. Allowed values: 'simple' or 'jwt'                                         | `jwt`                 |
+| `auth.token.privateKey.filename`       | Name of the file containing the private key for signing the JWT token                                | `jwt-token.pem`       |
+| `auth.token.privateKey.existingSecret` | Name of the existing secret containing the private key for signing the JWT token                     | `""`                  |
+| `auth.token.signMethod`                | JWT token sign method                                                                                | `RS256`               |
+| `auth.token.ttl`                       | JWT token TTL                                                                                        | `10m`                 |
+| `auth.client.secureTransport`          | Switch to encrypt client-to-server communications using TLS certificates                             | `false`               |
+| `auth.client.useAutoTLS`               | Switch to automatically create the TLS certificates                                                  | `false`               |
+| `auth.client.existingSecret`           | Name of the existing secret containing the TLS certificates for client-to-server communications      | `""`                  |
+| `auth.client.enableAuthentication`     | Switch to enable host authentication using TLS certificates. Requires existing secret                | `false`               |
+| `auth.client.certFilename`             | Name of the file containing the client certificate                                                   | `cert.pem`            |
+| `auth.client.certKeyFilename`          | Name of the file containing the client certificate private key                                       | `key.pem`             |
+| `auth.client.caFilename`               | Name of the file containing the client CA certificate                                                | `""`                  |
+| `auth.peer.secureTransport`            | Switch to encrypt server-to-server communications using TLS certificates                             | `false`               |
+| `auth.peer.useAutoTLS`                 | Switch to automatically create the TLS certificates                                                  | `false`               |
+| `auth.peer.existingSecret`             | Name of the existing secret containing the TLS certificates for server-to-server communications      | `""`                  |
+| `auth.peer.enableAuthentication`       | Switch to enable host authentication using TLS certificates. Requires existing secret                | `false`               |
+| `auth.peer.certFilename`               | Name of the file containing the peer certificate                                                     | `cert.pem`            |
+| `auth.peer.certKeyFilename`            | Name of the file containing the peer certificate private key                                         | `key.pem`             |
+| `auth.peer.caFilename`                 | Name of the file containing the peer CA certificate                                                  | `""`                  |
+| `autoCompactionMode`                   | Auto compaction mode, by default periodic. Valid values: "periodic", "revision".                     | `""`                  |
+| `autoCompactionRetention`              | Auto compaction retention for mvcc key value store in hour, by default 0, means disabled             | `""`                  |
+| `initialClusterState`                  | Initial cluster state. Allowed values: 'new' or 'existing'                                           | `""`                  |
+| `maxProcs`                             | Limits the number of operating system threads that can execute user-level                            | `""`                  |
+| `removeMemberOnContainerTermination`   | Use a PreStop hook to remove the etcd members from the etcd cluster on container termination         | `true`                |
+| `configuration`                        | etcd configuration. Specify content for etcd.conf.yml                                                | `""`                  |
+| `existingConfigmap`                    | Existing ConfigMap with etcd configuration                                                           | `""`                  |
+| `extraEnvVars`                         | Extra environment variables to be set on etcd container                                              | `[]`                  |
+| `extraEnvVarsCM`                       | Name of existing ConfigMap containing extra env vars                                                 | `""`                  |
+| `extraEnvVarsSecret`                   | Name of existing Secret containing extra env vars                                                    | `""`                  |
+| `command`                              | Default container command (useful when using custom images)                                          | `[]`                  |
+| `args`                                 | Default container args (useful when using custom images)                                             | `[]`                  |
 
 
 ### etcd statefulset parameters
@@ -225,16 +226,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Volume Permissions parameters
 
-| Name                                   | Description                                                                                                          | Value                   |
-| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `volumePermissions.enabled`            | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                 |
-| `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                     | `docker.io`             |
-| `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                         | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                          | `11-debian-11-r3`       |
-| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                  | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                     | `[]`                    |
-| `volumePermissions.resources.limits`   | Init container volume-permissions resource  limits                                                                   | `{}`                    |
-| `volumePermissions.resources.requests` | Init container volume-permissions resource  requests                                                                 | `{}`                    |
+| Name                                   | Description                                                                                                                       | Value                   |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`            | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`              | `false`                 |
+| `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                  | `docker.io`             |
+| `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                                      | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                       | `11-debian-11-r21`      |
+| `volumePermissions.image.digest`       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                  | `[]`                    |
+| `volumePermissions.resources.limits`   | Init container volume-permissions resource  limits                                                                                | `{}`                    |
+| `volumePermissions.resources.requests` | Init container volume-permissions resource  requests                                                                              | `{}`                    |
 
 
 ### Network Policy parameters

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -591,7 +591,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image name
   ## @param volumePermissions.image.tag Init container volume-permissions image tag
-  ## @param image.digest Init container volume-permissions image digest in the way sha256:aa...
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa...
   ##
   image:
     registry: docker.io

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -65,19 +65,20 @@ diagnosticMode:
 ## @param image.registry etcd image registry
 ## @param image.repository etcd image name
 ## @param image.tag etcd image tag
-## @param image.pullPolicy etcd image pull policy
-## @param image.pullSecrets [array] etcd image pull secrets
-## @param image.debug Enable image debug mode
+## @param image.digest etcd image digest in the way sha256:aa...
 ##
 image:
   registry: docker.io
   repository: bitnami/etcd
   tag: 3.5.4-debian-11-r22
+  digest: ""
+  ## @param image.pullPolicy etcd image pull policy
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
   pullPolicy: IfNotPresent
+  ## @param image.pullSecrets [array] etcd image pull secrets
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -86,6 +87,7 @@ image:
   ##   - myRegistryKeySecretName
   ##
   pullSecrets: []
+  ## @param image.debug Enable image debug mode
   ## Set to true if you would like to see extra information on logs
   ##
   debug: false
@@ -589,14 +591,17 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image name
   ## @param volumePermissions.image.tag Init container volume-permissions image tag
-  ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
-  ## @param volumePermissions.image.pullSecrets [array] Specify docker-registry secret names as an array
+  ## @param image.digest Init container volume-permissions image digest in the way sha256:aa...
   ##
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r21
+    digest: ""
+    ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
+    ##
     pullPolicy: IfNotPresent
+    ## @param volumePermissions.image.pullSecrets [array] Specify docker-registry secret names as an array
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/

--- a/bitnami/etcd/values.yaml
+++ b/bitnami/etcd/values.yaml
@@ -65,7 +65,7 @@ diagnosticMode:
 ## @param image.registry etcd image registry
 ## @param image.repository etcd image name
 ## @param image.tag etcd image tag
-## @param image.digest etcd image digest in the way sha256:aa...
+## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ##
 image:
   registry: docker.io
@@ -591,7 +591,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image name
   ## @param volumePermissions.image.tag Init container volume-permissions image tag
-  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa...
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ##
   image:
     registry: docker.io


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11797).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```