### PR TITLE
[bitnami/jupyterhub] Add support for image digest apart from tag

### DIFF
--- a/bitnami/jupyterhub/Chart.lock
+++ b/bitnami/jupyterhub/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.25
+  version: 11.7.4
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:001e5487e4cef89c040c2f50e0494f09d616b9d2025d76164a82314a5f306221
-generated: "2022-08-09T04:11:46.28880584Z"
+  version: 2.0.0
+digest: sha256:20703cc32b9c610fc57e644b539c93120d7e935dd95950597fc833e919db59ee
+generated: "2022-08-20T10:58:15.720885114Z"

--- a/bitnami/jupyterhub/Chart.lock
+++ b/bitnami/jupyterhub/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.7.4
+  version: 11.8.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
-digest: sha256:20703cc32b9c610fc57e644b539c93120d7e935dd95950597fc833e919db59ee
-generated: "2022-08-20T10:58:15.720885114Z"
+digest: sha256:e7b3a9104b4a4fffe02d5cce259535b49cca9b2af8fc4360a8fc4988d5debfe5
+generated: "2022-08-22T14:25:27.267231503Z"

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: JupyterHub brings the power of notebooks to groups of users. It gives users access to computational environments and resources without burdening the users with installation and maintenance tasks.
 engine: gotpl
 home: https://jupyter.org/hub
@@ -26,4 +26,4 @@ name: jupyterhub
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/jupyterhub
   - https://github.com/jupyterhub/jupyterhub
-version: 1.3.13
+version: 1.4.0

--- a/bitnami/jupyterhub/README.md
+++ b/bitnami/jupyterhub/README.md
@@ -83,78 +83,79 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Hub deployment parameters
 
-| Name                                        | Description                                                                                                              | Value                |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------- |
-| `hub.image.registry`                        | Hub image registry                                                                                                       | `docker.io`          |
-| `hub.image.repository`                      | Hub image repository                                                                                                     | `bitnami/jupyterhub` |
-| `hub.image.tag`                             | Hub image tag (immutable tags are recommended)                                                                           | `1.5.0-debian-11-r0` |
-| `hub.image.pullPolicy`                      | Hub image pull policy                                                                                                    | `IfNotPresent`       |
-| `hub.image.pullSecrets`                     | Hub image pull secrets                                                                                                   | `[]`                 |
-| `hub.baseUrl`                               | Hub base URL                                                                                                             | `/`                  |
-| `hub.adminUser`                             | Hub Dummy authenticator admin user                                                                                       | `user`               |
-| `hub.password`                              | Hub Dummy authenticator password                                                                                         | `""`                 |
-| `hub.configuration`                         | Hub configuration file (to be used by jupyterhub_config.py)                                                              | `""`                 |
-| `hub.existingConfigmap`                     | Configmap with Hub init scripts (replaces the scripts in templates/hub/configmap.yml)                                    | `""`                 |
-| `hub.existingSecret`                        | Secret with hub configuration (replaces the hub.configuration value) and proxy token                                     | `""`                 |
-| `hub.command`                               | Override Hub default command                                                                                             | `[]`                 |
-| `hub.args`                                  | Override Hub default args                                                                                                | `[]`                 |
-| `hub.extraEnvVars`                          | Add extra environment variables to the Hub container                                                                     | `[]`                 |
-| `hub.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                                                     | `""`                 |
-| `hub.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                                                        | `""`                 |
-| `hub.containerPorts.http`                   | Hub container port                                                                                                       | `8081`               |
-| `hub.startupProbe.enabled`                  | Enable startupProbe on Hub containers                                                                                    | `true`               |
-| `hub.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `10`                 |
-| `hub.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `10`                 |
-| `hub.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `3`                  |
-| `hub.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `30`                 |
-| `hub.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                  |
-| `hub.livenessProbe.enabled`                 | Enable livenessProbe on Hub containers                                                                                   | `true`               |
-| `hub.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `10`                 |
-| `hub.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `10`                 |
-| `hub.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `3`                  |
-| `hub.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `30`                 |
-| `hub.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                  |
-| `hub.readinessProbe.enabled`                | Enable readinessProbe on Hub containers                                                                                  | `true`               |
-| `hub.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `10`                 |
-| `hub.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                 |
-| `hub.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `3`                  |
-| `hub.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `30`                 |
-| `hub.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                  |
-| `hub.customStartupProbe`                    | Override default startup probe                                                                                           | `{}`                 |
-| `hub.customLivenessProbe`                   | Override default liveness probe                                                                                          | `{}`                 |
-| `hub.customReadinessProbe`                  | Override default readiness probe                                                                                         | `{}`                 |
-| `hub.resources.limits`                      | The resources limits for the Hub containers                                                                              | `{}`                 |
-| `hub.resources.requests`                    | The requested resources for the Hub containers                                                                           | `{}`                 |
-| `hub.containerSecurityContext.enabled`      | Enabled Hub containers' Security Context                                                                                 | `true`               |
-| `hub.containerSecurityContext.runAsUser`    | Set Hub container's Security Context runAsUser                                                                           | `1000`               |
-| `hub.containerSecurityContext.runAsNonRoot` | Set Hub container's Security Context runAsNonRoot                                                                        | `true`               |
-| `hub.podSecurityContext.enabled`            | Enabled Hub pods' Security Context                                                                                       | `true`               |
-| `hub.podSecurityContext.fsGroup`            | Set Hub pod's Security Context fsGroup                                                                                   | `1001`               |
-| `hub.lifecycleHooks`                        | LifecycleHooks for the Hub container to automate configuration before or after startup                                   | `{}`                 |
-| `hub.hostAliases`                           | Add deployment host aliases                                                                                              | `[]`                 |
-| `hub.podLabels`                             | Add extra labels to the Hub pods                                                                                         | `{}`                 |
-| `hub.podAnnotations`                        | Add extra annotations to the Hub pods                                                                                    | `{}`                 |
-| `hub.podAffinityPreset`                     | Pod affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                 |
-| `hub.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                             | `soft`               |
-| `hub.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                            | `""`                 |
-| `hub.nodeAffinityPreset.key`                | Node label key to match. Ignored if `hub.affinity` is set                                                                | `""`                 |
-| `hub.nodeAffinityPreset.values`             | Node label values to match. Ignored if `hub.affinity` is set                                                             | `[]`                 |
-| `hub.affinity`                              | Affinity for pod assignment.                                                                                             | `{}`                 |
-| `hub.nodeSelector`                          | Node labels for pod assignment.                                                                                          | `{}`                 |
-| `hub.tolerations`                           | Tolerations for pod assignment.                                                                                          | `[]`                 |
-| `hub.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                 |
-| `hub.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                 |
-| `hub.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                 |
-| `hub.terminationGracePeriodSeconds`         | Seconds Hub pod needs to terminate gracefully                                                                            | `""`                 |
-| `hub.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                           | `RollingUpdate`      |
-| `hub.updateStrategy.rollingUpdate`          | Hub deployment rolling update configuration parameters                                                                   | `{}`                 |
-| `hub.extraVolumes`                          | Optionally specify extra list of additional volumes for Hub pods                                                         | `[]`                 |
-| `hub.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for Hub container(s)                                            | `[]`                 |
-| `hub.initContainers`                        | Add additional init containers to the Hub pods                                                                           | `[]`                 |
-| `hub.sidecars`                              | Add additional sidecar containers to the Hub pod                                                                         | `[]`                 |
-| `hub.pdb.create`                            | Deploy Hub PodDisruptionBudget                                                                                           | `false`              |
-| `hub.pdb.minAvailable`                      | Set minimum available hub instances                                                                                      | `""`                 |
-| `hub.pdb.maxUnavailable`                    | Set maximum available hub instances                                                                                      | `""`                 |
+| Name                                        | Description                                                                                                              | Value                 |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------- |
+| `hub.image.registry`                        | Hub image registry                                                                                                       | `docker.io`           |
+| `hub.image.repository`                      | Hub image repository                                                                                                     | `bitnami/jupyterhub`  |
+| `hub.image.tag`                             | Hub image tag (immutable tags are recommended)                                                                           | `1.5.0-debian-11-r25` |
+| `hub.image.digest`                          | Hub image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                      | `""`                  |
+| `hub.image.pullPolicy`                      | Hub image pull policy                                                                                                    | `IfNotPresent`        |
+| `hub.image.pullSecrets`                     | Hub image pull secrets                                                                                                   | `[]`                  |
+| `hub.baseUrl`                               | Hub base URL                                                                                                             | `/`                   |
+| `hub.adminUser`                             | Hub Dummy authenticator admin user                                                                                       | `user`                |
+| `hub.password`                              | Hub Dummy authenticator password                                                                                         | `""`                  |
+| `hub.configuration`                         | Hub configuration file (to be used by jupyterhub_config.py)                                                              | `""`                  |
+| `hub.existingConfigmap`                     | Configmap with Hub init scripts (replaces the scripts in templates/hub/configmap.yml)                                    | `""`                  |
+| `hub.existingSecret`                        | Secret with hub configuration (replaces the hub.configuration value) and proxy token                                     | `""`                  |
+| `hub.command`                               | Override Hub default command                                                                                             | `[]`                  |
+| `hub.args`                                  | Override Hub default args                                                                                                | `[]`                  |
+| `hub.extraEnvVars`                          | Add extra environment variables to the Hub container                                                                     | `[]`                  |
+| `hub.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars                                                                     | `""`                  |
+| `hub.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars                                                                        | `""`                  |
+| `hub.containerPorts.http`                   | Hub container port                                                                                                       | `8081`                |
+| `hub.startupProbe.enabled`                  | Enable startupProbe on Hub containers                                                                                    | `true`                |
+| `hub.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `10`                  |
+| `hub.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `10`                  |
+| `hub.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `3`                   |
+| `hub.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `30`                  |
+| `hub.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                   |
+| `hub.livenessProbe.enabled`                 | Enable livenessProbe on Hub containers                                                                                   | `true`                |
+| `hub.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `10`                  |
+| `hub.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `10`                  |
+| `hub.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `3`                   |
+| `hub.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `30`                  |
+| `hub.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                   |
+| `hub.readinessProbe.enabled`                | Enable readinessProbe on Hub containers                                                                                  | `true`                |
+| `hub.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `10`                  |
+| `hub.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                  |
+| `hub.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `3`                   |
+| `hub.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `30`                  |
+| `hub.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                   |
+| `hub.customStartupProbe`                    | Override default startup probe                                                                                           | `{}`                  |
+| `hub.customLivenessProbe`                   | Override default liveness probe                                                                                          | `{}`                  |
+| `hub.customReadinessProbe`                  | Override default readiness probe                                                                                         | `{}`                  |
+| `hub.resources.limits`                      | The resources limits for the Hub containers                                                                              | `{}`                  |
+| `hub.resources.requests`                    | The requested resources for the Hub containers                                                                           | `{}`                  |
+| `hub.containerSecurityContext.enabled`      | Enabled Hub containers' Security Context                                                                                 | `true`                |
+| `hub.containerSecurityContext.runAsUser`    | Set Hub container's Security Context runAsUser                                                                           | `1000`                |
+| `hub.containerSecurityContext.runAsNonRoot` | Set Hub container's Security Context runAsNonRoot                                                                        | `true`                |
+| `hub.podSecurityContext.enabled`            | Enabled Hub pods' Security Context                                                                                       | `true`                |
+| `hub.podSecurityContext.fsGroup`            | Set Hub pod's Security Context fsGroup                                                                                   | `1001`                |
+| `hub.lifecycleHooks`                        | LifecycleHooks for the Hub container to automate configuration before or after startup                                   | `{}`                  |
+| `hub.hostAliases`                           | Add deployment host aliases                                                                                              | `[]`                  |
+| `hub.podLabels`                             | Add extra labels to the Hub pods                                                                                         | `{}`                  |
+| `hub.podAnnotations`                        | Add extra annotations to the Hub pods                                                                                    | `{}`                  |
+| `hub.podAffinityPreset`                     | Pod affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                  |
+| `hub.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                             | `soft`                |
+| `hub.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `hub.affinity` is set. Allowed values: `soft` or `hard`                            | `""`                  |
+| `hub.nodeAffinityPreset.key`                | Node label key to match. Ignored if `hub.affinity` is set                                                                | `""`                  |
+| `hub.nodeAffinityPreset.values`             | Node label values to match. Ignored if `hub.affinity` is set                                                             | `[]`                  |
+| `hub.affinity`                              | Affinity for pod assignment.                                                                                             | `{}`                  |
+| `hub.nodeSelector`                          | Node labels for pod assignment.                                                                                          | `{}`                  |
+| `hub.tolerations`                           | Tolerations for pod assignment.                                                                                          | `[]`                  |
+| `hub.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                  |
+| `hub.priorityClassName`                     | Priority Class Name                                                                                                      | `""`                  |
+| `hub.schedulerName`                         | Use an alternate scheduler, e.g. "stork".                                                                                | `""`                  |
+| `hub.terminationGracePeriodSeconds`         | Seconds Hub pod needs to terminate gracefully                                                                            | `""`                  |
+| `hub.updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                           | `RollingUpdate`       |
+| `hub.updateStrategy.rollingUpdate`          | Hub deployment rolling update configuration parameters                                                                   | `{}`                  |
+| `hub.extraVolumes`                          | Optionally specify extra list of additional volumes for Hub pods                                                         | `[]`                  |
+| `hub.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for Hub container(s)                                            | `[]`                  |
+| `hub.initContainers`                        | Add additional init containers to the Hub pods                                                                           | `[]`                  |
+| `hub.sidecars`                              | Add additional sidecar containers to the Hub pod                                                                         | `[]`                  |
+| `hub.pdb.create`                            | Deploy Hub PodDisruptionBudget                                                                                           | `false`               |
+| `hub.pdb.minAvailable`                      | Set minimum available hub instances                                                                                      | `""`                  |
+| `hub.pdb.maxUnavailable`                    | Set maximum available hub instances                                                                                      | `""`                  |
 
 
 ### Hub RBAC parameters
@@ -214,7 +215,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
 | `proxy.image.registry`                        | Proxy image registry                                                                                                     | `docker.io`                       |
 | `proxy.image.repository`                      | Proxy image repository                                                                                                   | `bitnami/configurable-http-proxy` |
-| `proxy.image.tag`                             | Proxy image tag (immutable tags are recommended)                                                                         | `4.5.1-debian-11-r0`              |
+| `proxy.image.tag`                             | Proxy image tag (immutable tags are recommended)                                                                         | `4.5.1-debian-11-r27`             |
+| `proxy.image.digest`                          | Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                    | `""`                              |
 | `proxy.image.pullPolicy`                      | Proxy image pull policy                                                                                                  | `IfNotPresent`                    |
 | `proxy.image.pullSecrets`                     | Proxy image pull secrets                                                                                                 | `[]`                              |
 | `proxy.image.debug`                           | Activate verbose output                                                                                                  | `false`                           |
@@ -402,33 +404,34 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Singleuser deployment parameters
 
-| Name                                            | Description                                                                                         | Value                                |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `singleuser.image.registry`                     | Single User image registry                                                                          | `docker.io`                          |
-| `singleuser.image.repository`                   | Single User image repository                                                                        | `bitnami/jupyter-base-notebook`      |
-| `singleuser.image.tag`                          | Single User image tag (immutabe tags are recommended)                                               | `1.5.0-debian-11-r0`                 |
-| `singleuser.image.pullPolicy`                   | Single User image pull policy                                                                       | `IfNotPresent`                       |
-| `singleuser.image.pullSecrets`                  | Single User image pull secrets                                                                      | `[]`                                 |
-| `singleuser.notebookDir`                        | Notebook directory (it will be the same as the PVC volume mount)                                    | `/opt/bitnami/jupyterhub-singleuser` |
-| `singleuser.command`                            | Override Single User default command                                                                | `[]`                                 |
-| `singleuser.extraEnvVars`                       | Add extra environment variables to the Single User container                                        | `[]`                                 |
-| `singleuser.containerPort`                      | Single User container port                                                                          | `8888`                               |
-| `singleuser.resources.limits`                   | The resources limits for the Singleuser containers                                                  | `{}`                                 |
-| `singleuser.resources.requests`                 | The requested resources for the Singleuser containers                                               | `{}`                                 |
-| `singleuser.containerSecurityContext.enabled`   | Enabled Single User containers' Security Context                                                    | `true`                               |
-| `singleuser.containerSecurityContext.runAsUser` | Set Single User container's Security Context runAsUser                                              | `1001`                               |
-| `singleuser.podSecurityContext.enabled`         | Enabled Single User pods' Security Context                                                          | `true`                               |
-| `singleuser.podSecurityContext.fsGroup`         | Set Single User pod's Security Context fsGroup                                                      | `1001`                               |
-| `singleuser.podLabels`                          | Extra labels for Single User pods                                                                   | `{}`                                 |
-| `singleuser.podAnnotations`                     | Annotations for Single User pods                                                                    | `{}`                                 |
-| `singleuser.nodeSelector`                       | Node labels for pod assignment. Evaluated as a template.                                            | `{}`                                 |
-| `singleuser.tolerations`                        | Tolerations for pod assignment. Evaluated as a template.                                            | `[]`                                 |
-| `singleuser.priorityClassName`                  | Single User pod priority class name                                                                 | `""`                                 |
-| `singleuser.lifecycleHooks`                     | Add lifecycle hooks to the Single User deployment to automate configuration before or after startup | `{}`                                 |
-| `singleuser.extraVolumes`                       | Optionally specify extra list of additional volumes for Single User pods                            | `[]`                                 |
-| `singleuser.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for Single User container(s)               | `[]`                                 |
-| `singleuser.initContainers`                     | Add additional init containers to the Single User pods                                              | `[]`                                 |
-| `singleuser.sidecars`                           | Add additional sidecar containers to the Single User pod                                            | `[]`                                 |
+| Name                                            | Description                                                                                                 | Value                                |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `singleuser.image.registry`                     | Single User image registry                                                                                  | `docker.io`                          |
+| `singleuser.image.repository`                   | Single User image repository                                                                                | `bitnami/jupyter-base-notebook`      |
+| `singleuser.image.tag`                          | Single User image tag (immutabe tags are recommended)                                                       | `1.5.0-debian-11-r25`                |
+| `singleuser.image.digest`                       | Single User image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                 |
+| `singleuser.image.pullPolicy`                   | Single User image pull policy                                                                               | `IfNotPresent`                       |
+| `singleuser.image.pullSecrets`                  | Single User image pull secrets                                                                              | `[]`                                 |
+| `singleuser.notebookDir`                        | Notebook directory (it will be the same as the PVC volume mount)                                            | `/opt/bitnami/jupyterhub-singleuser` |
+| `singleuser.command`                            | Override Single User default command                                                                        | `[]`                                 |
+| `singleuser.extraEnvVars`                       | Add extra environment variables to the Single User container                                                | `[]`                                 |
+| `singleuser.containerPort`                      | Single User container port                                                                                  | `8888`                               |
+| `singleuser.resources.limits`                   | The resources limits for the Singleuser containers                                                          | `{}`                                 |
+| `singleuser.resources.requests`                 | The requested resources for the Singleuser containers                                                       | `{}`                                 |
+| `singleuser.containerSecurityContext.enabled`   | Enabled Single User containers' Security Context                                                            | `true`                               |
+| `singleuser.containerSecurityContext.runAsUser` | Set Single User container's Security Context runAsUser                                                      | `1001`                               |
+| `singleuser.podSecurityContext.enabled`         | Enabled Single User pods' Security Context                                                                  | `true`                               |
+| `singleuser.podSecurityContext.fsGroup`         | Set Single User pod's Security Context fsGroup                                                              | `1001`                               |
+| `singleuser.podLabels`                          | Extra labels for Single User pods                                                                           | `{}`                                 |
+| `singleuser.podAnnotations`                     | Annotations for Single User pods                                                                            | `{}`                                 |
+| `singleuser.nodeSelector`                       | Node labels for pod assignment. Evaluated as a template.                                                    | `{}`                                 |
+| `singleuser.tolerations`                        | Tolerations for pod assignment. Evaluated as a template.                                                    | `[]`                                 |
+| `singleuser.priorityClassName`                  | Single User pod priority class name                                                                         | `""`                                 |
+| `singleuser.lifecycleHooks`                     | Add lifecycle hooks to the Single User deployment to automate configuration before or after startup         | `{}`                                 |
+| `singleuser.extraVolumes`                       | Optionally specify extra list of additional volumes for Single User pods                                    | `[]`                                 |
+| `singleuser.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for Single User container(s)                       | `[]`                                 |
+| `singleuser.initContainers`                     | Add additional init containers to the Single User pods                                                      | `[]`                                 |
+| `singleuser.sidecars`                           | Add additional sidecar containers to the Single User pod                                                    | `[]`                                 |
 
 
 ### Single User RBAC parameters
@@ -464,13 +467,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Auxiliary image parameters
 
-| Name                         | Description                                         | Value                   |
-| ---------------------------- | --------------------------------------------------- | ----------------------- |
-| `auxiliaryImage.registry`    | Auxiliary image registry                            | `docker.io`             |
-| `auxiliaryImage.repository`  | Auxiliary image repository                          | `bitnami/bitnami-shell` |
-| `auxiliaryImage.tag`         | Auxiliary image tag (immutabe tags are recommended) | `11-debian-11-r0`       |
-| `auxiliaryImage.pullPolicy`  | Auxiliary image pull policy                         | `IfNotPresent`          |
-| `auxiliaryImage.pullSecrets` | Auxiliary image pull secrets                        | `[]`                    |
+| Name                         | Description                                                                                               | Value                   |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `auxiliaryImage.registry`    | Auxiliary image registry                                                                                  | `docker.io`             |
+| `auxiliaryImage.repository`  | Auxiliary image repository                                                                                | `bitnami/bitnami-shell` |
+| `auxiliaryImage.tag`         | Auxiliary image tag (immutabe tags are recommended)                                                       | `11-debian-11-r23`      |
+| `auxiliaryImage.digest`      | Auxiliary image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `auxiliaryImage.pullPolicy`  | Auxiliary image pull policy                                                                               | `IfNotPresent`          |
+| `auxiliaryImage.pullSecrets` | Auxiliary image pull secrets                                                                              | `[]`                    |
 
 
 ### JupyterHub database parameters

--- a/bitnami/jupyterhub/values.yaml
+++ b/bitnami/jupyterhub/values.yaml
@@ -61,6 +61,7 @@ hub:
   ## @param hub.image.registry Hub image registry
   ## @param hub.image.repository Hub image repository
   ## @param hub.image.tag Hub image tag (immutable tags are recommended)
+  ## @param hub.image.digest Hub image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param hub.image.pullPolicy Hub image pull policy
   ## @param hub.image.pullSecrets Hub image pull secrets
   ##
@@ -68,6 +69,7 @@ hub:
     registry: docker.io
     repository: bitnami/jupyterhub
     tag: 1.5.0-debian-11-r25
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -146,6 +148,7 @@ hub:
         image:
           name: {{ include "jupyterhub.hubconfiguration.imageEntry" ( dict "imageRoot" .Values.auxiliaryImage "global" $) }}
           tag: {{ .Values.auxiliaryImage.tag }}
+          digest: {{ .Values.auxiliaryImage.digest }}
           pullPolicy: {{ .Values.auxiliaryImage.pullPolicy }}
           pullSecrets: {{- include "jupyterhub.imagePullSecrets.list" . | nindent 8 }}
       cloudMetadata:
@@ -212,6 +215,7 @@ hub:
       image:
         name: {{ include "jupyterhub.hubconfiguration.imageEntry" ( dict "imageRoot" .Values.singleuser.image "global" $) }}
         tag: {{ .Values.singleuser.image.tag }}
+        digest: {{ .Values.singleuser.image.digest }}
         pullPolicy: {{ .Values.singleuser.image.pullPolicy }}
         pullSecrets: {{- include "jupyterhub.imagePullSecrets.list" . | nindent 8 }}
       startTimeout: 300
@@ -625,6 +629,7 @@ proxy:
   ## @param proxy.image.registry Proxy image registry
   ## @param proxy.image.repository Proxy image repository
   ## @param proxy.image.tag Proxy image tag (immutable tags are recommended)
+  ## @param proxy.image.digest Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param proxy.image.pullPolicy Proxy image pull policy
   ## @param proxy.image.pullSecrets Proxy image pull secrets
   ## @param proxy.image.debug Activate verbose output
@@ -633,6 +638,7 @@ proxy:
     registry: docker.io
     repository: bitnami/configurable-http-proxy
     tag: 4.5.1-debian-11-r27
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1379,6 +1385,7 @@ imagePuller:
 ## @param singleuser.image.registry Single User image registry
 ## @param singleuser.image.repository Single User image repository
 ## @param singleuser.image.tag Single User image tag (immutabe tags are recommended)
+## @param singleuser.image.digest Single User image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param singleuser.image.pullPolicy Single User image pull policy
 ## @param singleuser.image.pullSecrets Single User image pull secrets
 ##
@@ -1387,6 +1394,7 @@ singleuser:
     registry: docker.io
     repository: bitnami/jupyter-base-notebook
     tag: 1.5.0-debian-11-r25
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1562,6 +1570,7 @@ singleuser:
 ## @param auxiliaryImage.registry Auxiliary image registry
 ## @param auxiliaryImage.repository Auxiliary image repository
 ## @param auxiliaryImage.tag Auxiliary image tag (immutabe tags are recommended)
+## @param auxiliaryImage.digest Auxiliary image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param auxiliaryImage.pullPolicy Auxiliary image pull policy
 ## @param auxiliaryImage.pullSecrets Auxiliary image pull secrets
 ##
@@ -1569,6 +1578,7 @@ auxiliaryImage:
   registry: docker.io
   repository: bitnami/bitnami-shell
   tag: 11-debian-11-r23
+  digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```