### PR TITLE
[bitnami/mxnet] Add support for image digest apart from tag

### DIFF
--- a/bitnami/mxnet/Chart.lock
+++ b/bitnami/mxnet/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
 digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
-generated: "2022-08-20T10:59:41.641046337Z"
+generated: "2022-08-22T14:26:32.108562061Z"

--- a/bitnami/mxnet/Chart.lock
+++ b/bitnami/mxnet/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-24T15:05:41.484439435Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:59:41.641046337Z"

--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Apache MXNet (Incubating) is a flexible and efficient library for deep learning designed to work as a neural network. Bitnami image ships OpenBLAS as math library.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/mxnet
@@ -24,4 +24,4 @@ name: mxnet
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mxnet
   - https://mxnet.apache.org/
-version: 3.0.24
+version: 3.1.0

--- a/bitnami/mxnet/README.md
+++ b/bitnami/mxnet/README.md
@@ -81,36 +81,37 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common Mxnet parameters
 
-| Name                                  | Description                                                                                           | Value                  |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------------- | ---------------------- |
-| `image.registry`                      | Apache MXNet (Incubating) image registry                                                              | `docker.io`            |
-| `image.repository`                    | Apache MXNet (Incubating) image repository                                                            | `bitnami/mxnet`        |
-| `image.tag`                           | Apache MXNet (Incubating) image tag (immutable tags are recommended)                                  | `1.9.0-debian-10-r117` |
-| `image.pullPolicy`                    | Image pull policy                                                                                     | `IfNotPresent`         |
-| `image.pullSecrets`                   | Specify docker-registry secret names as an array                                                      | `[]`                   |
-| `image.debug`                         | Specify if debug logs should be enabled                                                               | `false`                |
-| `entrypoint`                          | The main entrypoint of your app, this will be executed as:                                            | `{}`                   |
-| `mode`                                | Apache MXNet (Incubating) deployment mode. Can be `standalone` or `distributed`                       | `standalone`           |
-| `existingSecret`                      | Name of a secret with sensitive data to mount in the pods                                             | `""`                   |
-| `configMap`                           | Name of an existing config map containing all the files you want to load in Apache MXNet (Incubating) | `""`                   |
-| `cloneFilesFromGit.enabled`           | Enable in order to download files from git repository                                                 | `false`                |
-| `cloneFilesFromGit.repository`        | Repository to clone                                                                                   | `""`                   |
-| `cloneFilesFromGit.revision`          | Branch name to clone                                                                                  | `master`               |
-| `cloneFilesFromGit.extraVolumeMounts` | Add extra volume mounts for the GIT container                                                         | `[]`                   |
-| `persistence.enabled`                 | Use a PVC to persist data                                                                             | `false`                |
-| `persistence.storageClass`            | discourse & sidekiq data Persistent Volume Storage Class                                              | `""`                   |
-| `persistence.existingClaim`           | Use a existing PVC which must be created manually before bound                                        | `""`                   |
-| `persistence.mountPath`               | Path to mount the volume at                                                                           | `/bitnami/mxnet`       |
-| `persistence.accessModes`             | Persistent Volume Access Mode                                                                         | `["ReadWriteOnce"]`    |
-| `persistence.size`                    | Size of data volume                                                                                   | `8Gi`                  |
-| `persistence.annotations`             | Persistent Volume annotations                                                                         | `{}`                   |
-| `extraEnvVars`                        | Array with extra environment variables to add to all the pods                                         | `[]`                   |
-| `extraEnvVarsCM`                      | Name of existing ConfigMap containing extra env vars for all the pods                                 | `""`                   |
-| `extraEnvVarsSecret`                  | Name of existing Secret containing extra env vars for all the pods                                    | `""`                   |
-| `extraVolumes`                        | Array to add extra volumes (evaluated as a template)                                                  | `[]`                   |
-| `extraVolumeMounts`                   | Array to add extra mounts (normally used with extraVolumes, evaluated as a template)                  | `[]`                   |
-| `sidecars`                            | Attach additional containers to the pods (scheduler, worker and server nodes)                         | `[]`                   |
-| `initContainers`                      | Attach additional init containers to the pods (scheduler, worker and server nodes)                    | `[]`                   |
+| Name                                  | Description                                                                                                               | Value                 |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`                      | Apache MXNet (Incubating) image registry                                                                                  | `docker.io`           |
+| `image.repository`                    | Apache MXNet (Incubating) image repository                                                                                | `bitnami/mxnet`       |
+| `image.tag`                           | Apache MXNet (Incubating) image tag (immutable tags are recommended)                                                      | `1.9.1-debian-11-r24` |
+| `image.digest`                        | Apache MXNet (Incubating) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `image.pullPolicy`                    | Apache MXNet (Incubating) image pull policy                                                                               | `IfNotPresent`        |
+| `image.pullSecrets`                   | Specify docker-registry secret names as an array                                                                          | `[]`                  |
+| `image.debug`                         | Specify if debug logs should be enabled                                                                                   | `false`               |
+| `entrypoint`                          | The main entrypoint of your app, this will be executed as:                                                                | `{}`                  |
+| `mode`                                | Apache MXNet (Incubating) deployment mode. Can be `standalone` or `distributed`                                           | `standalone`          |
+| `existingSecret`                      | Name of a secret with sensitive data to mount in the pods                                                                 | `""`                  |
+| `configMap`                           | Name of an existing config map containing all the files you want to load in Apache MXNet (Incubating)                     | `""`                  |
+| `cloneFilesFromGit.enabled`           | Enable in order to download files from git repository                                                                     | `false`               |
+| `cloneFilesFromGit.repository`        | Repository to clone                                                                                                       | `""`                  |
+| `cloneFilesFromGit.revision`          | Branch name to clone                                                                                                      | `master`              |
+| `cloneFilesFromGit.extraVolumeMounts` | Add extra volume mounts for the GIT container                                                                             | `[]`                  |
+| `persistence.enabled`                 | Use a PVC to persist data                                                                                                 | `false`               |
+| `persistence.storageClass`            | discourse & sidekiq data Persistent Volume Storage Class                                                                  | `""`                  |
+| `persistence.existingClaim`           | Use a existing PVC which must be created manually before bound                                                            | `""`                  |
+| `persistence.mountPath`               | Path to mount the volume at                                                                                               | `/bitnami/mxnet`      |
+| `persistence.accessModes`             | Persistent Volume Access Mode                                                                                             | `["ReadWriteOnce"]`   |
+| `persistence.size`                    | Size of data volume                                                                                                       | `8Gi`                 |
+| `persistence.annotations`             | Persistent Volume annotations                                                                                             | `{}`                  |
+| `extraEnvVars`                        | Array with extra environment variables to add to all the pods                                                             | `[]`                  |
+| `extraEnvVarsCM`                      | Name of existing ConfigMap containing extra env vars for all the pods                                                     | `""`                  |
+| `extraEnvVarsSecret`                  | Name of existing Secret containing extra env vars for all the pods                                                        | `""`                  |
+| `extraVolumes`                        | Array to add extra volumes (evaluated as a template)                                                                      | `[]`                  |
+| `extraVolumeMounts`                   | Array to add extra mounts (normally used with extraVolumes, evaluated as a template)                                      | `[]`                  |
+| `sidecars`                            | Attach additional containers to the pods (scheduler, worker and server nodes)                                             | `[]`                  |
+| `initContainers`                      | Attach additional init containers to the pods (scheduler, worker and server nodes)                                        | `[]`                  |
 
 
 ### Mxnet Standalone parameters (only for standalone mode)
@@ -372,21 +373,23 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Init containers parameters
 
-| Name                                   | Description                                                                  | Value                   |
-| -------------------------------------- | ---------------------------------------------------------------------------- | ----------------------- |
-| `git.registry`                         | Git image registry                                                           | `docker.io`             |
-| `git.repository`                       | Git image repository                                                         | `bitnami/git`           |
-| `git.tag`                              | Git image tag (immutable tags are recommended)                               | `2.35.1-debian-10-r63`  |
-| `git.pullPolicy`                       | Git image pull policy                                                        | `IfNotPresent`          |
-| `git.pullSecrets`                      | Specify docker-registry secret names as an array                             | `[]`                    |
-| `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory  | `false`                 |
-| `volumePermissions.image.registry`     | Init container volume-permissions image registry                             | `docker.io`             |
-| `volumePermissions.image.repository`   | Init container volume-permissions image repository                           | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag (immutable tags are recommended) | `10-debian-10-r383`     |
-| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                          | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                             | `[]`                    |
-| `volumePermissions.resources.limits`   | The resources limits for the container                                       | `{}`                    |
-| `volumePermissions.resources.requests` | The requested resources for the container                                    | `{}`                    |
+| Name                                   | Description                                                                                                                       | Value                   |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `git.registry`                         | Git image registry                                                                                                                | `docker.io`             |
+| `git.repository`                       | Git image repository                                                                                                              | `bitnami/git`           |
+| `git.tag`                              | Git image tag (immutable tags are recommended)                                                                                    | `2.37.1-debian-11-r10`  |
+| `git.digest`                           | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                               | `""`                    |
+| `git.pullPolicy`                       | Git image pull policy                                                                                                             | `IfNotPresent`          |
+| `git.pullSecrets`                      | Specify docker-registry secret names as an array                                                                                  | `[]`                    |
+| `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory                                                       | `false`                 |
+| `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                  | `docker.io`             |
+| `volumePermissions.image.repository`   | Init container volume-permissions image repository                                                                                | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag (immutable tags are recommended)                                                      | `11-debian-11-r23`      |
+| `volumePermissions.image.digest`       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                  | `[]`                    |
+| `volumePermissions.resources.limits`   | The resources limits for the container                                                                                            | `{}`                    |
+| `volumePermissions.resources.requests` | The requested resources for the container                                                                                         | `{}`                    |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/mxnet/values.yaml
+++ b/bitnami/mxnet/values.yaml
@@ -65,7 +65,8 @@ diagnosticMode:
 ## @param image.registry Apache MXNet (Incubating) image registry
 ## @param image.repository Apache MXNet (Incubating) image repository
 ## @param image.tag Apache MXNet (Incubating) image tag (immutable tags are recommended)
-## @param image.pullPolicy Image pull policy
+## @param image.digest Apache MXNet (Incubating) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param image.pullPolicy Apache MXNet (Incubating) image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Specify if debug logs should be enabled
 ##
@@ -73,6 +74,7 @@ image:
   registry: docker.io
   repository: bitnami/mxnet
   tag: 1.9.1-debian-11-r24
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1165,6 +1167,7 @@ scheduler:
 ## @param git.registry Git image registry
 ## @param git.repository Git image repository
 ## @param git.tag Git image tag (immutable tags are recommended)
+## @param git.digest Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param git.pullPolicy Git image pull policy
 ## @param git.pullSecrets Specify docker-registry secret names as an array
 ##
@@ -1172,6 +1175,7 @@ git:
   registry: docker.io
   repository: bitnami/git
   tag: 2.37.1-debian-11-r10
+  digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
@@ -1191,6 +1195,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image repository
   ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -1198,6 +1203,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```