### PR TITLE
[bitnami/haproxy] Add support for image digest apart from tag

### DIFF
--- a/bitnami/haproxy/Chart.lock
+++ b/bitnami/haproxy/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.17.1
-digest: sha256:dacc73770a5640c011e067ff8840ddf89631fc19016c8d0a9e5ea160e7da8690
-generated: "2022-08-19T19:55:27.698037285Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:57:47.872944168Z"

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: HAProxy is a TCP proxy and a HTTP reverse proxy. It supports SSL termination and offloading, TCP and HTTP normalization, traffic regulation, caching and protection against DDoS attacks.
 engine: gotpl
 home: https://www.haproxy.org/
@@ -23,4 +23,4 @@ name: haproxy
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/haproxy
   - https://github.com/haproxytech/haproxy
-version: 0.4.1
+version: 0.5.0

--- a/bitnami/haproxy/README.md
+++ b/bitnami/haproxy/README.md
@@ -97,78 +97,79 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### HAProxy Parameters
 
-| Name                                    | Description                                                                               | Value                |
-| --------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
-| `image.registry`                        | HAProxy image registry                                                                    | `docker.io`          |
-| `image.repository`                      | HAProxy image repository                                                                  | `bitnami/haproxy`    |
-| `image.tag`                             | HAProxy image tag (immutable tags are recommended)                                        | `2.5.1-debian-10-r0` |
-| `image.pullPolicy`                      | HAProxy image pull policy                                                                 | `IfNotPresent`       |
-| `image.pullSecrets`                     | HAProxy image pull secrets                                                                | `[]`                 |
-| `replicaCount`                          | Number of haproxy replicas to deploy                                                      | `1`                  |
-| `startupProbe.enabled`                  | Enable startupProbe on haproxy nodes                                                      | `false`              |
-| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                    | `15`                 |
-| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                           | `10`                 |
-| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                          | `5`                  |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                        | `5`                  |
-| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                        | `1`                  |
-| `livenessProbe.enabled`                 | Enable livenessProbe on haproxy nodes                                                     | `true`               |
-| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                   | `15`                 |
-| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                          | `10`                 |
-| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                         | `5`                  |
-| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                       | `5`                  |
-| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                       | `1`                  |
-| `readinessProbe.enabled`                | Enable readinessProbe on haproxy nodes                                                    | `true`               |
-| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                  | `15`                 |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                         | `10`                 |
-| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                        | `5`                  |
-| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                      | `5`                  |
-| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                      | `1`                  |
-| `customStartupProbe`                    | Custom startupProbe that overrides the default one                                        | `{}`                 |
-| `customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                       | `{}`                 |
-| `customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                      | `{}`                 |
-| `resources.limits`                      | The resources limits for the haproxy containers                                           | `{}`                 |
-| `resources.requests`                    | The requested resources for the haproxy containers                                        | `{}`                 |
-| `podSecurityContext.enabled`            | Enabled haproxy pods' Security Context                                                    | `true`               |
-| `podSecurityContext.fsGroup`            | Set haproxy pod's Security Context fsGroup                                                | `1001`               |
-| `containerSecurityContext.enabled`      | Enabled haproxy containers' Security Context                                              | `true`               |
-| `containerSecurityContext.runAsUser`    | Set haproxy containers' Security Context runAsUser                                        | `1001`               |
-| `containerSecurityContext.runAsNonRoot` | Set haproxy container's Security Context runAsNonRoot                                     | `true`               |
-| `pdb.create`                            | Enable a Pod Disruption Budget creation                                                   | `false`              |
-| `pdb.minAvailable`                      | Minimum number/percentage of pods that should remain scheduled                            | `1`                  |
-| `pdb.maxUnavailable`                    | Maximum number/percentage of pods that may be made unavailable                            | `""`                 |
-| `autoscaling.enabled`                   | Enable Horizontal POD autoscaling for HAProxy                                             | `false`              |
-| `autoscaling.minReplicas`               | Minimum number of HAProxy replicas                                                        | `1`                  |
-| `autoscaling.maxReplicas`               | Maximum number of HAProxy replicas                                                        | `11`                 |
-| `autoscaling.targetCPU`                 | Target CPU utilization percentage                                                         | `50`                 |
-| `autoscaling.targetMemory`              | Target Memory utilization percentage                                                      | `50`                 |
-| `command`                               | Override default container command (useful when using custom images)                      | `[]`                 |
-| `args`                                  | Override default container args (useful when using custom images)                         | `[]`                 |
-| `hostAliases`                           | haproxy pods host aliases                                                                 | `[]`                 |
-| `podLabels`                             | Extra labels for haproxy pods                                                             | `{}`                 |
-| `podAnnotations`                        | Annotations for haproxy pods                                                              | `{}`                 |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                 |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`               |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                 |
-| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set                                     | `""`                 |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set                                  | `[]`                 |
-| `configuration`                         | haproxy configuration                                                                     | `""`                 |
-| `containerPorts`                        | List of container ports to enable in the haproxy container                                | `[]`                 |
-| `existingConfigmap`                     | configmap with HAProxy configuration                                                      | `""`                 |
-| `affinity`                              | Affinity for haproxy pods assignment                                                      | `{}`                 |
-| `nodeSelector`                          | Node labels for haproxy pods assignment                                                   | `{}`                 |
-| `tolerations`                           | Tolerations for haproxy pods assignment                                                   | `[]`                 |
-| `schedulerName`                         | Name of the k8s scheduler (other than default)                                            | `""`                 |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                            | `[]`                 |
-| `updateStrategy.type`                   | haproxy statefulset strategy type                                                         | `RollingUpdate`      |
-| `priorityClassName`                     | haproxy pods' priorityClassName                                                           | `""`                 |
-| `lifecycleHooks`                        | for the haproxy container(s) to automate configuration before or after startup            | `{}`                 |
-| `extraEnvVars`                          | Array with extra environment variables to add to haproxy nodes                            | `[]`                 |
-| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for haproxy nodes                    | `""`                 |
-| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for haproxy nodes                       | `""`                 |
-| `extraVolumes`                          | Optionally specify extra list of additional volumes for the haproxy pod(s)                | `[]`                 |
-| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the haproxy container(s)     | `[]`                 |
-| `sidecars`                              | Add additional sidecar containers to the haproxy pod(s)                                   | `[]`                 |
-| `initContainers`                        | Add additional init containers to the haproxy pod(s)                                      | `[]`                 |
+| Name                                    | Description                                                                                             | Value                |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------- |
+| `image.registry`                        | HAProxy image registry                                                                                  | `docker.io`          |
+| `image.repository`                      | HAProxy image repository                                                                                | `bitnami/haproxy`    |
+| `image.tag`                             | HAProxy image tag (immutable tags are recommended)                                                      | `2.6.3-debian-11-r0` |
+| `image.digest`                          | HAProxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                 |
+| `image.pullPolicy`                      | HAProxy image pull policy                                                                               | `IfNotPresent`       |
+| `image.pullSecrets`                     | HAProxy image pull secrets                                                                              | `[]`                 |
+| `replicaCount`                          | Number of haproxy replicas to deploy                                                                    | `1`                  |
+| `startupProbe.enabled`                  | Enable startupProbe on haproxy nodes                                                                    | `false`              |
+| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                  | `15`                 |
+| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                         | `10`                 |
+| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                        | `5`                  |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                      | `5`                  |
+| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                      | `1`                  |
+| `livenessProbe.enabled`                 | Enable livenessProbe on haproxy nodes                                                                   | `true`               |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                 | `15`                 |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                        | `10`                 |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                       | `5`                  |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                     | `5`                  |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                     | `1`                  |
+| `readinessProbe.enabled`                | Enable readinessProbe on haproxy nodes                                                                  | `true`               |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                | `15`                 |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                       | `10`                 |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                      | `5`                  |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                    | `5`                  |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                    | `1`                  |
+| `customStartupProbe`                    | Custom startupProbe that overrides the default one                                                      | `{}`                 |
+| `customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                     | `{}`                 |
+| `customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                    | `{}`                 |
+| `resources.limits`                      | The resources limits for the haproxy containers                                                         | `{}`                 |
+| `resources.requests`                    | The requested resources for the haproxy containers                                                      | `{}`                 |
+| `podSecurityContext.enabled`            | Enabled haproxy pods' Security Context                                                                  | `true`               |
+| `podSecurityContext.fsGroup`            | Set haproxy pod's Security Context fsGroup                                                              | `1001`               |
+| `containerSecurityContext.enabled`      | Enabled haproxy containers' Security Context                                                            | `true`               |
+| `containerSecurityContext.runAsUser`    | Set haproxy containers' Security Context runAsUser                                                      | `1001`               |
+| `containerSecurityContext.runAsNonRoot` | Set haproxy container's Security Context runAsNonRoot                                                   | `true`               |
+| `pdb.create`                            | Enable a Pod Disruption Budget creation                                                                 | `false`              |
+| `pdb.minAvailable`                      | Minimum number/percentage of pods that should remain scheduled                                          | `1`                  |
+| `pdb.maxUnavailable`                    | Maximum number/percentage of pods that may be made unavailable                                          | `""`                 |
+| `autoscaling.enabled`                   | Enable Horizontal POD autoscaling for HAProxy                                                           | `false`              |
+| `autoscaling.minReplicas`               | Minimum number of HAProxy replicas                                                                      | `1`                  |
+| `autoscaling.maxReplicas`               | Maximum number of HAProxy replicas                                                                      | `11`                 |
+| `autoscaling.targetCPU`                 | Target CPU utilization percentage                                                                       | `50`                 |
+| `autoscaling.targetMemory`              | Target Memory utilization percentage                                                                    | `50`                 |
+| `command`                               | Override default container command (useful when using custom images)                                    | `[]`                 |
+| `args`                                  | Override default container args (useful when using custom images)                                       | `[]`                 |
+| `hostAliases`                           | haproxy pods host aliases                                                                               | `[]`                 |
+| `podLabels`                             | Extra labels for haproxy pods                                                                           | `{}`                 |
+| `podAnnotations`                        | Annotations for haproxy pods                                                                            | `{}`                 |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`                 |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `soft`               |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`                 |
+| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set                                                   | `""`                 |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set                                                | `[]`                 |
+| `configuration`                         | haproxy configuration                                                                                   | `""`                 |
+| `containerPorts`                        | List of container ports to enable in the haproxy container                                              | `[]`                 |
+| `existingConfigmap`                     | configmap with HAProxy configuration                                                                    | `""`                 |
+| `affinity`                              | Affinity for haproxy pods assignment                                                                    | `{}`                 |
+| `nodeSelector`                          | Node labels for haproxy pods assignment                                                                 | `{}`                 |
+| `tolerations`                           | Tolerations for haproxy pods assignment                                                                 | `[]`                 |
+| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                          | `""`                 |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                          | `[]`                 |
+| `updateStrategy.type`                   | haproxy statefulset strategy type                                                                       | `RollingUpdate`      |
+| `priorityClassName`                     | haproxy pods' priorityClassName                                                                         | `""`                 |
+| `lifecycleHooks`                        | for the haproxy container(s) to automate configuration before or after startup                          | `{}`                 |
+| `extraEnvVars`                          | Array with extra environment variables to add to haproxy nodes                                          | `[]`                 |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for haproxy nodes                                  | `""`                 |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for haproxy nodes                                     | `""`                 |
+| `extraVolumes`                          | Optionally specify extra list of additional volumes for the haproxy pod(s)                              | `[]`                 |
+| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the haproxy container(s)                   | `[]`                 |
+| `sidecars`                              | Add additional sidecar containers to the haproxy pod(s)                                                 | `[]`                 |
+| `initContainers`                        | Add additional init containers to the haproxy pod(s)                                                    | `[]`                 |
 
 
 ### Other Parameters

--- a/bitnami/haproxy/values.yaml
+++ b/bitnami/haproxy/values.yaml
@@ -116,6 +116,7 @@ service:
 ## @param image.registry HAProxy image registry
 ## @param image.repository HAProxy image repository
 ## @param image.tag HAProxy image tag (immutable tags are recommended)
+## @param image.digest HAProxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy HAProxy image pull policy
 ## @param image.pullSecrets HAProxy image pull secrets
 ##
@@ -123,6 +124,7 @@ image:
   registry: docker.io
   repository: bitnami/haproxy
   tag: 2.6.3-debian-11-r0
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```