### PR TITLE
[bitnami/metallb] Add support for image digest apart from tag

### DIFF
--- a/bitnami/metallb/Chart.lock
+++ b/bitnami/metallb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-08-03T11:00:34.520391828Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:59:22.611175704Z"

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters, using standard routing protocols.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/metallb
@@ -30,4 +30,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/containers/tree/main/bitnami/metallb
   - https://metallb.universe.tf
-version: 4.0.2
+version: 4.1.0

--- a/bitnami/metallb/values.yaml
+++ b/bitnami/metallb/values.yaml
@@ -91,6 +91,7 @@ controller:
   ## @param controller.image.registry MetalLB Controller image registry
   ## @param controller.image.repository MetalLB Controller image repository
   ## @param controller.image.tag MetalLB Controller  image tag (immutable tags are recommended)
+  ## @param controller.image.digest MetalLB Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param controller.image.pullPolicy MetalLB Controller image pull policy
   ## @param controller.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -98,6 +99,7 @@ controller:
     registry: docker.io
     repository: bitnami/metallb-controller
     tag: 0.13.4-debian-11-r3
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -446,6 +448,7 @@ speaker:
   ## @param speaker.image.registry MetalLB Speaker image registry
   ## @param speaker.image.repository MetalLB Speaker image repository
   ## @param speaker.image.tag MetalLB Speaker  image tag (immutable tags are recommended)
+  ## @param speaker.image.digest MetalLB Speaker image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param speaker.image.pullPolicy MetalLB Speaker image pull policy
   ## @param speaker.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -453,6 +456,7 @@ speaker:
     registry: docker.io
     repository: bitnami/metallb-speaker
     tag: 0.13.4-debian-11-r7
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```