### PR TITLE
[bitnami/ejbca] Add support for image digest apart from tag

### DIFF
--- a/bitnami/ejbca/Chart.lock
+++ b/bitnami/ejbca/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.6
+  version: 11.1.8
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:c8323b2b8837e89512abd4c3cfd4e65cfbf7a27e3a11331c1c690909dfbe5d69
-generated: "2022-08-06T00:35:02.750631194Z"
+  version: 2.0.0
+digest: sha256:72329792b140a19c311be9b90cc48282b7b017792112d2b87251aa478d606ae3
+generated: "2022-08-20T10:57:07.302238097Z"

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: EJBCA is an enterprise class PKI Certificate Authority software, built using Java (JEE) technology.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/ejbca
@@ -30,4 +30,4 @@ name: ejbca
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/ejbca
   - https://www.ejbca.org/
-version: 6.2.14
+version: 6.3.0

--- a/bitnami/ejbca/README.md
+++ b/bitnami/ejbca/README.md
@@ -80,82 +80,83 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### EJBCA parameters
 
-| Name                                    | Description                                                                               | Value                    |
-| --------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------ |
-| `image.registry`                        | EJBCA image registry                                                                      | `docker.io`              |
-| `image.repository`                      | EJBCA image name                                                                          | `bitnami/ejbca`          |
-| `image.tag`                             | EJBCA image tag                                                                           | `7.4.3-2-debian-10-r146` |
-| `image.pullPolicy`                      | EJBCA image pull policy                                                                   | `IfNotPresent`           |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                          | `[]`                     |
-| `image.debug`                           | Enable image debug mode                                                                   | `false`                  |
-| `replicaCount`                          | Number of EJBCA replicas to deploy                                                        | `1`                      |
-| `extraVolumeMounts`                     | Additional volume mounts (used along with `extraVolumes`)                                 | `[]`                     |
-| `extraVolumes`                          | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`       | `[]`                     |
-| `podAnnotations`                        | Additional pod annotations                                                                | `{}`                     |
-| `podLabels`                             | Additional pod labels                                                                     | `{}`                     |
-| `podSecurityContext.enabled`            | Enable security context for EJBCA container                                               | `true`                   |
-| `podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                       | `1001`                   |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                     |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                   |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                     |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                     | `""`                     |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                 | `[]`                     |
-| `affinity`                              | Affinity for pod assignment                                                               | `{}`                     |
-| `nodeSelector`                          | Node labels for pod assignment                                                            | `{}`                     |
-| `tolerations`                           | Tolerations for pod assignment                                                            | `[]`                     |
-| `updateStrategy.type`                   | EJBCA deployment strategy type.                                                           | `RollingUpdate`          |
-| `persistence.enabled`                   | Whether to enable persistence based on Persistent Volume Claims                           | `true`                   |
-| `persistence.accessModes`               | Persistent Volume access modes                                                            | `[]`                     |
-| `persistence.size`                      | Size of the PVC to request                                                                | `2Gi`                    |
-| `persistence.storageClass`              | PVC Storage Class                                                                         | `""`                     |
-| `persistence.existingClaim`             | Name of an existing PVC to reuse                                                          | `""`                     |
-| `persistence.annotations`               | Persistent Volume Claim annotations                                                       | `{}`                     |
-| `sidecars`                              | Attach additional sidecar containers to the pod                                           | `[]`                     |
-| `initContainers`                        | Additional init containers to add to the pods                                             | `[]`                     |
-| `hostAliases`                           | Add deployment host aliases                                                               | `[]`                     |
-| `priorityClassName`                     | EJBCA pods' priorityClassName                                                             | `""`                     |
-| `schedulerName`                         | Name of the k8s scheduler (other than default)                                            | `""`                     |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                            | `[]`                     |
-| `ejbcaAdminUsername`                    | EJBCA administrator username                                                              | `bitnami`                |
-| `ejbcaAdminPassword`                    | Password for the administrator account                                                    | `""`                     |
-| `existingSecret`                        | Alternatively, you can provide the name of an existing secret containing                  | `""`                     |
-| `ejbcaJavaOpts`                         | Options used to launch the WildFly server                                                 | `""`                     |
-| `ejbcaCA.name`                          | Name of the CA EJBCA will instantiate by default                                          | `ManagementCA`           |
-| `ejbcaCA.baseDN`                        | Base DomainName of the CA EJBCA will instantiate by default                               | `""`                     |
-| `ejbcaKeystoreExistingSecret`           | Name of an existing Secret containing a Keystore object                                   | `""`                     |
-| `extraEnvVars`                          | Array with extra environment variables to add to EJBCA nodes                              | `[]`                     |
-| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for EJBCA nodes                      | `""`                     |
-| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for EJBCA nodes                         | `""`                     |
-| `command`                               | Custom command to override image cmd                                                      | `[]`                     |
-| `args`                                  | Custom args for the custom command                                                        | `[]`                     |
-| `lifecycleHooks`                        | for the EJBCA container(s) to automate configuration before or after startup              | `{}`                     |
-| `resources.limits`                      | The resources limits for the container                                                    | `{}`                     |
-| `resources.requests`                    | The requested resources for the container                                                 | `{}`                     |
-| `containerSecurityContext.enabled`      | Enabled EJBCA containers' Security Context                                                | `true`                   |
-| `containerSecurityContext.runAsUser`    | Set EJBCA containers' Security Context runAsUser                                          | `1001`                   |
-| `containerSecurityContext.runAsNonRoot` | Set EJBCA container's Security Context runAsNonRoot                                       | `true`                   |
-| `startupProbe.enabled`                  | Enable/disable startupProbe                                                               | `false`                  |
-| `startupProbe.initialDelaySeconds`      | Delay before startup probe is initiated                                                   | `500`                    |
-| `startupProbe.periodSeconds`            | How often to perform the probe                                                            | `10`                     |
-| `startupProbe.timeoutSeconds`           | When the probe times out                                                                  | `5`                      |
-| `startupProbe.failureThreshold`         | Minimum consecutive failures for the probe                                                | `6`                      |
-| `startupProbe.successThreshold`         | Minimum consecutive successes for the probe                                               | `1`                      |
-| `livenessProbe.enabled`                 | Enable/disable livenessProbe                                                              | `true`                   |
-| `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                  | `500`                    |
-| `livenessProbe.periodSeconds`           | How often to perform the probe                                                            | `10`                     |
-| `livenessProbe.timeoutSeconds`          | When the probe times out                                                                  | `5`                      |
-| `livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe                                                | `6`                      |
-| `livenessProbe.successThreshold`        | Minimum consecutive successes for the probe                                               | `1`                      |
-| `readinessProbe.enabled`                | Enable/disable readinessProbe                                                             | `true`                   |
-| `readinessProbe.initialDelaySeconds`    | Delay before readiness probe is initiated                                                 | `500`                    |
-| `readinessProbe.periodSeconds`          | How often to perform the probe                                                            | `10`                     |
-| `readinessProbe.timeoutSeconds`         | When the probe times out                                                                  | `5`                      |
-| `readinessProbe.failureThreshold`       | Minimum consecutive failures for the probe                                                | `6`                      |
-| `readinessProbe.successThreshold`       | Minimum consecutive successes for the probe                                               | `1`                      |
-| `customStartupProbe`                    | Custom startup probe to execute (when the main one is disabled)                           | `{}`                     |
-| `customLivenessProbe`                   | Custom liveness probe to execute (when the main one is disabled)                          | `{}`                     |
-| `customReadinessProbe`                  | Custom readiness probe to execute (when the main one is disabled)                         | `{}`                     |
-| `containerPorts`                        | EJBCA Container ports to open                                                             | `{}`                     |
+| Name                                    | Description                                                                                                 | Value                  |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `image.registry`                        | EJBCA image registry                                                                                        | `docker.io`            |
+| `image.repository`                      | EJBCA image name                                                                                            | `bitnami/ejbca`        |
+| `image.tag`                             | EJBCA image tag                                                                                             | `7.9.0-2-debian-11-r6` |
+| `image.digest`                          | EJBCA image image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
+| `image.pullPolicy`                      | EJBCA image pull policy                                                                                     | `IfNotPresent`         |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                                            | `[]`                   |
+| `image.debug`                           | Enable image debug mode                                                                                     | `false`                |
+| `replicaCount`                          | Number of EJBCA replicas to deploy                                                                          | `1`                    |
+| `extraVolumeMounts`                     | Additional volume mounts (used along with `extraVolumes`)                                                   | `[]`                   |
+| `extraVolumes`                          | Array of extra volumes to be added deployment. Requires setting `extraVolumeMounts`                         | `[]`                   |
+| `podAnnotations`                        | Additional pod annotations                                                                                  | `{}`                   |
+| `podLabels`                             | Additional pod labels                                                                                       | `{}`                   |
+| `podSecurityContext.enabled`            | Enable security context for EJBCA container                                                                 | `true`                 |
+| `podSecurityContext.fsGroup`            | Group ID for the volumes of the pod                                                                         | `1001`                 |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                         | `""`                   |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                    | `soft`                 |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                   | `""`                   |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                       | `""`                   |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                   | `[]`                   |
+| `affinity`                              | Affinity for pod assignment                                                                                 | `{}`                   |
+| `nodeSelector`                          | Node labels for pod assignment                                                                              | `{}`                   |
+| `tolerations`                           | Tolerations for pod assignment                                                                              | `[]`                   |
+| `updateStrategy.type`                   | EJBCA deployment strategy type.                                                                             | `RollingUpdate`        |
+| `persistence.enabled`                   | Whether to enable persistence based on Persistent Volume Claims                                             | `true`                 |
+| `persistence.accessModes`               | Persistent Volume access modes                                                                              | `[]`                   |
+| `persistence.size`                      | Size of the PVC to request                                                                                  | `2Gi`                  |
+| `persistence.storageClass`              | PVC Storage Class                                                                                           | `""`                   |
+| `persistence.existingClaim`             | Name of an existing PVC to reuse                                                                            | `""`                   |
+| `persistence.annotations`               | Persistent Volume Claim annotations                                                                         | `{}`                   |
+| `sidecars`                              | Attach additional sidecar containers to the pod                                                             | `[]`                   |
+| `initContainers`                        | Additional init containers to add to the pods                                                               | `[]`                   |
+| `hostAliases`                           | Add deployment host aliases                                                                                 | `[]`                   |
+| `priorityClassName`                     | EJBCA pods' priorityClassName                                                                               | `""`                   |
+| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                              | `""`                   |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                              | `[]`                   |
+| `ejbcaAdminUsername`                    | EJBCA administrator username                                                                                | `bitnami`              |
+| `ejbcaAdminPassword`                    | Password for the administrator account                                                                      | `""`                   |
+| `existingSecret`                        | Alternatively, you can provide the name of an existing secret containing                                    | `""`                   |
+| `ejbcaJavaOpts`                         | Options used to launch the WildFly server                                                                   | `""`                   |
+| `ejbcaCA.name`                          | Name of the CA EJBCA will instantiate by default                                                            | `ManagementCA`         |
+| `ejbcaCA.baseDN`                        | Base DomainName of the CA EJBCA will instantiate by default                                                 | `""`                   |
+| `ejbcaKeystoreExistingSecret`           | Name of an existing Secret containing a Keystore object                                                     | `""`                   |
+| `extraEnvVars`                          | Array with extra environment variables to add to EJBCA nodes                                                | `[]`                   |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for EJBCA nodes                                        | `""`                   |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for EJBCA nodes                                           | `""`                   |
+| `command`                               | Custom command to override image cmd                                                                        | `[]`                   |
+| `args`                                  | Custom args for the custom command                                                                          | `[]`                   |
+| `lifecycleHooks`                        | for the EJBCA container(s) to automate configuration before or after startup                                | `{}`                   |
+| `resources.limits`                      | The resources limits for the container                                                                      | `{}`                   |
+| `resources.requests`                    | The requested resources for the container                                                                   | `{}`                   |
+| `containerSecurityContext.enabled`      | Enabled EJBCA containers' Security Context                                                                  | `true`                 |
+| `containerSecurityContext.runAsUser`    | Set EJBCA containers' Security Context runAsUser                                                            | `1001`                 |
+| `containerSecurityContext.runAsNonRoot` | Set EJBCA container's Security Context runAsNonRoot                                                         | `true`                 |
+| `startupProbe.enabled`                  | Enable/disable startupProbe                                                                                 | `false`                |
+| `startupProbe.initialDelaySeconds`      | Delay before startup probe is initiated                                                                     | `500`                  |
+| `startupProbe.periodSeconds`            | How often to perform the probe                                                                              | `10`                   |
+| `startupProbe.timeoutSeconds`           | When the probe times out                                                                                    | `5`                    |
+| `startupProbe.failureThreshold`         | Minimum consecutive failures for the probe                                                                  | `6`                    |
+| `startupProbe.successThreshold`         | Minimum consecutive successes for the probe                                                                 | `1`                    |
+| `livenessProbe.enabled`                 | Enable/disable livenessProbe                                                                                | `true`                 |
+| `livenessProbe.initialDelaySeconds`     | Delay before liveness probe is initiated                                                                    | `500`                  |
+| `livenessProbe.periodSeconds`           | How often to perform the probe                                                                              | `10`                   |
+| `livenessProbe.timeoutSeconds`          | When the probe times out                                                                                    | `5`                    |
+| `livenessProbe.failureThreshold`        | Minimum consecutive failures for the probe                                                                  | `6`                    |
+| `livenessProbe.successThreshold`        | Minimum consecutive successes for the probe                                                                 | `1`                    |
+| `readinessProbe.enabled`                | Enable/disable readinessProbe                                                                               | `true`                 |
+| `readinessProbe.initialDelaySeconds`    | Delay before readiness probe is initiated                                                                   | `500`                  |
+| `readinessProbe.periodSeconds`          | How often to perform the probe                                                                              | `10`                   |
+| `readinessProbe.timeoutSeconds`         | When the probe times out                                                                                    | `5`                    |
+| `readinessProbe.failureThreshold`       | Minimum consecutive failures for the probe                                                                  | `6`                    |
+| `readinessProbe.successThreshold`       | Minimum consecutive successes for the probe                                                                 | `1`                    |
+| `customStartupProbe`                    | Custom startup probe to execute (when the main one is disabled)                                             | `{}`                   |
+| `customLivenessProbe`                   | Custom liveness probe to execute (when the main one is disabled)                                            | `{}`                   |
+| `customReadinessProbe`                  | Custom readiness probe to execute (when the main one is disabled)                                           | `{}`                   |
+| `containerPorts`                        | EJBCA Container ports to open                                                                               | `{}`                   |
 
 
 ### Service parameters

--- a/bitnami/ejbca/values.yaml
+++ b/bitnami/ejbca/values.yaml
@@ -62,6 +62,7 @@ diagnosticMode:
 ## @param image.registry EJBCA image registry
 ## @param image.repository EJBCA image name
 ## @param image.tag EJBCA image tag
+## @param image.digest EJBCA image image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy EJBCA image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Enable image debug mode
@@ -70,6 +71,7 @@ image:
   registry: docker.io
   repository: bitnami/ejbca
   tag: 7.9.0-2-debian-11-r6
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```