### PR TITLE
[bitnami/aspnet-core] Add support for image digest apart from tag

### DIFF
--- a/bitnami/aspnet-core/Chart.lock
+++ b/bitnami/aspnet-core/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-26T00:35:44.869815506Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:56:31.780590338Z"

--- a/bitnami/aspnet-core/Chart.lock
+++ b/bitnami/aspnet-core/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
 digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
-generated: "2022-08-20T10:56:31.780590338Z"
+generated: "2022-08-22T14:24:17.724354922Z"

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: ASP.NET Core is an open-source framework for web application development created by Microsoft. It runs on both the full .NET Framework, on Windows, and the cross-platform .NET Core.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/aspnet-core
@@ -22,4 +22,4 @@ name: aspnet-core
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/aspnet-core
   - https://dotnet.microsoft.com/apps/aspnet
-version: 3.4.21
+version: 3.5.0

--- a/bitnami/aspnet-core/README.md
+++ b/bitnami/aspnet-core/README.md
@@ -78,20 +78,21 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### ASP.NET Core parameters
 
-| Name                 | Description                                                          | Value                 |
-| -------------------- | -------------------------------------------------------------------- | --------------------- |
-| `image.registry`     | ASP.NET Core image registry                                          | `docker.io`           |
-| `image.repository`   | ASP.NET Core image repository                                        | `bitnami/aspnet-core` |
-| `image.tag`          | ASP.NET Core image tag (immutable tags are recommended)              | `6.0.7-debian-11-r0`  |
-| `image.pullPolicy`   | ASP.NET Core image pull policy                                       | `IfNotPresent`        |
-| `image.pullSecrets`  | ASP.NET Core image pull secrets                                      | `[]`                  |
-| `image.debug`        | Enable image debug mode                                              | `false`               |
-| `command`            | Override default container command (useful when using custom images) | `[]`                  |
-| `args`               | Override default container args (useful when using custom images)    | `[]`                  |
-| `bindURLs`           | URLs to bind                                                         | `http://+:8080`       |
-| `extraEnvVars`       | Extra environment variables to be set on ASP.NET Core container      | `[]`                  |
-| `extraEnvVarsCM`     | ConfigMap with extra environment variables                           | `""`                  |
-| `extraEnvVarsSecret` | Secret with extra environment variables                              | `""`                  |
+| Name                 | Description                                                                                                  | Value                 |
+| -------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------- |
+| `image.registry`     | ASP.NET Core image registry                                                                                  | `docker.io`           |
+| `image.repository`   | ASP.NET Core image repository                                                                                | `bitnami/aspnet-core` |
+| `image.tag`          | ASP.NET Core image tag (immutable tags are recommended)                                                      | `6.0.8-debian-11-r1`  |
+| `image.digest`       | ASP.NET Core image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `image.pullPolicy`   | ASP.NET Core image pull policy                                                                               | `IfNotPresent`        |
+| `image.pullSecrets`  | ASP.NET Core image pull secrets                                                                              | `[]`                  |
+| `image.debug`        | Enable image debug mode                                                                                      | `false`               |
+| `command`            | Override default container command (useful when using custom images)                                         | `[]`                  |
+| `args`               | Override default container args (useful when using custom images)                                            | `[]`                  |
+| `bindURLs`           | URLs to bind                                                                                                 | `http://+:8080`       |
+| `extraEnvVars`       | Extra environment variables to be set on ASP.NET Core container                                              | `[]`                  |
+| `extraEnvVarsCM`     | ConfigMap with extra environment variables                                                                   | `""`                  |
+| `extraEnvVarsSecret` | Secret with extra environment variables                                                                      | `""`                  |
 
 
 ### ASP.NET Core deployment parameters
@@ -161,27 +162,29 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Custom ASP.NET Core application parameters
 
-| Name                                            | Description                                                            | Value                                                               |
-| ----------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `appFromExternalRepo.enabled`                   | Enable to download/build ASP.NET Core app from external git repository | `true`                                                              |
-| `appFromExternalRepo.clone.image.registry`      | Git image registry                                                     | `docker.io`                                                         |
-| `appFromExternalRepo.clone.image.repository`    | Git image repository                                                   | `bitnami/git`                                                       |
-| `appFromExternalRepo.clone.image.tag`           | Git image tag (immutable tags are recommended)                         | `2.37.1-debian-11-r0`                                               |
-| `appFromExternalRepo.clone.image.pullPolicy`    | Git image pull policy                                                  | `IfNotPresent`                                                      |
-| `appFromExternalRepo.clone.image.pullSecrets`   | Git image pull secrets                                                 | `[]`                                                                |
-| `appFromExternalRepo.clone.repository`          | Git repository to clone                                                | `https://github.com/dotnet/AspNetCore.Docs.git`                     |
-| `appFromExternalRepo.clone.revision`            | Git revision to checkout                                               | `main`                                                              |
-| `appFromExternalRepo.clone.extraVolumeMounts`   | Add extra volume mounts for the GIT container                          | `[]`                                                                |
-| `appFromExternalRepo.publish.image.registry`    | .NET SDK image registry                                                | `docker.io`                                                         |
-| `appFromExternalRepo.publish.image.repository`  | .NET SDK image repository                                              | `bitnami/dotnet-sdk`                                                |
-| `appFromExternalRepo.publish.image.tag`         | .NET SDK image tag (immutable tags are recommended)                    | `6.0.301-debian-11-r9`                                              |
-| `appFromExternalRepo.publish.image.pullPolicy`  | .NET SDK image pull policy                                             | `IfNotPresent`                                                      |
-| `appFromExternalRepo.publish.image.pullSecrets` | .NET SDK image pull secrets                                            | `[]`                                                                |
-| `appFromExternalRepo.publish.subFolder`         | Sub folder under the Git repository containing the ASP.NET Core app    | `aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample` |
-| `appFromExternalRepo.publish.extraFlags`        | Extra flags to be appended to "dotnet publish" command                 | `[]`                                                                |
-| `appFromExternalRepo.startCommand`              | Command used to start ASP.NET Core app                                 | `["dotnet","KestrelSample.dll"]`                                    |
-| `appFromExistingPVC.enabled`                    | Enable mounting your ASP.NET Core app from an existing PVC             | `false`                                                             |
-| `appFromExistingPVC.existingClaim`              | A existing Persistent Volume Claim containing your ASP.NET Core app    | `""`                                                                |
+| Name                                            | Description                                                                                              | Value                                                               |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `appFromExternalRepo.enabled`                   | Enable to download/build ASP.NET Core app from external git repository                                   | `true`                                                              |
+| `appFromExternalRepo.clone.image.registry`      | Git image registry                                                                                       | `docker.io`                                                         |
+| `appFromExternalRepo.clone.image.repository`    | Git image repository                                                                                     | `bitnami/git`                                                       |
+| `appFromExternalRepo.clone.image.tag`           | Git image tag (immutable tags are recommended)                                                           | `2.37.1-debian-11-r11`                                              |
+| `appFromExternalRepo.clone.image.digest`        | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag      | `""`                                                                |
+| `appFromExternalRepo.clone.image.pullPolicy`    | Git image pull policy                                                                                    | `IfNotPresent`                                                      |
+| `appFromExternalRepo.clone.image.pullSecrets`   | Git image pull secrets                                                                                   | `[]`                                                                |
+| `appFromExternalRepo.clone.repository`          | Git repository to clone                                                                                  | `https://github.com/dotnet/AspNetCore.Docs.git`                     |
+| `appFromExternalRepo.clone.revision`            | Git revision to checkout                                                                                 | `main`                                                              |
+| `appFromExternalRepo.clone.extraVolumeMounts`   | Add extra volume mounts for the GIT container                                                            | `[]`                                                                |
+| `appFromExternalRepo.publish.image.registry`    | .NET SDK image registry                                                                                  | `docker.io`                                                         |
+| `appFromExternalRepo.publish.image.repository`  | .NET SDK image repository                                                                                | `bitnami/dotnet-sdk`                                                |
+| `appFromExternalRepo.publish.image.tag`         | .NET SDK image tag (immutable tags are recommended)                                                      | `6.0.400-debian-11-r0`                                              |
+| `appFromExternalRepo.publish.image.digest`      | .NET SDK image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                                                |
+| `appFromExternalRepo.publish.image.pullPolicy`  | .NET SDK image pull policy                                                                               | `IfNotPresent`                                                      |
+| `appFromExternalRepo.publish.image.pullSecrets` | .NET SDK image pull secrets                                                                              | `[]`                                                                |
+| `appFromExternalRepo.publish.subFolder`         | Sub folder under the Git repository containing the ASP.NET Core app                                      | `aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample` |
+| `appFromExternalRepo.publish.extraFlags`        | Extra flags to be appended to "dotnet publish" command                                                   | `[]`                                                                |
+| `appFromExternalRepo.startCommand`              | Command used to start ASP.NET Core app                                                                   | `["dotnet","KestrelSample.dll"]`                                    |
+| `appFromExistingPVC.enabled`                    | Enable mounting your ASP.NET Core app from an existing PVC                                               | `false`                                                             |
+| `appFromExistingPVC.existingClaim`              | A existing Persistent Volume Claim containing your ASP.NET Core app                                      | `""`                                                                |
 
 
 ### Traffic Exposure Parameters

--- a/bitnami/aspnet-core/values.yaml
+++ b/bitnami/aspnet-core/values.yaml
@@ -53,6 +53,7 @@ extraDeploy: []
 ## @param image.registry ASP.NET Core image registry
 ## @param image.repository ASP.NET Core image repository
 ## @param image.tag ASP.NET Core image tag (immutable tags are recommended)
+## @param image.digest ASP.NET Core image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy ASP.NET Core image pull policy
 ## @param image.pullSecrets ASP.NET Core image pull secrets
 ## @param image.debug Enable image debug mode
@@ -61,6 +62,7 @@ image:
   registry: docker.io
   repository: bitnami/aspnet-core
   tag: 6.0.8-debian-11-r1
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -364,6 +366,7 @@ appFromExternalRepo:
     ## @param appFromExternalRepo.clone.image.registry Git image registry
     ## @param appFromExternalRepo.clone.image.repository Git image repository
     ## @param appFromExternalRepo.clone.image.tag Git image tag (immutable tags are recommended)
+    ## @param appFromExternalRepo.clone.image.digest Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param appFromExternalRepo.clone.image.pullPolicy Git image pull policy
     ## @param appFromExternalRepo.clone.image.pullSecrets Git image pull secrets
     ##
@@ -371,6 +374,7 @@ appFromExternalRepo:
       registry: docker.io
       repository: bitnami/git
       tag: 2.37.1-debian-11-r11
+      digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -404,6 +408,7 @@ appFromExternalRepo:
     ## @param appFromExternalRepo.publish.image.registry .NET SDK image registry
     ## @param appFromExternalRepo.publish.image.repository .NET SDK image repository
     ## @param appFromExternalRepo.publish.image.tag .NET SDK image tag (immutable tags are recommended)
+    ## @param appFromExternalRepo.publish.image.digest .NET SDK image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param appFromExternalRepo.publish.image.pullPolicy .NET SDK image pull policy
     ## @param appFromExternalRepo.publish.image.pullSecrets .NET SDK image pull secrets
     ##
@@ -411,6 +416,7 @@ appFromExternalRepo:
       registry: docker.io
       repository: bitnami/dotnet-sdk
       tag: 6.0.400-debian-11-r0
+      digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```