### PR TITLE
[bitnami/joomla] Add support for image digest apart from tag

### DIFF
--- a/bitnami/joomla/Chart.lock
+++ b/bitnami/joomla/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.6
+  version: 11.1.8
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:395279775898db8821c3c27609b90da393cd00116da089a0720297c3d02e6ee3
-generated: "2022-08-09T04:05:53.095096336Z"
+  version: 2.0.0
+digest: sha256:ac0812d9dcac6d780f89689a9dd2f3761aecba9e5f32e37876bccf72f88b6e98
+generated: "2022-08-20T10:58:11.473243695Z"

--- a/bitnami/joomla/Chart.yaml
+++ b/bitnami/joomla/Chart.yaml
@@ -9,7 +9,9 @@ dependencies:
     version: 11.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: 1.x.x
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Joomla! is an award winning open source CMS platform for building websites and applications. It includes page caching, page compression and Let's Encrypt auto-configuration support.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/joomla
@@ -27,4 +29,4 @@ name: joomla
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/joomla
   - https://www.joomla.org/
-version: 13.2.18
+version: 13.3.0

--- a/bitnami/joomla/README.md
+++ b/bitnami/joomla/README.md
@@ -78,87 +78,88 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Joomla! parameters
 
-| Name                                    | Description                                                                                                          | Value                |
-| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| `image.registry`                        | Joomla! image registry                                                                                               | `docker.io`          |
-| `image.repository`                      | Joomla! Image name                                                                                                   | `bitnami/joomla`     |
-| `image.tag`                             | Joomla! Image tag                                                                                                    | `4.1.3-debian-10-r4` |
-| `image.pullPolicy`                      | Joomla! image pull policy                                                                                            | `IfNotPresent`       |
-| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                     | `[]`                 |
-| `image.debug`                           | Specify if debug logs should be enabled                                                                              | `false`              |
-| `joomlaSkipInstall`                     | Skip Joomla! installation wizard. Useful for migrations and restoring from SQL dump                                  | `no`                 |
-| `joomlaUsername`                        | User of the application                                                                                              | `user`               |
-| `joomlaPassword`                        | Application password                                                                                                 | `""`                 |
-| `joomlaEmail`                           | Admin email                                                                                                          | `user@example.com`   |
-| `allowEmptyPassword`                    | Allow DB blank passwords                                                                                             | `no`                 |
-| `command`                               | Override default container command (useful when using custom images)                                                 | `[]`                 |
-| `args`                                  | Override default container args (useful when using custom images)                                                    | `[]`                 |
-| `replicaCount`                          | Number of replicas (requires ReadWriteMany PVC support)                                                              | `1`                  |
-| `hostAliases`                           | Deployment pod host aliases                                                                                          | `[]`                 |
-| `updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                       | `RollingUpdate`      |
-| `extraEnvVars`                          | Extra environment variables                                                                                          | `[]`                 |
-| `extraEnvVarsCM`                        | ConfigMap containing extra env vars                                                                                  | `""`                 |
-| `extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)                                                         | `""`                 |
-| `extraVolumes`                          | Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`   | `[]`                 |
-| `extraVolumeMounts`                     | Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes` | `[]`                 |
-| `initContainers`                        | Add additional init containers to the pod (evaluated as a template)                                                  | `[]`                 |
-| `sidecars`                              | Attach additional containers to the pod (evaluated as a template)                                                    | `[]`                 |
-| `existingSecret`                        | Name of a secret with the application password                                                                       | `""`                 |
-| `smtpHost`                              | SMTP host                                                                                                            | `""`                 |
-| `smtpPort`                              | SMTP port                                                                                                            | `""`                 |
-| `smtpUser`                              | SMTP user                                                                                                            | `""`                 |
-| `smtpPassword`                          | SMTP password                                                                                                        | `""`                 |
-| `smtpProtocol`                          | SMTP Protocol (options: ssl,tls, nil)                                                                                | `""`                 |
-| `containerPorts`                        | Container ports                                                                                                      | `{}`                 |
-| `persistence.enabled`                   | Enable persistence using PVC                                                                                         | `true`               |
-| `persistence.storageClass`              | PVC Storage Class for Joomla! volume                                                                                 | `""`                 |
-| `persistence.accessModes`               | PVC Access Mode for Joomla! volume                                                                                   | `["ReadWriteOnce"]`  |
-| `persistence.size`                      | PVC Storage Request for Joomla! volume                                                                               | `8Gi`                |
-| `persistence.existingClaim`             | An Existing PVC name                                                                                                 | `""`                 |
-| `persistence.hostPath`                  | Host mount path for Joomla! volume                                                                                   | `""`                 |
-| `persistence.annotations`               | Persistent Volume Claim annotations                                                                                  | `{}`                 |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                 |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `soft`               |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                            | `""`                 |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                                | `""`                 |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                            | `[]`                 |
-| `affinity`                              | Affinity for pod assignment                                                                                          | `{}`                 |
-| `nodeSelector`                          | Node labels for pod assignment                                                                                       | `{}`                 |
-| `tolerations`                           | Tolerations for pod assignment                                                                                       | `[]`                 |
-| `resources.limits`                      | The resources limits for the container                                                                               | `{}`                 |
-| `resources.requests`                    | The requested resources for the container                                                                            | `{}`                 |
-| `podSecurityContext.enabled`            | Enable Joomla! pods' Security Context                                                                                | `true`               |
-| `podSecurityContext.fsGroup`            | Joomla! pods' group ID                                                                                               | `1001`               |
-| `containerSecurityContext.enabled`      | Enable Joomla! containers' Security Context                                                                          | `true`               |
-| `containerSecurityContext.runAsUser`    | Joomla! containers' Security Context                                                                                 | `1001`               |
-| `containerSecurityContext.runAsNonRoot` | Set Joomla! container's Security Context runAsNonRoot                                                                | `true`               |
-| `startupProbe.enabled`                  | Enable startupProbe                                                                                                  | `false`              |
-| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                               | `600`                |
-| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                      | `10`                 |
-| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                     | `5`                  |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                   | `6`                  |
-| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                   | `1`                  |
-| `livenessProbe.enabled`                 | Enable livenessProbe                                                                                                 | `true`               |
-| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                              | `600`                |
-| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                     | `10`                 |
-| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                    | `5`                  |
-| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                  | `6`                  |
-| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                  | `1`                  |
-| `readinessProbe.enabled`                | Enable readinessProbe                                                                                                | `true`               |
-| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                             | `30`                 |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                    | `5`                  |
-| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                   | `3`                  |
-| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                 | `6`                  |
-| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                 | `1`                  |
-| `customStartupProbe`                    | Override default startup probe                                                                                       | `{}`                 |
-| `customLivenessProbe`                   | Override default liveness probe                                                                                      | `{}`                 |
-| `customReadinessProbe`                  | Override default readiness probe                                                                                     | `{}`                 |
-| `priorityClassName`                     | Define the priority class name to use for the joomla pods here.                                                      | `""`                 |
-| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                                       | `""`                 |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                       | `[]`                 |
-| `lifecycleHooks`                        | LifecycleHook to set additional configuration at startup Evaluated as a template                                     | `{}`                 |
-| `podAnnotations`                        | Pod annotations                                                                                                      | `{}`                 |
-| `podLabels`                             | Add additional labels to the pod (evaluated as a template)                                                           | `{}`                 |
+| Name                                    | Description                                                                                                          | Value                 |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`                        | Joomla! image registry                                                                                               | `docker.io`           |
+| `image.repository`                      | Joomla! Image name                                                                                                   | `bitnami/joomla`      |
+| `image.tag`                             | Joomla! Image tag                                                                                                    | `4.1.5-debian-11-r20` |
+| `image.digest`                          | Joomla! image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag              | `""`                  |
+| `image.pullPolicy`                      | Joomla! image pull policy                                                                                            | `IfNotPresent`        |
+| `image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                     | `[]`                  |
+| `image.debug`                           | Specify if debug logs should be enabled                                                                              | `false`               |
+| `joomlaSkipInstall`                     | Skip Joomla! installation wizard. Useful for migrations and restoring from SQL dump                                  | `no`                  |
+| `joomlaUsername`                        | User of the application                                                                                              | `user`                |
+| `joomlaPassword`                        | Application password                                                                                                 | `""`                  |
+| `joomlaEmail`                           | Admin email                                                                                                          | `user@example.com`    |
+| `allowEmptyPassword`                    | Allow DB blank passwords                                                                                             | `no`                  |
+| `command`                               | Override default container command (useful when using custom images)                                                 | `[]`                  |
+| `args`                                  | Override default container args (useful when using custom images)                                                    | `[]`                  |
+| `replicaCount`                          | Number of replicas (requires ReadWriteMany PVC support)                                                              | `1`                   |
+| `hostAliases`                           | Deployment pod host aliases                                                                                          | `[]`                  |
+| `updateStrategy.type`                   | Update strategy - only really applicable for deployments with RWO PVs attached                                       | `RollingUpdate`       |
+| `extraEnvVars`                          | Extra environment variables                                                                                          | `[]`                  |
+| `extraEnvVarsCM`                        | ConfigMap containing extra env vars                                                                                  | `""`                  |
+| `extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)                                                         | `""`                  |
+| `extraVolumes`                          | Array of extra volumes to be added to the deployment (evaluated as template). Requires setting `extraVolumeMounts`   | `[]`                  |
+| `extraVolumeMounts`                     | Array of extra volume mounts to be added to the container (evaluated as template). Normally used with `extraVolumes` | `[]`                  |
+| `initContainers`                        | Add additional init containers to the pod (evaluated as a template)                                                  | `[]`                  |
+| `sidecars`                              | Attach additional containers to the pod (evaluated as a template)                                                    | `[]`                  |
+| `existingSecret`                        | Name of a secret with the application password                                                                       | `""`                  |
+| `smtpHost`                              | SMTP host                                                                                                            | `""`                  |
+| `smtpPort`                              | SMTP port                                                                                                            | `""`                  |
+| `smtpUser`                              | SMTP user                                                                                                            | `""`                  |
+| `smtpPassword`                          | SMTP password                                                                                                        | `""`                  |
+| `smtpProtocol`                          | SMTP Protocol (options: ssl,tls, nil)                                                                                | `""`                  |
+| `containerPorts`                        | Container ports                                                                                                      | `{}`                  |
+| `persistence.enabled`                   | Enable persistence using PVC                                                                                         | `true`                |
+| `persistence.storageClass`              | PVC Storage Class for Joomla! volume                                                                                 | `""`                  |
+| `persistence.accessModes`               | PVC Access Mode for Joomla! volume                                                                                   | `["ReadWriteOnce"]`   |
+| `persistence.size`                      | PVC Storage Request for Joomla! volume                                                                               | `8Gi`                 |
+| `persistence.existingClaim`             | An Existing PVC name                                                                                                 | `""`                  |
+| `persistence.hostPath`                  | Host mount path for Joomla! volume                                                                                   | `""`                  |
+| `persistence.annotations`               | Persistent Volume Claim annotations                                                                                  | `{}`                  |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                  | `""`                  |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `soft`                |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                            | `""`                  |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                                | `""`                  |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                            | `[]`                  |
+| `affinity`                              | Affinity for pod assignment                                                                                          | `{}`                  |
+| `nodeSelector`                          | Node labels for pod assignment                                                                                       | `{}`                  |
+| `tolerations`                           | Tolerations for pod assignment                                                                                       | `[]`                  |
+| `resources.limits`                      | The resources limits for the container                                                                               | `{}`                  |
+| `resources.requests`                    | The requested resources for the container                                                                            | `{}`                  |
+| `podSecurityContext.enabled`            | Enable Joomla! pods' Security Context                                                                                | `true`                |
+| `podSecurityContext.fsGroup`            | Joomla! pods' group ID                                                                                               | `1001`                |
+| `containerSecurityContext.enabled`      | Enable Joomla! containers' Security Context                                                                          | `true`                |
+| `containerSecurityContext.runAsUser`    | Joomla! containers' Security Context                                                                                 | `1001`                |
+| `containerSecurityContext.runAsNonRoot` | Set Joomla! container's Security Context runAsNonRoot                                                                | `true`                |
+| `startupProbe.enabled`                  | Enable startupProbe                                                                                                  | `false`               |
+| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                               | `600`                 |
+| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                      | `10`                  |
+| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                     | `5`                   |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                   | `6`                   |
+| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                   | `1`                   |
+| `livenessProbe.enabled`                 | Enable livenessProbe                                                                                                 | `true`                |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                              | `600`                 |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                     | `10`                  |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                    | `5`                   |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                  | `6`                   |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                  | `1`                   |
+| `readinessProbe.enabled`                | Enable readinessProbe                                                                                                | `true`                |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                             | `30`                  |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                    | `5`                   |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                   | `3`                   |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                 | `6`                   |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                 | `1`                   |
+| `customStartupProbe`                    | Override default startup probe                                                                                       | `{}`                  |
+| `customLivenessProbe`                   | Override default liveness probe                                                                                      | `{}`                  |
+| `customReadinessProbe`                  | Override default readiness probe                                                                                     | `{}`                  |
+| `priorityClassName`                     | Define the priority class name to use for the joomla pods here.                                                      | `""`                  |
+| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                                       | `""`                  |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                       | `[]`                  |
+| `lifecycleHooks`                        | LifecycleHook to set additional configuration at startup Evaluated as a template                                     | `{}`                  |
+| `podAnnotations`                        | Pod annotations                                                                                                      | `{}`                  |
+| `podLabels`                             | Add additional labels to the pod (evaluated as a template)                                                           | `{}`                  |
 
 
 ### Traffic Exposure Parameters
@@ -219,16 +220,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics parameters
 
-| Name                        | Description                                      | Value                     |
-| --------------------------- | ------------------------------------------------ | ------------------------- |
-| `metrics.enabled`           | Start a side-car prometheus exporter             | `false`                   |
-| `metrics.image.registry`    | Apache exporter image registry                   | `docker.io`               |
-| `metrics.image.repository`  | Apache exporter image name                       | `bitnami/apache-exporter` |
-| `metrics.image.tag`         | Apache exporter image tag                        | `0.11.0-debian-10-r145`   |
-| `metrics.image.pullPolicy`  | Image pull policy                                | `IfNotPresent`            |
-| `metrics.image.pullSecrets` | Specify docker-registry secret names as an array | `[]`                      |
-| `metrics.resources`         | Exporter resource requests/limit                 | `{}`                      |
-| `metrics.podAnnotations`    | Additional annotations for Metrics exporter pod  | `{}`                      |
+| Name                        | Description                                                                                                     | Value                     |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `metrics.enabled`           | Start a side-car prometheus exporter                                                                            | `false`                   |
+| `metrics.image.registry`    | Apache exporter image registry                                                                                  | `docker.io`               |
+| `metrics.image.repository`  | Apache exporter image name                                                                                      | `bitnami/apache-exporter` |
+| `metrics.image.tag`         | Apache exporter image tag                                                                                       | `0.11.0-debian-11-r27`    |
+| `metrics.image.digest`      | Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                      |
+| `metrics.image.pullPolicy`  | Image pull policy                                                                                               | `IfNotPresent`            |
+| `metrics.image.pullSecrets` | Specify docker-registry secret names as an array                                                                | `[]`                      |
+| `metrics.resources`         | Exporter resource requests/limit                                                                                | `{}`                      |
+| `metrics.podAnnotations`    | Additional annotations for Metrics exporter pod                                                                 | `{}`                      |
 
 
 ### NetworkPolicy parameters

--- a/bitnami/joomla/values.yaml
+++ b/bitnami/joomla/values.yaml
@@ -50,6 +50,7 @@ extraDeploy: []
 ## @param image.registry Joomla! image registry
 ## @param image.repository Joomla! Image name
 ## @param image.tag Joomla! Image tag
+## @param image.digest Joomla! image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Joomla! image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Specify if debug logs should be enabled
@@ -58,6 +59,7 @@ image:
   registry: docker.io
   repository: bitnami/joomla
   tag: 4.1.5-debian-11-r20
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -609,6 +611,7 @@ metrics:
   ## @param metrics.image.registry Apache exporter image registry
   ## @param metrics.image.repository Apache exporter image name
   ## @param metrics.image.tag Apache exporter image tag
+  ## @param metrics.image.digest Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy Image pull policy
   ## @param metrics.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -616,6 +619,7 @@ metrics:
     registry: docker.io
     repository: bitnami/apache-exporter
     tag: 0.11.0-debian-11-r27
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```