### PR TITLE
[bitnami/consul] Add support for image digest apart from tag

### DIFF
--- a/bitnami/consul/Chart.lock
+++ b/bitnami/consul/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-18T14:00:45.645962567Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:56:45.022228624Z"

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: HashiCorp Consul is a tool for discovering and configuring services in your infrastructure.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/consul
@@ -23,4 +23,4 @@ name: consul
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/consul
   - https://www.consul.io/
-version: 10.7.16
+version: 10.8.0

--- a/bitnami/consul/values.yaml
+++ b/bitnami/consul/values.yaml
@@ -65,6 +65,7 @@ diagnosticMode:
 ## @param image.registry HashiCorp Consul image registry
 ## @param image.repository HashiCorp Consul image repository
 ## @param image.tag HashiCorp Consul image tag (immutable tags are recommended)
+## @param image.digest HashiCorp Consul image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy HashiCorp Consul image pull policy
 ## @param image.pullSecrets HashiCorp Consul image pull secrets
 ## @param image.debug Enable image debug mode
@@ -73,6 +74,7 @@ image:
   registry: docker.io
   repository: bitnami/consul
   tag: 1.13.1-debian-11-r1
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -602,6 +604,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Bitnami Shell image registry
   ## @param volumePermissions.image.repository Bitnami Shell image repository
   ## @param volumePermissions.image.tag Bitnami Shell image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Bitnami Shell image pull policy
   ## @param volumePermissions.image.pullSecrets Bitnami Shell image pull secrets
   ##
@@ -609,6 +612,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r24
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -651,6 +655,7 @@ metrics:
   ## @param metrics.image.registry HashiCorp Consul Prometheus Exporter image registry
   ## @param metrics.image.repository HashiCorp Consul Prometheus Exporter image repository
   ## @param metrics.image.tag HashiCorp Consul Prometheus Exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest HashiCorp Consul Prometheus Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy HashiCorp Consul Prometheus Exporter image pull policy
   ## @param metrics.image.pullSecrets HashiCorp Consul Prometheus Exporter image pull secrets
   ##
@@ -658,6 +663,7 @@ metrics:
     registry: docker.io
     repository: bitnami/consul-exporter
     tag: 0.8.0-debian-11-r27
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```