### PR TITLE
[bitnami/influxdb] Add tests and publish using VIB

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -16,6 +16,7 @@ on: # rebuild any PRs and main branch changes
       - 'bitnami/grafana/**'
       - 'bitnami/haproxy-intel/**'
       - 'bitnami/harbor/**'
+      - 'bitnami/influxdb/**'
       - 'bitnami/jenkins/**'
       - 'bitnami/joomla/**'
       - 'bitnami/kafka/**'

--- a/.vib/influxdb/cypress/cypress.json
+++ b/.vib/influxdb/cypress/cypress.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "http://localhost",
   "env": {
-    "username": "admin",
+    "username": "influxAdmin",
     "password": "RootP4ssw0rd",
     "bucket": "primary",
     "org": "primary"

--- a/.vib/influxdb/cypress/cypress.json
+++ b/.vib/influxdb/cypress/cypress.json
@@ -1,0 +1,8 @@
+{
+  "baseUrl": "http://localhost",
+  "env": {
+    "username": "admin",
+    "password": "RootP4ssw0rd",
+    "bucket": "testBucket"
+  }
+}

--- a/.vib/influxdb/cypress/cypress.json
+++ b/.vib/influxdb/cypress/cypress.json
@@ -3,6 +3,8 @@
   "env": {
     "username": "admin",
     "password": "RootP4ssw0rd",
-    "bucket": "testBucket"
-  }
+    "bucket": "primary",
+    "org": "primary"
+  },
+  "defaultCommandTimeout": 30000
 }

--- a/.vib/influxdb/cypress/cypress/fixtures/buckets.json
+++ b/.vib/influxdb/cypress/cypress/fixtures/buckets.json
@@ -1,0 +1,5 @@
+{
+  "newBucket": {
+    "name": "Super Bucket"
+  }
+}

--- a/.vib/influxdb/cypress/cypress/fixtures/dashboards/health_tracker.json
+++ b/.vib/influxdb/cypress/cypress/fixtures/dashboards/health_tracker.json
@@ -9,7 +9,7 @@
     "data": {
       "type": "dashboard",
       "attributes": {
-        "name": "Health Tracker a89lm",
+        "name": "Health Tracker",
         "description": ""
       },
       "relationships": {
@@ -57,7 +57,7 @@
             "shape": "chronograf-v2",
             "queries": [
               {
-                "text": "from(bucket: \"testBucket\")\n  |> range(start: time(v: \"2022-08-16T22:00:00.000Z\"), stop: time(v: \"2022-08-17T21:00:00.929Z\"))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"health\")\n  |> filter(fn: (r) => r[\"_field\"] == \"glucose\")\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> yield(name: \"max\")",
+                "text": "from(bucket: \"primary\")\n  |> range(start: time(v: \"2022-08-16T22:00:00.000Z\"), stop: time(v: \"2022-08-17T21:00:00.929Z\"))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"health\")\n  |> filter(fn: (r) => r[\"_field\"] == \"glucose\")\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> yield(name: \"max\")",
                 "editMode": "advanced",
                 "name": "",
                 "builderConfig": {

--- a/.vib/influxdb/cypress/cypress/fixtures/dashboards/health_tracker.json
+++ b/.vib/influxdb/cypress/cypress/fixtures/dashboards/health_tracker.json
@@ -1,0 +1,156 @@
+{
+  "meta": {
+    "version": "1",
+    "type": "dashboard",
+    "name": "Health Tracker-Template",
+    "description": "template created from dashboard: Health Tracker"
+  },
+  "content": {
+    "data": {
+      "type": "dashboard",
+      "attributes": {
+        "name": "Health Tracker a89lm",
+        "description": ""
+      },
+      "relationships": {
+        "label": {
+          "data": []
+        },
+        "cell": {
+          "data": [
+            {
+              "type": "cell",
+              "id": "09d6ec9702a4c000"
+            }
+          ]
+        },
+        "variable": {
+          "data": []
+        }
+      }
+    },
+    "included": [
+      {
+        "id": "09d6ec9702a4c000",
+        "type": "cell",
+        "attributes": {
+          "x": 0,
+          "y": 0,
+          "w": 4,
+          "h": 4
+        },
+        "relationships": {
+          "view": {
+            "data": {
+              "type": "view",
+              "id": "09d6ec9702a4c000"
+            }
+          }
+        }
+      },
+      {
+        "type": "view",
+        "id": "09d6ec9702a4c000",
+        "attributes": {
+          "name": "Glucose Levels",
+          "properties": {
+            "shape": "chronograf-v2",
+            "queries": [
+              {
+                "text": "from(bucket: \"testBucket\")\n  |> range(start: time(v: \"2022-08-16T22:00:00.000Z\"), stop: time(v: \"2022-08-17T21:00:00.929Z\"))\n  |> filter(fn: (r) => r[\"_measurement\"] == \"health\")\n  |> filter(fn: (r) => r[\"_field\"] == \"glucose\")\n  |> aggregateWindow(every: v.windowPeriod, fn: max, createEmpty: false)\n  |> yield(name: \"max\")",
+                "editMode": "advanced",
+                "name": "",
+                "builderConfig": {
+                  "buckets": [],
+                  "tags": [
+                    {
+                      "key": "_measurement",
+                      "values": [],
+                      "aggregateFunctionType": "filter"
+                    }
+                  ],
+                  "functions": [
+                    {
+                      "name": "max"
+                    }
+                  ],
+                  "aggregateWindow": {
+                    "period": "auto",
+                    "fillValues": false
+                  }
+                }
+              }
+            ],
+            "axes": {
+              "x": {
+                "bounds": [
+                  "",
+                  ""
+                ],
+                "label": "",
+                "prefix": "",
+                "suffix": "",
+                "base": "10",
+                "scale": "linear"
+              },
+              "y": {
+                "bounds": [
+                  "",
+                  ""
+                ],
+                "label": "",
+                "prefix": "",
+                "suffix": "",
+                "base": "10",
+                "scale": "linear"
+              }
+            },
+            "type": "line-plus-single-stat",
+            "staticLegend": {
+              "colorizeRows": true,
+              "opacity": 1,
+              "orientationThreshold": 100000000,
+              "widthRatio": 1
+            },
+            "colors": [
+              {
+                "id": "base",
+                "type": "text",
+                "hex": "#00C9FF",
+                "name": "laser",
+                "value": 0
+              }
+            ],
+            "prefix": "",
+            "suffix": "",
+            "decimalPlaces": {
+              "isEnforced": true,
+              "digits": 2
+            },
+            "note": "",
+            "showNoteWhenEmpty": false,
+            "xColumn": "_time",
+            "generateXAxisTicks": [],
+            "xTotalTicks": 0,
+            "xTickStart": 0,
+            "xTickStep": 0,
+            "yColumn": "_value",
+            "generateYAxisTicks": [],
+            "yTotalTicks": 0,
+            "yTickStart": 0,
+            "yTickStep": 0,
+            "shadeBelow": false,
+            "position": "overlaid",
+            "timeFormat": "",
+            "hoverDimension": "auto",
+            "legendColorizeRows": true,
+            "legendHide": false,
+            "legendOpacity": 1,
+            "legendOrientationThreshold": 100000000
+          }
+        }
+      }
+    ]
+  },
+  "labels": []
+}

--- a/.vib/influxdb/cypress/cypress/fixtures/sample_data/glucose_levels.txt
+++ b/.vib/influxdb/cypress/cypress/fixtures/sample_data/glucose_levels.txt
@@ -1,0 +1,4 @@
+health,user=bitnami glucose=1 1660694480000000000
+health,user=bitnami glucose=0.7 1660694480000000000
+health,user=bitnami glucose=1.95 1660694480000000000
+health,user=bitnami glucose=2.43 1660694480000000000

--- a/.vib/influxdb/cypress/cypress/integration/influxdb_spec.js
+++ b/.vib/influxdb/cypress/cypress/integration/influxdb_spec.js
@@ -1,0 +1,47 @@
+/// <reference types="cypress" />
+import { random } from '../support/utils';
+
+it('can create a new bucket', () => {
+  cy.login();
+  cy.visitInOrg('/load-data/buckets');
+  cy.get('[data-testid="Create Bucket"]').click();
+  cy.fixture('buckets').then((buckets) => {
+    cy.get('[data-testid="bucket-form-name"]').type(
+      `${buckets.newBucket.name}-${random}`
+    );
+    cy.get('[data-testid="bucket-form-submit"]').click();
+    cy.get(`[data-testid="bucket-card ${buckets.newBucket.name}-${random}"]`);
+  });
+});
+
+it('allows to import and visualize new data to DB', () => {
+  const MAX_SAMPLE_VALUE = '2.43';
+  cy.login();
+
+  // Import sample data into the DB
+  cy.visitInOrg('/load-data/sources');
+  cy.get('[data-testid="load-data-item lp"]').click();
+  cy.contains('[data-testid="list-item"]', Cypress.env('bucket')).click();
+  cy.get('[type="file"]').selectFile(
+    'cypress/fixtures/sample_data/glucose_levels.txt',
+    { force: true }
+  );
+  cy.get('[data-testid="write-data--button"]').click();
+  cy.contains('Written Successfully');
+
+  // Import a preconfigured dashboard to visualize sample data
+  cy.visitInOrg('/dashboards-list/');
+  cy.get('[data-testid="add-resource-dropdown--button"]').click();
+  cy.get('[data-testid="add-resource-dropdown--import"]').click();
+  const newDashboard = 'cypress/fixtures/dashboards/health_tracker.json';
+  cy.readFile(newDashboard).then((obj) => {
+    obj.content.data.attributes.name = `Health Tracker ${random}`;
+    cy.writeFile(newDashboard, obj);
+  });
+  cy.get('[type="file"]').selectFile(newDashboard, { force: true });
+  cy.get('[data-testid="submit-button Dashboard"]').click();
+  cy.contains('Successfully imported');
+  cy.visitInOrg('/dashboards-list');
+  cy.contains(`Health Tracker ${random}`).click();
+  cy.contains(MAX_SAMPLE_VALUE);
+});

--- a/.vib/influxdb/cypress/cypress/integration/influxdb_spec.js
+++ b/.vib/influxdb/cypress/cypress/integration/influxdb_spec.js
@@ -1,8 +1,9 @@
 /// <reference types="cypress" />
-import { random } from '../support/utils';
+import { random, selectOrg } from '../support/utils';
 
 it('can create a new bucket', () => {
   cy.login();
+  selectOrg();
   cy.visitInOrg('/load-data/buckets');
   cy.get('[data-testid="Create Bucket"]').click();
   cy.fixture('buckets').then((buckets) => {
@@ -17,6 +18,7 @@ it('can create a new bucket', () => {
 it('allows to import and visualize new data to DB', () => {
   const MAX_SAMPLE_VALUE = '2.43';
   cy.login();
+  selectOrg();
 
   // Import sample data into the DB
   cy.visitInOrg('/load-data/sources');

--- a/.vib/influxdb/cypress/cypress/support/commands.js
+++ b/.vib/influxdb/cypress/cypress/support/commands.js
@@ -1,0 +1,34 @@
+const COMMAND_DELAY = 2000;
+
+for (const command of ['click']) {
+  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
+    const origVal = originalFn(...args);
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(origVal);
+      }, COMMAND_DELAY);
+    });
+  });
+}
+
+Cypress.Commands.add('visitInOrg', (url) => {
+  // Retrieve current organization and use it to navigate
+  cy.url().then((currentUrl) => {
+    expect(currentUrl).to.contain('orgs');
+    const org = currentUrl.match(/orgs\/(\w*)/)[1];
+    const path = url.startsWith('/') ? url : `/${url}`;
+    cy.visit(`/orgs/${org}${path}`);
+  });
+});
+
+Cypress.Commands.add(
+  'login',
+  (username = Cypress.env('username'), password = Cypress.env('password')) => {
+    cy.visit('/signin');
+    cy.get('#login').type(username);
+    cy.get('#password').type(`${password}{enter}`);
+    // The login process is not considered as completed until the UI is rendered
+    cy.contains('Logout');
+  }
+);

--- a/.vib/influxdb/cypress/cypress/support/index.js
+++ b/.vib/influxdb/cypress/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/.vib/influxdb/cypress/cypress/support/utils.js
+++ b/.vib/influxdb/cypress/cypress/support/utils.js
@@ -1,0 +1,3 @@
+/// <reference types="cypress" />
+
+export let random = (Math.random() + 1).toString(36).substring(7);

--- a/.vib/influxdb/cypress/cypress/support/utils.js
+++ b/.vib/influxdb/cypress/cypress/support/utils.js
@@ -1,3 +1,10 @@
 /// <reference types="cypress" />
 
 export let random = (Math.random() + 1).toString(36).substring(7);
+
+export let selectOrg = (org = Cypress.env('org')) => {
+  cy.get('[data-testid="user-nav"]').click();
+  cy.get('[data-testid="user-nav-item-switch-orgs"]').click();
+  cy.contains('li', org).click();
+  cy.contains('Getting Started');
+};

--- a/.vib/influxdb/goss/goss.yaml
+++ b/.vib/influxdb/goss/goss.yaml
@@ -9,6 +9,12 @@ file:
     filetype: directory
     mode: "3777"
 command:
+  check-user-info:
+    exec: id
+    exit-status: 0
+    stdout:
+    - uid={{ .Vars.influxdb.containerSecurityContext.runAsUser }}
+    - /groups=.*{{ .Vars.influxdb.podSecurityContext.fsGroup }}/
   {{- $org := .Vars.auth.user.org }}
   {{- $bucket := .Vars.auth.user.bucket }}
   {{- $port := .Vars.influxdb.service.ports.http }}

--- a/.vib/influxdb/goss/goss.yaml
+++ b/.vib/influxdb/goss/goss.yaml
@@ -5,7 +5,7 @@ file:
     mode: "2775"
     owner: root
   /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ and .Vars.serviceAccount.create .Vars.serviceAccount.automountServiceAccountToken }}
+    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
     filetype: directory
     mode: "3777"
 command:

--- a/.vib/influxdb/goss/goss.yaml
+++ b/.vib/influxdb/goss/goss.yaml
@@ -1,0 +1,22 @@
+file:
+  /bitnami/influxdb:
+    exists: true
+    filetype: directory
+    mode: "2775"
+    owner: root
+  /var/run/secrets/kubernetes.io/serviceaccount:
+    exists: {{ and .Vars.serviceAccount.create .Vars.serviceAccount.automountServiceAccountToken }}
+    filetype: directory
+    mode: "3777"
+command:
+  {{- $org := .Vars.auth.user.org }}
+  {{- $bucket := .Vars.auth.user.bucket }}
+  {{- $port := .Vars.influxdb.service.ports.http }}
+  {{- $adminToken := .Vars.auth.admin.token }}
+  {{- $user := .Vars.auth.user.username }}
+  {{- $msg := printf "error_%s" (randAlpha 5) }}
+  influx-write-read:
+    exec: export INFLUX_TOKEN='{{ $adminToken }}' && influx write --host http://influxdb:{{ $port }} --org {{ $org }} --bucket {{ $bucket }} 'cpu_error,host=bitnami-server value="{{ $msg }}"' && export INFLUX_TOKEN=$(influx auth list | grep {{ $user }} | awk '{print $2}') && influx query --host http://influxdb:{{ $port }} --org {{ $org }} 'from(bucket:"{{ $bucket }}") |> range(start:-2m)'
+    exit-status: 0
+    stdout:
+      - {{ $msg }}

--- a/.vib/influxdb/goss/vars.yaml
+++ b/.vib/influxdb/goss/vars.yaml
@@ -9,6 +9,10 @@ influxdb:
   service:
     ports:
       http: 80
+  containerSecurityContext:
+    runAsUser: 1002
+  podSecurityContext:
+    fsGroup: 1002
 serviceAccount:
   create: true
   automountServiceAccountToken: true

--- a/.vib/influxdb/goss/vars.yaml
+++ b/.vib/influxdb/goss/vars.yaml
@@ -14,5 +14,4 @@ influxdb:
   podSecurityContext:
     fsGroup: 1002
 serviceAccount:
-  create: true
   automountServiceAccountToken: true

--- a/.vib/influxdb/goss/vars.yaml
+++ b/.vib/influxdb/goss/vars.yaml
@@ -1,0 +1,14 @@
+auth:
+  admin:
+    token: "4dm1nT0k3n"
+  user:
+    username: "testUser"
+    org: "testOrganization"
+    bucket: "testBucket"
+influxdb:
+  service:
+    ports:
+      http: 80
+serviceAccount:
+  create: true
+  automountServiceAccountToken: true

--- a/.vib/influxdb/vib-publish.json
+++ b/.vib/influxdb/vib-publish.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/influxdb"
         },
-        "runtime_parameters": "YXV0aDoKICBlbmFibGVkOiB0cnVlCiAgYWRtaW46CiAgICB1c2VybmFtZTogImFkbWluIgogICAgcGFzc3dvcmQ6ICJSb290UDRzc3cwcmQiCiAgICB0b2tlbjogIjRkbTFuVDBrM24iCiAgICBvcmc6IHByaW1hcnkKICAgIGJ1Y2tldDogcHJpbWFyeQogIGNyZWF0ZVVzZXJUb2tlbjogdHJ1ZQogIHVzZXI6CiAgICB1c2VybmFtZTogInRlc3RVc2VyIgogICAgcGFzc3dvcmQ6ICJDb21wbGljYXRlZFBhc3N3b3JkMTIzITQiCiAgICBvcmc6ICJ0ZXN0T3JnYW5pemF0aW9uIgogICAgYnVja2V0OiAidGVzdEJ1Y2tldCIKaW5mbHV4ZGI6CiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDgwCiAgICAgIHJwYzogODA4OApzZXJ2aWNlQWNjb3VudDoKICBjcmVhdGU6IHRydWUKICBhdXRvbW91bnRTZXJ2aWNlQWNjb3VudFRva2VuOiB0cnVlCg==",
+        "runtime_parameters": "YXV0aDoKICBlbmFibGVkOiB0cnVlCiAgYWRtaW46CiAgICB1c2VybmFtZTogImluZmx1eEFkbWluIgogICAgcGFzc3dvcmQ6ICJSb290UDRzc3cwcmQiCiAgICB0b2tlbjogIjRkbTFuVDBrM24iCiAgICBvcmc6IHByaW1hcnkKICAgIGJ1Y2tldDogcHJpbWFyeQogIGNyZWF0ZVVzZXJUb2tlbjogdHJ1ZQogIHVzZXI6CiAgICB1c2VybmFtZTogInRlc3RVc2VyIgogICAgcGFzc3dvcmQ6ICJDb21wbGljYXRlZFBhc3N3b3JkMTIzITQiCiAgICBvcmc6ICJ0ZXN0T3JnYW5pemF0aW9uIgogICAgYnVja2V0OiAidGVzdEJ1Y2tldCIKaW5mbHV4ZGI6CiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDgwCiAgICAgIHJwYzogODA4OQogIGNvbnRhaW5lclBvcnRzOgogICAgaHR0cDogODA4NgogICAgcnBjOiA4MDg5CiAgY29udGFpbmVyU2VjdXJpdHlDb250ZXh0OgogICAgZW5hYmxlZDogdHJ1ZQogICAgcnVuQXNVc2VyOiAxMDAyCiAgcG9kU2VjdXJpdHlDb250ZXh0OgogICAgZW5hYmxlZDogdHJ1ZQogICAgZnNHcm91cDogMTAwMgpzZXJ2aWNlQWNjb3VudDoKICBjcmVhdGU6IHRydWUKICBhdXRvbW91bnRTZXJ2aWNlQWNjb3VudFRva2VuOiB0cnVlCg==",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -59,7 +59,7 @@
             "endpoint": "lb-influxdb-http",
             "app_protocol": "HTTP",
             "env": {
-              "username": "admin",
+              "username": "influxAdmin",
               "password": "RootP4ssw0rd",
               "bucket": "primary",
               "org": "primary"

--- a/.vib/influxdb/vib-publish.json
+++ b/.vib/influxdb/vib-publish.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/influxdb"
         },
-        "runtime_parameters": "ImF1dGgiOgogICJhZG1pbiI6CiAgICAicGFzc3dvcmQiOiAiYWRtaW5wYXNzd29yZCIKICAgICJ0b2tlbiI6ICJhZG1pbnBhc3N3b3JkIgogICAgInVzZXJuYW1lIjogImFkbWluIgogICJjcmVhdGVVc2VyVG9rZW4iOiB0cnVlCiAgInJlYWRVc2VyIjoKICAgICJwYXNzd29yZCI6ICJyZWFkLXBhc3N3b3JkIgogICAgInVzZXJuYW1lIjogInJlYWQtdXNlciIKICAidXNlciI6CiAgICAiYnVja2V0IjogImJpdG5hbWlfdGVzdF9idWNrZXQiCiAgICAicGFzc3dvcmQiOiAicGFzc3dvcmQiCiAgICAidXNlcm5hbWUiOiAidXNlciIKICAid3JpdGVVc2VyIjoKICAgICJwYXNzd29yZCI6ICJ3cml0ZS1wYXNzd29yZCIKICAgICJ1c2VybmFtZSI6ICJ3cml0ZS11c2VyIgoiaW5mbHV4ZGIiOgogICJzZXJ2aWNlIjoKICAgICJwb3J0cyI6CiAgICAgICJodHRwIjogODAKICAgICJ0eXBlIjogIkxvYWRCYWxhbmNlciIKICAidXBkYXRlU3RyYXRlZ3kiOgogICAgInR5cGUiOiAiUmVjcmVhdGUi",
+        "runtime_parameters": "YXV0aDoKICBlbmFibGVkOiB0cnVlCiAgYWRtaW46CiAgICB1c2VybmFtZTogImFkbWluIgogICAgcGFzc3dvcmQ6ICJSb290UDRzc3cwcmQiCiAgICB0b2tlbjogIjRkbTFuVDBrM24iCiAgY3JlYXRlVXNlclRva2VuOiB0cnVlCiAgdXNlcjoKICAgIHVzZXJuYW1lOiAidGVzdFVzZXIiCiAgICBwYXNzd29yZDogIkNvbXBsaWNhdGVkUGFzc3dvcmQxMjMhNCIKICAgIG9yZzogInRlc3RPcmdhbml6YXRpb24iCiAgICBidWNrZXQ6ICJ0ZXN0QnVja2V0IgppbmZsdXhkYjoKICBzZXJ2aWNlOgogICAgdHlwZTogTG9hZEJhbGFuY2VyCiAgICBwb3J0czoKICAgICAgaHR0cDogODAKICAgICAgcnBjOiA4MDg4CnNlcnZpY2VBY2NvdW50OgogIGNyZWF0ZTogdHJ1ZQogIGF1dG9tb3VudFNlcnZpY2VBY2NvdW50VG9rZW46IHRydWUK",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -36,6 +36,33 @@
           "params": {
             "endpoint": "lb-influxdb-http",
             "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/influxdb/goss"
+            },
+            "remote": {
+              "workload": "deploy-influxdb"
+            },
+            "vars_file": "vars.yaml"
+          }
+        },
+        {
+          "action_id": "cypress",
+          "params": {
+            "resources": {
+              "path": "/.vib/influxdb/cypress"
+            },
+            "endpoint": "lb-influxdb-http",
+            "app_protocol": "HTTP",
+            "env": {
+              "username": "admin",
+              "password": "RootP4ssw0rd",
+              "bucket": "testBucket"
+            }
           }
         }
       ]

--- a/.vib/influxdb/vib-publish.json
+++ b/.vib/influxdb/vib-publish.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/influxdb"
         },
-        "runtime_parameters": "YXV0aDoKICBlbmFibGVkOiB0cnVlCiAgYWRtaW46CiAgICB1c2VybmFtZTogImFkbWluIgogICAgcGFzc3dvcmQ6ICJSb290UDRzc3cwcmQiCiAgICB0b2tlbjogIjRkbTFuVDBrM24iCiAgY3JlYXRlVXNlclRva2VuOiB0cnVlCiAgdXNlcjoKICAgIHVzZXJuYW1lOiAidGVzdFVzZXIiCiAgICBwYXNzd29yZDogIkNvbXBsaWNhdGVkUGFzc3dvcmQxMjMhNCIKICAgIG9yZzogInRlc3RPcmdhbml6YXRpb24iCiAgICBidWNrZXQ6ICJ0ZXN0QnVja2V0IgppbmZsdXhkYjoKICBzZXJ2aWNlOgogICAgdHlwZTogTG9hZEJhbGFuY2VyCiAgICBwb3J0czoKICAgICAgaHR0cDogODAKICAgICAgcnBjOiA4MDg4CnNlcnZpY2VBY2NvdW50OgogIGNyZWF0ZTogdHJ1ZQogIGF1dG9tb3VudFNlcnZpY2VBY2NvdW50VG9rZW46IHRydWUK",
+        "runtime_parameters": "YXV0aDoKICBlbmFibGVkOiB0cnVlCiAgYWRtaW46CiAgICB1c2VybmFtZTogImFkbWluIgogICAgcGFzc3dvcmQ6ICJSb290UDRzc3cwcmQiCiAgICB0b2tlbjogIjRkbTFuVDBrM24iCiAgICBvcmc6IHByaW1hcnkKICAgIGJ1Y2tldDogcHJpbWFyeQogIGNyZWF0ZVVzZXJUb2tlbjogdHJ1ZQogIHVzZXI6CiAgICB1c2VybmFtZTogInRlc3RVc2VyIgogICAgcGFzc3dvcmQ6ICJDb21wbGljYXRlZFBhc3N3b3JkMTIzITQiCiAgICBvcmc6ICJ0ZXN0T3JnYW5pemF0aW9uIgogICAgYnVja2V0OiAidGVzdEJ1Y2tldCIKaW5mbHV4ZGI6CiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDgwCiAgICAgIHJwYzogODA4OApzZXJ2aWNlQWNjb3VudDoKICBjcmVhdGU6IHRydWUKICBhdXRvbW91bnRTZXJ2aWNlQWNjb3VudFRva2VuOiB0cnVlCg==",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -61,7 +61,8 @@
             "env": {
               "username": "admin",
               "password": "RootP4ssw0rd",
-              "bucket": "testBucket"
+              "bucket": "primary",
+              "org": "primary"
             }
           }
         }

--- a/.vib/influxdb/vib-verify.json
+++ b/.vib/influxdb/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/influxdb"
         },
-        "runtime_parameters": "YXV0aDoKICBlbmFibGVkOiB0cnVlCiAgYWRtaW46CiAgICB1c2VybmFtZTogImFkbWluIgogICAgcGFzc3dvcmQ6ICJSb290UDRzc3cwcmQiCiAgICB0b2tlbjogIjRkbTFuVDBrM24iCiAgICBvcmc6IHByaW1hcnkKICAgIGJ1Y2tldDogcHJpbWFyeQogIGNyZWF0ZVVzZXJUb2tlbjogdHJ1ZQogIHVzZXI6CiAgICB1c2VybmFtZTogInRlc3RVc2VyIgogICAgcGFzc3dvcmQ6ICJDb21wbGljYXRlZFBhc3N3b3JkMTIzITQiCiAgICBvcmc6ICJ0ZXN0T3JnYW5pemF0aW9uIgogICAgYnVja2V0OiAidGVzdEJ1Y2tldCIKaW5mbHV4ZGI6CiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDgwCiAgICAgIHJwYzogODA4OApzZXJ2aWNlQWNjb3VudDoKICBjcmVhdGU6IHRydWUKICBhdXRvbW91bnRTZXJ2aWNlQWNjb3VudFRva2VuOiB0cnVlCg==",
+        "runtime_parameters": "YXV0aDoKICBlbmFibGVkOiB0cnVlCiAgYWRtaW46CiAgICB1c2VybmFtZTogImluZmx1eEFkbWluIgogICAgcGFzc3dvcmQ6ICJSb290UDRzc3cwcmQiCiAgICB0b2tlbjogIjRkbTFuVDBrM24iCiAgICBvcmc6IHByaW1hcnkKICAgIGJ1Y2tldDogcHJpbWFyeQogIGNyZWF0ZVVzZXJUb2tlbjogdHJ1ZQogIHVzZXI6CiAgICB1c2VybmFtZTogInRlc3RVc2VyIgogICAgcGFzc3dvcmQ6ICJDb21wbGljYXRlZFBhc3N3b3JkMTIzITQiCiAgICBvcmc6ICJ0ZXN0T3JnYW5pemF0aW9uIgogICAgYnVja2V0OiAidGVzdEJ1Y2tldCIKaW5mbHV4ZGI6CiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDgwCiAgICAgIHJwYzogODA4OQogIGNvbnRhaW5lclBvcnRzOgogICAgaHR0cDogODA4NgogICAgcnBjOiA4MDg5CiAgY29udGFpbmVyU2VjdXJpdHlDb250ZXh0OgogICAgZW5hYmxlZDogdHJ1ZQogICAgcnVuQXNVc2VyOiAxMDAyCiAgcG9kU2VjdXJpdHlDb250ZXh0OgogICAgZW5hYmxlZDogdHJ1ZQogICAgZnNHcm91cDogMTAwMgpzZXJ2aWNlQWNjb3VudDoKICBjcmVhdGU6IHRydWUKICBhdXRvbW91bnRTZXJ2aWNlQWNjb3VudFRva2VuOiB0cnVlCg==",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -59,7 +59,7 @@
             "endpoint": "lb-influxdb-http",
             "app_protocol": "HTTP",
             "env": {
-              "username": "admin",
+              "username": "influxAdmin",
               "password": "RootP4ssw0rd",
               "bucket": "primary",
               "org": "primary"

--- a/.vib/influxdb/vib-verify.json
+++ b/.vib/influxdb/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/influxdb"
         },
-        "runtime_parameters": "ImF1dGgiOgogICJhZG1pbiI6CiAgICAicGFzc3dvcmQiOiAiYWRtaW5wYXNzd29yZCIKICAgICJ0b2tlbiI6ICJhZG1pbnBhc3N3b3JkIgogICAgInVzZXJuYW1lIjogImFkbWluIgogICJjcmVhdGVVc2VyVG9rZW4iOiB0cnVlCiAgInJlYWRVc2VyIjoKICAgICJwYXNzd29yZCI6ICJyZWFkLXBhc3N3b3JkIgogICAgInVzZXJuYW1lIjogInJlYWQtdXNlciIKICAidXNlciI6CiAgICAiYnVja2V0IjogImJpdG5hbWlfdGVzdF9idWNrZXQiCiAgICAicGFzc3dvcmQiOiAicGFzc3dvcmQiCiAgICAidXNlcm5hbWUiOiAidXNlciIKICAid3JpdGVVc2VyIjoKICAgICJwYXNzd29yZCI6ICJ3cml0ZS1wYXNzd29yZCIKICAgICJ1c2VybmFtZSI6ICJ3cml0ZS11c2VyIgoiaW5mbHV4ZGIiOgogICJzZXJ2aWNlIjoKICAgICJwb3J0cyI6CiAgICAgICJodHRwIjogODAKICAgICJ0eXBlIjogIkxvYWRCYWxhbmNlciIKICAidXBkYXRlU3RyYXRlZ3kiOgogICAgInR5cGUiOiAiUmVjcmVhdGUi",
+        "runtime_parameters": "YXV0aDoKICBlbmFibGVkOiB0cnVlCiAgYWRtaW46CiAgICB1c2VybmFtZTogImFkbWluIgogICAgcGFzc3dvcmQ6ICJSb290UDRzc3cwcmQiCiAgICB0b2tlbjogIjRkbTFuVDBrM24iCiAgY3JlYXRlVXNlclRva2VuOiB0cnVlCiAgdXNlcjoKICAgIHVzZXJuYW1lOiAidGVzdFVzZXIiCiAgICBwYXNzd29yZDogIkNvbXBsaWNhdGVkUGFzc3dvcmQxMjMhNCIKICAgIG9yZzogInRlc3RPcmdhbml6YXRpb24iCiAgICBidWNrZXQ6ICJ0ZXN0QnVja2V0IgppbmZsdXhkYjoKICBzZXJ2aWNlOgogICAgdHlwZTogTG9hZEJhbGFuY2VyCiAgICBwb3J0czoKICAgICAgaHR0cDogODAKICAgICAgcnBjOiA4MDg4CnNlcnZpY2VBY2NvdW50OgogIGNyZWF0ZTogdHJ1ZQogIGF1dG9tb3VudFNlcnZpY2VBY2NvdW50VG9rZW46IHRydWUK",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -36,6 +36,33 @@
           "params": {
             "endpoint": "lb-influxdb-http",
             "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/influxdb/goss"
+            },
+            "remote": {
+              "workload": "deploy-influxdb"
+            },
+            "vars_file": "vars.yaml"
+          }
+        },
+        {
+          "action_id": "cypress",
+          "params": {
+            "resources": {
+              "path": "/.vib/influxdb/cypress"
+            },
+            "endpoint": "lb-influxdb-http",
+            "app_protocol": "HTTP",
+            "env": {
+              "username": "admin",
+              "password": "RootP4ssw0rd",
+              "bucket": "testBucket"
+            }
           }
         }
       ]

--- a/.vib/influxdb/vib-verify.json
+++ b/.vib/influxdb/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/influxdb"
         },
-        "runtime_parameters": "YXV0aDoKICBlbmFibGVkOiB0cnVlCiAgYWRtaW46CiAgICB1c2VybmFtZTogImFkbWluIgogICAgcGFzc3dvcmQ6ICJSb290UDRzc3cwcmQiCiAgICB0b2tlbjogIjRkbTFuVDBrM24iCiAgY3JlYXRlVXNlclRva2VuOiB0cnVlCiAgdXNlcjoKICAgIHVzZXJuYW1lOiAidGVzdFVzZXIiCiAgICBwYXNzd29yZDogIkNvbXBsaWNhdGVkUGFzc3dvcmQxMjMhNCIKICAgIG9yZzogInRlc3RPcmdhbml6YXRpb24iCiAgICBidWNrZXQ6ICJ0ZXN0QnVja2V0IgppbmZsdXhkYjoKICBzZXJ2aWNlOgogICAgdHlwZTogTG9hZEJhbGFuY2VyCiAgICBwb3J0czoKICAgICAgaHR0cDogODAKICAgICAgcnBjOiA4MDg4CnNlcnZpY2VBY2NvdW50OgogIGNyZWF0ZTogdHJ1ZQogIGF1dG9tb3VudFNlcnZpY2VBY2NvdW50VG9rZW46IHRydWUK",
+        "runtime_parameters": "YXV0aDoKICBlbmFibGVkOiB0cnVlCiAgYWRtaW46CiAgICB1c2VybmFtZTogImFkbWluIgogICAgcGFzc3dvcmQ6ICJSb290UDRzc3cwcmQiCiAgICB0b2tlbjogIjRkbTFuVDBrM24iCiAgICBvcmc6IHByaW1hcnkKICAgIGJ1Y2tldDogcHJpbWFyeQogIGNyZWF0ZVVzZXJUb2tlbjogdHJ1ZQogIHVzZXI6CiAgICB1c2VybmFtZTogInRlc3RVc2VyIgogICAgcGFzc3dvcmQ6ICJDb21wbGljYXRlZFBhc3N3b3JkMTIzITQiCiAgICBvcmc6ICJ0ZXN0T3JnYW5pemF0aW9uIgogICAgYnVja2V0OiAidGVzdEJ1Y2tldCIKaW5mbHV4ZGI6CiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDgwCiAgICAgIHJwYzogODA4OApzZXJ2aWNlQWNjb3VudDoKICBjcmVhdGU6IHRydWUKICBhdXRvbW91bnRTZXJ2aWNlQWNjb3VudFRva2VuOiB0cnVlCg==",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -61,7 +61,8 @@
             "env": {
               "username": "admin",
               "password": "RootP4ssw0rd",
-              "bucket": "testBucket"
+              "bucket": "primary",
+              "org": "primary"
             }
           }
         }


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami InfluxDB Helm Chart using VMware Image Builder. In order to do that, several changes are included:

- Adding the asset to the publishing workflow
- Increasing the existing test coverage of the asset by adding Cypress tests.
- Increasing the existing test coverage of the asset by adding GOSS tests.

### Benefits

- Ensuring higher quality of the Helm charts.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could show to be potentially flaky. 

### Applicable issues

NA

### Additional information

Tested in https://github.com/joancafom/charts/pull/69

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

