### PR TITLE
[bitnami/harbor] Add support for image digest apart from tag

### DIFF
--- a/bitnami/harbor/Chart.lock
+++ b/bitnami/harbor/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.0.8
+  version: 17.0.11
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.25
+  version: 11.7.4
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:e592937596c37e23b29c59f94aff2dbcc95d5bea181d088f3454954a441c9e29
-generated: "2022-08-09T05:29:00.427755752Z"
+  version: 2.0.0
+digest: sha256:69304b8b09d9246daaa84db705caeef65765f37e92c7a42daa915a760bb004cc
+generated: "2022-08-20T10:57:56.368386956Z"

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -13,7 +13,9 @@ dependencies:
     version: 11.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: 1.x.x
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Harbor is an open source trusted cloud-native registry to store, sign, and scan content. It adds functionalities like security, identity, and management to the open source Docker distribution.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/harbor
@@ -34,4 +36,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registry
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registryctl
   - https://goharbor.io/
-version: 15.1.0
+version: 15.2.0

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -715,6 +715,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image repository
   ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
   ## @param volumePermissions.image.pullSecrets Init container volume-permissions image pull secrets
   ##
@@ -722,6 +723,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -758,6 +760,7 @@ nginx:
   ## @param nginx.image.registry NGINX image registry
   ## @param nginx.image.repository NGINX image repository
   ## @param nginx.image.tag NGINX image tag (immutable tags are recommended)
+  ## @param nginx.digest NGINX image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param nginx.image.pullPolicy NGINX image pull policy
   ## @param nginx.image.pullSecrets NGINX image pull secrets
   ## @param nginx.image.debug Enable NGINX image debug mode
@@ -766,6 +769,7 @@ nginx:
     registry: docker.io
     repository: bitnami/nginx
     tag: 1.23.1-debian-11-r7
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1021,6 +1025,7 @@ portal:
   ## @param portal.image.registry Harbor Portal image registry
   ## @param portal.image.repository Harbor Portal image repository
   ## @param portal.image.tag Harbor Portal image tag (immutable tags are recommended)
+  ## @param portal.image.digest Harbor Portal image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param portal.image.pullPolicy Harbor Portal image pull policy
   ## @param portal.image.pullSecrets Harbor Portal image pull secrets
   ## @param portal.image.debug Enable Harbor Portal image debug mode
@@ -1029,6 +1034,7 @@ portal:
     registry: docker.io
     repository: bitnami/harbor-portal
     tag: 2.5.3-debian-11-r14
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1279,6 +1285,7 @@ core:
   ## @param core.image.registry Harbor Core image registry
   ## @param core.image.repository Harbor Core image repository
   ## @param core.image.tag Harbor Core image tag (immutable tags are recommended)
+  ## @param core.image.digest Harbor Core image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param core.image.pullPolicy Harbor Core image pull policy
   ## @param core.image.pullSecrets Harbor Core image pull secrets
   ## @param core.image.debug Enable Harbor Core image debug mode
@@ -1287,6 +1294,7 @@ core:
     registry: docker.io
     repository: bitnami/harbor-core
     tag: 2.5.3-debian-11-r11
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1570,6 +1578,7 @@ jobservice:
   ## @param jobservice.image.registry Harbor Jobservice image registry
   ## @param jobservice.image.repository Harbor Jobservice image repository
   ## @param jobservice.image.tag Harbor Jobservice image tag (immutable tags are recommended)
+  ## @param jobservice.image.digest Harbor Jobservice image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param jobservice.image.pullPolicy Harbor Jobservice image pull policy
   ## @param jobservice.image.pullSecrets Harbor Jobservice image pull secrets
   ## @param jobservice.image.debug Enable Harbor Jobservice image debug mode
@@ -1578,6 +1587,7 @@ jobservice:
     registry: docker.io
     repository: bitnami/harbor-jobservice
     tag: 2.5.3-debian-11-r11
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2011,6 +2021,7 @@ registry:
     ## @param registry.server.image.registry Harbor Registry image registry
     ## @param registry.server.image.repository Harbor Registry image repository
     ## @param registry.server.image.tag Harbor Registry image tag (immutable tags are recommended)
+    ## @param registry.server.digest Harbor Registry image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param registry.server.image.pullPolicy Harbor Registry image pull policy
     ## @param registry.server.image.pullSecrets Harbor Registry image pull secrets
     ## @param registry.server.image.debug Enable Harbor Registry image debug mode
@@ -2019,6 +2030,7 @@ registry:
       registry: docker.io
       repository: bitnami/harbor-registry
       tag: 2.5.3-debian-11-r14
+      digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2156,6 +2168,7 @@ registry:
     ## @param registry.controller.image.registry Harbor Registryctl image registry
     ## @param registry.controller.image.repository Harbor Registryctl image repository
     ## @param registry.controller.image.tag Harbor Registryctl image tag (immutable tags are recommended)
+    ## @param registry.controller.digest Harbor Registryctl image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param registry.controller.image.pullPolicy Harbor Registryctl image pull policy
     ## @param registry.controller.image.pullSecrets Harbor Registryctl image pull secrets
     ## @param registry.controller.image.debug Enable Harbor Registryctl image debug mode
@@ -2164,6 +2177,7 @@ registry:
       registry: docker.io
       repository: bitnami/harbor-registryctl
       tag: 2.5.3-debian-11-r11
+      digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2297,6 +2311,7 @@ chartmuseum:
   ## @param chartmuseum.image.registry ChartMuseum image registry
   ## @param chartmuseum.image.repository ChartMuseum image repository
   ## @param chartmuseum.image.tag ChartMuseum image tag (immutable tags are recommended)
+  ## @param chartmuseum.image.digest ChartMuseum image image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param chartmuseum.image.pullPolicy ChartMuseum image pull policy
   ## @param chartmuseum.image.pullSecrets ChartMuseum image pull secrets
   ## @param chartmuseum.image.debug Enable ChartMuseum image debug mode
@@ -2305,6 +2320,7 @@ chartmuseum:
     registry: docker.io
     repository: bitnami/chartmuseum
     tag: 0.15.0-debian-11-r11
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2619,6 +2635,7 @@ notary:
     ## @param notary.server.image.registry Harbor Notary Server image registry
     ## @param notary.server.image.repository Harbor Notary Server image repository
     ## @param notary.server.image.tag Harbor Notary Server image tag (immutable tags are recommended)
+    ## @param notary.server.digest Notary Server image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param notary.server.image.pullPolicy Harbor Notary Server image pull policy
     ## @param notary.server.image.pullSecrets Harbor Notary Server image pull secrets
     ## @param notary.server.image.debug Enable Harbor Notary Server image debug mode
@@ -2627,6 +2644,7 @@ notary:
       registry: docker.io
       repository: bitnami/harbor-notary-server
       tag: 2.5.3-debian-11-r14
+      digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2854,6 +2872,7 @@ notary:
     ## @param notary.signer.image.registry Harbor Notary Signer image registry
     ## @param notary.signer.image.repository Harbor Notary Signer image repository
     ## @param notary.signer.image.tag Harbor Notary Signer image tag (immutable tags are recommended)
+    ## @param notary.signer.digest Harbor Notary Signer image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param notary.signer.image.pullPolicy Harbor Notary Signer image pull policy
     ## @param notary.signer.image.pullSecrets Harbor Notary Signer image pull secrets
     ## @param notary.signer.image.debug Enable Harbor Notary Signer image debug mode
@@ -2862,6 +2881,7 @@ notary:
       registry: docker.io
       repository: bitnami/harbor-notary-signer
       tag: 2.5.3-debian-11-r12
+      digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3102,6 +3122,7 @@ trivy:
   ## @param trivy.image.registry Harbor Adapter Trivy image registry
   ## @param trivy.image.repository Harbor Adapter Trivy image repository
   ## @param trivy.image.tag Harbor Adapter Trivy image tag (immutable tags are recommended)
+  ## @param trivy.image.digest Harbor Adapter Trivy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param trivy.image.pullPolicy Harbor Adapter Trivy image pull policy
   ## @param trivy.image.pullSecrets Harbor Adapter Trivy image pull secrets
   ## @param trivy.image.debug Enable Harbor Adapter Trivy image debug mode
@@ -3110,6 +3131,7 @@ trivy:
     registry: docker.io
     repository: bitnami/harbor-adapter-trivy
     tag: 2.5.3-debian-11-r9
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3405,9 +3427,10 @@ trivy:
 exporter:
   ## Bitnami Harbor Exporter image
   ## ref: https://hub.docker.com/r/bitnami/harbor-exporter/tags/
-  ## @param exporter.image.registry Registry for exporter image
-  ## @param exporter.image.repository Repository for exporter image
-  ## @param exporter.image.tag Tag for exporter image
+  ## @param exporter.image.registry Harbor Exporter image registry
+  ## @param exporter.image.repository Harbor Exporter image repository
+  ## @param exporter.image.tag Harbor Exporter image tag
+  ## @param exporter.image.digest Harbor Exporter image image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param exporter.image.pullPolicy Harbor exporter image pull policy
   ## @param exporter.image.pullSecrets Specify docker-registry secret names as an array
   ## @param exporter.image.debug Specify if debug logs should be enabled
@@ -3416,6 +3439,7 @@ exporter:
     registry: docker.io
     repository: bitnami/harbor-exporter
     tag: 2.5.3-debian-11-r12
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3658,11 +3682,13 @@ postgresql:
   ## @param postgresql.image.registry PostgreSQL image registry
   ## @param postgresql.image.repository PostgreSQL image repository
   ## @param postgresql.image.tag PostgreSQL image tag (immutable tags are recommended)
+  ## @param postgresql.image.digest PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ##
   image:
     registry: docker.io
     repository: bitnami/postgresql
     tag: 13.7.0-debian-11-r32
+    digest: ""
   auth:
     enablePostgresUser: true
     postgresPassword: not-secure-database-password


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```