### PR TITLE
[bitnami/magento] Add support for image digest apart from tag

### DIFF
--- a/bitnami/magento/Chart.lock
+++ b/bitnami/magento/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.8
+  version: 11.2.0
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 19.1.11
+  version: 19.2.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
-digest: sha256:4b5af502b024641c4b7c495b29adcd1ec358720910953105aed317845939afb3
-generated: "2022-08-20T10:59:00.919671146Z"
+digest: sha256:c92705f3d1096e675cc1b74ab8d3d862771952606166120008af4c6619c28dca
+generated: "2022-08-22T14:16:50.817632654Z"

--- a/bitnami/magento/Chart.lock
+++ b/bitnami/magento/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.7
+  version: 11.1.8
 - name: elasticsearch
   repository: https://charts.bitnami.com/bitnami
-  version: 19.1.9
+  version: 19.1.11
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:45588d4a597f0643a1542405172db50eaf0b9c18a309c94570763cdc06532b2c
-generated: "2022-08-09T10:36:37.855766519Z"
+  version: 2.0.0
+digest: sha256:4b5af502b024641c4b7c495b29adcd1ec358720910953105aed317845939afb3
+generated: "2022-08-20T10:59:00.919671146Z"

--- a/bitnami/magento/Chart.lock
+++ b/bitnami/magento/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
 digest: sha256:c92705f3d1096e675cc1b74ab8d3d862771952606166120008af4c6619c28dca
-generated: "2022-08-22T14:16:50.817632654Z"
+generated: "2022-08-22T14:26:04.940081316Z"

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Magento is a powerful open source e-commerce platform. With easy customizations and rich features, it allows retailers to grow their online businesses in a cost-effective way.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/magento
@@ -35,4 +35,4 @@ name: magento
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/magento
   - https://magento.com/
-version: 21.0.8
+version: 21.1.0

--- a/bitnami/magento/README.md
+++ b/bitnami/magento/README.md
@@ -86,6 +86,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.registry`                        | Magento image registry                                                                                               | `docker.io`          |
 | `image.repository`                      | Magento image repository                                                                                             | `bitnami/magento`    |
 | `image.tag`                             | Magento image tag (immutable tags are recommended)                                                                   | `2.4.5-debian-11-r0` |
+| `image.digest`                          | Magento image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag              | `""`                 |
 | `image.pullPolicy`                      | Magento image pull policy                                                                                            | `IfNotPresent`       |
 | `image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                     | `[]`                 |
 | `image.debug`                           | Specify if debug logs should be enabled                                                                              | `false`              |
@@ -187,46 +188,48 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Database parameters
 
-| Name                                        | Description                                                                              | Value                   |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------- |
-| `mariadb.enabled`                           | Whether to deploy a mariadb server to satisfy the applications database requirements.    | `true`                  |
-| `mariadb.image.registry`                    | MariaDB image registry                                                                   | `docker.io`             |
-| `mariadb.image.repository`                  | MariaDB image repository                                                                 | `bitnami/mariadb`       |
-| `mariadb.image.tag`                         | MariaDB image tag (immutable tags are recommended)                                       | `10.4.25-debian-11-r26` |
-| `mariadb.architecture`                      | MariaDB architecture. Allowed values: `standalone` or `replication`                      | `standalone`            |
-| `mariadb.auth.rootPassword`                 | Password for the MariaDB `root` user                                                     | `""`                    |
-| `mariadb.auth.database`                     | Database name to create                                                                  | `bitnami_magento`       |
-| `mariadb.auth.username`                     | Database user to create                                                                  | `bn_magento`            |
-| `mariadb.auth.password`                     | Password for the database                                                                | `""`                    |
-| `mariadb.primary.persistence.enabled`       | Enable database persistence using PVC                                                    | `true`                  |
-| `mariadb.primary.persistence.storageClass`  | MariaDB primary persistent volume storage Class                                          | `""`                    |
-| `mariadb.primary.persistence.accessModes`   | Database Persistent Volume Access Modes                                                  | `["ReadWriteOnce"]`     |
-| `mariadb.primary.persistence.size`          | Database Persistent Volume Size                                                          | `8Gi`                   |
-| `mariadb.primary.persistence.hostPath`      | Set path in case you want to use local host path volumes (not recommended in production) | `""`                    |
-| `mariadb.primary.persistence.existingClaim` | Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas                 | `""`                    |
-| `externalDatabase.host`                     | Host of the existing database                                                            | `""`                    |
-| `externalDatabase.port`                     | Port of the existing database                                                            | `3306`                  |
-| `externalDatabase.user`                     | Existing username in the external db                                                     | `bn_magento`            |
-| `externalDatabase.password`                 | Password for the above username                                                          | `""`                    |
-| `externalDatabase.database`                 | Name of the existing database                                                            | `bitnami_magento`       |
-| `externalDatabase.existingSecret`           | Name of an existing secret resource containing the DB password                           | `""`                    |
+| Name                                        | Description                                                                                             | Value                   |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `mariadb.enabled`                           | Whether to deploy a mariadb server to satisfy the applications database requirements.                   | `true`                  |
+| `mariadb.image.registry`                    | MariaDB image registry                                                                                  | `docker.io`             |
+| `mariadb.image.repository`                  | MariaDB image repository                                                                                | `bitnami/mariadb`       |
+| `mariadb.image.tag`                         | MariaDB image tag (immutable tags are recommended)                                                      | `10.4.25-debian-11-r26` |
+| `mariadb.image.digest`                      | MariaDB image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `mariadb.architecture`                      | MariaDB architecture. Allowed values: `standalone` or `replication`                                     | `standalone`            |
+| `mariadb.auth.rootPassword`                 | Password for the MariaDB `root` user                                                                    | `""`                    |
+| `mariadb.auth.database`                     | Database name to create                                                                                 | `bitnami_magento`       |
+| `mariadb.auth.username`                     | Database user to create                                                                                 | `bn_magento`            |
+| `mariadb.auth.password`                     | Password for the database                                                                               | `""`                    |
+| `mariadb.primary.persistence.enabled`       | Enable database persistence using PVC                                                                   | `true`                  |
+| `mariadb.primary.persistence.storageClass`  | MariaDB primary persistent volume storage Class                                                         | `""`                    |
+| `mariadb.primary.persistence.accessModes`   | Database Persistent Volume Access Modes                                                                 | `["ReadWriteOnce"]`     |
+| `mariadb.primary.persistence.size`          | Database Persistent Volume Size                                                                         | `8Gi`                   |
+| `mariadb.primary.persistence.hostPath`      | Set path in case you want to use local host path volumes (not recommended in production)                | `""`                    |
+| `mariadb.primary.persistence.existingClaim` | Name of an existing `PersistentVolumeClaim` for MariaDB primary replicas                                | `""`                    |
+| `externalDatabase.host`                     | Host of the existing database                                                                           | `""`                    |
+| `externalDatabase.port`                     | Port of the existing database                                                                           | `3306`                  |
+| `externalDatabase.user`                     | Existing username in the external db                                                                    | `bn_magento`            |
+| `externalDatabase.password`                 | Password for the above username                                                                         | `""`                    |
+| `externalDatabase.database`                 | Name of the existing database                                                                           | `bitnami_magento`       |
+| `externalDatabase.existingSecret`           | Name of an existing secret resource containing the DB password                                          | `""`                    |
 
 
 ### Elasticsearch parameters
 
-| Name                                      | Description                                                                | Value                   |
-| ----------------------------------------- | -------------------------------------------------------------------------- | ----------------------- |
-| `elasticsearch.enabled`                   | Whether to deploy a elasticsearch server to use as magento's search engine | `true`                  |
-| `elasticsearch.image.registry`            | Elasticsearch image registry                                               | `docker.io`             |
-| `elasticsearch.image.repository`          | Elasticsearch image repository                                             | `bitnami/elasticsearch` |
-| `elasticsearch.image.tag`                 | Elasticsearch image tag (immutable tags are recommended)                   | `7.17.5-debian-11-r15`  |
-| `elasticsearch.sysctlImage.enabled`       | Enable kernel settings modifier image for Elasticsearch                    | `true`                  |
-| `elasticsearch.master.replicaCount`       | Desired number of Elasticsearch master-eligible nodes                      | `1`                     |
-| `elasticsearch.coordinating.replicaCount` | Desired number of Elasticsearch coordinating-only nodes                    | `1`                     |
-| `elasticsearch.data.replicaCount`         | Desired number of Elasticsearch data nodes                                 | `1`                     |
-| `elasticsearch.ingest.replicaCount`       | Desired number of Elasticsearch ingest nodes                               | `1`                     |
-| `externalElasticsearch.host`              | Host of the external elasticsearch server                                  | `""`                    |
-| `externalElasticsearch.port`              | Port of the external elasticsearch server                                  | `""`                    |
+| Name                                      | Description                                                                                                   | Value                   |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `elasticsearch.enabled`                   | Whether to deploy a elasticsearch server to use as magento's search engine                                    | `true`                  |
+| `elasticsearch.image.registry`            | Elasticsearch image registry                                                                                  | `docker.io`             |
+| `elasticsearch.image.repository`          | Elasticsearch image repository                                                                                | `bitnami/elasticsearch` |
+| `elasticsearch.image.tag`                 | Elasticsearch image tag (immutable tags are recommended)                                                      | `7.17.5-debian-11-r15`  |
+| `elasticsearch.image.digest`              | Elasticsearch image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `elasticsearch.sysctlImage.enabled`       | Enable kernel settings modifier image for Elasticsearch                                                       | `true`                  |
+| `elasticsearch.master.replicaCount`       | Desired number of Elasticsearch master-eligible nodes                                                         | `1`                     |
+| `elasticsearch.coordinating.replicaCount` | Desired number of Elasticsearch coordinating-only nodes                                                       | `1`                     |
+| `elasticsearch.data.replicaCount`         | Desired number of Elasticsearch data nodes                                                                    | `1`                     |
+| `elasticsearch.ingest.replicaCount`       | Desired number of Elasticsearch ingest nodes                                                                  | `1`                     |
+| `externalElasticsearch.host`              | Host of the external elasticsearch server                                                                     | `""`                    |
+| `externalElasticsearch.port`              | Port of the external elasticsearch server                                                                     | `""`                    |
 
 
 ### Persistence parameters
@@ -253,6 +256,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                                          | `docker.io`             |
 | `volumePermissions.image.repository`   | Init container volume-permissions image repository                                                                                                        | `bitnami/bitnami-shell` |
 | `volumePermissions.image.tag`          | Init container volume-permissions image tag (immutable tags are recommended)                                                                              | `11-debian-11-r23`      |
+| `volumePermissions.image.digest`       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                         | `""`                    |
 | `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                                                       | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                                          | `[]`                    |
 | `volumePermissions.resources.limits`   | The resources limits for the init container                                                                                                               | `{}`                    |
@@ -294,42 +298,44 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics parameters
 
-| Name                          | Description                                                | Value                     |
-| ----------------------------- | ---------------------------------------------------------- | ------------------------- |
-| `metrics.enabled`             | Start a side-car prometheus exporter                       | `false`                   |
-| `metrics.image.registry`      | Apache exporter image registry                             | `docker.io`               |
-| `metrics.image.repository`    | Apache exporter image repository                           | `bitnami/apache-exporter` |
-| `metrics.image.tag`           | Apache exporter image tag (immutable tags are recommended) | `0.11.0-debian-11-r28`    |
-| `metrics.image.pullPolicy`    | Image pull policy                                          | `IfNotPresent`            |
-| `metrics.image.pullSecrets`   | Specify docker-registry secret names as an array           | `[]`                      |
-| `metrics.resources.limits`    | The resources limits for the metrics container             | `{}`                      |
-| `metrics.resources.requests`  | The requested resources for the metrics container          | `{}`                      |
-| `metrics.service.type`        | Prometheus metrics service type                            | `ClusterIP`               |
-| `metrics.service.port`        | Service Metrics port                                       | `9117`                    |
-| `metrics.service.annotations` | Annotations for the Prometheus exporter service            | `{}`                      |
+| Name                          | Description                                                                                                     | Value                     |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `metrics.enabled`             | Start a side-car prometheus exporter                                                                            | `false`                   |
+| `metrics.image.registry`      | Apache exporter image registry                                                                                  | `docker.io`               |
+| `metrics.image.repository`    | Apache exporter image repository                                                                                | `bitnami/apache-exporter` |
+| `metrics.image.tag`           | Apache exporter image tag (immutable tags are recommended)                                                      | `0.11.0-debian-11-r28`    |
+| `metrics.image.digest`        | Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                      |
+| `metrics.image.pullPolicy`    | Image pull policy                                                                                               | `IfNotPresent`            |
+| `metrics.image.pullSecrets`   | Specify docker-registry secret names as an array                                                                | `[]`                      |
+| `metrics.resources.limits`    | The resources limits for the metrics container                                                                  | `{}`                      |
+| `metrics.resources.requests`  | The requested resources for the metrics container                                                               | `{}`                      |
+| `metrics.service.type`        | Prometheus metrics service type                                                                                 | `ClusterIP`               |
+| `metrics.service.port`        | Service Metrics port                                                                                            | `9117`                    |
+| `metrics.service.annotations` | Annotations for the Prometheus exporter service                                                                 | `{}`                      |
 
 
 ### Certificate injection parameters
 
-| Name                                                 | Description                                                          | Value                                    |
-| ---------------------------------------------------- | -------------------------------------------------------------------- | ---------------------------------------- |
-| `certificates.customCertificate.certificateSecret`   | Secret containing the certificate and key to add                     | `""`                                     |
-| `certificates.customCertificate.chainSecret.name`    | Name of the secret containing the certificate chain                  | `""`                                     |
-| `certificates.customCertificate.chainSecret.key`     | Key of the certificate chain file inside the secret                  | `""`                                     |
-| `certificates.customCertificate.certificateLocation` | Location in the container to store the certificate                   | `/etc/ssl/certs/ssl-cert-snakeoil.pem`   |
-| `certificates.customCertificate.keyLocation`         | Location in the container to store the private key                   | `/etc/ssl/private/ssl-cert-snakeoil.key` |
-| `certificates.customCertificate.chainLocation`       | Location in the container to store the certificate chain             | `/etc/ssl/certs/mychain.pem`             |
-| `certificates.customCAs`                             | Defines a list of secrets to import into the container trust store   | `[]`                                     |
-| `certificates.command`                               | Override default container command (useful when using custom images) | `[]`                                     |
-| `certificates.args`                                  | Override default container args (useful when using custom images)    | `[]`                                     |
-| `certificates.extraEnvVars`                          | Container sidecar extra environment variables (eg proxy)             | `[]`                                     |
-| `certificates.extraEnvVarsCM`                        | ConfigMap containing extra env vars                                  | `""`                                     |
-| `certificates.extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)         | `""`                                     |
-| `certificates.image.registry`                        | Container sidecar registry                                           | `docker.io`                              |
-| `certificates.image.repository`                      | Container sidecar image                                              | `bitnami/bitnami-shell`                  |
-| `certificates.image.tag`                             | Container sidecar image tag (immutable tags are recommended)         | `11-debian-11-r23`                       |
-| `certificates.image.pullPolicy`                      | Container sidecar image pull policy                                  | `IfNotPresent`                           |
-| `certificates.image.pullSecrets`                     | Container sidecar image pull secrets                                 | `[]`                                     |
+| Name                                                 | Description                                                                                                       | Value                                    |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `certificates.customCertificate.certificateSecret`   | Secret containing the certificate and key to add                                                                  | `""`                                     |
+| `certificates.customCertificate.chainSecret.name`    | Name of the secret containing the certificate chain                                                               | `""`                                     |
+| `certificates.customCertificate.chainSecret.key`     | Key of the certificate chain file inside the secret                                                               | `""`                                     |
+| `certificates.customCertificate.certificateLocation` | Location in the container to store the certificate                                                                | `/etc/ssl/certs/ssl-cert-snakeoil.pem`   |
+| `certificates.customCertificate.keyLocation`         | Location in the container to store the private key                                                                | `/etc/ssl/private/ssl-cert-snakeoil.key` |
+| `certificates.customCertificate.chainLocation`       | Location in the container to store the certificate chain                                                          | `/etc/ssl/certs/mychain.pem`             |
+| `certificates.customCAs`                             | Defines a list of secrets to import into the container trust store                                                | `[]`                                     |
+| `certificates.command`                               | Override default container command (useful when using custom images)                                              | `[]`                                     |
+| `certificates.args`                                  | Override default container args (useful when using custom images)                                                 | `[]`                                     |
+| `certificates.extraEnvVars`                          | Container sidecar extra environment variables (eg proxy)                                                          | `[]`                                     |
+| `certificates.extraEnvVarsCM`                        | ConfigMap containing extra env vars                                                                               | `""`                                     |
+| `certificates.extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)                                                      | `""`                                     |
+| `certificates.image.registry`                        | Container sidecar registry                                                                                        | `docker.io`                              |
+| `certificates.image.repository`                      | Container sidecar image                                                                                           | `bitnami/bitnami-shell`                  |
+| `certificates.image.tag`                             | Container sidecar image tag (immutable tags are recommended)                                                      | `11-debian-11-r23`                       |
+| `certificates.image.digest`                          | Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                     |
+| `certificates.image.pullPolicy`                      | Container sidecar image pull policy                                                                               | `IfNotPresent`                           |
+| `certificates.image.pullSecrets`                     | Container sidecar image pull secrets                                                                              | `[]`                                     |
 
 
 ### Other Parameters

--- a/bitnami/magento/values.yaml
+++ b/bitnami/magento/values.yaml
@@ -61,6 +61,7 @@ diagnosticMode:
 ## @param image.registry Magento image registry
 ## @param image.repository Magento image repository
 ## @param image.tag Magento image tag (immutable tags are recommended)
+## @param image.digest Magento image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Magento image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Specify if debug logs should be enabled
@@ -69,6 +70,7 @@ image:
   registry: docker.io
   repository: bitnami/magento
   tag: 2.4.5-debian-11-r0
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -484,11 +486,13 @@ mariadb:
   ## @param mariadb.image.registry MariaDB image registry
   ## @param mariadb.image.repository MariaDB image repository
   ## @param mariadb.image.tag MariaDB image tag (immutable tags are recommended)
+  ## @param mariadb.image.digest MariaDB image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ##
   image:
     registry: docker.io
     repository: bitnami/mariadb
     tag: 10.4.25-debian-11-r26
+    digest: ""
   ## @param mariadb.architecture MariaDB architecture. Allowed values: `standalone` or `replication`
   ##
   architecture: standalone
@@ -576,11 +580,13 @@ elasticsearch:
   ## @param elasticsearch.image.registry Elasticsearch image registry
   ## @param elasticsearch.image.repository Elasticsearch image repository
   ## @param elasticsearch.image.tag Elasticsearch image tag (immutable tags are recommended)
+  ## @param elasticsearch.image.digest Elasticsearch image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ##
   image:
     registry: docker.io
     repository: bitnami/elasticsearch
     tag: 7.17.5-debian-11-r15
+    digest: ""
   ## @param elasticsearch.sysctlImage.enabled Enable kernel settings modifier image for Elasticsearch
   ##
   sysctlImage:
@@ -682,6 +688,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image repository
   ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -689,6 +696,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets (secrets must be manually created in the namespace)
     ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -881,6 +889,7 @@ metrics:
   ## @param metrics.image.registry Apache exporter image registry
   ## @param metrics.image.repository Apache exporter image repository
   ## @param metrics.image.tag Apache exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy Image pull policy
   ## @param metrics.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -888,6 +897,7 @@ metrics:
     registry: docker.io
     repository: bitnami/apache-exporter
     tag: 0.11.0-debian-11-r28
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -979,6 +989,7 @@ certificates:
   ## @param certificates.image.registry Container sidecar registry
   ## @param certificates.image.repository Container sidecar image
   ## @param certificates.image.tag Container sidecar image tag (immutable tags are recommended)
+  ## @param certificates.image.digest Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param certificates.image.pullPolicy Container sidecar image pull policy
   ## @param certificates.image.pullSecrets Container sidecar image pull secrets
   ##
@@ -986,6 +997,7 @@ certificates:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```