### PR TITLE
[bitnami/kiam] Add support for image digest apart from tag

### DIFF
--- a/bitnami/kiam/Chart.lock
+++ b/bitnami/kiam/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-29T19:55:27.195049044Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:58:27.976913115Z"

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: kiam is a proxy that captures AWS Metadata API requests. It allows AWS IAM roles to be set for Kubernetes workloads.
 engine: gotpl
 home: https://github.com/uswitch/kiam
@@ -23,4 +23,4 @@ name: kiam
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kiam
   - https://github.com/uswitch/kiam
-version: 1.0.18
+version: 1.1.0

--- a/bitnami/kiam/README.md
+++ b/bitnami/kiam/README.md
@@ -81,13 +81,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### kiam image parameters
 
-| Name                | Description                                      | Value                  |
-| ------------------- | ------------------------------------------------ | ---------------------- |
-| `image.registry`    | kiam image registry                              | `docker.io`            |
-| `image.repository`  | kiam image name                                  | `bitnami/kiam`         |
-| `image.tag`         | kiam image tag                                   | `4.2.0-debian-10-r188` |
-| `image.pullPolicy`  | kiam image pull policy                           | `IfNotPresent`         |
-| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]`                   |
+| Name                | Description                                                                                          | Value                 |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`    | kiam image registry                                                                                  | `docker.io`           |
+| `image.repository`  | kiam image name                                                                                      | `bitnami/kiam`        |
+| `image.tag`         | kiam image tag                                                                                       | `4.2.0-debian-11-r24` |
+| `image.digest`      | kiam image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `image.pullPolicy`  | kiam image pull policy                                                                               | `IfNotPresent`        |
+| `image.pullSecrets` | Specify docker-registry secret names as an array                                                     | `[]`                  |
 
 
 ### kiam server parameters

--- a/bitnami/kiam/values.yaml
+++ b/bitnami/kiam/values.yaml
@@ -57,6 +57,7 @@ diagnosticMode:
 ## @param image.registry kiam image registry
 ## @param image.repository kiam image name
 ## @param image.tag kiam image tag
+## @param image.digest kiam image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy kiam image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ##
@@ -64,6 +65,7 @@ image:
   registry: docker.io
   repository: bitnami/kiam
   tag: 4.2.0-debian-11-r24
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```