### PR TITLE
[bitnami/contour] Add support for image digest apart from tag

### DIFF
--- a/bitnami/contour/Chart.lock
+++ b/bitnami/contour/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-26T17:29:17.747963281Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:56:47.897708449Z"

--- a/bitnami/contour/Chart.lock
+++ b/bitnami/contour/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
 digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
-generated: "2022-08-20T10:56:47.897708449Z"
+generated: "2022-08-22T14:24:32.397485759Z"

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Contour is an open source Kubernetes ingress controller that works by deploying the Envoy proxy as a reverse proxy and load balancer.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/contour
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/containers/tree/main/bitnami/contour
   - https://projectcontour.io
-version: 9.0.3
+version: 9.1.0

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -93,6 +93,7 @@ $ helm uninstall my-release
 | `contour.image.registry`                                      | Contour image registry                                                                                                             | `docker.io`           |
 | `contour.image.repository`                                    | Contour image name                                                                                                                 | `bitnami/contour`     |
 | `contour.image.tag`                                           | Contour image tag                                                                                                                  | `1.22.0-debian-11-r4` |
+| `contour.image.digest`                                        | Contour image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                            | `""`                  |
 | `contour.image.pullPolicy`                                    | Contour Image pull policy                                                                                                          | `IfNotPresent`        |
 | `contour.image.pullSecrets`                                   | Contour Image pull secrets                                                                                                         | `[]`                  |
 | `contour.image.debug`                                         | Enable image debug mode                                                                                                            | `false`               |
@@ -193,6 +194,7 @@ $ helm uninstall my-release
 | `envoy.image.registry`                              | Envoy Proxy image registry                                                                                            | `docker.io`           |
 | `envoy.image.repository`                            | Envoy Proxy image repository                                                                                          | `bitnami/envoy`       |
 | `envoy.image.tag`                                   | Envoy Proxy image tag (immutable tags are recommended)                                                                | `1.23.0-debian-11-r8` |
+| `envoy.image.digest`                                | Envoy Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag           | `""`                  |
 | `envoy.image.pullPolicy`                            | Envoy image pull policy                                                                                               | `IfNotPresent`        |
 | `envoy.image.pullSecrets`                           | Envoy image pull secrets                                                                                              | `[]`                  |
 | `envoy.priorityClassName`                           | Priority class assigned to the pods                                                                                   | `""`                  |
@@ -300,95 +302,96 @@ $ helm uninstall my-release
 
 ### Default backend parameters
 
-| Name                                                   | Description                                                                                          | Value                    |
-| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------ |
-| `defaultBackend.enabled`                               | Enable a default backend based on NGINX                                                              | `false`                  |
-| `defaultBackend.image.registry`                        | Default backend image registry                                                                       | `docker.io`              |
-| `defaultBackend.image.repository`                      | Default backend image name                                                                           | `bitnami/nginx`          |
-| `defaultBackend.image.tag`                             | Default backend image tag                                                                            | `1.23.1-debian-11-r7`   |
-| `defaultBackend.image.pullPolicy`                      | Image pull policy                                                                                    | `IfNotPresent`           |
-| `defaultBackend.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                     | `[]`                     |
-| `defaultBackend.extraArgs`                             | Additional command line arguments to pass to NGINX container                                         | `{}`                     |
-| `defaultBackend.lifecycleHooks`                        | lifecycleHooks for the container to automate configuration before or after startup.                  | `{}`                     |
-| `defaultBackend.extraEnvVars`                          | Array containing extra env vars to be added to all Contour containers                                | `[]`                     |
-| `defaultBackend.extraEnvVarsCM`                        | ConfigMap containing extra env vars to be added to all Contour containers                            | `""`                     |
-| `defaultBackend.extraEnvVarsSecret`                    | Secret containing extra env vars to be added to all Contour containers                               | `""`                     |
-| `defaultBackend.extraVolumes`                          | Array to add extra volumes                                                                           | `[]`                     |
-| `defaultBackend.extraVolumeMounts`                     | Array to add extra mounts (normally used with extraVolumes)                                          | `[]`                     |
-| `defaultBackend.initContainers`                        | Attach additional init containers to the http backend pods                                           | `[]`                     |
-| `defaultBackend.sidecars`                              | Add additional sidecar containers to the default backend                                             | `[]`                     |
-| `defaultBackend.containerPorts.http`                   | Set http port inside Contour pod                                                                     | `8001`                   |
-| `defaultBackend.updateStrategy`                        | Strategy to use to update Pods                                                                       | `{}`                     |
-| `defaultBackend.command`                               | Override default command                                                                             | `[]`                     |
-| `defaultBackend.args`                                  | Override default args                                                                                | `[]`                     |
-| `defaultBackend.hostAliases`                           | Add deployment host aliases                                                                          | `[]`                     |
-| `defaultBackend.replicaCount`                          | Desired number of default backend pods                                                               | `1`                      |
-| `defaultBackend.podSecurityContext.enabled`            | Default backend Pod securityContext                                                                  | `true`                   |
-| `defaultBackend.podSecurityContext.fsGroup`            | Set Default backend Pod's Security Context fsGroup                                                   | `1001`                   |
-| `defaultBackend.containerSecurityContext.enabled`      | Default backend container securityContext                                                            | `true`                   |
-| `defaultBackend.containerSecurityContext.runAsUser`    | User ID for the Envoy container (to change this, http and https containerPorts must be set to >1024) | `1001`                   |
-| `defaultBackend.containerSecurityContext.runAsNonRoot` | Run as non root                                                                                      | `true`                   |
-| `defaultBackend.resources.limits`                      | The resources limits for the Default backend container                                               | `{}`                     |
-| `defaultBackend.resources.requests`                    | The requested resources for the Default backend container                                            | `{}`                     |
-| `defaultBackend.livenessProbe.enabled`                 | Enable livenessProbe                                                                                 | `true`                   |
-| `defaultBackend.livenessProbe.httpGet`                 | Path, port and scheme for the livenessProbe                                                          | `{}`                     |
-| `defaultBackend.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                              | `30`                     |
-| `defaultBackend.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                     | `10`                     |
-| `defaultBackend.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                    | `5`                      |
-| `defaultBackend.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                  | `3`                      |
-| `defaultBackend.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                  | `1`                      |
-| `defaultBackend.readinessProbe.enabled`                | Enable readinessProbe                                                                                | `true`                   |
-| `defaultBackend.readinessProbe.httpGet`                | Path, port and scheme for the readinessProbe                                                         | `{}`                     |
-| `defaultBackend.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                             | `0`                      |
-| `defaultBackend.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                    | `5`                      |
-| `defaultBackend.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                   | `5`                      |
-| `defaultBackend.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                 | `6`                      |
-| `defaultBackend.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                 | `1`                      |
-| `defaultBackend.startupProbe.enabled`                  | Enable/disable the startup probe                                                                     | `false`                  |
-| `defaultBackend.startupProbe.initialDelaySeconds`      | Delay before startup probe is initiated                                                              | `15`                     |
-| `defaultBackend.startupProbe.periodSeconds`            | How often to perform the probe                                                                       | `10`                     |
-| `defaultBackend.startupProbe.timeoutSeconds`           | When the probe times out                                                                             | `5`                      |
-| `defaultBackend.startupProbe.failureThreshold`         | Minimum consecutive failures for the probe to be considered failed after having succeeded.           | `3`                      |
-| `defaultBackend.startupProbe.successThreshold`         | Minimum consecutive successes for the probe to be considered successful after having failed.         | `1`                      |
-| `defaultBackend.customLivenessProbe`                   | Override default liveness probe, it overrides the default one (evaluated as a template)              | `{}`                     |
-| `defaultBackend.customReadinessProbe`                  | Override default readiness probe, it overrides the default one (evaluated as a template)             | `{}`                     |
-| `defaultBackend.customStartupProbe`                    | Override default startup probe                                                                       | `{}`                     |
-| `defaultBackend.podLabels`                             | Extra labels for Controller pods                                                                     | `{}`                     |
-| `defaultBackend.podAnnotations`                        | Annotations for Controller pods                                                                      | `{}`                     |
-| `defaultBackend.priorityClassName`                     | Priority class assigned to the pods                                                                  | `""`                     |
-| `defaultBackend.schedulerName`                         | Name of the k8s scheduler (other than default)                                                       | `""`                     |
-| `defaultBackend.terminationGracePeriodSeconds`         | In seconds, time the given to the default backend pod needs to terminate gracefully                  | `60`                     |
-| `defaultBackend.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                       | `[]`                     |
-| `defaultBackend.podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                  | `""`                     |
-| `defaultBackend.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`             | `soft`                   |
-| `defaultBackend.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`            | `""`                     |
-| `defaultBackend.nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                               | `""`                     |
-| `defaultBackend.nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                            | `[]`                     |
-| `defaultBackend.affinity`                              | Affinity for pod assignment. Evaluated as a template.                                                | `{}`                     |
-| `defaultBackend.nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                             | `{}`                     |
-| `defaultBackend.tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                             | `[]`                     |
-| `defaultBackend.service.type`                          | Service type                                                                                         | `ClusterIP`              |
-| `defaultBackend.service.ports.http`                    | Service port                                                                                         | `80`                     |
-| `defaultBackend.service.annotations`                   | Annotations to add to the service                                                                    | `{}`                     |
-| `defaultBackend.pdb.create`                            | Enable Pod Disruption Budget configuration                                                           | `false`                  |
-| `defaultBackend.pdb.minAvailable`                      | Minimum number/percentage of Default backend pods that should remain scheduled                       | `1`                      |
-| `defaultBackend.pdb.maxUnavailable`                    | Maximum number/percentage of Default backend pods that should remain scheduled                       | `""`                     |
-| `ingress.enabled`                                      | Ingress configuration enabled                                                                        | `false`                  |
-| `ingress.apiVersion`                                   | Force Ingress API version (automatically detected if not set)                                        | `""`                     |
-| `ingress.certManager`                                  | Add annotations for cert-manager                                                                     | `false`                  |
-| `ingress.annotations`                                  | Annotations to be added to the web ingress.                                                          | `{}`                     |
-| `ingress.hostname`                                     | Hostname for the Ingress object                                                                      | `contour.local`          |
-| `ingress.path`                                         | The Path to Concourse                                                                                | `/`                      |
-| `ingress.rulesOverride`                                | Ingress rules override                                                                               | `[]`                     |
-| `ingress.selfSigned`                                   | Create a TLS secret for this ingress record using self-signed certificates generated by Helm         | `false`                  |
-| `ingress.ingressClassName`                             | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                        | `""`                     |
-| `ingress.extraPaths`                                   | Add additional arbitrary paths that may need to be added to the ingress under the main host.         | `[]`                     |
-| `ingress.tls`                                          | TLS configuration.                                                                                   | `false`                  |
-| `ingress.pathType`                                     | Ingress Path type                                                                                    | `ImplementationSpecific` |
-| `ingress.extraHosts`                                   | The list of additional hostnames to be covered with this ingress record.                             | `[]`                     |
-| `ingress.extraTls`                                     | The tls configuration for additional hostnames to be covered with this ingress record.               | `[]`                     |
-| `ingress.secrets`                                      | If you're providing your own certificates, please use this to add the certificates as secrets        | `[]`                     |
-| `ingress.extraRules`                                   | Additional rules to be covered with this ingress record                                              | `[]`                     |
+| Name                                                   | Description                                                                                                     | Value                    |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `defaultBackend.enabled`                               | Enable a default backend based on NGINX                                                                         | `false`                  |
+| `defaultBackend.image.registry`                        | Default backend image registry                                                                                  | `docker.io`              |
+| `defaultBackend.image.repository`                      | Default backend image name                                                                                      | `bitnami/nginx`          |
+| `defaultBackend.image.tag`                             | Default backend image tag                                                                                       | `1.23.1-debian-11-r7`    |
+| `defaultBackend.image.digest`                          | Default backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
+| `defaultBackend.image.pullPolicy`                      | Image pull policy                                                                                               | `IfNotPresent`           |
+| `defaultBackend.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                | `[]`                     |
+| `defaultBackend.extraArgs`                             | Additional command line arguments to pass to NGINX container                                                    | `{}`                     |
+| `defaultBackend.lifecycleHooks`                        | lifecycleHooks for the container to automate configuration before or after startup.                             | `{}`                     |
+| `defaultBackend.extraEnvVars`                          | Array containing extra env vars to be added to all Contour containers                                           | `[]`                     |
+| `defaultBackend.extraEnvVarsCM`                        | ConfigMap containing extra env vars to be added to all Contour containers                                       | `""`                     |
+| `defaultBackend.extraEnvVarsSecret`                    | Secret containing extra env vars to be added to all Contour containers                                          | `""`                     |
+| `defaultBackend.extraVolumes`                          | Array to add extra volumes                                                                                      | `[]`                     |
+| `defaultBackend.extraVolumeMounts`                     | Array to add extra mounts (normally used with extraVolumes)                                                     | `[]`                     |
+| `defaultBackend.initContainers`                        | Attach additional init containers to the http backend pods                                                      | `[]`                     |
+| `defaultBackend.sidecars`                              | Add additional sidecar containers to the default backend                                                        | `[]`                     |
+| `defaultBackend.containerPorts.http`                   | Set http port inside Contour pod                                                                                | `8001`                   |
+| `defaultBackend.updateStrategy`                        | Strategy to use to update Pods                                                                                  | `{}`                     |
+| `defaultBackend.command`                               | Override default command                                                                                        | `[]`                     |
+| `defaultBackend.args`                                  | Override default args                                                                                           | `[]`                     |
+| `defaultBackend.hostAliases`                           | Add deployment host aliases                                                                                     | `[]`                     |
+| `defaultBackend.replicaCount`                          | Desired number of default backend pods                                                                          | `1`                      |
+| `defaultBackend.podSecurityContext.enabled`            | Default backend Pod securityContext                                                                             | `true`                   |
+| `defaultBackend.podSecurityContext.fsGroup`            | Set Default backend Pod's Security Context fsGroup                                                              | `1001`                   |
+| `defaultBackend.containerSecurityContext.enabled`      | Default backend container securityContext                                                                       | `true`                   |
+| `defaultBackend.containerSecurityContext.runAsUser`    | User ID for the Envoy container (to change this, http and https containerPorts must be set to >1024)            | `1001`                   |
+| `defaultBackend.containerSecurityContext.runAsNonRoot` | Run as non root                                                                                                 | `true`                   |
+| `defaultBackend.resources.limits`                      | The resources limits for the Default backend container                                                          | `{}`                     |
+| `defaultBackend.resources.requests`                    | The requested resources for the Default backend container                                                       | `{}`                     |
+| `defaultBackend.livenessProbe.enabled`                 | Enable livenessProbe                                                                                            | `true`                   |
+| `defaultBackend.livenessProbe.httpGet`                 | Path, port and scheme for the livenessProbe                                                                     | `{}`                     |
+| `defaultBackend.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                         | `30`                     |
+| `defaultBackend.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                | `10`                     |
+| `defaultBackend.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                               | `5`                      |
+| `defaultBackend.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                             | `3`                      |
+| `defaultBackend.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                             | `1`                      |
+| `defaultBackend.readinessProbe.enabled`                | Enable readinessProbe                                                                                           | `true`                   |
+| `defaultBackend.readinessProbe.httpGet`                | Path, port and scheme for the readinessProbe                                                                    | `{}`                     |
+| `defaultBackend.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                        | `0`                      |
+| `defaultBackend.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                               | `5`                      |
+| `defaultBackend.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                              | `5`                      |
+| `defaultBackend.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                            | `6`                      |
+| `defaultBackend.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                            | `1`                      |
+| `defaultBackend.startupProbe.enabled`                  | Enable/disable the startup probe                                                                                | `false`                  |
+| `defaultBackend.startupProbe.initialDelaySeconds`      | Delay before startup probe is initiated                                                                         | `15`                     |
+| `defaultBackend.startupProbe.periodSeconds`            | How often to perform the probe                                                                                  | `10`                     |
+| `defaultBackend.startupProbe.timeoutSeconds`           | When the probe times out                                                                                        | `5`                      |
+| `defaultBackend.startupProbe.failureThreshold`         | Minimum consecutive failures for the probe to be considered failed after having succeeded.                      | `3`                      |
+| `defaultBackend.startupProbe.successThreshold`         | Minimum consecutive successes for the probe to be considered successful after having failed.                    | `1`                      |
+| `defaultBackend.customLivenessProbe`                   | Override default liveness probe, it overrides the default one (evaluated as a template)                         | `{}`                     |
+| `defaultBackend.customReadinessProbe`                  | Override default readiness probe, it overrides the default one (evaluated as a template)                        | `{}`                     |
+| `defaultBackend.customStartupProbe`                    | Override default startup probe                                                                                  | `{}`                     |
+| `defaultBackend.podLabels`                             | Extra labels for Controller pods                                                                                | `{}`                     |
+| `defaultBackend.podAnnotations`                        | Annotations for Controller pods                                                                                 | `{}`                     |
+| `defaultBackend.priorityClassName`                     | Priority class assigned to the pods                                                                             | `""`                     |
+| `defaultBackend.schedulerName`                         | Name of the k8s scheduler (other than default)                                                                  | `""`                     |
+| `defaultBackend.terminationGracePeriodSeconds`         | In seconds, time the given to the default backend pod needs to terminate gracefully                             | `60`                     |
+| `defaultBackend.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                  | `[]`                     |
+| `defaultBackend.podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                     |
+| `defaultBackend.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `soft`                   |
+| `defaultBackend.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                       | `""`                     |
+| `defaultBackend.nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                                          | `""`                     |
+| `defaultBackend.nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                       | `[]`                     |
+| `defaultBackend.affinity`                              | Affinity for pod assignment. Evaluated as a template.                                                           | `{}`                     |
+| `defaultBackend.nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                                        | `{}`                     |
+| `defaultBackend.tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                                        | `[]`                     |
+| `defaultBackend.service.type`                          | Service type                                                                                                    | `ClusterIP`              |
+| `defaultBackend.service.ports.http`                    | Service port                                                                                                    | `80`                     |
+| `defaultBackend.service.annotations`                   | Annotations to add to the service                                                                               | `{}`                     |
+| `defaultBackend.pdb.create`                            | Enable Pod Disruption Budget configuration                                                                      | `false`                  |
+| `defaultBackend.pdb.minAvailable`                      | Minimum number/percentage of Default backend pods that should remain scheduled                                  | `1`                      |
+| `defaultBackend.pdb.maxUnavailable`                    | Maximum number/percentage of Default backend pods that should remain scheduled                                  | `""`                     |
+| `ingress.enabled`                                      | Ingress configuration enabled                                                                                   | `false`                  |
+| `ingress.apiVersion`                                   | Force Ingress API version (automatically detected if not set)                                                   | `""`                     |
+| `ingress.certManager`                                  | Add annotations for cert-manager                                                                                | `false`                  |
+| `ingress.annotations`                                  | Annotations to be added to the web ingress.                                                                     | `{}`                     |
+| `ingress.hostname`                                     | Hostname for the Ingress object                                                                                 | `contour.local`          |
+| `ingress.path`                                         | The Path to Concourse                                                                                           | `/`                      |
+| `ingress.rulesOverride`                                | Ingress rules override                                                                                          | `[]`                     |
+| `ingress.selfSigned`                                   | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                    | `false`                  |
+| `ingress.ingressClassName`                             | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                   | `""`                     |
+| `ingress.extraPaths`                                   | Add additional arbitrary paths that may need to be added to the ingress under the main host.                    | `[]`                     |
+| `ingress.tls`                                          | TLS configuration.                                                                                              | `false`                  |
+| `ingress.pathType`                                     | Ingress Path type                                                                                               | `ImplementationSpecific` |
+| `ingress.extraHosts`                                   | The list of additional hostnames to be covered with this ingress record.                                        | `[]`                     |
+| `ingress.extraTls`                                     | The tls configuration for additional hostnames to be covered with this ingress record.                          | `[]`                     |
+| `ingress.secrets`                                      | If you're providing your own certificates, please use this to add the certificates as secrets                   | `[]`                     |
+| `ingress.extraRules`                                   | Additional rules to be covered with this ingress record                                                         | `[]`                     |
 
 
 ### Metrics parameters

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -85,6 +85,7 @@ contour:
   ## @param contour.image.registry Contour image registry
   ## @param contour.image.repository Contour image name
   ## @param contour.image.tag Contour image tag
+  ## @param contour.image.digest Contour image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param contour.image.pullPolicy Contour Image pull policy
   ## @param contour.image.pullSecrets [array] Contour Image pull secrets
   ## @param contour.image.debug Enable image debug mode
@@ -93,6 +94,7 @@ contour:
     registry: docker.io
     repository: bitnami/contour
     tag: 1.22.0-debian-11-r4
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -459,6 +461,7 @@ envoy:
   ## @param envoy.image.registry Envoy Proxy image registry
   ## @param envoy.image.repository Envoy Proxy image repository
   ## @param envoy.image.tag Envoy Proxy image tag (immutable tags are recommended)
+  ## @param envoy.image.digest Envoy Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param envoy.image.pullPolicy Envoy image pull policy
   ## @param envoy.image.pullSecrets [array] Envoy image pull secrets
   ##
@@ -466,6 +469,7 @@ envoy:
     registry: docker.io
     repository: bitnami/envoy
     tag: 1.23.0-debian-11-r8
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -876,6 +880,7 @@ defaultBackend:
   ## @param defaultBackend.image.registry Default backend image registry
   ## @param defaultBackend.image.repository Default backend image name
   ## @param defaultBackend.image.tag Default backend image tag
+  ## @param defaultBackend.image.digest Default backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param defaultBackend.image.pullPolicy Image pull policy
   ## @param defaultBackend.image.pullSecrets [array] Specify docker-registry secret names as an array
   ##
@@ -883,6 +888,7 @@ defaultBackend:
     registry: docker.io
     repository: bitnami/nginx
     tag: 1.23.1-debian-11-r7
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```