### PR TITLE
support for image digest apart from tag

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.0.0
+appVersion: 1.17.2
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - https://www.bitnami.com/
 type: library
-version: 2.0.0
+version: 1.17.2

--- a/bitnami/common/templates/_images.tpl
+++ b/bitnami/common/templates/_images.tpl
@@ -7,16 +7,20 @@ Return the proper image name
 {{- $registryName := .imageRoot.registry -}}
 {{- $repositoryName := .imageRoot.repository -}}
 {{- $tag := .imageRoot.tag | toString -}}
-{{- $digest := .imageRoot.digest | toString -}}
+{{- $separator := ":" -}}
 {{- if .global }}
     {{- if .global.imageRegistry }}
      {{- $registryName = .global.imageRegistry -}}
     {{- end -}}
 {{- end -}}
-{{- if $digest }}
-    {{- printf "%s/%s@%s" $registryName $repositoryName $digest -}}
+{{- if .imageRoot.digest -}}
+    {{- $separator = "@" -}}
+    {{- $tag = .imageRoot.digest | toString -}}
+{{- end -}}
+{{- if $registryName }}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $tag -}}
 {{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+    {{- printf "%s%s%s" $repositoryName $separator $tag -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Signed-off-by: Cyril Jouve <jv.cyril@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Same as https://github.com/bitnami/charts/pull/11830, but backard compatible

### Benefits

<!-- What benefits will be realized by the code change? -->
`digest: ""`  
``` 
helm template . | grep image 
walk.go:74: found symbolic link in path: /home/cyril/work/charts/bitnami/etcd/charts/common resolves to /home/cyril/work/charts/bitnami/common. Contents of linked file included and used
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
          imagePullPolicy: "IfNotPresent"
``` 

no digest / digest: null
``` 
helm template . | grep image 
walk.go:74: found symbolic link in path: /home/cyril/work/charts/bitnami/etcd/charts/common resolves to /home/cyril/work/charts/bitnami/common. Contents of linked file included and used
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
          imagePullPolicy: "IfNotPresent"
``` 

` digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897` 
``` 
walk.go:74: found symbolic link in path: /home/cyril/work/charts/bitnami/etcd/charts/common resolves to /home/cyril/work/charts/bitnami/common. Contents of linked file included and used
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
          imagePullPolicy: "IfNotPresent"
``` 


### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
what to do about 2.0.0 ?

``` 
helm search repo common
NAME                    CHART VERSION   APP VERSION     DESCRIPTION                                       
bitnami/common          2.0.0           2.0.0           A Library Helm Chart for grouping common logic ...
``` 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
