### PR TITLE
[bitnami/argo-cd] Add support for image digest apart from tag

### DIFF
--- a/bitnami/argo-cd/Chart.lock
+++ b/bitnami/argo-cd/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.0.8
+  version: 17.0.11
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:cba66f6a4692c4ce3d8f3fe21789f1a5bb531d2d4059e71555e6a992fa7cfc63
-generated: "2022-08-04T19:49:08.430931252Z"
+  version: 2.0.0
+digest: sha256:da74b8fa464320406082fa24f3dce935e3a06212482b8b648404296b0e229526
+generated: "2022-08-20T10:56:22.614765018Z"

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Argo CD is a continuous delivery tool for Kubernetes based on GitOps.
 engine: gotpl
 home: https://argoproj.github.io/argo-cd/
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/containers/tree/main/bitnami/dex
   - https://github.com/dexidp/dex
-version: 4.0.6
+version: 4.1.0

--- a/bitnami/argo-cd/README.md
+++ b/bitnami/argo-cd/README.md
@@ -76,14 +76,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Argo CD image parameters
 
-| Name                | Description                                        | Value                |
-| ------------------- | -------------------------------------------------- | -------------------- |
-| `image.registry`    | Argo CD image registry                             | `docker.io`          |
-| `image.repository`  | Argo CD image repository                           | `bitnami/argo-cd`    |
-| `image.tag`         | Argo CD image tag (immutable tags are recommended) | `2.4.7-debian-11-r0` |
-| `image.pullPolicy`  | Argo CD image pull policy                          | `IfNotPresent`       |
-| `image.pullSecrets` | Argo CD image pull secrets                         | `[]`                 |
-| `image.debug`       | Enable Argo CD image debug mode                    | `false`              |
+| Name                | Description                                                                                             | Value                |
+| ------------------- | ------------------------------------------------------------------------------------------------------- | -------------------- |
+| `image.registry`    | Argo CD image registry                                                                                  | `docker.io`          |
+| `image.repository`  | Argo CD image repository                                                                                | `bitnami/argo-cd`    |
+| `image.tag`         | Argo CD image tag (immutable tags are recommended)                                                      | `2.4.8-debian-11-r3` |
+| `image.digest`      | Argo CD image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                 |
+| `image.pullPolicy`  | Argo CD image pull policy                                                                               | `IfNotPresent`       |
+| `image.pullSecrets` | Argo CD image pull secrets                                                                              | `[]`                 |
+| `image.debug`       | Enable Argo CD image debug mode                                                                         | `false`              |
 
 
 ### Argo CD application controller parameters
@@ -456,113 +457,114 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Dex Parameters
 
-| Name                                                    | Description                                                                                   | Value                  |
-| ------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------- |
-| `dex.image.registry`                                    | Dex image registry                                                                            | `docker.io`            |
-| `dex.image.repository`                                  | Dex image repository                                                                          | `bitnami/dex`          |
-| `dex.image.tag`                                         | Dex image tag (immutable tags are recommended)                                                | `2.32.0-debian-11-r13` |
-| `dex.image.pullPolicy`                                  | Dex image pull policy                                                                         | `IfNotPresent`         |
-| `dex.image.pullSecrets`                                 | Dex image pull secrets                                                                        | `[]`                   |
-| `dex.image.debug`                                       | Enable Dex image debug mode                                                                   | `false`                |
-| `dex.enabled`                                           | Enable the creation of a Dex deployment for SSO                                               | `false`                |
-| `dex.replicaCount`                                      | Number of Dex replicas to deploy                                                              | `1`                    |
-| `dex.startupProbe.enabled`                              | Enable startupProbe on Dex nodes                                                              | `false`                |
-| `dex.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                        | `10`                   |
-| `dex.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                               | `10`                   |
-| `dex.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                              | `1`                    |
-| `dex.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                            | `3`                    |
-| `dex.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                            | `1`                    |
-| `dex.livenessProbe.enabled`                             | Enable livenessProbe on Dex nodes                                                             | `true`                 |
-| `dex.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                       | `10`                   |
-| `dex.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                              | `10`                   |
-| `dex.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                             | `1`                    |
-| `dex.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                           | `3`                    |
-| `dex.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                           | `1`                    |
-| `dex.readinessProbe.enabled`                            | Enable readinessProbe on Dex nodes                                                            | `true`                 |
-| `dex.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                      | `10`                   |
-| `dex.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                             | `10`                   |
-| `dex.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                            | `1`                    |
-| `dex.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                          | `3`                    |
-| `dex.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                          | `1`                    |
-| `dex.customStartupProbe`                                | Custom startupProbe that overrides the default one                                            | `{}`                   |
-| `dex.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                           | `{}`                   |
-| `dex.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                          | `{}`                   |
-| `dex.resources.limits`                                  | The resources limits for the Dex containers                                                   | `{}`                   |
-| `dex.resources.requests`                                | The requested resources for the Dex containers                                                | `{}`                   |
-| `dex.podSecurityContext.enabled`                        | Enabled Dex pods' Security Context                                                            | `true`                 |
-| `dex.podSecurityContext.fsGroup`                        | Set Dex pod's Security Context fsGroup                                                        | `1001`                 |
-| `dex.containerSecurityContext.enabled`                  | Enabled Dex containers' Security Context                                                      | `true`                 |
-| `dex.containerSecurityContext.runAsUser`                | Set Dex containers' Security Context runAsUser                                                | `1001`                 |
-| `dex.containerSecurityContext.allowPrivilegeEscalation` | Set Dex containers' Security Context allowPrivilegeEscalation                                 | `false`                |
-| `dex.containerSecurityContext.readOnlyRootFilesystem`   | Set Dex containers' server Security Context readOnlyRootFilesystem                            | `false`                |
-| `dex.containerSecurityContext.runAsNonRoot`             | Set Dex containers' Security Context runAsNonRoot                                             | `true`                 |
-| `dex.service.type`                                      | Dex service type                                                                              | `ClusterIP`            |
-| `dex.service.ports.http`                                | Dex HTTP service port                                                                         | `5556`                 |
-| `dex.service.ports.grpc`                                | Dex grpc service port                                                                         | `5557`                 |
-| `dex.service.nodePorts.http`                            | HTTP node port for the Dex service                                                            | `""`                   |
-| `dex.service.nodePorts.grpc`                            | gRPC node port for the Dex service                                                            | `""`                   |
-| `dex.service.clusterIP`                                 | Dex service Cluster IP                                                                        | `""`                   |
-| `dex.service.loadBalancerIP`                            | Dex service Load Balancer IP                                                                  | `""`                   |
-| `dex.service.loadBalancerSourceRanges`                  | Dex service Load Balancer sources                                                             | `[]`                   |
-| `dex.service.externalTrafficPolicy`                     | Dex service external traffic policy                                                           | `Cluster`              |
-| `dex.service.annotations`                               | Additional custom annotations for Dex service                                                 | `{}`                   |
-| `dex.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                | `[]`                   |
-| `dex.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                          | `None`                 |
-| `dex.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                   | `{}`                   |
-| `dex.containerPorts.http`                               | Dex container HTTP port                                                                       | `5556`                 |
-| `dex.containerPorts.grpc`                               | Dex gRPC port                                                                                 | `5557`                 |
-| `dex.containerPorts.metrics`                            | Dex metrics port                                                                              | `5558`                 |
-| `dex.metrics.enabled`                                   | Enable metrics for Dex                                                                        | `false`                |
-| `dex.metrics.service.type`                              | Dex service type                                                                              | `ClusterIP`            |
-| `dex.metrics.service.port`                              | Dex metrics service port                                                                      | `5558`                 |
-| `dex.metrics.service.nodePort`                          | Node port for the Dex service                                                                 | `""`                   |
-| `dex.metrics.service.clusterIP`                         | Dex service metrics service Cluster IP                                                        | `""`                   |
-| `dex.metrics.service.loadBalancerIP`                    | Dex service Load Balancer IP                                                                  | `""`                   |
-| `dex.metrics.service.loadBalancerSourceRanges`          | Dex service Load Balancer sources                                                             | `[]`                   |
-| `dex.metrics.service.externalTrafficPolicy`             | Dex service external traffic policy                                                           | `Cluster`              |
-| `dex.metrics.service.annotations`                       | Additional custom annotations for Dex service                                                 | `{}`                   |
-| `dex.metrics.service.sessionAffinity`                   | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                          | `None`                 |
-| `dex.metrics.service.sessionAffinityConfig`             | Additional settings for the sessionAffinity                                                   | `{}`                   |
-| `dex.metrics.serviceMonitor.enabled`                    | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                  | `false`                |
-| `dex.metrics.serviceMonitor.namespace`                  | Namespace which Prometheus is running in                                                      | `""`                   |
-| `dex.metrics.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in prometheus.             | `""`                   |
-| `dex.metrics.serviceMonitor.interval`                   | Interval at which metrics should be scraped                                                   | `30s`                  |
-| `dex.metrics.serviceMonitor.scrapeTimeout`              | Timeout after which the scrape is ended                                                       | `10s`                  |
-| `dex.metrics.serviceMonitor.relabelings`                | RelabelConfigs to apply to samples before scraping                                            | `[]`                   |
-| `dex.metrics.serviceMonitor.metricRelabelings`          | MetricRelabelConfigs to apply to samples before ingestion                                     | `[]`                   |
-| `dex.metrics.serviceMonitor.selector`                   | ServiceMonitor selector labels                                                                | `{}`                   |
-| `dex.metrics.serviceMonitor.honorLabels`                | honorLabels chooses the metric's labels on collisions with target labels                      | `false`                |
-| `dex.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created for Dex                                  | `true`                 |
-| `dex.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                        | `""`                   |
-| `dex.serviceAccount.automountServiceAccountToken`       | Automount service account token for the Dex service account                                   | `true`                 |
-| `dex.serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.    | `{}`                   |
-| `dex.command`                                           | Override default container command (useful when using custom images)                          | `[]`                   |
-| `dex.args`                                              | Override default container args (useful when using custom images)                             | `[]`                   |
-| `dex.extraArgs`                                         | Add extra args to the default args for Dex                                                    | `[]`                   |
-| `dex.hostAliases`                                       | Dex pods host aliases                                                                         | `[]`                   |
-| `dex.podLabels`                                         | Extra labels for Dex pods                                                                     | `{}`                   |
-| `dex.podAnnotations`                                    | Annotations for Dex pods                                                                      | `{}`                   |
-| `dex.podAffinityPreset`                                 | Pod affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`       | `""`                   |
-| `dex.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                 |
-| `dex.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard` | `""`                   |
-| `dex.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `dex.affinity` is set                                     | `""`                   |
-| `dex.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `dex.affinity` is set                                  | `[]`                   |
-| `dex.affinity`                                          | Affinity for Dex pods assignment                                                              | `{}`                   |
-| `dex.nodeSelector`                                      | Node labels for Dex pods assignment                                                           | `{}`                   |
-| `dex.tolerations`                                       | Tolerations for Dex pods assignment                                                           | `[]`                   |
-| `dex.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                | `""`                   |
-| `dex.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                | `[]`                   |
-| `dex.updateStrategy.type`                               | Dex statefulset strategy type                                                                 | `RollingUpdate`        |
-| `dex.priorityClassName`                                 | Dex pods' priorityClassName                                                                   | `""`                   |
-| `dex.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                | `""`                   |
-| `dex.lifecycleHooks`                                    | for the Dex container(s) to automate configuration before or after startup                    | `{}`                   |
-| `dex.extraEnvVars`                                      | Array with extra environment variables to add to Dex nodes                                    | `[]`                   |
-| `dex.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Dex nodes                            | `""`                   |
-| `dex.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Dex nodes                               | `""`                   |
-| `dex.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Dex pod(s)                        | `[]`                   |
-| `dex.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Dex container(s)             | `[]`                   |
-| `dex.sidecars`                                          | Add additional sidecar containers to the Dex pod(s)                                           | `[]`                   |
-| `dex.initContainers`                                    | Add additional init containers to the Dex pod(s)                                              | `[]`                   |
+| Name                                                    | Description                                                                                         | Value                 |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------- |
+| `dex.image.registry`                                    | Dex image registry                                                                                  | `docker.io`           |
+| `dex.image.repository`                                  | Dex image repository                                                                                | `bitnami/dex`         |
+| `dex.image.tag`                                         | Dex image tag (immutable tags are recommended)                                                      | `2.33.0-debian-11-r3` |
+| `dex.image.digest`                                      | Dex image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `dex.image.pullPolicy`                                  | Dex image pull policy                                                                               | `IfNotPresent`        |
+| `dex.image.pullSecrets`                                 | Dex image pull secrets                                                                              | `[]`                  |
+| `dex.image.debug`                                       | Enable Dex image debug mode                                                                         | `false`               |
+| `dex.enabled`                                           | Enable the creation of a Dex deployment for SSO                                                     | `false`               |
+| `dex.replicaCount`                                      | Number of Dex replicas to deploy                                                                    | `1`                   |
+| `dex.startupProbe.enabled`                              | Enable startupProbe on Dex nodes                                                                    | `false`               |
+| `dex.startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                              | `10`                  |
+| `dex.startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                     | `10`                  |
+| `dex.startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                    | `1`                   |
+| `dex.startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                  | `3`                   |
+| `dex.startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                  | `1`                   |
+| `dex.livenessProbe.enabled`                             | Enable livenessProbe on Dex nodes                                                                   | `true`                |
+| `dex.livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                             | `10`                  |
+| `dex.livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                    | `10`                  |
+| `dex.livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                   | `1`                   |
+| `dex.livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                 | `3`                   |
+| `dex.livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                 | `1`                   |
+| `dex.readinessProbe.enabled`                            | Enable readinessProbe on Dex nodes                                                                  | `true`                |
+| `dex.readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                            | `10`                  |
+| `dex.readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                   | `10`                  |
+| `dex.readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                  | `1`                   |
+| `dex.readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                | `3`                   |
+| `dex.readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                | `1`                   |
+| `dex.customStartupProbe`                                | Custom startupProbe that overrides the default one                                                  | `{}`                  |
+| `dex.customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                 | `{}`                  |
+| `dex.customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                                | `{}`                  |
+| `dex.resources.limits`                                  | The resources limits for the Dex containers                                                         | `{}`                  |
+| `dex.resources.requests`                                | The requested resources for the Dex containers                                                      | `{}`                  |
+| `dex.podSecurityContext.enabled`                        | Enabled Dex pods' Security Context                                                                  | `true`                |
+| `dex.podSecurityContext.fsGroup`                        | Set Dex pod's Security Context fsGroup                                                              | `1001`                |
+| `dex.containerSecurityContext.enabled`                  | Enabled Dex containers' Security Context                                                            | `true`                |
+| `dex.containerSecurityContext.runAsUser`                | Set Dex containers' Security Context runAsUser                                                      | `1001`                |
+| `dex.containerSecurityContext.allowPrivilegeEscalation` | Set Dex containers' Security Context allowPrivilegeEscalation                                       | `false`               |
+| `dex.containerSecurityContext.readOnlyRootFilesystem`   | Set Dex containers' server Security Context readOnlyRootFilesystem                                  | `false`               |
+| `dex.containerSecurityContext.runAsNonRoot`             | Set Dex containers' Security Context runAsNonRoot                                                   | `true`                |
+| `dex.service.type`                                      | Dex service type                                                                                    | `ClusterIP`           |
+| `dex.service.ports.http`                                | Dex HTTP service port                                                                               | `5556`                |
+| `dex.service.ports.grpc`                                | Dex grpc service port                                                                               | `5557`                |
+| `dex.service.nodePorts.http`                            | HTTP node port for the Dex service                                                                  | `""`                  |
+| `dex.service.nodePorts.grpc`                            | gRPC node port for the Dex service                                                                  | `""`                  |
+| `dex.service.clusterIP`                                 | Dex service Cluster IP                                                                              | `""`                  |
+| `dex.service.loadBalancerIP`                            | Dex service Load Balancer IP                                                                        | `""`                  |
+| `dex.service.loadBalancerSourceRanges`                  | Dex service Load Balancer sources                                                                   | `[]`                  |
+| `dex.service.externalTrafficPolicy`                     | Dex service external traffic policy                                                                 | `Cluster`             |
+| `dex.service.annotations`                               | Additional custom annotations for Dex service                                                       | `{}`                  |
+| `dex.service.extraPorts`                                | Extra ports to expose (normally used with the `sidecar` value)                                      | `[]`                  |
+| `dex.service.sessionAffinity`                           | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                | `None`                |
+| `dex.service.sessionAffinityConfig`                     | Additional settings for the sessionAffinity                                                         | `{}`                  |
+| `dex.containerPorts.http`                               | Dex container HTTP port                                                                             | `5556`                |
+| `dex.containerPorts.grpc`                               | Dex gRPC port                                                                                       | `5557`                |
+| `dex.containerPorts.metrics`                            | Dex metrics port                                                                                    | `5558`                |
+| `dex.metrics.enabled`                                   | Enable metrics for Dex                                                                              | `false`               |
+| `dex.metrics.service.type`                              | Dex service type                                                                                    | `ClusterIP`           |
+| `dex.metrics.service.port`                              | Dex metrics service port                                                                            | `5558`                |
+| `dex.metrics.service.nodePort`                          | Node port for the Dex service                                                                       | `""`                  |
+| `dex.metrics.service.clusterIP`                         | Dex service metrics service Cluster IP                                                              | `""`                  |
+| `dex.metrics.service.loadBalancerIP`                    | Dex service Load Balancer IP                                                                        | `""`                  |
+| `dex.metrics.service.loadBalancerSourceRanges`          | Dex service Load Balancer sources                                                                   | `[]`                  |
+| `dex.metrics.service.externalTrafficPolicy`             | Dex service external traffic policy                                                                 | `Cluster`             |
+| `dex.metrics.service.annotations`                       | Additional custom annotations for Dex service                                                       | `{}`                  |
+| `dex.metrics.service.sessionAffinity`                   | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                | `None`                |
+| `dex.metrics.service.sessionAffinityConfig`             | Additional settings for the sessionAffinity                                                         | `{}`                  |
+| `dex.metrics.serviceMonitor.enabled`                    | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                        | `false`               |
+| `dex.metrics.serviceMonitor.namespace`                  | Namespace which Prometheus is running in                                                            | `""`                  |
+| `dex.metrics.serviceMonitor.jobLabel`                   | The name of the label on the target service to use as the job name in prometheus.                   | `""`                  |
+| `dex.metrics.serviceMonitor.interval`                   | Interval at which metrics should be scraped                                                         | `30s`                 |
+| `dex.metrics.serviceMonitor.scrapeTimeout`              | Timeout after which the scrape is ended                                                             | `10s`                 |
+| `dex.metrics.serviceMonitor.relabelings`                | RelabelConfigs to apply to samples before scraping                                                  | `[]`                  |
+| `dex.metrics.serviceMonitor.metricRelabelings`          | MetricRelabelConfigs to apply to samples before ingestion                                           | `[]`                  |
+| `dex.metrics.serviceMonitor.selector`                   | ServiceMonitor selector labels                                                                      | `{}`                  |
+| `dex.metrics.serviceMonitor.honorLabels`                | honorLabels chooses the metric's labels on collisions with target labels                            | `false`               |
+| `dex.serviceAccount.create`                             | Specifies whether a ServiceAccount should be created for Dex                                        | `true`                |
+| `dex.serviceAccount.name`                               | The name of the ServiceAccount to use.                                                              | `""`                  |
+| `dex.serviceAccount.automountServiceAccountToken`       | Automount service account token for the Dex service account                                         | `true`                |
+| `dex.serviceAccount.annotations`                        | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.          | `{}`                  |
+| `dex.command`                                           | Override default container command (useful when using custom images)                                | `[]`                  |
+| `dex.args`                                              | Override default container args (useful when using custom images)                                   | `[]`                  |
+| `dex.extraArgs`                                         | Add extra args to the default args for Dex                                                          | `[]`                  |
+| `dex.hostAliases`                                       | Dex pods host aliases                                                                               | `[]`                  |
+| `dex.podLabels`                                         | Extra labels for Dex pods                                                                           | `{}`                  |
+| `dex.podAnnotations`                                    | Annotations for Dex pods                                                                            | `{}`                  |
+| `dex.podAffinityPreset`                                 | Pod affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`             | `""`                  |
+| `dex.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`        | `soft`                |
+| `dex.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `dex.affinity` is set. Allowed values: `soft` or `hard`       | `""`                  |
+| `dex.nodeAffinityPreset.key`                            | Node label key to match. Ignored if `dex.affinity` is set                                           | `""`                  |
+| `dex.nodeAffinityPreset.values`                         | Node label values to match. Ignored if `dex.affinity` is set                                        | `[]`                  |
+| `dex.affinity`                                          | Affinity for Dex pods assignment                                                                    | `{}`                  |
+| `dex.nodeSelector`                                      | Node labels for Dex pods assignment                                                                 | `{}`                  |
+| `dex.tolerations`                                       | Tolerations for Dex pods assignment                                                                 | `[]`                  |
+| `dex.schedulerName`                                     | Name of the k8s scheduler (other than default)                                                      | `""`                  |
+| `dex.topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment                                                      | `[]`                  |
+| `dex.updateStrategy.type`                               | Dex statefulset strategy type                                                                       | `RollingUpdate`       |
+| `dex.priorityClassName`                                 | Dex pods' priorityClassName                                                                         | `""`                  |
+| `dex.runtimeClassName`                                  | Name of the runtime class to be used by pod(s)                                                      | `""`                  |
+| `dex.lifecycleHooks`                                    | for the Dex container(s) to automate configuration before or after startup                          | `{}`                  |
+| `dex.extraEnvVars`                                      | Array with extra environment variables to add to Dex nodes                                          | `[]`                  |
+| `dex.extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Dex nodes                                  | `""`                  |
+| `dex.extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Dex nodes                                     | `""`                  |
+| `dex.extraVolumes`                                      | Optionally specify extra list of additional volumes for the Dex pod(s)                              | `[]`                  |
+| `dex.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Dex container(s)                   | `[]`                  |
+| `dex.sidecars`                                          | Add additional sidecar containers to the Dex pod(s)                                                 | `[]`                  |
+| `dex.initContainers`                                    | Add additional init containers to the Dex pod(s)                                                    | `[]`                  |
 
 
 ### Shared config for Argo CD components
@@ -593,41 +595,43 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Init Container Parameters
 
-| Name                                                   | Description                                                                                     | Value                   |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ----------------------- |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
-| `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                    | `docker.io`             |
-| `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `11-debian-11-r16`      |
-| `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                | `[]`                    |
-| `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                    |
-| `volumePermissions.resources.requests`                 | The requested resources for the init container                                                  | `{}`                    |
-| `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                 | `0`                     |
+| Name                                                   | Description                                                                                                   | Value                   |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`               | `false`                 |
+| `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                                  | `docker.io`             |
+| `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                                | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                                      | `11-debian-11-r22`      |
+| `volumePermissions.image.digest`                       | Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                               | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                              | `[]`                    |
+| `volumePermissions.resources.limits`                   | The resources limits for the init container                                                                   | `{}`                    |
+| `volumePermissions.resources.requests`                 | The requested resources for the init container                                                                | `{}`                    |
+| `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                               | `0`                     |
 
 
 ### Other Parameters
 
-| Name                                      | Description                                                                 | Value                |
-| ----------------------------------------- | --------------------------------------------------------------------------- | -------------------- |
-| `rbac.create`                             | Specifies whether RBAC resources should be created                          | `true`               |
-| `redis.image.registry`                    | Argo CD controller image registry                                           | `docker.io`          |
-| `redis.image.repository`                  | Argo CD controller image repository                                         | `bitnami/redis`      |
-| `redis.image.tag`                         | Argo CD controller image tag (immutable tags are recommended)               | `7.0.4-debian-11-r2` |
-| `redis.image.pullPolicy`                  | Argo CD controller image pull policy                                        | `IfNotPresent`       |
-| `redis.image.pullSecrets`                 | Argo CD controller image pull secrets                                       | `[]`                 |
-| `redis.enabled`                           | Enable Redis dependency                                                     | `true`               |
-| `redis.nameOverride`                      | Name override for the Redis dependency                                      | `""`                 |
-| `redis.service.port`                      | Service port for Redis dependency                                           | `6379`               |
-| `redis.auth.enabled`                      | Enable Redis dependency authentication                                      | `true`               |
-| `redis.auth.existingSecret`               | Existing secret to load redis dependency password                           | `""`                 |
-| `redis.auth.existingSecretPasswordKey`    | Pasword key name inside the existing secret                                 | `redis-password`     |
-| `redis.architecture`                      | Redis&reg; architecture. Allowed values: `standalone` or `replication`      | `standalone`         |
-| `externalRedis.host`                      | External Redis host                                                         | `""`                 |
-| `externalRedis.port`                      | External Redis port                                                         | `6379`               |
-| `externalRedis.password`                  | External Redis password                                                     | `""`                 |
-| `externalRedis.existingSecret`            | Existing secret for the external redis                                      | `""`                 |
-| `externalRedis.existingSecretPasswordKey` | Password key for the existing secret containing the external redis password | `redis-password`     |
+| Name                                      | Description                                                                                           | Value                |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------------- |
+| `rbac.create`                             | Specifies whether RBAC resources should be created                                                    | `true`               |
+| `redis.image.registry`                    | Redis image registry                                                                                  | `docker.io`          |
+| `redis.image.repository`                  | Redis image repository                                                                                | `bitnami/redis`      |
+| `redis.image.tag`                         | Redis image tag (immutable tags are recommended)                                                      | `7.0.4-debian-11-r9` |
+| `redis.image.digest`                      | Redis image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                 |
+| `redis.image.pullPolicy`                  | Redis image pull policy                                                                               | `IfNotPresent`       |
+| `redis.image.pullSecrets`                 | Redis image pull secrets                                                                              | `[]`                 |
+| `redis.enabled`                           | Enable Redis dependency                                                                               | `true`               |
+| `redis.nameOverride`                      | Name override for the Redis dependency                                                                | `""`                 |
+| `redis.service.port`                      | Service port for Redis dependency                                                                     | `6379`               |
+| `redis.auth.enabled`                      | Enable Redis dependency authentication                                                                | `true`               |
+| `redis.auth.existingSecret`               | Existing secret to load redis dependency password                                                     | `""`                 |
+| `redis.auth.existingSecretPasswordKey`    | Pasword key name inside the existing secret                                                           | `redis-password`     |
+| `redis.architecture`                      | Redis&reg; architecture. Allowed values: `standalone` or `replication`                                | `standalone`         |
+| `externalRedis.host`                      | External Redis host                                                                                   | `""`                 |
+| `externalRedis.port`                      | External Redis port                                                                                   | `6379`               |
+| `externalRedis.password`                  | External Redis password                                                                               | `""`                 |
+| `externalRedis.existingSecret`            | Existing secret for the external redis                                                                | `""`                 |
+| `externalRedis.existingSecretPasswordKey` | Password key for the existing secret containing the external redis password                           | `redis-password`     |
 
 
 The above parameters map to the env variables defined in [bitnami/argo-cd](https://github.com/bitnami/containers/tree/main/bitnami/argo-cd). For more information please refer to the [bitnami/argo-cd](https://github.com/bitnami/containers/tree/main/bitnami/argo-cd) image documentation.

--- a/bitnami/argo-cd/values.yaml
+++ b/bitnami/argo-cd/values.yaml
@@ -47,6 +47,7 @@ extraDeploy: []
 ## @param image.registry Argo CD image registry
 ## @param image.repository Argo CD image repository
 ## @param image.tag Argo CD image tag (immutable tags are recommended)
+## @param image.digest Argo CD image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Argo CD image pull policy
 ## @param image.pullSecrets Argo CD image pull secrets
 ## @param image.debug Enable Argo CD image debug mode
@@ -55,6 +56,7 @@ image:
   registry: docker.io
   repository: bitnami/argo-cd
   tag: 2.4.8-debian-11-r3
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -845,7 +847,7 @@ server:
     ## - host: example.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:
@@ -1064,7 +1066,7 @@ server:
     ## - host: example.server.local
     ##     http:
     ##       path: /
-    ##       backend: 
+    ##       backend:
     ##         service:
     ##           name: example-svc
     ##           port:
@@ -1713,6 +1715,7 @@ dex:
   ## @param dex.image.registry Dex image registry
   ## @param dex.image.repository Dex image repository
   ## @param dex.image.tag Dex image tag (immutable tags are recommended)
+  ## @param dex.image.digest Dex image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param dex.image.pullPolicy Dex image pull policy
   ## @param dex.image.pullSecrets Dex image pull secrets
   ## @param dex.image.debug Enable Dex image debug mode
@@ -1721,6 +1724,7 @@ dex:
     registry: docker.io
     repository: bitnami/dex
     tag: 2.33.0-debian-11-r3
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2305,6 +2309,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Bitnami Shell image registry
   ## @param volumePermissions.image.repository Bitnami Shell image repository
   ## @param volumePermissions.image.tag Bitnami Shell image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Bitnami Shell image pull policy
   ## @param volumePermissions.image.pullSecrets Bitnami Shell image pull secrets
   ##
@@ -2312,6 +2317,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r22
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -2353,16 +2359,18 @@ rbac:
 redis:
   ## Bitnami Redis image
   ## ref: https://hub.docker.com/r/bitnami/redis/tags/
-  ## @param redis.image.registry Argo CD controller image registry
-  ## @param redis.image.repository Argo CD controller image repository
-  ## @param redis.image.tag Argo CD controller image tag (immutable tags are recommended)
-  ## @param redis.image.pullPolicy Argo CD controller image pull policy
-  ## @param redis.image.pullSecrets Argo CD controller image pull secrets
+  ## @param redis.image.registry Redis image registry
+  ## @param redis.image.repository Redis image repository
+  ## @param redis.image.tag Redis image tag (immutable tags are recommended)
+  ## @param redis.image.digest Redis image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param redis.image.pullPolicy Redis image pull policy
+  ## @param redis.image.pullSecrets Redis image pull secrets
   ##
   image:
     registry: docker.io
     repository: bitnami/redis
     tag: 7.0.4-debian-11-r9
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```