### PR TITLE
[bitnami/apache] Add support for image digest apart from tag

### DIFF
--- a/bitnami/apache/Chart.lock
+++ b/bitnami/apache/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
 digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
-generated: "2022-08-20T10:33:56.131124604Z"
+generated: "2022-08-22T14:24:13.138773856Z"

--- a/bitnami/apache/Chart.lock
+++ b/bitnami/apache/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-30T08:11:22.871449385Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:33:56.131124604Z"

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Apache HTTP Server is an open-source HTTP server. The goal of this project is to provide a secure, efficient and extensible server that provides HTTP services in sync with the current HTTP standards.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/apache
@@ -26,4 +26,4 @@ name: apache
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/apache
   - https://httpd.apache.org
-version: 9.1.18
+version: 9.2.0

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -82,13 +82,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
 | `image.registry`                        | Apache image registry                                                                                                    | `docker.io`            |
 | `image.repository`                      | Apache image repository                                                                                                  | `bitnami/apache`       |
-| `image.tag`                             | Apache image tag (immutable tags are recommended)                                                                        | `2.4.54-debian-11-r10` |
+| `image.tag`                             | Apache image tag (immutable tags are recommended)                                                                        | `2.4.54-debian-11-r23` |
+| `image.digest`                          | Apache image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                   | `""`                   |
 | `image.pullPolicy`                      | Apache image pull policy                                                                                                 | `IfNotPresent`         |
 | `image.pullSecrets`                     | Apache image pull secrets                                                                                                | `[]`                   |
 | `image.debug`                           | Enable image debug mode                                                                                                  | `false`                |
 | `git.registry`                          | Git image registry                                                                                                       | `docker.io`            |
 | `git.repository`                        | Git image name                                                                                                           | `bitnami/git`          |
-| `git.tag`                               | Git image tag                                                                                                            | `2.37.0-debian-11-r2`  |
+| `git.tag`                               | Git image tag (immutable tags are recommended)                                                                           | `2.37.1-debian-11-r11` |
+| `git.digest`                            | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                      | `""`                   |
 | `git.pullPolicy`                        | Git image pull policy                                                                                                    | `IfNotPresent`         |
 | `git.pullSecrets`                       | Specify docker-registry secret names as an array                                                                         | `[]`                   |
 | `replicaCount`                          | Number of replicas of the Apache deployment                                                                              | `1`                    |
@@ -222,7 +224,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                          | Start a sidecar prometheus exporter to expose Apache metrics                                                                              | `false`                   |
 | `metrics.image.registry`                   | Apache Exporter image registry                                                                                                            | `docker.io`               |
 | `metrics.image.repository`                 | Apache Exporter image repository                                                                                                          | `bitnami/apache-exporter` |
-| `metrics.image.tag`                        | Apache Exporter image tag (immutable tags are recommended)                                                                                | `0.11.0-debian-11-r11`    |
+| `metrics.image.tag`                        | Apache Exporter image tag (immutable tags are recommended)                                                                                | `0.11.0-debian-11-r28`    |
+| `metrics.image.digest`                     | Apache Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                           | `""`                      |
 | `metrics.image.pullPolicy`                 | Apache Exporter image pull policy                                                                                                         | `IfNotPresent`            |
 | `metrics.image.pullSecrets`                | Apache Exporter image pull secrets                                                                                                        | `[]`                      |
 | `metrics.image.debug`                      | Apache Exporter image debug mode                                                                                                          | `false`                   |

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -44,6 +44,7 @@ extraDeploy: []
 ## @param image.registry Apache image registry
 ## @param image.repository Apache image repository
 ## @param image.tag Apache image tag (immutable tags are recommended)
+## @param image.digest Apache image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Apache image pull policy
 ## @param image.pullSecrets Apache image pull secrets
 ## @param image.debug Enable image debug mode
@@ -52,6 +53,7 @@ image:
   registry: docker.io
   repository: bitnami/apache
   tag: 2.4.54-debian-11-r23
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -72,7 +74,8 @@ image:
 ## ref: https://hub.docker.com/r/bitnami/git/tags/
 ## @param git.registry Git image registry
 ## @param git.repository Git image name
-## @param git.tag Git image tag
+## @param git.tag Git image tag (immutable tags are recommended)
+## @param git.digest Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param git.pullPolicy Git image pull policy
 ## @param git.pullSecrets Specify docker-registry secret names as an array
 ##
@@ -80,6 +83,7 @@ git:
   registry: docker.io
   repository: bitnami/git
   tag: 2.37.1-debian-11-r11
+  digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -567,7 +571,7 @@ ingress:
   ## - host: apache.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: apache-svc
   ##           port:
@@ -586,6 +590,7 @@ metrics:
   ## @param metrics.image.registry Apache Exporter image registry
   ## @param metrics.image.repository Apache Exporter image repository
   ## @param metrics.image.tag Apache Exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest Apache Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy Apache Exporter image pull policy
   ## @param metrics.image.pullSecrets Apache Exporter image pull secrets
   ## @param metrics.image.debug Apache Exporter image debug mode
@@ -594,6 +599,7 @@ metrics:
     registry: docker.io
     repository: bitnami/apache-exporter
     tag: 0.11.0-debian-11-r28
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```