### PR TITLE
[bitnami/cassandra] Add support for image digest apart from tag

### DIFF
--- a/bitnami/cassandra/Chart.lock
+++ b/bitnami/cassandra/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-19T00:17:37.666510453Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:56:34.700781854Z"

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Apache Cassandra is an open source distributed database management system designed to handle large amounts of data across many servers, providing high availability with no single point of failure.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/cassandra
@@ -23,4 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/cassandra
   - http://cassandra.apache.org
-version: 9.2.12
+version: 9.3.0

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -83,7 +83,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `image.registry`              | Cassandra image registry                                                                                               | `docker.io`          |
 | `image.repository`            | Cassandra image repository                                                                                             | `bitnami/cassandra`  |
-| `image.tag`                   | Cassandra image tag (immutable tags are recommended)                                                                   | `4.0.5-debian-11-r0` |
+| `image.tag`                   | Cassandra image tag (immutable tags are recommended)                                                                   | `4.0.5-debian-11-r8` |
+| `image.digest`                | Cassandra image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag              | `""`                 |
 | `image.pullPolicy`            | image pull policy                                                                                                      | `IfNotPresent`       |
 | `image.pullSecrets`           | Cassandra image pull secrets                                                                                           | `[]`                 |
 | `image.debug`                 | Enable image debug mode                                                                                                | `false`              |
@@ -227,44 +228,46 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Volume Permissions parameters
 
-| Name                                          | Description                                                                     | Value                   |
-| --------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------- |
-| `volumePermissions.enabled`                   | Enable init container that changes the owner and group of the persistent volume | `false`                 |
-| `volumePermissions.image.registry`            | Init container volume                                                           | `docker.io`             |
-| `volumePermissions.image.repository`          | Init container volume                                                           | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                 | Init container volume                                                           | `11-debian-11-r16`      |
-| `volumePermissions.image.pullPolicy`          | Init container volume                                                           | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                | `[]`                    |
-| `volumePermissions.resources.limits`          | The resources limits for the container                                          | `{}`                    |
-| `volumePermissions.resources.requests`        | The requested resources for the container                                       | `{}`                    |
-| `volumePermissions.securityContext.runAsUser` | User ID for the init container                                                  | `0`                     |
+| Name                                          | Description                                                                                                           | Value                   |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`                   | Enable init container that changes the owner and group of the persistent volume                                       | `false`                 |
+| `volumePermissions.image.registry`            | Init container volume image registry                                                                                  | `docker.io`             |
+| `volumePermissions.image.repository`          | Init container volume image repository                                                                                | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`                 | Init container volume image tag (immutable tags are recommended)                                                      | `11-debian-11-r23`      |
+| `volumePermissions.image.digest`              | Init container volume image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `volumePermissions.image.pullPolicy`          | Init container volume pull policy                                                                                     | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                                                      | `[]`                    |
+| `volumePermissions.resources.limits`          | The resources limits for the container                                                                                | `{}`                    |
+| `volumePermissions.resources.requests`        | The requested resources for the container                                                                             | `{}`                    |
+| `volumePermissions.securityContext.runAsUser` | User ID for the init container                                                                                        | `0`                     |
 
 
 ### Metrics parameters
 
-| Name                                       | Description                                                                                            | Value                        |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------ | ---------------------------- |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                   | `false`                      |
-| `metrics.image.registry`                   | Cassandra exporter image registry                                                                      | `docker.io`                  |
-| `metrics.image.repository`                 | Cassandra exporter image name                                                                          | `bitnami/cassandra-exporter` |
-| `metrics.image.tag`                        | Cassandra exporter image tag                                                                           | `2.3.8-debian-11-r16`        |
-| `metrics.image.pullPolicy`                 | image pull policy                                                                                      | `IfNotPresent`               |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                       | `[]`                         |
-| `metrics.resources.limits`                 | The resources limits for the container                                                                 | `{}`                         |
-| `metrics.resources.requests`               | The requested resources for the container                                                              | `{}`                         |
-| `metrics.podAnnotations`                   | Metrics exporter pod Annotation and Labels                                                             | `{}`                         |
-| `metrics.serviceMonitor.enabled`           | If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                      |
-| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                               | `monitoring`                 |
-| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                           | `""`                         |
-| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                | `""`                         |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                    | `{}`                         |
-| `metrics.serviceMonitor.metricRelabelings` | Specify Metric Relabelings to add to the scrape endpoint                                               | `[]`                         |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                     | `[]`                         |
-| `metrics.serviceMonitor.honorLabels`       | Specify honorLabels parameter to add the scrape endpoint                                               | `false`                      |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                      | `""`                         |
-| `metrics.serviceMonitor.labels`            | Used to pass Labels that are required by the installed Prometheus Operator                             | `{}`                         |
-| `metrics.containerPorts.http`              | HTTP Port on the Host and Container                                                                    | `8080`                       |
-| `metrics.containerPorts.jmx`               | JMX Port on the Host and Container                                                                     | `5555`                       |
+| Name                                       | Description                                                                                                        | Value                        |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                               | `false`                      |
+| `metrics.image.registry`                   | Cassandra exporter image registry                                                                                  | `docker.io`                  |
+| `metrics.image.repository`                 | Cassandra exporter image name                                                                                      | `bitnami/cassandra-exporter` |
+| `metrics.image.tag`                        | Cassandra exporter image tag                                                                                       | `2.3.8-debian-11-r26`        |
+| `metrics.image.digest`                     | Cassandra exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                         |
+| `metrics.image.pullPolicy`                 | image pull policy                                                                                                  | `IfNotPresent`               |
+| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                                   | `[]`                         |
+| `metrics.resources.limits`                 | The resources limits for the container                                                                             | `{}`                         |
+| `metrics.resources.requests`               | The requested resources for the container                                                                          | `{}`                         |
+| `metrics.podAnnotations`                   | Metrics exporter pod Annotation and Labels                                                                         | `{}`                         |
+| `metrics.serviceMonitor.enabled`           | If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)             | `false`                      |
+| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                                           | `monitoring`                 |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                                       | `""`                         |
+| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                            | `""`                         |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                                | `{}`                         |
+| `metrics.serviceMonitor.metricRelabelings` | Specify Metric Relabelings to add to the scrape endpoint                                                           | `[]`                         |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                                 | `[]`                         |
+| `metrics.serviceMonitor.honorLabels`       | Specify honorLabels parameter to add the scrape endpoint                                                           | `false`                      |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                                  | `""`                         |
+| `metrics.serviceMonitor.labels`            | Used to pass Labels that are required by the installed Prometheus Operator                                         | `{}`                         |
+| `metrics.containerPorts.http`              | HTTP Port on the Host and Container                                                                                | `8080`                       |
+| `metrics.containerPorts.jmx`               | JMX Port on the Host and Container                                                                                 | `5555`                       |
 
 
 ### TLS/SSL parameters

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -65,6 +65,7 @@ diagnosticMode:
 ## @param image.registry Cassandra image registry
 ## @param image.repository Cassandra image repository
 ## @param image.tag Cassandra image tag (immutable tags are recommended)
+## @param image.digest Cassandra image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy image pull policy
 ## @param image.pullSecrets Cassandra image pull secrets
 ## @param image.debug Enable image debug mode
@@ -73,6 +74,7 @@ image:
   registry: docker.io
   repository: bitnami/cassandra
   tag: 4.0.5-debian-11-r8
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -579,16 +581,18 @@ volumePermissions:
   ## @param volumePermissions.enabled Enable init container that changes the owner and group of the persistent volume
   ##
   enabled: false
-  ## @param volumePermissions.image.registry Init container volume
-  ## @param volumePermissions.image.repository Init container volume
-  ## @param volumePermissions.image.tag Init container volume
-  ## @param volumePermissions.image.pullPolicy Init container volume
+  ## @param volumePermissions.image.registry Init container volume image registry
+  ## @param volumePermissions.image.repository Init container volume image repository
+  ## @param volumePermissions.image.tag Init container volume image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Init container volume image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param volumePermissions.image.pullPolicy Init container volume pull policy
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -648,6 +652,7 @@ metrics:
   ## @param metrics.image.registry Cassandra exporter image registry
   ## @param metrics.image.repository Cassandra exporter image name
   ## @param metrics.image.tag Cassandra exporter image tag
+  ## @param metrics.image.digest Cassandra exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy image pull policy
   ## @param metrics.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -656,6 +661,7 @@ metrics:
     pullPolicy: IfNotPresent
     repository: bitnami/cassandra-exporter
     tag: 2.3.8-debian-11-r26
+    digest: ""
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```