### PR TITLE
[bitnami/kong] Add support for image digest apart from tag

### DIFF
--- a/bitnami/kong/Chart.lock
+++ b/bitnami/kong/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.7.4
+  version: 11.8.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
 - name: cassandra
   repository: https://charts.bitnami.com/bitnami
   version: 9.2.12
-digest: sha256:cafd048e65eed84285b5784fa5478ed6e8b21748cdc61a6037bae0260d22588a
-generated: "2022-08-20T10:58:35.178684145Z"
+digest: sha256:90c42ddf4ab4bd9f99de12dc2de179299074e88bb2959f7ec489d7feab3dccb8
+generated: "2022-08-22T14:25:39.214825437Z"

--- a/bitnami/kong/Chart.lock
+++ b/bitnami/kong/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.26
+  version: 11.7.4
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
+  version: 2.0.0
 - name: cassandra
   repository: https://charts.bitnami.com/bitnami
   version: 9.2.12
-digest: sha256:17117e688a65c882983c359d34275bb7c1f80f82623785dd537c23b83f98ff9b
-generated: "2022-08-09T14:55:14.599858681Z"
+digest: sha256:cafd048e65eed84285b5784fa5478ed6e8b21748cdc61a6037bae0260d22588a
+generated: "2022-08-20T10:58:35.178684145Z"

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -9,7 +9,9 @@ dependencies:
     version: 11.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: 1.x.x
+    tags:
+      - bitnami-common
+    version: 2.x.x
   - condition: cassandra.enabled
     name: cassandra
     repository: https://charts.bitnami.com/bitnami
@@ -34,4 +36,4 @@ name: kong
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kong
   - https://konghq.com/
-version: 6.3.32
+version: 6.4.0

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -79,15 +79,16 @@ To uninstall/delete the `my-release` deployment:
 
 ### Kong common parameters
 
-| Name                | Description                                                                     | Value                |
-| ------------------- | ------------------------------------------------------------------------------- | -------------------- |
-| `image.registry`    | kong image registry                                                             | `docker.io`          |
-| `image.repository`  | kong image repository                                                           | `bitnami/kong`       |
-| `image.tag`         | kong image tag (immutable tags are recommended)                                 | `2.8.1-debian-11-r0` |
-| `image.pullPolicy`  | kong image pull policy                                                          | `IfNotPresent`       |
-| `image.pullSecrets` | Specify docker-registry secret names as an array                                | `[]`                 |
-| `image.debug`       | Enable image debug mode                                                         | `false`              |
-| `database`          | Select which database backend Kong will use. Can be 'postgresql' or 'cassandra' | `postgresql`         |
+| Name                | Description                                                                                          | Value                 |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`    | kong image registry                                                                                  | `docker.io`           |
+| `image.repository`  | kong image repository                                                                                | `bitnami/kong`        |
+| `image.tag`         | kong image tag (immutable tags are recommended)                                                      | `2.8.1-debian-11-r34` |
+| `image.digest`      | kong image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `image.pullPolicy`  | kong image pull policy                                                                               | `IfNotPresent`        |
+| `image.pullSecrets` | Specify docker-registry secret names as an array                                                     | `[]`                  |
+| `image.debug`       | Enable image debug mode                                                                              | `false`               |
+| `database`          | Select which database backend Kong will use. Can be 'postgresql' or 'cassandra'                      | `postgresql`          |
 
 
 ### Kong deployment / daemonset parameters
@@ -218,7 +219,8 @@ To uninstall/delete the `my-release` deployment:
 | `ingressController.enabled`                                     | Enable/disable the Kong Ingress Controller                                                                                                    | `true`                            |
 | `ingressController.image.registry`                              | Kong Ingress Controller image registry                                                                                                        | `docker.io`                       |
 | `ingressController.image.repository`                            | Kong Ingress Controller image name                                                                                                            | `bitnami/kong-ingress-controller` |
-| `ingressController.image.tag`                                   | Kong Ingress Controller image tag                                                                                                             | `2.3.1-debian-11-r0`              |
+| `ingressController.image.tag`                                   | Kong Ingress Controller image tag                                                                                                             | `2.5.0-debian-11-r13`             |
+| `ingressController.image.digest`                                | Kong Ingress Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                       | `""`                              |
 | `ingressController.image.pullPolicy`                            | Kong Ingress Controller image pull policy                                                                                                     | `IfNotPresent`                    |
 | `ingressController.image.pullSecrets`                           | Specify docker-registry secret names as an array                                                                                              | `[]`                              |
 | `ingressController.proxyReadyTimeout`                           | Maximum time (in seconds) to wait for the Kong container to be ready                                                                          | `300`                             |
@@ -282,26 +284,27 @@ To uninstall/delete the `my-release` deployment:
 
 ### PostgreSQL Parameters
 
-| Name                                            | Description                                                             | Value                  |
-| ----------------------------------------------- | ----------------------------------------------------------------------- | ---------------------- |
-| `postgresql.enabled`                            | Switch to enable or disable the PostgreSQL helm chart                   | `true`                 |
-| `postgresql.auth.postgresPassword`              | Password for the "postgres" admin user                                  | `""`                   |
-| `postgresql.auth.username`                      | Name for a custom user to create                                        | `kong`                 |
-| `postgresql.auth.password`                      | Password for the custom user to create                                  | `""`                   |
-| `postgresql.auth.database`                      | Name for a custom database to create                                    | `kong`                 |
-| `postgresql.auth.existingSecret`                | Name of existing secret to use for PostgreSQL credentials               | `""`                   |
-| `postgresql.auth.usePasswordFiles`              | Mount credentials as a files instead of using an environment variable   | `false`                |
-| `postgresql.architecture`                       | PostgreSQL architecture (`standalone` or `replication`)                 | `standalone`           |
-| `postgresql.image.registry`                     | PostgreSQL image registry                                               | `docker.io`            |
-| `postgresql.image.repository`                   | PostgreSQL image repository                                             | `bitnami/postgresql`   |
-| `postgresql.image.tag`                          | PostgreSQL image tag (immutable tags are recommended)                   | `11.16.0-debian-11-r0` |
-| `postgresql.external.host`                      | Database host                                                           | `""`                   |
-| `postgresql.external.port`                      | Database port number                                                    | `5432`                 |
-| `postgresql.external.user`                      | Non-root username for Kong                                              | `kong`                 |
-| `postgresql.external.password`                  | Password for the non-root username for Kong                             | `""`                   |
-| `postgresql.external.database`                  | Kong database name                                                      | `kong`                 |
-| `postgresql.external.existingSecret`            | Name of an existing secret resource containing the database credentials | `""`                   |
-| `postgresql.external.existingSecretPasswordKey` | Name of an existing secret key containing the database credentials      | `""`                   |
+| Name                                            | Description                                                                                                | Value                   |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `postgresql.enabled`                            | Switch to enable or disable the PostgreSQL helm chart                                                      | `true`                  |
+| `postgresql.auth.postgresPassword`              | Password for the "postgres" admin user                                                                     | `""`                    |
+| `postgresql.auth.username`                      | Name for a custom user to create                                                                           | `kong`                  |
+| `postgresql.auth.password`                      | Password for the custom user to create                                                                     | `""`                    |
+| `postgresql.auth.database`                      | Name for a custom database to create                                                                       | `kong`                  |
+| `postgresql.auth.existingSecret`                | Name of existing secret to use for PostgreSQL credentials                                                  | `""`                    |
+| `postgresql.auth.usePasswordFiles`              | Mount credentials as a files instead of using an environment variable                                      | `false`                 |
+| `postgresql.architecture`                       | PostgreSQL architecture (`standalone` or `replication`)                                                    | `standalone`            |
+| `postgresql.image.registry`                     | PostgreSQL image registry                                                                                  | `docker.io`             |
+| `postgresql.image.repository`                   | PostgreSQL image repository                                                                                | `bitnami/postgresql`    |
+| `postgresql.image.tag`                          | PostgreSQL image tag (immutable tags are recommended)                                                      | `11.16.0-debian-11-r33` |
+| `postgresql.image.digest`                       | PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `postgresql.external.host`                      | Database host                                                                                              | `""`                    |
+| `postgresql.external.port`                      | Database port number                                                                                       | `5432`                  |
+| `postgresql.external.user`                      | Non-root username for Kong                                                                                 | `kong`                  |
+| `postgresql.external.password`                  | Password for the non-root username for Kong                                                                | `""`                    |
+| `postgresql.external.database`                  | Kong database name                                                                                         | `kong`                  |
+| `postgresql.external.existingSecret`            | Name of an existing secret resource containing the database credentials                                    | `""`                    |
+| `postgresql.external.existingSecretPasswordKey` | Name of an existing secret key containing the database credentials                                         | `""`                    |
 
 
 ### Cassandra Parameters

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -63,6 +63,7 @@ diagnosticMode:
 ## @param image.registry kong image registry
 ## @param image.repository kong image repository
 ## @param image.tag kong image tag (immutable tags are recommended)
+## @param image.digest kong image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy kong image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Enable image debug mode
@@ -71,6 +72,7 @@ image:
   registry: docker.io
   repository: bitnami/kong
   tag: 2.8.1-debian-11-r34
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -547,6 +549,7 @@ ingressController:
   ## @param ingressController.image.registry Kong Ingress Controller image registry
   ## @param ingressController.image.repository Kong Ingress Controller image name
   ## @param ingressController.image.tag Kong Ingress Controller image tag
+  ## @param ingressController.image.digest Kong Ingress Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param ingressController.image.pullPolicy Kong Ingress Controller image pull policy
   ## @param ingressController.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -554,6 +557,7 @@ ingressController:
     registry: docker.io
     repository: bitnami/kong-ingress-controller
     tag: 2.5.0-debian-11-r13
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -699,6 +703,7 @@ migration:
   ##   registry:
   ##   repository:
   ##   tag:
+  ##   digest: ""
   ##
   ## @param migration.command Override default container command (useful when using custom images)
   ##
@@ -769,11 +774,13 @@ postgresql:
   ## @param postgresql.image.registry PostgreSQL image registry
   ## @param postgresql.image.repository PostgreSQL image repository
   ## @param postgresql.image.tag PostgreSQL image tag (immutable tags are recommended)
+  ## @param postgresql.image.digest PostgreSQL image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ##
   image:
     registry: docker.io
     repository: bitnami/postgresql
     tag: 11.16.0-debian-11-r33
+    digest: ""
   auth:
     username: kong
     password: ""


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```