### PR TITLE
[bitnami/memcached] Add support for image digest apart from tag

### DIFF
--- a/bitnami/memcached/Chart.lock
+++ b/bitnami/memcached/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-26T23:56:02.861755238Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:59:19.68309688Z"

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Memcached is an high-performance, distributed memory object caching system, generic in nature, but intended for use in speeding up dynamic web applications by alleviating database load.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/memcached
@@ -22,4 +22,4 @@ name: memcached
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/memcached
   - http://memcached.org/
-version: 6.1.11
+version: 6.2.0

--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -78,23 +78,24 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Memcached parameters
 
-| Name                 | Description                                                              | Value                 |
-| -------------------- | ------------------------------------------------------------------------ | --------------------- |
-| `image.registry`     | Memcached image registry                                                 | `docker.io`           |
-| `image.repository`   | Memcached image repository                                               | `bitnami/memcached`   |
-| `image.tag`          | Memcached image tag (immutable tags are recommended)                     | `1.6.15-debian-11-r0` |
-| `image.pullPolicy`   | Memcached image pull policy                                              | `IfNotPresent`        |
-| `image.pullSecrets`  | Specify docker-registry secret names as an array                         | `[]`                  |
-| `image.debug`        | Specify if debug values should be set                                    | `false`               |
-| `architecture`       | Memcached architecture. Allowed values: standalone or high-availability  | `standalone`          |
-| `auth.enabled`       | Enable Memcached authentication                                          | `false`               |
-| `auth.username`      | Memcached admin user                                                     | `""`                  |
-| `auth.password`      | Memcached admin password                                                 | `""`                  |
-| `command`            | Override default container command (useful when using custom images)     | `[]`                  |
-| `args`               | Override default container args (useful when using custom images)        | `[]`                  |
-| `extraEnvVars`       | Array with extra environment variables to add to Memcached nodes         | `[]`                  |
-| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars for Memcached nodes | `""`                  |
-| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars for Memcached nodes    | `""`                  |
+| Name                 | Description                                                                                               | Value                 |
+| -------------------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`     | Memcached image registry                                                                                  | `docker.io`           |
+| `image.repository`   | Memcached image repository                                                                                | `bitnami/memcached`   |
+| `image.tag`          | Memcached image tag (immutable tags are recommended)                                                      | `1.6.16-debian-11-r3` |
+| `image.digest`       | Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `image.pullPolicy`   | Memcached image pull policy                                                                               | `IfNotPresent`        |
+| `image.pullSecrets`  | Specify docker-registry secret names as an array                                                          | `[]`                  |
+| `image.debug`        | Specify if debug values should be set                                                                     | `false`               |
+| `architecture`       | Memcached architecture. Allowed values: standalone or high-availability                                   | `standalone`          |
+| `auth.enabled`       | Enable Memcached authentication                                                                           | `false`               |
+| `auth.username`      | Memcached admin user                                                                                      | `""`                  |
+| `auth.password`      | Memcached admin password                                                                                  | `""`                  |
+| `command`            | Override default container command (useful when using custom images)                                      | `[]`                  |
+| `args`               | Override default container args (useful when using custom images)                                         | `[]`                  |
+| `extraEnvVars`       | Array with extra environment variables to add to Memcached nodes                                          | `[]`                  |
+| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars for Memcached nodes                                  | `""`                  |
+| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars for Memcached nodes                                     | `""`                  |
 
 
 ### Deployment/Statefulset parameters
@@ -206,62 +207,64 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Volume Permissions parameters
 
-| Name                                                   | Description                                                                           | Value                        |
-| ------------------------------------------------------ | ------------------------------------------------------------------------------------- | ---------------------------- |
-| `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume       | `false`                      |
-| `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                      | `docker.io`                  |
-| `volumePermissions.image.repository`                   | Init container volume-permissions image repository                                    | `bitnami/bitnami-shell`      |
-| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)          | `11-debian-11-r0`            |
-| `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                                   | `IfNotPresent`               |
-| `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                                  | `[]`                         |
-| `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                                     | `{}`                         |
-| `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                                   | `{}`                         |
-| `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                        | `0`                          |
-| `metrics.enabled`                                      | Start a side-car prometheus exporter                                                  | `false`                      |
-| `metrics.image.registry`                               | Memcached exporter image registry                                                     | `docker.io`                  |
-| `metrics.image.repository`                             | Memcached exporter image repository                                                   | `bitnami/memcached-exporter` |
-| `metrics.image.tag`                                    | Memcached exporter image tag (immutable tags are recommended)                         | `0.9.0-debian-11-r0`         |
-| `metrics.image.pullPolicy`                             | Image pull policy                                                                     | `IfNotPresent`               |
-| `metrics.image.pullSecrets`                            | Specify docker-registry secret names as an array                                      | `[]`                         |
-| `metrics.containerPorts.metrics`                       | Memcached Prometheus Exporter container port                                          | `9150`                       |
-| `metrics.resources.limits`                             | Init container volume-permissions resource limits                                     | `{}`                         |
-| `metrics.resources.requests`                           | Init container volume-permissions resource requests                                   | `{}`                         |
-| `metrics.livenessProbe.enabled`                        | Enable livenessProbe on Memcached Prometheus exporter containers                      | `true`                       |
-| `metrics.livenessProbe.initialDelaySeconds`            | Initial delay seconds for livenessProbe                                               | `15`                         |
-| `metrics.livenessProbe.periodSeconds`                  | Period seconds for livenessProbe                                                      | `10`                         |
-| `metrics.livenessProbe.timeoutSeconds`                 | Timeout seconds for livenessProbe                                                     | `5`                          |
-| `metrics.livenessProbe.failureThreshold`               | Failure threshold for livenessProbe                                                   | `3`                          |
-| `metrics.livenessProbe.successThreshold`               | Success threshold for livenessProbe                                                   | `1`                          |
-| `metrics.readinessProbe.enabled`                       | Enable readinessProbe on Memcached Prometheus exporter containers                     | `true`                       |
-| `metrics.readinessProbe.initialDelaySeconds`           | Initial delay seconds for readinessProbe                                              | `5`                          |
-| `metrics.readinessProbe.periodSeconds`                 | Period seconds for readinessProbe                                                     | `10`                         |
-| `metrics.readinessProbe.timeoutSeconds`                | Timeout seconds for readinessProbe                                                    | `3`                          |
-| `metrics.readinessProbe.failureThreshold`              | Failure threshold for readinessProbe                                                  | `3`                          |
-| `metrics.readinessProbe.successThreshold`              | Success threshold for readinessProbe                                                  | `1`                          |
-| `metrics.startupProbe.enabled`                         | Enable startupProbe on Memcached Prometheus exporter containers                       | `false`                      |
-| `metrics.startupProbe.initialDelaySeconds`             | Initial delay seconds for startupProbe                                                | `10`                         |
-| `metrics.startupProbe.periodSeconds`                   | Period seconds for startupProbe                                                       | `10`                         |
-| `metrics.startupProbe.timeoutSeconds`                  | Timeout seconds for startupProbe                                                      | `1`                          |
-| `metrics.startupProbe.failureThreshold`                | Failure threshold for startupProbe                                                    | `15`                         |
-| `metrics.startupProbe.successThreshold`                | Success threshold for startupProbe                                                    | `1`                          |
-| `metrics.customLivenessProbe`                          | Custom livenessProbe that overrides the default one                                   | `{}`                         |
-| `metrics.customReadinessProbe`                         | Custom readinessProbe that overrides the default one                                  | `{}`                         |
-| `metrics.customStartupProbe`                           | Custom startupProbe that overrides the default one                                    | `{}`                         |
-| `metrics.podAnnotations`                               | Memcached Prometheus exporter pod Annotation and Labels                               | `{}`                         |
-| `metrics.service.ports.metrics`                        | Prometheus metrics service port                                                       | `9150`                       |
-| `metrics.service.clusterIP`                            | Static clusterIP or None for headless services                                        | `""`                         |
-| `metrics.service.sessionAffinity`                      | Control where client requests go, to the same pod or round-robin                      | `None`                       |
-| `metrics.service.annotations`                          | Annotations for the Prometheus metrics service                                        | `{}`                         |
-| `metrics.serviceMonitor.enabled`                       | Create ServiceMonitor Resource for scraping metrics using Prometheus Operator         | `false`                      |
-| `metrics.serviceMonitor.namespace`                     | Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)         | `""`                         |
-| `metrics.serviceMonitor.interval`                      | Interval at which metrics should be scraped.                                          | `""`                         |
-| `metrics.serviceMonitor.scrapeTimeout`                 | Timeout after which the scrape is ended                                               | `""`                         |
-| `metrics.serviceMonitor.labels`                        | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | `{}`                         |
-| `metrics.serviceMonitor.selector`                      | Prometheus instance selector labels                                                   | `{}`                         |
-| `metrics.serviceMonitor.relabelings`                   | RelabelConfigs to apply to samples before scraping                                    | `[]`                         |
-| `metrics.serviceMonitor.metricRelabelings`             | MetricRelabelConfigs to apply to samples before ingestion                             | `[]`                         |
-| `metrics.serviceMonitor.honorLabels`                   | Specify honorLabels parameter to add the scrape endpoint                              | `false`                      |
-| `metrics.serviceMonitor.jobLabel`                      | The name of the label on the target service to use as the job name in prometheus.     | `""`                         |
+| Name                                                   | Description                                                                                                                       | Value                        |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `volumePermissions.enabled`                            | Enable init container that changes the owner and group of the persistent volume                                                   | `false`                      |
+| `volumePermissions.image.registry`                     | Init container volume-permissions image registry                                                                                  | `docker.io`                  |
+| `volumePermissions.image.repository`                   | Init container volume-permissions image repository                                                                                | `bitnami/bitnami-shell`      |
+| `volumePermissions.image.tag`                          | Init container volume-permissions image tag (immutable tags are recommended)                                                      | `11-debian-11-r23`           |
+| `volumePermissions.image.digest`                       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                         |
+| `volumePermissions.image.pullPolicy`                   | Init container volume-permissions image pull policy                                                                               | `IfNotPresent`               |
+| `volumePermissions.image.pullSecrets`                  | Init container volume-permissions image pull secrets                                                                              | `[]`                         |
+| `volumePermissions.resources.limits`                   | Init container volume-permissions resource limits                                                                                 | `{}`                         |
+| `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                                                                               | `{}`                         |
+| `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                                                                    | `0`                          |
+| `metrics.enabled`                                      | Start a side-car prometheus exporter                                                                                              | `false`                      |
+| `metrics.image.registry`                               | Memcached exporter image registry                                                                                                 | `docker.io`                  |
+| `metrics.image.repository`                             | Memcached exporter image repository                                                                                               | `bitnami/memcached-exporter` |
+| `metrics.image.tag`                                    | Memcached exporter image tag (immutable tags are recommended)                                                                     | `0.10.0-debian-11-r21`       |
+| `metrics.image.digest`                                 | Memcached exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                | `""`                         |
+| `metrics.image.pullPolicy`                             | Image pull policy                                                                                                                 | `IfNotPresent`               |
+| `metrics.image.pullSecrets`                            | Specify docker-registry secret names as an array                                                                                  | `[]`                         |
+| `metrics.containerPorts.metrics`                       | Memcached Prometheus Exporter container port                                                                                      | `9150`                       |
+| `metrics.resources.limits`                             | Init container volume-permissions resource limits                                                                                 | `{}`                         |
+| `metrics.resources.requests`                           | Init container volume-permissions resource requests                                                                               | `{}`                         |
+| `metrics.livenessProbe.enabled`                        | Enable livenessProbe on Memcached Prometheus exporter containers                                                                  | `true`                       |
+| `metrics.livenessProbe.initialDelaySeconds`            | Initial delay seconds for livenessProbe                                                                                           | `15`                         |
+| `metrics.livenessProbe.periodSeconds`                  | Period seconds for livenessProbe                                                                                                  | `10`                         |
+| `metrics.livenessProbe.timeoutSeconds`                 | Timeout seconds for livenessProbe                                                                                                 | `5`                          |
+| `metrics.livenessProbe.failureThreshold`               | Failure threshold for livenessProbe                                                                                               | `3`                          |
+| `metrics.livenessProbe.successThreshold`               | Success threshold for livenessProbe                                                                                               | `1`                          |
+| `metrics.readinessProbe.enabled`                       | Enable readinessProbe on Memcached Prometheus exporter containers                                                                 | `true`                       |
+| `metrics.readinessProbe.initialDelaySeconds`           | Initial delay seconds for readinessProbe                                                                                          | `5`                          |
+| `metrics.readinessProbe.periodSeconds`                 | Period seconds for readinessProbe                                                                                                 | `10`                         |
+| `metrics.readinessProbe.timeoutSeconds`                | Timeout seconds for readinessProbe                                                                                                | `3`                          |
+| `metrics.readinessProbe.failureThreshold`              | Failure threshold for readinessProbe                                                                                              | `3`                          |
+| `metrics.readinessProbe.successThreshold`              | Success threshold for readinessProbe                                                                                              | `1`                          |
+| `metrics.startupProbe.enabled`                         | Enable startupProbe on Memcached Prometheus exporter containers                                                                   | `false`                      |
+| `metrics.startupProbe.initialDelaySeconds`             | Initial delay seconds for startupProbe                                                                                            | `10`                         |
+| `metrics.startupProbe.periodSeconds`                   | Period seconds for startupProbe                                                                                                   | `10`                         |
+| `metrics.startupProbe.timeoutSeconds`                  | Timeout seconds for startupProbe                                                                                                  | `1`                          |
+| `metrics.startupProbe.failureThreshold`                | Failure threshold for startupProbe                                                                                                | `15`                         |
+| `metrics.startupProbe.successThreshold`                | Success threshold for startupProbe                                                                                                | `1`                          |
+| `metrics.customLivenessProbe`                          | Custom livenessProbe that overrides the default one                                                                               | `{}`                         |
+| `metrics.customReadinessProbe`                         | Custom readinessProbe that overrides the default one                                                                              | `{}`                         |
+| `metrics.customStartupProbe`                           | Custom startupProbe that overrides the default one                                                                                | `{}`                         |
+| `metrics.podAnnotations`                               | Memcached Prometheus exporter pod Annotation and Labels                                                                           | `{}`                         |
+| `metrics.service.ports.metrics`                        | Prometheus metrics service port                                                                                                   | `9150`                       |
+| `metrics.service.clusterIP`                            | Static clusterIP or None for headless services                                                                                    | `""`                         |
+| `metrics.service.sessionAffinity`                      | Control where client requests go, to the same pod or round-robin                                                                  | `None`                       |
+| `metrics.service.annotations`                          | Annotations for the Prometheus metrics service                                                                                    | `{}`                         |
+| `metrics.serviceMonitor.enabled`                       | Create ServiceMonitor Resource for scraping metrics using Prometheus Operator                                                     | `false`                      |
+| `metrics.serviceMonitor.namespace`                     | Namespace for the ServiceMonitor Resource (defaults to the Release Namespace)                                                     | `""`                         |
+| `metrics.serviceMonitor.interval`                      | Interval at which metrics should be scraped.                                                                                      | `""`                         |
+| `metrics.serviceMonitor.scrapeTimeout`                 | Timeout after which the scrape is ended                                                                                           | `""`                         |
+| `metrics.serviceMonitor.labels`                        | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                             | `{}`                         |
+| `metrics.serviceMonitor.selector`                      | Prometheus instance selector labels                                                                                               | `{}`                         |
+| `metrics.serviceMonitor.relabelings`                   | RelabelConfigs to apply to samples before scraping                                                                                | `[]`                         |
+| `metrics.serviceMonitor.metricRelabelings`             | MetricRelabelConfigs to apply to samples before ingestion                                                                         | `[]`                         |
+| `metrics.serviceMonitor.honorLabels`                   | Specify honorLabels parameter to add the scrape endpoint                                                                          | `false`                      |
+| `metrics.serviceMonitor.jobLabel`                      | The name of the label on the target service to use as the job name in prometheus.                                                 | `""`                         |
 
 
 The above parameters map to the environment variables defined in the [bitnami/memcached](https://github.com/bitnami/containers/tree/main/bitnami/memcached) container image. For more information please refer to the [bitnami/memcached](https://github.com/bitnami/containers/tree/main/bitnami/memcached) container image documentation.

--- a/bitnami/memcached/values.yaml
+++ b/bitnami/memcached/values.yaml
@@ -62,6 +62,7 @@ diagnosticMode:
 ## @param image.registry Memcached image registry
 ## @param image.repository Memcached image repository
 ## @param image.tag Memcached image tag (immutable tags are recommended)
+## @param image.digest Memcached image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Memcached image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Specify if debug values should be set
@@ -70,6 +71,7 @@ image:
   registry: docker.io
   repository: bitnami/memcached
   tag: 1.6.16-debian-11-r3
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -497,6 +499,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image repository
   ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
   ## @param volumePermissions.image.pullSecrets Init container volume-permissions image pull secrets
   ##
@@ -504,6 +507,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -540,6 +544,7 @@ metrics:
   ## @param metrics.image.registry Memcached exporter image registry
   ## @param metrics.image.repository Memcached exporter image repository
   ## @param metrics.image.tag Memcached exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest Memcached exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy Image pull policy
   ## @param metrics.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -547,6 +552,7 @@ metrics:
     registry: docker.io
     repository: bitnami/memcached-exporter
     tag: 0.10.0-debian-11-r21
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```