### PR TITLE
[bitnami/influxdb] Add support for image digest apart from tag

### DIFF
--- a/bitnami/influxdb/Chart.lock
+++ b/bitnami/influxdb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.17.1
-digest: sha256:dacc73770a5640c011e067ff8840ddf89631fc19016c8d0a9e5ea160e7da8690
-generated: "2022-08-19T13:32:07.401838436Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:58:00.675405501Z"

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: InfluxDB(TM) is an open source time-series database. It is a core component of the TICK (Telegraf, InfluxDB(TM), Chronograf, Kapacitor) stack.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/influxdb
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 5.3.12
+version: 5.4.0

--- a/bitnami/influxdb/values.yaml
+++ b/bitnami/influxdb/values.yaml
@@ -62,6 +62,7 @@ diagnosticMode:
 ## @param image.registry InfluxDB&trade; image registry
 ## @param image.repository InfluxDB&trade; image repository
 ## @param image.tag InfluxDB&trade; image tag (immutable tags are recommended)
+## @param image.digest InfluxDB&trade; image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy InfluxDB&trade; image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Specify if debug logs should be enabled
@@ -70,6 +71,7 @@ image:
   registry: docker.io
   repository: bitnami/influxdb
   tag: 2.4.0-debian-11-r0
+  digest: ""
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -808,6 +810,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image name
   ## @param volumePermissions.image.tag Init container volume-permissions image tag
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -815,6 +818,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r27
+    digest: ""
     ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
@@ -937,6 +941,7 @@ backup:
       ## @param backup.uploadProviders.google.image.registry Google Cloud SDK image registry
       ## @param backup.uploadProviders.google.image.repository Google Cloud SDK image name
       ## @param backup.uploadProviders.google.image.tag Google Cloud SDK image tag
+      ## @param backup.uploadProviders.google.image.digest Google Cloud SDK image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
       ## @param backup.uploadProviders.google.image.pullPolicy Google Cloud SDK image pull policy
       ## @param backup.uploadProviders.google.image.pullSecrets Specify docker-registry secret names as an array
       ##
@@ -944,6 +949,7 @@ backup:
         registry: docker.io
         repository: bitnami/google-cloud-sdk
         tag: 0.398.0-debian-11-r0
+        digest: ""
         ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
         ##
@@ -974,6 +980,7 @@ backup:
       ## @param backup.uploadProviders.azure.image.registry Azure CLI image registry
       ## @param backup.uploadProviders.azure.image.repository Azure CLI image repository
       ## @param backup.uploadProviders.azure.image.tag Azure CLI image tag (immutable tags are recommended)
+      ## @param backup.uploadProviders.azure.image.digest Azure CLI image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
       ## @param backup.uploadProviders.azure.image.pullPolicy Azure CLI image pull policy
       ## @param backup.uploadProviders.azure.image.pullSecrets Specify docker-registry secret names as an array
       ##
@@ -981,6 +988,7 @@ backup:
         registry: docker.io
         repository: bitnami/azure-cli
         tag: 2.39.0-debian-11-r6
+        digest: ""
         ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
         ##
@@ -1011,6 +1019,7 @@ backup:
       ## @param backup.uploadProviders.aws.image.registry AWS CLI image registry
       ## @param backup.uploadProviders.aws.image.repository AWS CLI image repository
       ## @param backup.uploadProviders.aws.image.tag AWS CLI image tag (immutable tags are recommended)
+      ## @param backup.uploadProviders.aws.image.digest AWS CLI image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
       ## @param backup.uploadProviders.aws.image.pullPolicy AWS CLI image pull policy
       ## @param backup.uploadProviders.aws.image.pullSecrets Specify docker-registry secret names as an array
       ##
@@ -1018,6 +1027,7 @@ backup:
         registry: docker.io
         repository: bitnami/aws-cli
         tag: 2.4.7-debian-10-r4
+        digest: ""
         ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
         ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
         ##


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```