### PR TITLE
[bitnami/haproxy-intel] Add support for image digest apart from tag

### DIFF
--- a/bitnami/haproxy-intel/Chart.lock
+++ b/bitnami/haproxy-intel/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.3.34
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.17.1
-digest: sha256:57fd94a6182db21fcb8b251cc27975af2f45985695e0a5399dbc1ace99e71ab9
-generated: "2022-08-19T20:05:09.238618918Z"
+  version: 2.0.0
+digest: sha256:615efe9166f578b2cced5fa7bf04730f8ac259805dfb7e2c2e637c26949e726b
+generated: "2022-08-20T10:57:51.425450634Z"

--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -10,7 +10,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: HAProxy is a high-performance, open-source load balancer and reverse proxy for TCP and HTTP applications. This image is optimized with Intel(R) QuickAssist Technology OpenSSL* Engine (QAT_Engine).
 home: https://www.haproxy.org/
 icon: https://bitnami.com/assets/stacks/haproxy/img/haproxy-stack-220x234.png
@@ -26,4 +26,4 @@ name: haproxy-intel
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/haproxy-intel
   - https://github.com/haproxytech/haproxy
-version: 0.1.13
+version: 0.2.0

--- a/bitnami/haproxy-intel/README.md
+++ b/bitnami/haproxy-intel/README.md
@@ -65,13 +65,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### HAProxy chart parameters
 
-| Name                        | Description                                        | Value                   |
-| --------------------------- | -------------------------------------------------- | ----------------------- |
-| `haproxy.image.registry`    | HAProxy image registry                             | `docker.io`             |
-| `haproxy.image.repository`  | HAProxy image repository                           | `bitnami/haproxy-intel` |
-| `haproxy.image.tag`         | HAProxy image tag (immutable tags are recommended) | `2.6.3-debian-11-r0`    |
-| `haproxy.image.pullPolicy`  | HAProxy image pull policy                          | `IfNotPresent`          |
-| `haproxy.image.pullSecrets` | HAProxy image pull secrets                         | `[]`                    |
+| Name                        | Description                                                                                             | Value                   |
+| --------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `haproxy.image.registry`    | HAProxy image registry                                                                                  | `docker.io`             |
+| `haproxy.image.repository`  | HAProxy image repository                                                                                | `bitnami/haproxy-intel` |
+| `haproxy.image.tag`         | HAProxy image tag (immutable tags are recommended)                                                      | `2.6.3-debian-11-r0`    |
+| `haproxy.image.digest`      | HAProxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `haproxy.image.pullPolicy`  | HAProxy image pull policy                                                                               | `IfNotPresent`          |
+| `haproxy.image.pullSecrets` | HAProxy image pull secrets                                                                              | `[]`                    |
 
 
 HAProxy is installed as a subchart, meaning that the whole list of parameters is defined in [bitnami/haproxy](https://github.com/bitnami/charts/tree/master/bitnami/haproxy). Please, note that parameters from the subchart should be prefixed with `haproxy.` in this chart.

--- a/bitnami/haproxy-intel/values.yaml
+++ b/bitnami/haproxy-intel/values.yaml
@@ -26,6 +26,7 @@ global:
 ## @param haproxy.image.registry HAProxy image registry
 ## @param haproxy.image.repository HAProxy image repository
 ## @param haproxy.image.tag HAProxy image tag (immutable tags are recommended)
+## @param haproxy.image.digest HAProxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param haproxy.image.pullPolicy HAProxy image pull policy
 ## @param haproxy.image.pullSecrets HAProxy image pull secrets
 ##
@@ -34,6 +35,7 @@ haproxy:
     registry: docker.io
     repository: bitnami/haproxy-intel
     tag: 2.6.3-debian-11-r0
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```