### PR TITLE
[bitnami/nats] fix networkpolicy

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/nats
   - https://nats.io/
-version: 7.3.11
+version: 7.3.12

--- a/bitnami/nats/templates/networkpolicy.yaml
+++ b/bitnami/nats/templates/networkpolicy.yaml
@@ -24,7 +24,7 @@ spec:
               {{ template "common.names.fullname" . }}-client: "true"
       {{- end }}
     - ports:
-        - port: {{ .Values.service.ports.client }}
+        - port: {{ .Values.service.ports.cluster }}
     - ports:
         - port: {{ .Values.service.ports.monitoring }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: rui.guo <rui.guo@bytedance.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fix cluster port in nats networkpolicy resource

Fixes https://github.com/bitnami/charts/issues/11749

