### PR TITLE
[bitnami/kubeapps] Add nodeSelector: kubernetes.io/arch: amd64 in values.yaml

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 10.2.0
+version: 10.2.1

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 10.2.1
+version: 10.2.2

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -402,7 +402,8 @@ frontend:
   ## @param frontend.nodeSelector Node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/arch: amd64
   ## @param frontend.tolerations Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
@@ -750,7 +751,8 @@ dashboard:
   ## @param dashboard.nodeSelector Node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/arch: amd64
   ## @param dashboard.tolerations Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
@@ -1057,7 +1059,8 @@ apprepository:
   ## @param apprepository.nodeSelector Node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/arch: amd64
   ## @param apprepository.tolerations Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
@@ -1343,7 +1346,8 @@ kubeops:
   ## @param kubeops.nodeSelector Node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/arch: amd64
   ## @param kubeops.tolerations Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##
@@ -2039,7 +2043,8 @@ kubeappsapis:
   ## @param kubeappsapis.nodeSelector Node labels for pod assignment
   ## ref: https://kubernetes.io/docs/user-guide/node-selection/
   ##
-  nodeSelector: {}
+  nodeSelector:
+    kubernetes.io/arch: amd64
   ## @param kubeappsapis.tolerations Tolerations for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##


### PR DESCRIPTION
preventing errors while deploying on mixed clusters

I need to fix the deployments and syncjob by hand. Because i running a mixed cluster amd64 and arm64. The arm64 support from bitnami is planed to 2023/Q3 in the meantime it should have the nodeSelector as default.

### Benefits

Working without hesitate.

### Possible drawbacks

Needs removed or edit, if the arm64 support arrive.

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
