### PR TITLE
[bitnami/kafka] Add support for image digest apart from tag

### DIFF
--- a/bitnami/kafka/Chart.lock
+++ b/bitnami/kafka/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 10.0.6
+  version: 10.0.8
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:c9c5b5d061fffdad96899d1d517cabe8c8971413caf02cc30d58de0cff0f4385
-generated: "2022-08-04T22:15:07.955196971Z"
+  version: 2.0.0
+digest: sha256:6243fce8beaad0d86bdc66b38679380d3e8f8cb9f80c95e582d6dfcecda8234f
+generated: "2022-08-20T10:58:20.007467729Z"

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Apache Kafka is a distributed streaming platform designed to build real-time pipelines and can be used as a message broker or as a replacement for a log aggregation solution for big data applications.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/kafka
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kafka
   - https://kafka.apache.org/
-version: 18.0.8
+version: 18.1.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -84,6 +84,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.registry`                                  | Kafka image registry                                                                                                                                                                | `docker.io`                         |
 | `image.repository`                                | Kafka image repository                                                                                                                                                              | `bitnami/kafka`                     |
 | `image.tag`                                       | Kafka image tag (immutable tags are recommended)                                                                                                                                    | `3.2.1-debian-11-r4`                |
+| `image.digest`                                    | Kafka image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                                                               | `""`                                |
 | `image.pullPolicy`                                | Kafka image pull policy                                                                                                                                                             | `IfNotPresent`                      |
 | `image.pullSecrets`                               | Specify docker-registry secret names as an array                                                                                                                                    | `[]`                                |
 | `image.debug`                                     | Specify if debug values should be set                                                                                                                                               | `false`                             |
@@ -230,50 +231,51 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Traffic Exposure parameters
 
-| Name                                              | Description                                                                                       | Value                  |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------- |
-| `service.type`                                    | Kubernetes Service type                                                                           | `ClusterIP`            |
-| `service.ports.client`                            | Kafka svc port for client connections                                                             | `9092`                 |
-| `service.ports.internal`                          | Kafka svc port for inter-broker connections                                                       | `9093`                 |
-| `service.ports.external`                          | Kafka svc port for external connections                                                           | `9094`                 |
-| `service.nodePorts.client`                        | Node port for the Kafka client connections                                                        | `""`                   |
-| `service.nodePorts.external`                      | Node port for the Kafka external connections                                                      | `""`                   |
-| `service.sessionAffinity`                         | Control where client requests go, to the same pod or round-robin                                  | `None`                 |
-| `service.sessionAffinityConfig`                   | Additional settings for the sessionAffinity                                                       | `{}`                   |
-| `service.clusterIP`                               | Kafka service Cluster IP                                                                          | `""`                   |
-| `service.loadBalancerIP`                          | Kafka service Load Balancer IP                                                                    | `""`                   |
-| `service.loadBalancerSourceRanges`                | Kafka service Load Balancer sources                                                               | `[]`                   |
-| `service.externalTrafficPolicy`                   | Kafka service external traffic policy                                                             | `Cluster`              |
-| `service.annotations`                             | Additional custom annotations for Kafka service                                                   | `{}`                   |
-| `service.headless.annotations`                    | Annotations for the headless service.                                                             | `{}`                   |
-| `service.headless.labels`                         | Labels for the headless service.                                                                  | `{}`                   |
-| `service.extraPorts`                              | Extra ports to expose in the Kafka service (normally used with the `sidecar` value)               | `[]`                   |
-| `externalAccess.enabled`                          | Enable Kubernetes external cluster access to Kafka brokers                                        | `false`                |
-| `externalAccess.autoDiscovery.enabled`            | Enable using an init container to auto-detect external IPs/ports by querying the K8s API          | `false`                |
-| `externalAccess.autoDiscovery.image.registry`     | Init container auto-discovery image registry                                                      | `docker.io`            |
-| `externalAccess.autoDiscovery.image.repository`   | Init container auto-discovery image repository                                                    | `bitnami/kubectl`      |
-| `externalAccess.autoDiscovery.image.tag`          | Init container auto-discovery image tag (immutable tags are recommended)                          | `1.24.3-debian-11-r10` |
-| `externalAccess.autoDiscovery.image.pullPolicy`   | Init container auto-discovery image pull policy                                                   | `IfNotPresent`         |
-| `externalAccess.autoDiscovery.image.pullSecrets`  | Init container auto-discovery image pull secrets                                                  | `[]`                   |
-| `externalAccess.autoDiscovery.resources.limits`   | The resources limits for the auto-discovery init container                                        | `{}`                   |
-| `externalAccess.autoDiscovery.resources.requests` | The requested resources for the auto-discovery init container                                     | `{}`                   |
-| `externalAccess.service.type`                     | Kubernetes Service type for external access. It can be NodePort or LoadBalancer                   | `LoadBalancer`         |
-| `externalAccess.service.ports.external`           | Kafka port used for external access when service type is LoadBalancer                             | `9094`                 |
-| `externalAccess.service.loadBalancerIPs`          | Array of load balancer IPs for each Kafka broker. Length must be the same as replicaCount         | `[]`                   |
-| `externalAccess.service.loadBalancerNames`        | Array of load balancer Names for each Kafka broker. Length must be the same as replicaCount       | `[]`                   |
-| `externalAccess.service.loadBalancerAnnotations`  | Array of load balancer annotations for each Kafka broker. Length must be the same as replicaCount | `[]`                   |
-| `externalAccess.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                         | `[]`                   |
-| `externalAccess.service.nodePorts`                | Array of node ports used for each Kafka broker. Length must be the same as replicaCount           | `[]`                   |
-| `externalAccess.service.useHostIPs`               | Use service host IPs to configure Kafka external listener when service type is NodePort           | `false`                |
-| `externalAccess.service.usePodIPs`                | using the MY_POD_IP address for external access.                                                  | `false`                |
-| `externalAccess.service.domain`                   | Domain or external ip used to configure Kafka external listener when service type is NodePort     | `""`                   |
-| `externalAccess.service.annotations`              | Service annotations for external access                                                           | `{}`                   |
-| `externalAccess.service.extraPorts`               | Extra ports to expose in the Kafka external service                                               | `[]`                   |
-| `networkPolicy.enabled`                           | Specifies whether a NetworkPolicy should be created                                               | `false`                |
-| `networkPolicy.allowExternal`                     | Don't require client label for connections                                                        | `true`                 |
-| `networkPolicy.explicitNamespacesSelector`        | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed    | `{}`                   |
-| `networkPolicy.externalAccess.from`               | customize the from section for External Access on tcp-external port                               | `[]`                   |
-| `networkPolicy.egressRules.customRules`           | Custom network policy rule                                                                        | `{}`                   |
+| Name                                              | Description                                                                                            | Value                  |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------- |
+| `service.type`                                    | Kubernetes Service type                                                                                | `ClusterIP`            |
+| `service.ports.client`                            | Kafka svc port for client connections                                                                  | `9092`                 |
+| `service.ports.internal`                          | Kafka svc port for inter-broker connections                                                            | `9093`                 |
+| `service.ports.external`                          | Kafka svc port for external connections                                                                | `9094`                 |
+| `service.nodePorts.client`                        | Node port for the Kafka client connections                                                             | `""`                   |
+| `service.nodePorts.external`                      | Node port for the Kafka external connections                                                           | `""`                   |
+| `service.sessionAffinity`                         | Control where client requests go, to the same pod or round-robin                                       | `None`                 |
+| `service.sessionAffinityConfig`                   | Additional settings for the sessionAffinity                                                            | `{}`                   |
+| `service.clusterIP`                               | Kafka service Cluster IP                                                                               | `""`                   |
+| `service.loadBalancerIP`                          | Kafka service Load Balancer IP                                                                         | `""`                   |
+| `service.loadBalancerSourceRanges`                | Kafka service Load Balancer sources                                                                    | `[]`                   |
+| `service.externalTrafficPolicy`                   | Kafka service external traffic policy                                                                  | `Cluster`              |
+| `service.annotations`                             | Additional custom annotations for Kafka service                                                        | `{}`                   |
+| `service.headless.annotations`                    | Annotations for the headless service.                                                                  | `{}`                   |
+| `service.headless.labels`                         | Labels for the headless service.                                                                       | `{}`                   |
+| `service.extraPorts`                              | Extra ports to expose in the Kafka service (normally used with the `sidecar` value)                    | `[]`                   |
+| `externalAccess.enabled`                          | Enable Kubernetes external cluster access to Kafka brokers                                             | `false`                |
+| `externalAccess.autoDiscovery.enabled`            | Enable using an init container to auto-detect external IPs/ports by querying the K8s API               | `false`                |
+| `externalAccess.autoDiscovery.image.registry`     | Init container auto-discovery image registry                                                           | `docker.io`            |
+| `externalAccess.autoDiscovery.image.repository`   | Init container auto-discovery image repository                                                         | `bitnami/kubectl`      |
+| `externalAccess.autoDiscovery.image.tag`          | Init container auto-discovery image tag (immutable tags are recommended)                               | `1.24.3-debian-11-r10` |
+| `externalAccess.autoDiscovery.image.digest`       | Petete image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
+| `externalAccess.autoDiscovery.image.pullPolicy`   | Init container auto-discovery image pull policy                                                        | `IfNotPresent`         |
+| `externalAccess.autoDiscovery.image.pullSecrets`  | Init container auto-discovery image pull secrets                                                       | `[]`                   |
+| `externalAccess.autoDiscovery.resources.limits`   | The resources limits for the auto-discovery init container                                             | `{}`                   |
+| `externalAccess.autoDiscovery.resources.requests` | The requested resources for the auto-discovery init container                                          | `{}`                   |
+| `externalAccess.service.type`                     | Kubernetes Service type for external access. It can be NodePort or LoadBalancer                        | `LoadBalancer`         |
+| `externalAccess.service.ports.external`           | Kafka port used for external access when service type is LoadBalancer                                  | `9094`                 |
+| `externalAccess.service.loadBalancerIPs`          | Array of load balancer IPs for each Kafka broker. Length must be the same as replicaCount              | `[]`                   |
+| `externalAccess.service.loadBalancerNames`        | Array of load balancer Names for each Kafka broker. Length must be the same as replicaCount            | `[]`                   |
+| `externalAccess.service.loadBalancerAnnotations`  | Array of load balancer annotations for each Kafka broker. Length must be the same as replicaCount      | `[]`                   |
+| `externalAccess.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                              | `[]`                   |
+| `externalAccess.service.nodePorts`                | Array of node ports used for each Kafka broker. Length must be the same as replicaCount                | `[]`                   |
+| `externalAccess.service.useHostIPs`               | Use service host IPs to configure Kafka external listener when service type is NodePort                | `false`                |
+| `externalAccess.service.usePodIPs`                | using the MY_POD_IP address for external access.                                                       | `false`                |
+| `externalAccess.service.domain`                   | Domain or external ip used to configure Kafka external listener when service type is NodePort          | `""`                   |
+| `externalAccess.service.annotations`              | Service annotations for external access                                                                | `{}`                   |
+| `externalAccess.service.extraPorts`               | Extra ports to expose in the Kafka external service                                                    | `[]`                   |
+| `networkPolicy.enabled`                           | Specifies whether a NetworkPolicy should be created                                                    | `false`                |
+| `networkPolicy.allowExternal`                     | Don't require client label for connections                                                             | `true`                 |
+| `networkPolicy.explicitNamespacesSelector`        | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed         | `{}`                   |
+| `networkPolicy.externalAccess.from`               | customize the from section for External Access on tcp-external port                                    | `[]`                   |
+| `networkPolicy.egressRules.customRules`           | Custom network policy rule                                                                             | `{}`                   |
 
 
 ### Persistence parameters
@@ -300,17 +302,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Volume Permissions parameters
 
-| Name                                                   | Description                                                                     | Value                   |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------- |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume | `false`                 |
-| `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                | `docker.io`             |
-| `volumePermissions.image.repository`                   | Init container volume-permissions image repository                              | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)    | `11-debian-11-r23`      |
-| `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                             | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                            | `[]`                    |
-| `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                               | `{}`                    |
-| `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                             | `{}`                    |
-| `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                  | `0`                     |
+| Name                                                   | Description                                                                                                                       | Value                   |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume                                                   | `false`                 |
+| `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                                                                  | `docker.io`             |
+| `volumePermissions.image.repository`                   | Init container volume-permissions image repository                                                                                | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)                                                      | `11-debian-11-r23`      |
+| `volumePermissions.image.digest`                       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                                                                              | `[]`                    |
+| `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                                                                                 | `{}`                    |
+| `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                                                                               | `{}`                    |
+| `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                                                                    | `0`                     |
 
 
 ### Other Parameters
@@ -332,6 +335,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.kafka.image.registry`                              | Kafka exporter image registry                                                                                                    | `docker.io`                                                                             |
 | `metrics.kafka.image.repository`                            | Kafka exporter image repository                                                                                                  | `bitnami/kafka-exporter`                                                                |
 | `metrics.kafka.image.tag`                                   | Kafka exporter image tag (immutable tags are recommended)                                                                        | `1.4.2-debian-11-r25`                                                                   |
+| `metrics.kafka.image.digest`                                | Kafka exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                   | `""`                                                                                    |
 | `metrics.kafka.image.pullPolicy`                            | Kafka exporter image pull policy                                                                                                 | `IfNotPresent`                                                                          |
 | `metrics.kafka.image.pullSecrets`                           | Specify docker-registry secret names as an array                                                                                 | `[]`                                                                                    |
 | `metrics.kafka.certificatesSecret`                          | Name of the existing secret containing the optional certificate and key files                                                    | `""`                                                                                    |
@@ -379,6 +383,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.jmx.image.registry`                                | JMX exporter image registry                                                                                                      | `docker.io`                                                                             |
 | `metrics.jmx.image.repository`                              | JMX exporter image repository                                                                                                    | `bitnami/jmx-exporter`                                                                  |
 | `metrics.jmx.image.tag`                                     | JMX exporter image tag (immutable tags are recommended)                                                                          | `0.17.0-debian-11-r24`                                                                  |
+| `metrics.jmx.image.digest`                                  | JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                     | `""`                                                                                    |
 | `metrics.jmx.image.pullPolicy`                              | JMX exporter image pull policy                                                                                                   | `IfNotPresent`                                                                          |
 | `metrics.jmx.image.pullSecrets`                             | Specify docker-registry secret names as an array                                                                                 | `[]`                                                                                    |
 | `metrics.jmx.containerSecurityContext.enabled`              | Enable Prometheus JMX exporter containers' Security Context                                                                      | `true`                                                                                  |

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -61,6 +61,7 @@ diagnosticMode:
 ## @param image.registry Kafka image registry
 ## @param image.repository Kafka image repository
 ## @param image.tag Kafka image tag (immutable tags are recommended)
+## @param image.digest Kafka image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Kafka image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Specify if debug values should be set
@@ -69,6 +70,7 @@ image:
   registry: docker.io
   repository: bitnami/kafka
   tag: 3.2.1-debian-11-r4
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -744,6 +746,7 @@ externalAccess:
     ## @param externalAccess.autoDiscovery.image.registry Init container auto-discovery image registry
     ## @param externalAccess.autoDiscovery.image.repository Init container auto-discovery image repository
     ## @param externalAccess.autoDiscovery.image.tag Init container auto-discovery image tag (immutable tags are recommended)
+    ## @param externalAccess.autoDiscovery.image.digest Petete image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param externalAccess.autoDiscovery.image.pullPolicy Init container auto-discovery image pull policy
     ## @param externalAccess.autoDiscovery.image.pullSecrets Init container auto-discovery image pull secrets
     ##
@@ -751,6 +754,7 @@ externalAccess:
       registry: docker.io
       repository: bitnami/kubectl
       tag: 1.24.3-debian-11-r10
+      digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -971,6 +975,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image repository
   ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
   ## @param volumePermissions.image.pullSecrets Init container volume-permissions image pull secrets
   ##
@@ -978,6 +983,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -1049,6 +1055,7 @@ metrics:
     ## @param metrics.kafka.image.registry Kafka exporter image registry
     ## @param metrics.kafka.image.repository Kafka exporter image repository
     ## @param metrics.kafka.image.tag Kafka exporter image tag (immutable tags are recommended)
+    ## @param metrics.kafka.image.digest Kafka exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param metrics.kafka.image.pullPolicy Kafka exporter image pull policy
     ## @param metrics.kafka.image.pullSecrets Specify docker-registry secret names as an array
     ##
@@ -1056,6 +1063,7 @@ metrics:
       registry: docker.io
       repository: bitnami/kafka-exporter
       tag: 1.4.2-debian-11-r25
+      digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1283,6 +1291,7 @@ metrics:
     ## @param metrics.jmx.image.registry JMX exporter image registry
     ## @param metrics.jmx.image.repository JMX exporter image repository
     ## @param metrics.jmx.image.tag JMX exporter image tag (immutable tags are recommended)
+    ## @param metrics.jmx.image.digest JMX exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param metrics.jmx.image.pullPolicy JMX exporter image pull policy
     ## @param metrics.jmx.image.pullSecrets Specify docker-registry secret names as an array
     ##
@@ -1290,6 +1299,7 @@ metrics:
       registry: docker.io
       repository: bitnami/jmx-exporter
       tag: 0.17.0-debian-11-r24
+      digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```