### PR TITLE
[bitnami/jasperreports] Add support for image digest apart from tag

### DIFF
--- a/bitnami/jasperreports/Chart.lock
+++ b/bitnami/jasperreports/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
 digest: sha256:f42928c69e683d72cf3b7f57e2108f1ba8222fa3b44cbcd1376ded4e8f1c3ba4
-generated: "2022-08-22T14:16:44.585877795Z"
+generated: "2022-08-22T14:25:21.660434054Z"

--- a/bitnami/jasperreports/Chart.lock
+++ b/bitnami/jasperreports/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 11.1.8
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:3541941eebae195a314e878da8135d6e24a002aa622e491788bd9b14b6a0014f
-generated: "2022-08-17T20:48:41.442715159Z"
+  version: 2.0.0
+digest: sha256:ac0812d9dcac6d780f89689a9dd2f3761aecba9e5f32e37876bccf72f88b6e98
+generated: "2022-08-20T10:58:04.308509616Z"

--- a/bitnami/jasperreports/Chart.lock
+++ b/bitnami/jasperreports/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.8
+  version: 11.2.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
-digest: sha256:ac0812d9dcac6d780f89689a9dd2f3761aecba9e5f32e37876bccf72f88b6e98
-generated: "2022-08-20T10:58:04.308509616Z"
+digest: sha256:f42928c69e683d72cf3b7f57e2108f1ba8222fa3b44cbcd1376ded4e8f1c3ba4
+generated: "2022-08-22T14:16:44.585877795Z"

--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: JasperReports Server is a stand-alone and embeddable reporting server. It is a central information hub, with reporting and analytics that can be embedded into web and mobile applications.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/jasperreports
@@ -30,4 +30,4 @@ name: jasperreports
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/jasperreports
   - http://community.jaspersoft.com/project/jasperreports-server
-version: 14.1.18
+version: 14.2.0

--- a/bitnami/jasperreports/README.md
+++ b/bitnami/jasperreports/README.md
@@ -78,29 +78,30 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### JasperReports parameters
 
-| Name                    | Description                                                            | Value                   |
-| ----------------------- | ---------------------------------------------------------------------- | ----------------------- |
-| `image.registry`        | JasperReports image registry                                           | `docker.io`             |
-| `image.repository`      | JasperReports image repository                                         | `bitnami/jasperreports` |
-| `image.tag`             | JasperReports image tag (immutable tags are recommended)               | `8.0.0-debian-10-r33`   |
-| `image.pullPolicy`      | JasperReports image pull policy                                        | `IfNotPresent`          |
-| `image.pullSecrets`     | Specify docker-registry secret names as an array                       | `[]`                    |
-| `jasperreportsUsername` | JasperReports user                                                     | `jasperadmin`           |
-| `jasperreportsPassword` | JasperReports password                                                 | `""`                    |
-| `jasperreportsEmail`    | JasperReports user email                                               | `user@example.com`      |
-| `allowEmptyPassword`    | Set to `yes` to allow the container to be started with blank passwords | `no`                    |
-| `smtpHost`              | SMTP host                                                              | `""`                    |
-| `smtpPort`              | SMTP port                                                              | `""`                    |
-| `smtpEmail`             | SMTP email                                                             | `""`                    |
-| `smtpUser`              | SMTP user                                                              | `""`                    |
-| `smtpPassword`          | SMTP password                                                          | `""`                    |
-| `smtpProtocol`          | SMTP protocol [`ssl`, `none`]                                          | `""`                    |
-| `command`               | Override default container command (useful when using custom images)   | `[]`                    |
-| `args`                  | Override default container args (useful when using custom images)      | `[]`                    |
-| `extraEnvVars`          | Extra environment variables to be set on Jasperreports container       | `[]`                    |
-| `extraEnvVarsCM`        | Name of existing ConfigMap containing extra env vars                   | `""`                    |
-| `extraEnvVarsSecret`    | Name of existing Secret containing extra env vars                      | `""`                    |
-| `updateStrategy.type`   | StrategyType                                                           | `RollingUpdate`         |
+| Name                    | Description                                                                                                   | Value                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `image.registry`        | JasperReports image registry                                                                                  | `docker.io`             |
+| `image.repository`      | JasperReports image repository                                                                                | `bitnami/jasperreports` |
+| `image.tag`             | JasperReports image tag (immutable tags are recommended)                                                      | `8.0.2-debian-11-r25`   |
+| `image.digest`          | JasperReports image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `image.pullPolicy`      | JasperReports image pull policy                                                                               | `IfNotPresent`          |
+| `image.pullSecrets`     | Specify docker-registry secret names as an array                                                              | `[]`                    |
+| `jasperreportsUsername` | JasperReports user                                                                                            | `jasperadmin`           |
+| `jasperreportsPassword` | JasperReports password                                                                                        | `""`                    |
+| `jasperreportsEmail`    | JasperReports user email                                                                                      | `user@example.com`      |
+| `allowEmptyPassword`    | Set to `yes` to allow the container to be started with blank passwords                                        | `no`                    |
+| `smtpHost`              | SMTP host                                                                                                     | `""`                    |
+| `smtpPort`              | SMTP port                                                                                                     | `""`                    |
+| `smtpEmail`             | SMTP email                                                                                                    | `""`                    |
+| `smtpUser`              | SMTP user                                                                                                     | `""`                    |
+| `smtpPassword`          | SMTP password                                                                                                 | `""`                    |
+| `smtpProtocol`          | SMTP protocol [`ssl`, `none`]                                                                                 | `""`                    |
+| `command`               | Override default container command (useful when using custom images)                                          | `[]`                    |
+| `args`                  | Override default container args (useful when using custom images)                                             | `[]`                    |
+| `extraEnvVars`          | Extra environment variables to be set on Jasperreports container                                              | `[]`                    |
+| `extraEnvVarsCM`        | Name of existing ConfigMap containing extra env vars                                                          | `""`                    |
+| `extraEnvVarsSecret`    | Name of existing Secret containing extra env vars                                                             | `""`                    |
+| `updateStrategy.type`   | StrategyType                                                                                                  | `RollingUpdate`         |
 
 
 ### Jasperreports deployment parameters

--- a/bitnami/jasperreports/values.yaml
+++ b/bitnami/jasperreports/values.yaml
@@ -50,6 +50,7 @@ extraDeploy: []
 ## @param image.registry JasperReports image registry
 ## @param image.repository JasperReports image repository
 ## @param image.tag JasperReports image tag (immutable tags are recommended)
+## @param image.digest JasperReports image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy JasperReports image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ##
@@ -57,6 +58,7 @@ image:
   registry: docker.io
   repository: bitnami/jasperreports
   tag: 8.0.2-debian-11-r25
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```