### PR TITLE
[bitnami/grafana-loki] Add support for image digest apart from tag

### DIFF
--- a/bitnami/grafana-loki/Chart.lock
+++ b/bitnami/grafana-loki/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.1.10
+  version: 6.1.11
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.1.10
+  version: 6.1.11
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.1.10
+  version: 6.1.11
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.1.10
+  version: 6.1.11
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:12beee254c57f12c41f505f2f79e29e67a04ef87ea0ad0b19b11df1bb61847b6
-generated: "2022-08-09T05:17:36.861868797Z"
+  version: 2.0.0
+digest: sha256:37fe090c58d17f936f1ff43bc93618c73a2d863567ddc15605d3ec392d65c456
+generated: "2022-08-20T10:57:36.966466899Z"

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -27,8 +27,8 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
-description: Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage. 
+    version: 2.x.x
+description: Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage.
 engine: gotpl
 home: https://github.com/grafana/loki/
 icon: https://bitnami.com/assets/stacks/grafana-loki/img/grafana-loki-stack-220x234.png
@@ -44,4 +44,4 @@ name: grafana-loki
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/grafana-loki
   - https://github.com/grafana/loki/
-version: 2.2.8
+version: 2.3.0

--- a/bitnami/grafana-loki/README.md
+++ b/bitnami/grafana-loki/README.md
@@ -82,21 +82,22 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common Grafana Loki Parameters
 
-| Name                                  | Description                                                    | Value                   |
-| ------------------------------------- | -------------------------------------------------------------- | ----------------------- |
-| `loki.image.registry`                 | Grafana Loki image registry                                    | `docker.io`             |
-| `loki.image.repository`               | Grafana Loki image repository                                  | `bitnami/grafana-loki`  |
-| `loki.image.tag`                      | Grafana Loki image tag (immutable tags are recommended)        | `2.6.1-debian-11-r9`    |
-| `loki.image.pullPolicy`               | Grafana Loki image pull policy                                 | `IfNotPresent`          |
-| `loki.image.pullSecrets`              | Grafana Loki image pull secrets                                | `[]`                    |
-| `loki.configuration`                  | Loki components configuration                                  | `""`                    |
-| `loki.existingConfigmap`              | Name of a ConfigMap with the Loki configuration                | `""`                    |
-| `loki.dataDir`                        | path to the Loki data directory                                | `/bitnami/grafana-loki` |
-| `loki.containerPorts.http`            | Loki components web container port                             | `3100`                  |
-| `loki.containerPorts.grpc`            | Loki components GRPC container port                            | `9095`                  |
-| `loki.containerPorts.gossipRing`      | Loki components Gossip Ring container port                     | `7946`                  |
-| `loki.gossipRing.service.ports.http`  | Gossip Ring HTTP headless service port                         | `7946`                  |
-| `loki.gossipRing.service.annotations` | Additional custom annotations for Gossip Ring headless service | `{}`                    |
+| Name                                  | Description                                                                                                  | Value                   |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------- |
+| `loki.image.registry`                 | Grafana Loki image registry                                                                                  | `docker.io`             |
+| `loki.image.repository`               | Grafana Loki image repository                                                                                | `bitnami/grafana-loki`  |
+| `loki.image.tag`                      | Grafana Loki image tag (immutable tags are recommended)                                                      | `2.6.1-debian-11-r9`    |
+| `loki.image.digest`                   | Grafana Loki image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `loki.image.pullPolicy`               | Grafana Loki image pull policy                                                                               | `IfNotPresent`          |
+| `loki.image.pullSecrets`              | Grafana Loki image pull secrets                                                                              | `[]`                    |
+| `loki.configuration`                  | Loki components configuration                                                                                | `""`                    |
+| `loki.existingConfigmap`              | Name of a ConfigMap with the Loki configuration                                                              | `""`                    |
+| `loki.dataDir`                        | path to the Loki data directory                                                                              | `/bitnami/grafana-loki` |
+| `loki.containerPorts.http`            | Loki components web container port                                                                           | `3100`                  |
+| `loki.containerPorts.grpc`            | Loki components GRPC container port                                                                          | `9095`                  |
+| `loki.containerPorts.gossipRing`      | Loki components Gossip Ring container port                                                                   | `7946`                  |
+| `loki.gossipRing.service.ports.http`  | Gossip Ring HTTP headless service port                                                                       | `7946`                  |
+| `loki.gossipRing.service.annotations` | Additional custom annotations for Gossip Ring headless service                                               | `{}`                    |
 
 
 ### Compactor Deployment Parameters
@@ -188,76 +189,77 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Gateway Deployment Parameters
 
-| Name                                            | Description                                                                                       | Value                 |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------- | --------------------- |
-| `gateway.enabled`                               | Enable Gateway deployment                                                                         | `true`                |
-| `gateway.image.registry`                        | Nginx image registry                                                                              | `docker.io`           |
-| `gateway.image.repository`                      | Nginx image repository                                                                            | `bitnami/nginx`       |
-| `gateway.image.tag`                             | Nginx image tag (immutable tags are recommended)                                                  | `1.23.1-debian-11-r7` |
-| `gateway.image.pullPolicy`                      | Nginx image pull policy                                                                           | `IfNotPresent`        |
-| `gateway.image.pullSecrets`                     | Nginx image pull secrets                                                                          | `[]`                  |
-| `gateway.image.debug`                           | Enable debugging in the initialization process                                                    | `false`               |
-| `gateway.extraEnvVars`                          | Array with extra environment variables to add to gateway nodes                                    | `[]`                  |
-| `gateway.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for gateway nodes                            | `""`                  |
-| `gateway.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for gateway nodes                               | `""`                  |
-| `gateway.command`                               | Override default container command (useful when using custom images)                              | `[]`                  |
-| `gateway.args`                                  | Override default container args (useful when using custom images)                                 | `[]`                  |
-| `gateway.verboseLogging`                        | Show the gateway access_log                                                                       | `false`               |
-| `gateway.replicaCount`                          | Number of Gateway replicas to deploy                                                              | `1`                   |
-| `gateway.auth.enabled`                          | Enable basic auth                                                                                 | `false`               |
-| `gateway.auth.username`                         | Basic auth username                                                                               | `user`                |
-| `gateway.auth.password`                         | Basic auth password                                                                               | `""`                  |
-| `gateway.auth.existingSecret`                   | Name of a secret containing the Basic auth password                                               | `""`                  |
-| `gateway.livenessProbe.enabled`                 | Enable livenessProbe on Gateway nodes                                                             | `true`                |
-| `gateway.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                           | `10`                  |
-| `gateway.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                  | `10`                  |
-| `gateway.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                 | `1`                   |
-| `gateway.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                               | `3`                   |
-| `gateway.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                               | `1`                   |
-| `gateway.readinessProbe.enabled`                | Enable readinessProbe on Gateway nodes                                                            | `true`                |
-| `gateway.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                          | `10`                  |
-| `gateway.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                 | `10`                  |
-| `gateway.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                | `1`                   |
-| `gateway.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                              | `3`                   |
-| `gateway.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                              | `1`                   |
-| `gateway.startupProbe.enabled`                  | Enable startupProbe on Gateway containers                                                         | `false`               |
-| `gateway.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                            | `10`                  |
-| `gateway.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                   | `10`                  |
-| `gateway.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                  | `1`                   |
-| `gateway.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                | `15`                  |
-| `gateway.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                | `1`                   |
-| `gateway.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                               | `{}`                  |
-| `gateway.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                              | `{}`                  |
-| `gateway.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                | `{}`                  |
-| `gateway.containerPorts.http`                   | Gateway HTTP port                                                                                 | `8080`                |
-| `gateway.resources.limits`                      | The resources limits for the gateway containers                                                   | `{}`                  |
-| `gateway.resources.requests`                    | The requested resources for the gateway containers                                                | `{}`                  |
-| `gateway.podSecurityContext.enabled`            | Enabled Gateway pods' Security Context                                                            | `true`                |
-| `gateway.podSecurityContext.fsGroup`            | Set Gateway pod's Security Context fsGroup                                                        | `1001`                |
-| `gateway.containerSecurityContext.enabled`      | Enabled Gateway containers' Security Context                                                      | `true`                |
-| `gateway.containerSecurityContext.runAsUser`    | Set Gateway containers' Security Context runAsUser                                                | `1001`                |
-| `gateway.containerSecurityContext.runAsNonRoot` | Set Gateway containers' Security Context runAsNonRoot                                             | `true`                |
-| `gateway.lifecycleHooks`                        | for the gateway container(s) to automate configuration before or after startup                    | `{}`                  |
-| `gateway.hostAliases`                           | gateway pods host aliases                                                                         | `[]`                  |
-| `gateway.podLabels`                             | Extra labels for gateway pods                                                                     | `{}`                  |
-| `gateway.podAnnotations`                        | Annotations for gateway pods                                                                      | `{}`                  |
-| `gateway.podAffinityPreset`                     | Pod affinity preset. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`       | `""`                  |
-| `gateway.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`  | `soft`                |
-| `gateway.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard` | `""`                  |
-| `gateway.nodeAffinityPreset.key`                | Node label key to match. Ignored if `gateway.affinity` is set                                     | `""`                  |
-| `gateway.nodeAffinityPreset.values`             | Node label values to match. Ignored if `gateway.affinity` is set                                  | `[]`                  |
-| `gateway.affinity`                              | Affinity for Gateway pods assignment                                                              | `{}`                  |
-| `gateway.nodeSelector`                          | Node labels for Gateway pods assignment                                                           | `{}`                  |
-| `gateway.tolerations`                           | Tolerations for Gateway pods assignment                                                           | `[]`                  |
-| `gateway.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains   | `[]`                  |
-| `gateway.priorityClassName`                     | Gateway pods' priorityClassName                                                                   | `""`                  |
-| `gateway.schedulerName`                         | Kubernetes pod scheduler registry                                                                 | `""`                  |
-| `gateway.updateStrategy.type`                   | Gateway statefulset strategy type                                                                 | `RollingUpdate`       |
-| `gateway.updateStrategy.rollingUpdate`          | Gateway statefulset rolling update configuration parameters                                       | `{}`                  |
-| `gateway.extraVolumes`                          | Optionally specify extra list of additional volumes for the Gateway pod(s)                        | `[]`                  |
-| `gateway.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Gateway container(s)             | `[]`                  |
-| `gateway.sidecars`                              | Add additional sidecar containers to the Gateway pod(s)                                           | `[]`                  |
-| `gateway.initContainers`                        | Add additional init containers to the Gateway pod(s)                                              | `[]`                  |
+| Name                                            | Description                                                                                           | Value                 |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------- | --------------------- |
+| `gateway.enabled`                               | Enable Gateway deployment                                                                             | `true`                |
+| `gateway.image.registry`                        | Nginx image registry                                                                                  | `docker.io`           |
+| `gateway.image.repository`                      | Nginx image repository                                                                                | `bitnami/nginx`       |
+| `gateway.image.tag`                             | Nginx image tag (immutable tags are recommended)                                                      | `1.23.1-debian-11-r7` |
+| `gateway.image.digest`                          | Nginx image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `gateway.image.pullPolicy`                      | Nginx image pull policy                                                                               | `IfNotPresent`        |
+| `gateway.image.pullSecrets`                     | Nginx image pull secrets                                                                              | `[]`                  |
+| `gateway.image.debug`                           | Enable debugging in the initialization process                                                        | `false`               |
+| `gateway.extraEnvVars`                          | Array with extra environment variables to add to gateway nodes                                        | `[]`                  |
+| `gateway.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for gateway nodes                                | `""`                  |
+| `gateway.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for gateway nodes                                   | `""`                  |
+| `gateway.command`                               | Override default container command (useful when using custom images)                                  | `[]`                  |
+| `gateway.args`                                  | Override default container args (useful when using custom images)                                     | `[]`                  |
+| `gateway.verboseLogging`                        | Show the gateway access_log                                                                           | `false`               |
+| `gateway.replicaCount`                          | Number of Gateway replicas to deploy                                                                  | `1`                   |
+| `gateway.auth.enabled`                          | Enable basic auth                                                                                     | `false`               |
+| `gateway.auth.username`                         | Basic auth username                                                                                   | `user`                |
+| `gateway.auth.password`                         | Basic auth password                                                                                   | `""`                  |
+| `gateway.auth.existingSecret`                   | Name of a secret containing the Basic auth password                                                   | `""`                  |
+| `gateway.livenessProbe.enabled`                 | Enable livenessProbe on Gateway nodes                                                                 | `true`                |
+| `gateway.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                               | `10`                  |
+| `gateway.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                      | `10`                  |
+| `gateway.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                     | `1`                   |
+| `gateway.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                   | `3`                   |
+| `gateway.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                   | `1`                   |
+| `gateway.readinessProbe.enabled`                | Enable readinessProbe on Gateway nodes                                                                | `true`                |
+| `gateway.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                              | `10`                  |
+| `gateway.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                     | `10`                  |
+| `gateway.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                    | `1`                   |
+| `gateway.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                  | `3`                   |
+| `gateway.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                  | `1`                   |
+| `gateway.startupProbe.enabled`                  | Enable startupProbe on Gateway containers                                                             | `false`               |
+| `gateway.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                | `10`                  |
+| `gateway.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                       | `10`                  |
+| `gateway.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                      | `1`                   |
+| `gateway.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                    | `15`                  |
+| `gateway.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                    | `1`                   |
+| `gateway.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                   | `{}`                  |
+| `gateway.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                  | `{}`                  |
+| `gateway.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                    | `{}`                  |
+| `gateway.containerPorts.http`                   | Gateway HTTP port                                                                                     | `8080`                |
+| `gateway.resources.limits`                      | The resources limits for the gateway containers                                                       | `{}`                  |
+| `gateway.resources.requests`                    | The requested resources for the gateway containers                                                    | `{}`                  |
+| `gateway.podSecurityContext.enabled`            | Enabled Gateway pods' Security Context                                                                | `true`                |
+| `gateway.podSecurityContext.fsGroup`            | Set Gateway pod's Security Context fsGroup                                                            | `1001`                |
+| `gateway.containerSecurityContext.enabled`      | Enabled Gateway containers' Security Context                                                          | `true`                |
+| `gateway.containerSecurityContext.runAsUser`    | Set Gateway containers' Security Context runAsUser                                                    | `1001`                |
+| `gateway.containerSecurityContext.runAsNonRoot` | Set Gateway containers' Security Context runAsNonRoot                                                 | `true`                |
+| `gateway.lifecycleHooks`                        | for the gateway container(s) to automate configuration before or after startup                        | `{}`                  |
+| `gateway.hostAliases`                           | gateway pods host aliases                                                                             | `[]`                  |
+| `gateway.podLabels`                             | Extra labels for gateway pods                                                                         | `{}`                  |
+| `gateway.podAnnotations`                        | Annotations for gateway pods                                                                          | `{}`                  |
+| `gateway.podAffinityPreset`                     | Pod affinity preset. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`           | `""`                  |
+| `gateway.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`      | `soft`                |
+| `gateway.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `gateway.affinity` is set. Allowed values: `soft` or `hard`     | `""`                  |
+| `gateway.nodeAffinityPreset.key`                | Node label key to match. Ignored if `gateway.affinity` is set                                         | `""`                  |
+| `gateway.nodeAffinityPreset.values`             | Node label values to match. Ignored if `gateway.affinity` is set                                      | `[]`                  |
+| `gateway.affinity`                              | Affinity for Gateway pods assignment                                                                  | `{}`                  |
+| `gateway.nodeSelector`                          | Node labels for Gateway pods assignment                                                               | `{}`                  |
+| `gateway.tolerations`                           | Tolerations for Gateway pods assignment                                                               | `[]`                  |
+| `gateway.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains       | `[]`                  |
+| `gateway.priorityClassName`                     | Gateway pods' priorityClassName                                                                       | `""`                  |
+| `gateway.schedulerName`                         | Kubernetes pod scheduler registry                                                                     | `""`                  |
+| `gateway.updateStrategy.type`                   | Gateway statefulset strategy type                                                                     | `RollingUpdate`       |
+| `gateway.updateStrategy.rollingUpdate`          | Gateway statefulset rolling update configuration parameters                                           | `{}`                  |
+| `gateway.extraVolumes`                          | Optionally specify extra list of additional volumes for the Gateway pod(s)                            | `[]`                  |
+| `gateway.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Gateway container(s)                 | `[]`                  |
+| `gateway.sidecars`                              | Add additional sidecar containers to the Gateway pod(s)                                               | `[]`                  |
+| `gateway.initContainers`                        | Add additional init containers to the Gateway pod(s)                                                  | `[]`                  |
 
 
 ### Gateway Traffic Exposure Parameters
@@ -973,72 +975,73 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Promtail Deployment Parameters
 
-| Name                                             | Description                                                                                        | Value                |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------- | -------------------- |
-| `promtail.enabled`                               | Deploy promtail                                                                                    | `true`               |
-| `promtail.image.registry`                        | Grafana Promtail image registry                                                                    | `docker.io`          |
-| `promtail.image.repository`                      | Grafana Promtail image repository                                                                  | `bitnami/promtail`   |
-| `promtail.image.tag`                             | Grafana Promtail image tag (immutable tags are recommended)                                        | `2.6.1-debian-11-r8` |
-| `promtail.image.pullPolicy`                      | Grafana Promtail image pull policy                                                                 | `IfNotPresent`       |
-| `promtail.image.pullSecrets`                     | Grafana Promtail image pull secrets                                                                | `[]`                 |
-| `promtail.extraEnvVars`                          | Array with extra environment variables to add to promtail nodes                                    | `[]`                 |
-| `promtail.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for promtail nodes                            | `""`                 |
-| `promtail.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for promtail nodes                               | `""`                 |
-| `promtail.command`                               | Override default container command (useful when using custom images)                               | `[]`                 |
-| `promtail.args`                                  | Override default container args (useful when using custom images)                                  | `[]`                 |
-| `promtail.containerPorts.http`                   | Promtail HTTP port                                                                                 | `8080`               |
-| `promtail.livenessProbe.enabled`                 | Enable livenessProbe on Promtail nodes                                                             | `true`               |
-| `promtail.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                            | `10`                 |
-| `promtail.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                   | `10`                 |
-| `promtail.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                  | `1`                  |
-| `promtail.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                | `3`                  |
-| `promtail.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                | `1`                  |
-| `promtail.readinessProbe.enabled`                | Enable readinessProbe on Promtail nodes                                                            | `true`               |
-| `promtail.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                           | `10`                 |
-| `promtail.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                  | `10`                 |
-| `promtail.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                 | `1`                  |
-| `promtail.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                               | `3`                  |
-| `promtail.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                               | `1`                  |
-| `promtail.startupProbe.enabled`                  | Enable startupProbe on Promtail containers                                                         | `false`              |
-| `promtail.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                             | `30`                 |
-| `promtail.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                    | `10`                 |
-| `promtail.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                   | `1`                  |
-| `promtail.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                 | `15`                 |
-| `promtail.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                 | `1`                  |
-| `promtail.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                | `{}`                 |
-| `promtail.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                               | `{}`                 |
-| `promtail.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                 | `{}`                 |
-| `promtail.lifecycleHooks`                        | for the promtail container(s) to automate configuration before or after startup                    | `{}`                 |
-| `promtail.resources.limits`                      | The resources limits for the Promtail containers                                                   | `{}`                 |
-| `promtail.resources.requests`                    | The requested resources for the Promtail containers                                                | `{}`                 |
-| `promtail.podSecurityContext.enabled`            | Enabled Promtail pods' Security Context                                                            | `true`               |
-| `promtail.podSecurityContext.fsGroup`            | Set Promtail pod's Security Context fsGroup                                                        | `0`                  |
-| `promtail.containerSecurityContext.enabled`      | Enabled Promtail containers' Security Context                                                      | `true`               |
-| `promtail.containerSecurityContext.runAsUser`    | Set Promtail containers' Security Context runAsUser                                                | `0`                  |
-| `promtail.containerSecurityContext.runAsNonRoot` | Set Promtail containers' Security Context runAsNonRoot                                             | `false`              |
-| `promtail.hostAliases`                           | promtail pods host aliases                                                                         | `[]`                 |
-| `promtail.podLabels`                             | Extra labels for promtail pods                                                                     | `{}`                 |
-| `promtail.podAnnotations`                        | Annotations for promtail pods                                                                      | `{}`                 |
-| `promtail.podAffinityPreset`                     | Pod affinity preset. Ignored if `promtail.affinity` is set. Allowed values: `soft` or `hard`       | `""`                 |
-| `promtail.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `promtail.affinity` is set. Allowed values: `soft` or `hard`  | `soft`               |
-| `promtail.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `promtail.affinity` is set. Allowed values: `soft` or `hard` | `""`                 |
-| `promtail.nodeAffinityPreset.key`                | Node label key to match. Ignored if `promtail.affinity` is set                                     | `""`                 |
-| `promtail.nodeAffinityPreset.values`             | Node label values to match. Ignored if `promtail.affinity` is set                                  | `[]`                 |
-| `promtail.affinity`                              | Affinity for promtail pods assignment                                                              | `{}`                 |
-| `promtail.nodeSelector`                          | Node labels for Promtail pods assignment                                                           | `{}`                 |
-| `promtail.tolerations`                           | Tolerations for Promtail pods assignment                                                           | `[]`                 |
-| `promtail.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains    | `[]`                 |
-| `promtail.priorityClassName`                     | Promtail pods' priorityClassName                                                                   | `""`                 |
-| `promtail.schedulerName`                         | Kubernetes pod scheduler registry                                                                  | `""`                 |
-| `promtail.updateStrategy.type`                   | Promtail statefulset strategy type                                                                 | `RollingUpdate`      |
-| `promtail.updateStrategy.rollingUpdate`          | Promtail statefulset rolling update configuration parameters                                       | `{}`                 |
-| `promtail.extraVolumes`                          | Optionally specify extra list of additional volumes for the Promtail pod(s)                        | `[]`                 |
-| `promtail.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the promtail container(s)             | `[]`                 |
-| `promtail.sidecars`                              | Add additional sidecar containers to the Promtail pod(s)                                           | `[]`                 |
-| `promtail.initContainers`                        | Add additional init containers to the Promtail pod(s)                                              | `[]`                 |
-| `promtail.configuration`                         | Promtail configuration                                                                             | `""`                 |
-| `promtail.existingSecret`                        | Name of a Secret that contains the Promtail configuration                                          | `""`                 |
-| `promtail.logLevel`                              | Promtail logging level                                                                             | `info`               |
+| Name                                             | Description                                                                                                      | Value                |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `promtail.enabled`                               | Deploy promtail                                                                                                  | `true`               |
+| `promtail.image.registry`                        | Grafana Promtail image registry                                                                                  | `docker.io`          |
+| `promtail.image.repository`                      | Grafana Promtail image repository                                                                                | `bitnami/promtail`   |
+| `promtail.image.tag`                             | Grafana Promtail image tag (immutable tags are recommended)                                                      | `2.6.1-debian-11-r8` |
+| `promtail.image.digest`                          | Grafana Promtail image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                 |
+| `promtail.image.pullPolicy`                      | Grafana Promtail image pull policy                                                                               | `IfNotPresent`       |
+| `promtail.image.pullSecrets`                     | Grafana Promtail image pull secrets                                                                              | `[]`                 |
+| `promtail.extraEnvVars`                          | Array with extra environment variables to add to promtail nodes                                                  | `[]`                 |
+| `promtail.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for promtail nodes                                          | `""`                 |
+| `promtail.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for promtail nodes                                             | `""`                 |
+| `promtail.command`                               | Override default container command (useful when using custom images)                                             | `[]`                 |
+| `promtail.args`                                  | Override default container args (useful when using custom images)                                                | `[]`                 |
+| `promtail.containerPorts.http`                   | Promtail HTTP port                                                                                               | `8080`               |
+| `promtail.livenessProbe.enabled`                 | Enable livenessProbe on Promtail nodes                                                                           | `true`               |
+| `promtail.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                          | `10`                 |
+| `promtail.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                 | `10`                 |
+| `promtail.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                | `1`                  |
+| `promtail.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                              | `3`                  |
+| `promtail.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                              | `1`                  |
+| `promtail.readinessProbe.enabled`                | Enable readinessProbe on Promtail nodes                                                                          | `true`               |
+| `promtail.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                         | `10`                 |
+| `promtail.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                | `10`                 |
+| `promtail.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                               | `1`                  |
+| `promtail.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                             | `3`                  |
+| `promtail.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                             | `1`                  |
+| `promtail.startupProbe.enabled`                  | Enable startupProbe on Promtail containers                                                                       | `false`              |
+| `promtail.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                           | `30`                 |
+| `promtail.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                  | `10`                 |
+| `promtail.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                 | `1`                  |
+| `promtail.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                               | `15`                 |
+| `promtail.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                               | `1`                  |
+| `promtail.customLivenessProbe`                   | Custom livenessProbe that overrides the default one                                                              | `{}`                 |
+| `promtail.customReadinessProbe`                  | Custom readinessProbe that overrides the default one                                                             | `{}`                 |
+| `promtail.customStartupProbe`                    | Custom startupProbe that overrides the default one                                                               | `{}`                 |
+| `promtail.lifecycleHooks`                        | for the promtail container(s) to automate configuration before or after startup                                  | `{}`                 |
+| `promtail.resources.limits`                      | The resources limits for the Promtail containers                                                                 | `{}`                 |
+| `promtail.resources.requests`                    | The requested resources for the Promtail containers                                                              | `{}`                 |
+| `promtail.podSecurityContext.enabled`            | Enabled Promtail pods' Security Context                                                                          | `true`               |
+| `promtail.podSecurityContext.fsGroup`            | Set Promtail pod's Security Context fsGroup                                                                      | `0`                  |
+| `promtail.containerSecurityContext.enabled`      | Enabled Promtail containers' Security Context                                                                    | `true`               |
+| `promtail.containerSecurityContext.runAsUser`    | Set Promtail containers' Security Context runAsUser                                                              | `0`                  |
+| `promtail.containerSecurityContext.runAsNonRoot` | Set Promtail containers' Security Context runAsNonRoot                                                           | `false`              |
+| `promtail.hostAliases`                           | promtail pods host aliases                                                                                       | `[]`                 |
+| `promtail.podLabels`                             | Extra labels for promtail pods                                                                                   | `{}`                 |
+| `promtail.podAnnotations`                        | Annotations for promtail pods                                                                                    | `{}`                 |
+| `promtail.podAffinityPreset`                     | Pod affinity preset. Ignored if `promtail.affinity` is set. Allowed values: `soft` or `hard`                     | `""`                 |
+| `promtail.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `promtail.affinity` is set. Allowed values: `soft` or `hard`                | `soft`               |
+| `promtail.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `promtail.affinity` is set. Allowed values: `soft` or `hard`               | `""`                 |
+| `promtail.nodeAffinityPreset.key`                | Node label key to match. Ignored if `promtail.affinity` is set                                                   | `""`                 |
+| `promtail.nodeAffinityPreset.values`             | Node label values to match. Ignored if `promtail.affinity` is set                                                | `[]`                 |
+| `promtail.affinity`                              | Affinity for promtail pods assignment                                                                            | `{}`                 |
+| `promtail.nodeSelector`                          | Node labels for Promtail pods assignment                                                                         | `{}`                 |
+| `promtail.tolerations`                           | Tolerations for Promtail pods assignment                                                                         | `[]`                 |
+| `promtail.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains                  | `[]`                 |
+| `promtail.priorityClassName`                     | Promtail pods' priorityClassName                                                                                 | `""`                 |
+| `promtail.schedulerName`                         | Kubernetes pod scheduler registry                                                                                | `""`                 |
+| `promtail.updateStrategy.type`                   | Promtail statefulset strategy type                                                                               | `RollingUpdate`      |
+| `promtail.updateStrategy.rollingUpdate`          | Promtail statefulset rolling update configuration parameters                                                     | `{}`                 |
+| `promtail.extraVolumes`                          | Optionally specify extra list of additional volumes for the Promtail pod(s)                                      | `[]`                 |
+| `promtail.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the promtail container(s)                           | `[]`                 |
+| `promtail.sidecars`                              | Add additional sidecar containers to the Promtail pod(s)                                                         | `[]`                 |
+| `promtail.initContainers`                        | Add additional init containers to the Promtail pod(s)                                                            | `[]`                 |
+| `promtail.configuration`                         | Promtail configuration                                                                                           | `""`                 |
+| `promtail.existingSecret`                        | Name of a Secret that contains the Promtail configuration                                                        | `""`                 |
+| `promtail.logLevel`                              | Promtail logging level                                                                                           | `info`               |
 
 
 ### Promtail Traffic Exposure Parameters
@@ -1065,17 +1068,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Init Container Parameters
 
-| Name                                                   | Description                                                                                     | Value                   |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | ----------------------- |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
-| `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                    | `docker.io`             |
-| `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                        | `11-debian-11-r23`      |
-| `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                | `[]`                    |
-| `volumePermissions.resources.limits`                   | The resources limits for the init container                                                     | `{}`                    |
-| `volumePermissions.resources.requests`                 | The requested resources for the init container                                                  | `{}`                    |
-| `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                 | `0`                     |
+| Name                                                   | Description                                                                                                   | Value                   |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`               | `false`                 |
+| `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                                  | `docker.io`             |
+| `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                                | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                                      | `11-debian-11-r23`      |
+| `volumePermissions.image.digest`                       | Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                               | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                              | `[]`                    |
+| `volumePermissions.resources.limits`                   | The resources limits for the init container                                                                   | `{}`                    |
+| `volumePermissions.resources.requests`                 | The requested resources for the init container                                                                | `{}`                    |
+| `volumePermissions.containerSecurityContext.runAsUser` | Set init container's Security Context runAsUser                                                               | `0`                     |
 
 
 ### Other Parameters
@@ -1115,15 +1119,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Memcached Sub-chart Parameters (Chunks)
 
-| Name                                      | Description                                          | Value                 |
-| ----------------------------------------- | ---------------------------------------------------- | --------------------- |
-| `memcachedchunks.enabled`                 | Deploy memcached sub-chart                           | `true`                |
-| `memcachedchunks.image.registry`          | Memcached image registry                             | `docker.io`           |
-| `memcachedchunks.image.repository`        | Memcached image repository                           | `bitnami/memcached`   |
-| `memcachedchunks.image.tag`               | Memcached image tag (immutable tags are recommended) | `1.6.16-debian-11-r2` |
-| `memcachedchunks.nameOverride`            | override the subchart name                           | `""`                  |
-| `memcachedchunks.architecture`            | Memcached architecture                               | `high-availability`   |
-| `memcachedchunks.service.ports.memcached` | Memcached service port                               | `11211`               |
+| Name                                      | Description                                                                                               | Value                 |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
+| `memcachedchunks.enabled`                 | Deploy memcached sub-chart                                                                                | `true`                |
+| `memcachedchunks.image.registry`          | Memcached image registry                                                                                  | `docker.io`           |
+| `memcachedchunks.image.repository`        | Memcached image repository                                                                                | `bitnami/memcached`   |
+| `memcachedchunks.image.tag`               | Memcached image tag (immutable tags are recommended)                                                      | `1.6.16-debian-11-r2` |
+| `memcachedchunks.image.digest`            | Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `memcachedchunks.nameOverride`            | override the subchart name                                                                                | `""`                  |
+| `memcachedchunks.architecture`            | Memcached architecture                                                                                    | `high-availability`   |
+| `memcachedchunks.service.ports.memcached` | Memcached service port                                                                                    | `11211`               |
 
 
 ### External Memcached (Frontend) Parameters
@@ -1136,15 +1141,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Memcached Sub-chart Parameters (Frontend)
 
-| Name                                        | Description                                          | Value                 |
-| ------------------------------------------- | ---------------------------------------------------- | --------------------- |
-| `memcachedfrontend.enabled`                 | Deploy memcached sub-chart                           | `true`                |
-| `memcachedfrontend.image.registry`          | Memcached image registry                             | `docker.io`           |
-| `memcachedfrontend.image.repository`        | Memcached image repository                           | `bitnami/memcached`   |
-| `memcachedfrontend.image.tag`               | Memcached image tag (immutable tags are recommended) | `1.6.16-debian-11-r2` |
-| `memcachedfrontend.architecture`            | Memcached architecture                               | `high-availability`   |
-| `memcachedfrontend.nameOverride`            | override the subchart name                           | `""`                  |
-| `memcachedfrontend.service.ports.memcached` | Memcached service port                               | `11211`               |
+| Name                                        | Description                                                                                               | Value                 |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
+| `memcachedfrontend.enabled`                 | Deploy memcached sub-chart                                                                                | `true`                |
+| `memcachedfrontend.image.registry`          | Memcached image registry                                                                                  | `docker.io`           |
+| `memcachedfrontend.image.repository`        | Memcached image repository                                                                                | `bitnami/memcached`   |
+| `memcachedfrontend.image.tag`               | Memcached image tag (immutable tags are recommended)                                                      | `1.6.16-debian-11-r2` |
+| `memcachedfrontend.image.digest`            | Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `memcachedfrontend.architecture`            | Memcached architecture                                                                                    | `high-availability`   |
+| `memcachedfrontend.nameOverride`            | override the subchart name                                                                                | `""`                  |
+| `memcachedfrontend.service.ports.memcached` | Memcached service port                                                                                    | `11211`               |
 
 
 ### External Memcached (Index-Queries) Parameters
@@ -1157,15 +1163,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Memcached Sub-chart Parameters (Index-Queries)
 
-| Name                                            | Description                                          | Value                 |
-| ----------------------------------------------- | ---------------------------------------------------- | --------------------- |
-| `memcachedindexqueries.enabled`                 | Deploy memcached sub-chart                           | `true`                |
-| `memcachedindexqueries.image.registry`          | Memcached image registry                             | `docker.io`           |
-| `memcachedindexqueries.image.repository`        | Memcached image repository                           | `bitnami/memcached`   |
-| `memcachedindexqueries.image.tag`               | Memcached image tag (immutable tags are recommended) | `1.6.16-debian-11-r2` |
-| `memcachedindexqueries.architecture`            | Memcached architecture                               | `high-availability`   |
-| `memcachedindexqueries.nameOverride`            | override the subchart name                           | `""`                  |
-| `memcachedindexqueries.service.ports.memcached` | Memcached service port                               | `11211`               |
+| Name                                            | Description                                                                                               | Value                 |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
+| `memcachedindexqueries.enabled`                 | Deploy memcached sub-chart                                                                                | `true`                |
+| `memcachedindexqueries.image.registry`          | Memcached image registry                                                                                  | `docker.io`           |
+| `memcachedindexqueries.image.repository`        | Memcached image repository                                                                                | `bitnami/memcached`   |
+| `memcachedindexqueries.image.tag`               | Memcached image tag (immutable tags are recommended)                                                      | `1.6.16-debian-11-r2` |
+| `memcachedindexqueries.image.digest`            | Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `memcachedindexqueries.architecture`            | Memcached architecture                                                                                    | `high-availability`   |
+| `memcachedindexqueries.nameOverride`            | override the subchart name                                                                                | `""`                  |
+| `memcachedindexqueries.service.ports.memcached` | Memcached service port                                                                                    | `11211`               |
 
 
 ### External Memcached (IndexWrites) Parameters
@@ -1178,15 +1185,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Memcached Sub-chart Parameters (Index-Writes)
 
-| Name                                           | Description                                          | Value                 |
-| ---------------------------------------------- | ---------------------------------------------------- | --------------------- |
-| `memcachedindexwrites.enabled`                 | Deploy memcached sub-chart                           | `false`               |
-| `memcachedindexwrites.image.registry`          | Memcached image registry                             | `docker.io`           |
-| `memcachedindexwrites.image.repository`        | Memcached image repository                           | `bitnami/memcached`   |
-| `memcachedindexwrites.image.tag`               | Memcached image tag (immutable tags are recommended) | `1.6.16-debian-11-r2` |
-| `memcachedindexwrites.architecture`            | Memcached architecture                               | `high-availability`   |
-| `memcachedindexwrites.nameOverride`            | override the subchart name                           | `""`                  |
-| `memcachedindexwrites.service.ports.memcached` | Memcached service port                               | `11211`               |
+| Name                                           | Description                                                                                               | Value                 |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
+| `memcachedindexwrites.enabled`                 | Deploy memcached sub-chart                                                                                | `false`               |
+| `memcachedindexwrites.image.registry`          | Memcached image registry                                                                                  | `docker.io`           |
+| `memcachedindexwrites.image.repository`        | Memcached image repository                                                                                | `bitnami/memcached`   |
+| `memcachedindexwrites.image.tag`               | Memcached image tag (immutable tags are recommended)                                                      | `1.6.16-debian-11-r2` |
+| `memcachedindexwrites.image.digest`            | Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `memcachedindexwrites.architecture`            | Memcached architecture                                                                                    | `high-availability`   |
+| `memcachedindexwrites.nameOverride`            | override the subchart name                                                                                | `""`                  |
+| `memcachedindexwrites.service.ports.memcached` | Memcached service port                                                                                    | `11211`               |
 
 
 See https://github.com/bitnami-labs/readme-generator-for-helm to create the table

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -3652,7 +3652,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Bitnami Shell image registry
   ## @param volumePermissions.image.repository Bitnami Shell image repository
   ## @param volumePermissions.image.tag Bitnami Shell image tag (immutable tags are recommended)
-  ## @param pevolumePermissions.imagetete.digest Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param volumePermissions.image.digest Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Bitnami Shell image pull policy
   ## @param volumePermissions.image.pullSecrets Bitnami Shell image pull secrets
   ##

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -65,7 +65,7 @@ loki:
   ## @param loki.image.registry Grafana Loki image registry
   ## @param loki.image.repository Grafana Loki image repository
   ## @param loki.image.tag Grafana Loki image tag (immutable tags are recommended)
-## @param loki.image.digest Grafana Loki image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param loki.image.digest Grafana Loki image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param loki.image.pullPolicy Grafana Loki image pull policy
   ## @param loki.image.pullSecrets Grafana Loki image pull secrets
   ##

--- a/bitnami/grafana-loki/values.yaml
+++ b/bitnami/grafana-loki/values.yaml
@@ -65,6 +65,7 @@ loki:
   ## @param loki.image.registry Grafana Loki image registry
   ## @param loki.image.repository Grafana Loki image repository
   ## @param loki.image.tag Grafana Loki image tag (immutable tags are recommended)
+## @param loki.image.digest Grafana Loki image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param loki.image.pullPolicy Grafana Loki image pull policy
   ## @param loki.image.pullSecrets Grafana Loki image pull secrets
   ##
@@ -72,6 +73,7 @@ loki:
     registry: docker.io
     repository: bitnami/grafana-loki
     tag: 2.6.1-debian-11-r9
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -570,6 +572,7 @@ gateway:
   ## @param gateway.image.registry Nginx image registry
   ## @param gateway.image.repository Nginx image repository
   ## @param gateway.image.tag Nginx image tag (immutable tags are recommended)
+  ## @param gateway.image.digest Nginx image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param gateway.image.pullPolicy Nginx image pull policy
   ## @param gateway.image.pullSecrets Nginx image pull secrets
   ## @param gateway.image.debug Enable debugging in the initialization process
@@ -578,6 +581,7 @@ gateway:
     registry: docker.io
     repository: bitnami/nginx
     tag: 1.23.1-debian-11-r7
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -2416,10 +2420,10 @@ queryScheduler:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
-    
+
   ## @param queryScheduler.minReadySeconds Minimum time to wait before performing readiness check
   ##
-  minReadySeconds: 10 
+  minReadySeconds: 10
 
   ## @param queryScheduler.readinessProbe.enabled Enable readinessProbe on queryScheduler nodes
   ## @param queryScheduler.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
@@ -2643,7 +2647,7 @@ queryScheduler:
     ## @param queryScheduler.service.extraPorts Extra ports to expose in the queryScheduler service
     ##
     extraPorts: []
-    
+
 ## @section Ruler Deployment Parameters
 ##
 ruler:
@@ -3233,6 +3237,7 @@ promtail:
   ## @param promtail.image.registry Grafana Promtail image registry
   ## @param promtail.image.repository Grafana Promtail image repository
   ## @param promtail.image.tag Grafana Promtail image tag (immutable tags are recommended)
+  ## @param promtail.image.digest Grafana Promtail image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param promtail.image.pullPolicy Grafana Promtail image pull policy
   ## @param promtail.image.pullSecrets Grafana Promtail image pull secrets
   ##
@@ -3240,6 +3245,7 @@ promtail:
     registry: docker.io
     repository: bitnami/promtail
     tag: 2.6.1-debian-11-r8
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -3646,6 +3652,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Bitnami Shell image registry
   ## @param volumePermissions.image.repository Bitnami Shell image repository
   ## @param volumePermissions.image.tag Bitnami Shell image tag (immutable tags are recommended)
+  ## @param pevolumePermissions.imagetete.digest Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Bitnami Shell image pull policy
   ## @param volumePermissions.image.pullSecrets Bitnami Shell image pull secrets
   ##
@@ -3653,6 +3660,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -3768,12 +3776,13 @@ memcachedchunks:
   ## @param memcachedchunks.image.registry Memcached image registry
   ## @param memcachedchunks.image.repository Memcached image repository
   ## @param memcachedchunks.image.tag Memcached image tag (immutable tags are recommended)
+  ## @param memcachedchunks.image.digest Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ##
   image:
     registry: docker.io
     repository: bitnami/memcached
     tag: 1.6.16-debian-11-r2
-
+    digest: ""
   ## @param memcachedchunks.nameOverride override the subchart name
   ##
   nameOverride: ""
@@ -3808,11 +3817,13 @@ memcachedfrontend:
   ## @param memcachedfrontend.image.registry Memcached image registry
   ## @param memcachedfrontend.image.repository Memcached image repository
   ## @param memcachedfrontend.image.tag Memcached image tag (immutable tags are recommended)
+  ## @param memcachedfrontend.image.digest Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ##
   image:
     registry: docker.io
     repository: bitnami/memcached
     tag: 1.6.16-debian-11-r2
+    digest: ""
   ## @param memcachedfrontend.architecture Memcached architecture
   ##
   architecture: high-availability
@@ -3848,11 +3859,13 @@ memcachedindexqueries:
   ## @param memcachedindexqueries.image.registry Memcached image registry
   ## @param memcachedindexqueries.image.repository Memcached image repository
   ## @param memcachedindexqueries.image.tag Memcached image tag (immutable tags are recommended)
+  ## @param memcachedindexqueries.image.digest Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ##
   image:
     registry: docker.io
     repository: bitnami/memcached
     tag: 1.6.16-debian-11-r2
+    digest: ""
   ## @param memcachedindexqueries.architecture Memcached architecture
   ##
   architecture: high-availability
@@ -3887,11 +3900,13 @@ memcachedindexwrites:
   ## @param memcachedindexwrites.image.registry Memcached image registry
   ## @param memcachedindexwrites.image.repository Memcached image repository
   ## @param memcachedindexwrites.image.tag Memcached image tag (immutable tags are recommended)
+  ## @param memcachedindexwrites.image.digest Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ##
   image:
     registry: docker.io
     repository: bitnami/memcached
     tag: 1.6.16-debian-11-r2
+    digest: ""
   ## @param memcachedindexwrites.architecture Memcached architecture
   ##
   architecture: high-availability


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```