### PR TITLE
[bitnami/airflow] Add support for image digest apart from tag

### DIFF
--- a/bitnami/airflow/Chart.lock
+++ b/bitnami/airflow/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 17.0.11
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.7.3
+  version: 11.7.4
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:f3aa8695d295f4a176fb6cf62a9ffa4c69c8c939960f4e0f25aed45978f5a8c9
-generated: "2022-08-18T00:26:01.943437503Z"
+  version: 2.0.0
+digest: sha256:69304b8b09d9246daaa84db705caeef65765f37e92c7a42daa915a760bb004cc
+generated: "2022-08-20T10:25:54.185336767Z"

--- a/bitnami/airflow/Chart.lock
+++ b/bitnami/airflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.0.11
+  version: 17.1.0
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.7.4
+  version: 11.8.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
-digest: sha256:69304b8b09d9246daaa84db705caeef65765f37e92c7a42daa915a760bb004cc
-generated: "2022-08-20T10:25:54.185336767Z"
+digest: sha256:4e32010720655193e7c8b2c7cb65eb2d56479452efb194202d45b0b06fe0e366
+generated: "2022-08-22T14:24:07.467051178Z"

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Apache Airflow is a tool to express and execute workflows as directed acyclic graphs (DAGs). It includes utilities to schedule tasks, monitor task progress and handle task dependencies.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/airflow
@@ -32,4 +32,4 @@ name: airflow
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/airflow
   - https://airflow.apache.org/
-version: 13.0.5
+version: 13.1.0

--- a/bitnami/airflow/README.md
+++ b/bitnami/airflow/README.md
@@ -92,6 +92,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `dags.image.registry`    | Init container load-dags image registry                                                                                                                                   | `docker.io`             |
 | `dags.image.repository`  | Init container load-dags image repository                                                                                                                                 | `bitnami/bitnami-shell` |
 | `dags.image.tag`         | Init container load-dags image tag (immutable tags are recommended)                                                                                                       | `11-debian-11-r26`      |
+| `dags.image.digest`      | Init container load-dags image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                                  | `""`                    |
 | `dags.image.pullPolicy`  | Init container load-dags image pull policy                                                                                                                                | `IfNotPresent`          |
 | `dags.image.pullSecrets` | Init container load-dags image pull secrets                                                                                                                               | `[]`                    |
 | `extraEnvVars`           | Add extra environment variables for all the Airflow pods                                                                                                                  | `[]`                    |
@@ -111,6 +112,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `web.image.registry`                        | Airflow image registry                                                                                                   | `docker.io`           |
 | `web.image.repository`                      | Airflow image repository                                                                                                 | `bitnami/airflow`     |
 | `web.image.tag`                             | Airflow image tag (immutable tags are recommended)                                                                       | `2.3.3-debian-11-r14` |
+| `web.image.digest`                          | Airflow image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                  | `""`                  |
 | `web.image.pullPolicy`                      | Airflow image pull policy                                                                                                | `IfNotPresent`        |
 | `web.image.pullSecrets`                     | Airflow image pull secrets                                                                                               | `[]`                  |
 | `web.image.debug`                           | Enable image debug mode                                                                                                  | `false`               |
@@ -186,6 +188,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `scheduler.image.registry`                        | Airflow Scheduler image registry                                                                                         | `docker.io`                 |
 | `scheduler.image.repository`                      | Airflow Scheduler image repository                                                                                       | `bitnami/airflow-scheduler` |
 | `scheduler.image.tag`                             | Airflow Scheduler image tag (immutable tags are recommended)                                                             | `2.3.3-debian-11-r14`       |
+| `scheduler.image.digest`                          | Airflow Schefuler image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag        | `""`                        |
 | `scheduler.image.pullPolicy`                      | Airflow Scheduler image pull policy                                                                                      | `IfNotPresent`              |
 | `scheduler.image.pullSecrets`                     | Airflow Scheduler image pull secrets                                                                                     | `[]`                        |
 | `scheduler.image.debug`                           | Enable image debug mode                                                                                                  | `false`                     |
@@ -240,6 +243,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `worker.image.registry`                        | Airflow Worker image registry                                                                                            | `docker.io`              |
 | `worker.image.repository`                      | Airflow Worker image repository                                                                                          | `bitnami/airflow-worker` |
 | `worker.image.tag`                             | Airflow Worker image tag (immutable tags are recommended)                                                                | `2.3.3-debian-11-r15`    |
+| `worker.image.digest`                          | Airflow Worker image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag           | `""`                     |
 | `worker.image.pullPolicy`                      | Airflow Worker image pull policy                                                                                         | `IfNotPresent`           |
 | `worker.image.pullSecrets`                     | Airflow Worker image pull secrets                                                                                        | `[]`                     |
 | `worker.image.debug`                           | Enable image debug mode                                                                                                  | `false`                  |
@@ -315,32 +319,33 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Airflow git sync parameters
 
-| Name                           | Description                                                                            | Value                 |
-| ------------------------------ | -------------------------------------------------------------------------------------- | --------------------- |
-| `git.image.registry`           | Git image registry                                                                     | `docker.io`           |
-| `git.image.repository`         | Git image repository                                                                   | `bitnami/git`         |
-| `git.image.tag`                | Git image tag (immutable tags are recommended)                                         | `2.37.2-debian-11-r2` |
-| `git.image.pullPolicy`         | Git image pull policy                                                                  | `IfNotPresent`        |
-| `git.image.pullSecrets`        | Git image pull secrets                                                                 | `[]`                  |
-| `git.dags.enabled`             | Enable in order to download DAG files from git repositories.                           | `false`               |
-| `git.dags.repositories`        | Array of repositories from which to download DAG files                                 | `[]`                  |
-| `git.plugins.enabled`          | Enable in order to download Plugins files from git repositories.                       | `false`               |
-| `git.plugins.repositories`     | Array of repositories from which to download DAG files                                 | `[]`                  |
-| `git.clone.command`            | Override cmd                                                                           | `[]`                  |
-| `git.clone.args`               | Override args                                                                          | `[]`                  |
-| `git.clone.extraVolumeMounts`  | Add extra volume mounts                                                                | `[]`                  |
-| `git.clone.extraEnvVars`       | Add extra environment variables                                                        | `[]`                  |
-| `git.clone.extraEnvVarsCM`     | ConfigMap with extra environment variables                                             | `""`                  |
-| `git.clone.extraEnvVarsSecret` | Secret with extra environment variables                                                | `""`                  |
-| `git.clone.resources`          | Clone init container resource requests and limits                                      | `{}`                  |
-| `git.sync.interval`            | Interval in seconds to pull the git repository containing the plugins and/or DAG files | `60`                  |
-| `git.sync.command`             | Override cmd                                                                           | `[]`                  |
-| `git.sync.args`                | Override args                                                                          | `[]`                  |
-| `git.sync.extraVolumeMounts`   | Add extra volume mounts                                                                | `[]`                  |
-| `git.sync.extraEnvVars`        | Add extra environment variables                                                        | `[]`                  |
-| `git.sync.extraEnvVarsCM`      | ConfigMap with extra environment variables                                             | `""`                  |
-| `git.sync.extraEnvVarsSecret`  | Secret with extra environment variables                                                | `""`                  |
-| `git.sync.resources`           | Sync sidecar container resource requests and limits                                    | `{}`                  |
+| Name                           | Description                                                                                         | Value                 |
+| ------------------------------ | --------------------------------------------------------------------------------------------------- | --------------------- |
+| `git.image.registry`           | Git image registry                                                                                  | `docker.io`           |
+| `git.image.repository`         | Git image repository                                                                                | `bitnami/git`         |
+| `git.image.tag`                | Git image tag (immutable tags are recommended)                                                      | `2.37.2-debian-11-r2` |
+| `git.image.digest`             | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `git.image.pullPolicy`         | Git image pull policy                                                                               | `IfNotPresent`        |
+| `git.image.pullSecrets`        | Git image pull secrets                                                                              | `[]`                  |
+| `git.dags.enabled`             | Enable in order to download DAG files from git repositories.                                        | `false`               |
+| `git.dags.repositories`        | Array of repositories from which to download DAG files                                              | `[]`                  |
+| `git.plugins.enabled`          | Enable in order to download Plugins files from git repositories.                                    | `false`               |
+| `git.plugins.repositories`     | Array of repositories from which to download DAG files                                              | `[]`                  |
+| `git.clone.command`            | Override cmd                                                                                        | `[]`                  |
+| `git.clone.args`               | Override args                                                                                       | `[]`                  |
+| `git.clone.extraVolumeMounts`  | Add extra volume mounts                                                                             | `[]`                  |
+| `git.clone.extraEnvVars`       | Add extra environment variables                                                                     | `[]`                  |
+| `git.clone.extraEnvVarsCM`     | ConfigMap with extra environment variables                                                          | `""`                  |
+| `git.clone.extraEnvVarsSecret` | Secret with extra environment variables                                                             | `""`                  |
+| `git.clone.resources`          | Clone init container resource requests and limits                                                   | `{}`                  |
+| `git.sync.interval`            | Interval in seconds to pull the git repository containing the plugins and/or DAG files              | `60`                  |
+| `git.sync.command`             | Override cmd                                                                                        | `[]`                  |
+| `git.sync.args`                | Override args                                                                                       | `[]`                  |
+| `git.sync.extraVolumeMounts`   | Add extra volume mounts                                                                             | `[]`                  |
+| `git.sync.extraEnvVars`        | Add extra environment variables                                                                     | `[]`                  |
+| `git.sync.extraEnvVarsCM`      | ConfigMap with extra environment variables                                                          | `""`                  |
+| `git.sync.extraEnvVarsSecret`  | Secret with extra environment variables                                                             | `""`                  |
+| `git.sync.resources`           | Sync sidecar container resource requests and limits                                                 | `{}`                  |
 
 
 ### Airflow ldap parameters
@@ -409,52 +414,53 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Airflow metrics parameters
 
-| Name                                            | Description                                                                                         | Value                        |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `metrics.enabled`                               | Whether or not to create a standalone Airflow exporter to expose Airflow metrics                    | `false`                      |
-| `metrics.image.registry`                        | Airflow exporter image registry                                                                     | `docker.io`                  |
-| `metrics.image.repository`                      | Airflow exporter image repository                                                                   | `bitnami/airflow-exporter`   |
-| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                         | `0.20220314.0-debian-11-r28` |
-| `metrics.image.pullPolicy`                      | Airflow exporter image pull policy                                                                  | `IfNotPresent`               |
-| `metrics.image.pullSecrets`                     | Airflow exporter image pull secrets                                                                 | `[]`                         |
-| `metrics.extraEnvVars`                          | Array with extra environment variables to add Airflow exporter pods                                 | `[]`                         |
-| `metrics.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow exporter pods                          | `""`                         |
-| `metrics.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow exporter pods | `""`                         |
-| `metrics.containerPorts.http`                   | Airflow exporter metrics container port                                                             | `9112`                       |
-| `metrics.resources.limits`                      | The resources limits for the container                                                              | `{}`                         |
-| `metrics.resources.requests`                    | The requested resources for the container                                                           | `{}`                         |
-| `metrics.podSecurityContext.enabled`            | Enable security context for the pods                                                                | `true`                       |
-| `metrics.podSecurityContext.fsGroup`            | Set Airflow exporter pod's Security Context fsGroup                                                 | `1001`                       |
-| `metrics.containerSecurityContext.enabled`      | Enable Airflow exporter containers' Security Context                                                | `true`                       |
-| `metrics.containerSecurityContext.runAsUser`    | Set Airflow exporter containers' Security Context runAsUser                                         | `1001`                       |
-| `metrics.containerSecurityContext.runAsNonRoot` | Set Airflow exporter containers' Security Context runAsNonRoot                                      | `true`                       |
-| `metrics.lifecycleHooks`                        | for the Airflow exporter container(s) to automate configuration before or after startup             | `{}`                         |
-| `metrics.hostAliases`                           | Airflow exporter pods host aliases                                                                  | `[]`                         |
-| `metrics.podLabels`                             | Extra labels for Airflow exporter pods                                                              | `{}`                         |
-| `metrics.podAnnotations`                        | Extra annotations for Airflow exporter pods                                                         | `{}`                         |
-| `metrics.podAffinityPreset`                     | Pod affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`         | `""`                         |
-| `metrics.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`    | `soft`                       |
-| `metrics.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`   | `""`                         |
-| `metrics.nodeAffinityPreset.key`                | Node label key to match Ignored if `metrics.affinity` is set.                                       | `""`                         |
-| `metrics.nodeAffinityPreset.values`             | Node label values to match. Ignored if `metrics.affinity` is set.                                   | `[]`                         |
-| `metrics.affinity`                              | Affinity for pod assignment                                                                         | `{}`                         |
-| `metrics.nodeSelector`                          | Node labels for pod assignment                                                                      | `{}`                         |
-| `metrics.tolerations`                           | Tolerations for pod assignment                                                                      | `[]`                         |
-| `metrics.schedulerName`                         | Name of the k8s scheduler (other than default) for Airflow exporter                                 | `""`                         |
-| `metrics.service.ports.http`                    | Airflow exporter metrics service port                                                               | `9112`                       |
-| `metrics.service.clusterIP`                     | Static clusterIP or None for headless services                                                      | `""`                         |
-| `metrics.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                    | `None`                       |
-| `metrics.service.annotations`                   | Annotations for the Airflow exporter service                                                        | `{}`                         |
-| `metrics.serviceMonitor.enabled`                | if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.enabled` to be `true`)   | `false`                      |
-| `metrics.serviceMonitor.namespace`              | Namespace in which Prometheus is running                                                            | `""`                         |
-| `metrics.serviceMonitor.interval`               | Interval at which metrics should be scraped                                                         | `""`                         |
-| `metrics.serviceMonitor.scrapeTimeout`          | Timeout after which the scrape is ended                                                             | `""`                         |
-| `metrics.serviceMonitor.labels`                 | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus               | `{}`                         |
-| `metrics.serviceMonitor.selector`               | Prometheus instance selector labels                                                                 | `{}`                         |
-| `metrics.serviceMonitor.relabelings`            | RelabelConfigs to apply to samples before scraping                                                  | `[]`                         |
-| `metrics.serviceMonitor.metricRelabelings`      | MetricRelabelConfigs to apply to samples before ingestion                                           | `[]`                         |
-| `metrics.serviceMonitor.honorLabels`            | Specify honorLabels parameter to add the scrape endpoint                                            | `false`                      |
-| `metrics.serviceMonitor.jobLabel`               | The name of the label on the target service to use as the job name in prometheus.                   | `""`                         |
+| Name                                            | Description                                                                                                      | Value                        |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `metrics.enabled`                               | Whether or not to create a standalone Airflow exporter to expose Airflow metrics                                 | `false`                      |
+| `metrics.image.registry`                        | Airflow exporter image registry                                                                                  | `docker.io`                  |
+| `metrics.image.repository`                      | Airflow exporter image repository                                                                                | `bitnami/airflow-exporter`   |
+| `metrics.image.tag`                             | Airflow exporter image tag (immutable tags are recommended)                                                      | `0.20220314.0-debian-11-r28` |
+| `metrics.image.digest`                          | Airflow exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                         |
+| `metrics.image.pullPolicy`                      | Airflow exporter image pull policy                                                                               | `IfNotPresent`               |
+| `metrics.image.pullSecrets`                     | Airflow exporter image pull secrets                                                                              | `[]`                         |
+| `metrics.extraEnvVars`                          | Array with extra environment variables to add Airflow exporter pods                                              | `[]`                         |
+| `metrics.extraEnvVarsCM`                        | ConfigMap containing extra environment variables for Airflow exporter pods                                       | `""`                         |
+| `metrics.extraEnvVarsSecret`                    | Secret containing extra environment variables (in case of sensitive data) for Airflow exporter pods              | `""`                         |
+| `metrics.containerPorts.http`                   | Airflow exporter metrics container port                                                                          | `9112`                       |
+| `metrics.resources.limits`                      | The resources limits for the container                                                                           | `{}`                         |
+| `metrics.resources.requests`                    | The requested resources for the container                                                                        | `{}`                         |
+| `metrics.podSecurityContext.enabled`            | Enable security context for the pods                                                                             | `true`                       |
+| `metrics.podSecurityContext.fsGroup`            | Set Airflow exporter pod's Security Context fsGroup                                                              | `1001`                       |
+| `metrics.containerSecurityContext.enabled`      | Enable Airflow exporter containers' Security Context                                                             | `true`                       |
+| `metrics.containerSecurityContext.runAsUser`    | Set Airflow exporter containers' Security Context runAsUser                                                      | `1001`                       |
+| `metrics.containerSecurityContext.runAsNonRoot` | Set Airflow exporter containers' Security Context runAsNonRoot                                                   | `true`                       |
+| `metrics.lifecycleHooks`                        | for the Airflow exporter container(s) to automate configuration before or after startup                          | `{}`                         |
+| `metrics.hostAliases`                           | Airflow exporter pods host aliases                                                                               | `[]`                         |
+| `metrics.podLabels`                             | Extra labels for Airflow exporter pods                                                                           | `{}`                         |
+| `metrics.podAnnotations`                        | Extra annotations for Airflow exporter pods                                                                      | `{}`                         |
+| `metrics.podAffinityPreset`                     | Pod affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`                      | `""`                         |
+| `metrics.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`                 | `soft`                       |
+| `metrics.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `metrics.affinity` is set. Allowed values: `soft` or `hard`                | `""`                         |
+| `metrics.nodeAffinityPreset.key`                | Node label key to match Ignored if `metrics.affinity` is set.                                                    | `""`                         |
+| `metrics.nodeAffinityPreset.values`             | Node label values to match. Ignored if `metrics.affinity` is set.                                                | `[]`                         |
+| `metrics.affinity`                              | Affinity for pod assignment                                                                                      | `{}`                         |
+| `metrics.nodeSelector`                          | Node labels for pod assignment                                                                                   | `{}`                         |
+| `metrics.tolerations`                           | Tolerations for pod assignment                                                                                   | `[]`                         |
+| `metrics.schedulerName`                         | Name of the k8s scheduler (other than default) for Airflow exporter                                              | `""`                         |
+| `metrics.service.ports.http`                    | Airflow exporter metrics service port                                                                            | `9112`                       |
+| `metrics.service.clusterIP`                     | Static clusterIP or None for headless services                                                                   | `""`                         |
+| `metrics.service.sessionAffinity`               | Control where client requests go, to the same pod or round-robin                                                 | `None`                       |
+| `metrics.service.annotations`                   | Annotations for the Airflow exporter service                                                                     | `{}`                         |
+| `metrics.serviceMonitor.enabled`                | if `true`, creates a Prometheus Operator ServiceMonitor (requires `metrics.enabled` to be `true`)                | `false`                      |
+| `metrics.serviceMonitor.namespace`              | Namespace in which Prometheus is running                                                                         | `""`                         |
+| `metrics.serviceMonitor.interval`               | Interval at which metrics should be scraped                                                                      | `""`                         |
+| `metrics.serviceMonitor.scrapeTimeout`          | Timeout after which the scrape is ended                                                                          | `""`                         |
+| `metrics.serviceMonitor.labels`                 | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                            | `{}`                         |
+| `metrics.serviceMonitor.selector`               | Prometheus instance selector labels                                                                              | `{}`                         |
+| `metrics.serviceMonitor.relabelings`            | RelabelConfigs to apply to samples before scraping                                                               | `[]`                         |
+| `metrics.serviceMonitor.metricRelabelings`      | MetricRelabelConfigs to apply to samples before ingestion                                                        | `[]`                         |
+| `metrics.serviceMonitor.honorLabels`            | Specify honorLabels parameter to add the scrape endpoint                                                         | `false`                      |
+| `metrics.serviceMonitor.jobLabel`               | The name of the label on the target service to use as the job name in prometheus.                                | `""`                         |
 
 
 ### Airflow database parameters

--- a/bitnami/airflow/values.yaml
+++ b/bitnami/airflow/values.yaml
@@ -111,6 +111,7 @@ dags:
   ## @param dags.image.registry Init container load-dags image registry
   ## @param dags.image.repository Init container load-dags image repository
   ## @param dags.image.tag Init container load-dags image tag (immutable tags are recommended)
+  ## @param dags.image.digest Init container load-dags image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param dags.image.pullPolicy Init container load-dags image pull policy
   ## @param dags.image.pullSecrets Init container load-dags image pull secrets
   ##
@@ -118,6 +119,7 @@ dags:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r26
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -176,6 +178,7 @@ web:
   ## @param web.image.registry Airflow image registry
   ## @param web.image.repository Airflow image repository
   ## @param web.image.tag Airflow image tag (immutable tags are recommended)
+  ## @param web.image.digest Airflow image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param web.image.pullPolicy Airflow image pull policy
   ## @param web.image.pullSecrets Airflow image pull secrets
   ## @param web.image.debug Enable image debug mode
@@ -183,6 +186,7 @@ web:
     registry: docker.io
     repository: bitnami/airflow
     tag: 2.3.3-debian-11-r14
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -431,6 +435,7 @@ scheduler:
   ## @param scheduler.image.registry Airflow Scheduler image registry
   ## @param scheduler.image.repository Airflow Scheduler image repository
   ## @param scheduler.image.tag Airflow Scheduler image tag (immutable tags are recommended)
+  ## @param scheduler.image.digest Airflow Schefuler image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param scheduler.image.pullPolicy Airflow Scheduler image pull policy
   ## @param scheduler.image.pullSecrets Airflow Scheduler image pull secrets
   ## @param scheduler.image.debug Enable image debug mode
@@ -439,6 +444,7 @@ scheduler:
     registry: docker.io
     repository: bitnami/airflow-scheduler
     tag: 2.3.3-debian-11-r14
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -633,6 +639,7 @@ worker:
   ## @param worker.image.registry Airflow Worker image registry
   ## @param worker.image.repository Airflow Worker image repository
   ## @param worker.image.tag Airflow Worker image tag (immutable tags are recommended)
+  ## @param worker.image.digest Airflow Worker image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param worker.image.pullPolicy Airflow Worker image pull policy
   ## @param worker.image.pullSecrets Airflow Worker image pull secrets
   ## @param worker.image.debug Enable image debug mode
@@ -641,6 +648,7 @@ worker:
     registry: docker.io
     repository: bitnami/airflow-worker
     tag: 2.3.3-debian-11-r15
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -905,6 +913,7 @@ git:
   ## @param git.image.registry Git image registry
   ## @param git.image.repository Git image repository
   ## @param git.image.tag Git image tag (immutable tags are recommended)
+  ## @param git.image.digest Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param git.image.pullPolicy Git image pull policy
   ## @param git.image.pullSecrets Git image pull secrets
   ##
@@ -912,6 +921,7 @@ git:
     registry: docker.io
     repository: bitnami/git
     tag: 2.37.2-debian-11-r2
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1266,6 +1276,7 @@ metrics:
   ## @param metrics.image.registry Airflow exporter image registry
   ## @param metrics.image.repository Airflow exporter image repository
   ## @param metrics.image.tag Airflow exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest Airflow exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy Airflow exporter image pull policy
   ## @param metrics.image.pullSecrets Airflow exporter image pull secrets
   ##
@@ -1273,6 +1284,7 @@ metrics:
     registry: docker.io
     repository: bitnami/airflow-exporter
     tag: 0.20220314.0-debian-11-r28
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```