### PR TITLE
[bitnami/mongodb] Add support for image digest apart from tag

### DIFF
--- a/bitnami/mongodb/Chart.lock
+++ b/bitnami/mongodb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.17.1
-digest: sha256:dacc73770a5640c011e067ff8840ddf89631fc19016c8d0a9e5ea160e7da8690
-generated: "2022-08-19T17:46:15.104241387Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:59:31.480141489Z"

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: MongoDB(R) is a relational open source NoSQL database. Easy to use, it stores data in JSON-like documents. Automated scalability and high-performance. Ideal for developing cloud native applications.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/mongodb
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.0.2
+version: 13.1.0

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -96,6 +96,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `image.registry`         | MongoDB(&reg;) image registry                                                                                                                                | `docker.io`            |
 | `image.repository`       | MongoDB(&reg;) image registry                                                                                                                                | `bitnami/mongodb`      |
 | `image.tag`              | MongoDB(&reg;) image tag (immutable tags are recommended)                                                                                                    | `6.0.1-debian-11-r1`   |
+| `image.digest`           | MongoDB(&reg;) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                               | `""`                   |
 | `image.pullPolicy`       | MongoDB(&reg;) image pull policy                                                                                                                             | `IfNotPresent`         |
 | `image.pullSecrets`      | Specify docker-registry secret names as an array                                                                                                             | `[]`                   |
 | `image.debug`            | Set to true if you would like to see extra information on logs                                                                                               | `false`                |
@@ -121,6 +122,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `tls.image.registry`     | Init container TLS certs setup image registry                                                                                                                | `docker.io`            |
 | `tls.image.repository`   | Init container TLS certs setup image repository                                                                                                              | `bitnami/nginx`        |
 | `tls.image.tag`          | Init container TLS certs setup image tag (immutable tags are recommended)                                                                                    | `1.23.1-debian-11-r11` |
+| `tls.image.digest`       | Init container TLS certs setup image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                               | `""`                   |
 | `tls.image.pullPolicy`   | Init container TLS certs setup image pull policy                                                                                                             | `IfNotPresent`         |
 | `tls.image.pullSecrets`  | Init container TLS certs specify docker-registry secret names as an array                                                                                    | `[]`                   |
 | `tls.extraDnsNames`      | Add extra dns names to the CA, can solve x509 auth issue for pod clients                                                                                     | `[]`                   |
@@ -242,6 +244,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `externalAccess.autoDiscovery.image.registry`            | Init container auto-discovery image registry                                                                                                    | `docker.io`           |
 | `externalAccess.autoDiscovery.image.repository`          | Init container auto-discovery image repository                                                                                                  | `bitnami/kubectl`     |
 | `externalAccess.autoDiscovery.image.tag`                 | Init container auto-discovery image tag (immutable tags are recommended)                                                                        | `1.24.4-debian-11-r0` |
+| `externalAccess.autoDiscovery.image.digest`              | Init container auto-discovery image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                   | `""`                  |
 | `externalAccess.autoDiscovery.image.pullPolicy`          | Init container auto-discovery image pull policy                                                                                                 | `IfNotPresent`        |
 | `externalAccess.autoDiscovery.image.pullSecrets`         | Init container auto-discovery image pull secrets                                                                                                | `[]`                  |
 | `externalAccess.autoDiscovery.resources.limits`          | Init container auto-discovery resource limits                                                                                                   | `{}`                  |
@@ -310,17 +313,18 @@ Refer to the [chart documentation for more information on each of these architec
 
 ### Volume Permissions parameters
 
-| Name                                          | Description                                                                                                          | Value                   |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| `volumePermissions.enabled`                   | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup` | `false`                 |
-| `volumePermissions.image.registry`            | Init container volume-permissions image registry                                                                     | `docker.io`             |
-| `volumePermissions.image.repository`          | Init container volume-permissions image repository                                                                   | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                 | Init container volume-permissions image tag (immutable tags are recommended)                                         | `11-debian-11-r27`      |
-| `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy                                                                  | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                                                     | `[]`                    |
-| `volumePermissions.resources.limits`          | Init container volume-permissions resource limits                                                                    | `{}`                    |
-| `volumePermissions.resources.requests`        | Init container volume-permissions resource requests                                                                  | `{}`                    |
-| `volumePermissions.securityContext.runAsUser` | User ID for the volumePermissions container                                                                          | `0`                     |
+| Name                                          | Description                                                                                                                       | Value                   |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `volumePermissions.enabled`                   | Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`              | `false`                 |
+| `volumePermissions.image.registry`            | Init container volume-permissions image registry                                                                                  | `docker.io`             |
+| `volumePermissions.image.repository`          | Init container volume-permissions image repository                                                                                | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`                 | Init container volume-permissions image tag (immutable tags are recommended)                                                      | `11-debian-11-r27`      |
+| `volumePermissions.image.digest`              | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                                                                  | `[]`                    |
+| `volumePermissions.resources.limits`          | Init container volume-permissions resource limits                                                                                 | `{}`                    |
+| `volumePermissions.resources.requests`        | Init container volume-permissions resource requests                                                                               | `{}`                    |
+| `volumePermissions.securityContext.runAsUser` | User ID for the volumePermissions container                                                                                       | `0`                     |
 
 
 ### Arbiter parameters
@@ -497,6 +501,7 @@ Refer to the [chart documentation for more information on each of these architec
 | `metrics.image.registry`                     | MongoDB(&reg;) Prometheus exporter image registry                                                                     | `docker.io`                |
 | `metrics.image.repository`                   | MongoDB(&reg;) Prometheus exporter image repository                                                                   | `bitnami/mongodb-exporter` |
 | `metrics.image.tag`                          | MongoDB(&reg;) Prometheus exporter image tag (immutable tags are recommended)                                         | `0.34.0-debian-11-r5`      |
+| `metrics.image.digest`                       | MongoDB(&reg;) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag        | `""`                       |
 | `metrics.image.pullPolicy`                   | MongoDB(&reg;) Prometheus exporter image pull policy                                                                  | `IfNotPresent`             |
 | `metrics.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                                      | `[]`                       |
 | `metrics.username`                           | String with username for the metrics exporter                                                                         | `""`                       |

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -98,6 +98,7 @@ diagnosticMode:
 ## @param image.registry MongoDB(&reg;) image registry
 ## @param image.repository MongoDB(&reg;) image registry
 ## @param image.tag MongoDB(&reg;) image tag (immutable tags are recommended)
+## @param image.digest MongoDB(&reg;) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy MongoDB(&reg;) image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Set to true if you would like to see extra information on logs
@@ -106,6 +107,7 @@ image:
   registry: docker.io
   repository: bitnami/mongodb
   tag: 6.0.1-debian-11-r1
+  digest: ""
   ## Specify a imagePullPolicy
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -189,6 +191,7 @@ tls:
   ## @param tls.image.registry Init container TLS certs setup image registry
   ## @param tls.image.repository Init container TLS certs setup image repository
   ## @param tls.image.tag Init container TLS certs setup image tag (immutable tags are recommended)
+  ## @param tls.image.digest Init container TLS certs setup image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param tls.image.pullPolicy Init container TLS certs setup image pull policy
   ## @param tls.image.pullSecrets Init container TLS certs specify docker-registry secret names as an array
   ## @param tls.extraDnsNames Add extra dns names to the CA, can solve x509 auth issue for pod clients
@@ -197,6 +200,7 @@ tls:
     registry: docker.io
     repository: bitnami/nginx
     tag: 1.23.1-debian-11-r11
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -728,6 +732,7 @@ externalAccess:
     ## @param externalAccess.autoDiscovery.image.registry Init container auto-discovery image registry
     ## @param externalAccess.autoDiscovery.image.repository Init container auto-discovery image repository
     ## @param externalAccess.autoDiscovery.image.tag Init container auto-discovery image tag (immutable tags are recommended)
+    ## @param externalAccess.autoDiscovery.image.digest Init container auto-discovery image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
     ## @param externalAccess.autoDiscovery.image.pullPolicy Init container auto-discovery image pull policy
     ## @param externalAccess.autoDiscovery.image.pullSecrets Init container auto-discovery image pull secrets
     ##
@@ -735,6 +740,7 @@ externalAccess:
       registry: docker.io
       repository: bitnami/kubectl
       tag: 1.24.4-debian-11-r0
+      digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
       ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1075,6 +1081,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image repository
   ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -1082,6 +1089,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r27
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -1819,6 +1827,7 @@ metrics:
   ## @param metrics.image.registry MongoDB(&reg;) Prometheus exporter image registry
   ## @param metrics.image.repository MongoDB(&reg;) Prometheus exporter image repository
   ## @param metrics.image.tag MongoDB(&reg;) Prometheus exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest MongoDB(&reg;) image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy MongoDB(&reg;) Prometheus exporter image pull policy
   ## @param metrics.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -1826,6 +1835,7 @@ metrics:
     registry: docker.io
     repository: bitnami/mongodb-exporter
     tag: 0.34.0-debian-11-r5
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```