### PR TITLE
[bitnami/osclass] Add support for image digest apart from tag

### DIFF
--- a/bitnami/osclass/Chart.lock
+++ b/bitnami/osclass/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.7
+  version: 11.1.8
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:e7fec1ceee285f079a915708fbc7a66249aed11429184236d3184b8f4193707b
-generated: "2022-08-09T10:28:11.856036885Z"
+  version: 2.0.0
+digest: sha256:c83bbcfe3992800a6076622bdd5413634a62503ca39c45feba437d9ae3667257
+generated: "2022-08-20T11:00:20.023047506Z"

--- a/bitnami/osclass/Chart.lock
+++ b/bitnami/osclass/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
 digest: sha256:cd86e94f1db62edf01844e4d378b3baf71cf1cdea85df396886c041bc2502b21
-generated: "2022-08-22T14:17:20.589904113Z"
+generated: "2022-08-22T14:26:54.245170787Z"

--- a/bitnami/osclass/Chart.lock
+++ b/bitnami/osclass/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.8
+  version: 11.2.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
-digest: sha256:c83bbcfe3992800a6076622bdd5413634a62503ca39c45feba437d9ae3667257
-generated: "2022-08-20T11:00:20.023047506Z"
+digest: sha256:cd86e94f1db62edf01844e4d378b3baf71cf1cdea85df396886c041bc2502b21
+generated: "2022-08-22T14:17:20.589904113Z"

--- a/bitnami/osclass/Chart.yaml
+++ b/bitnami/osclass/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Osclass allows you to easily create a classifieds site without any technical knowledge. It provides support for presenting general ads or specialized ads, is customizable, extensible and multilingual.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/osclass
@@ -31,4 +31,4 @@ name: osclass
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/osclass
   - https://osclass.org/
-version: 14.1.17
+version: 14.2.0

--- a/bitnami/osclass/README.md
+++ b/bitnami/osclass/README.md
@@ -77,14 +77,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Osclass Image parameters
 
-| Name                | Description                                        | Value                  |
-| ------------------- | -------------------------------------------------- | ---------------------- |
-| `image.registry`    | Osclass image registry                             | `docker.io`            |
-| `image.repository`  | Osclass image repository                           | `bitnami/osclass`      |
-| `image.tag`         | Osclass image tag (immutable tags are recommended) | `8.0.1-debian-10-r126` |
-| `image.pullPolicy`  | Osclass image pull policy                          | `IfNotPresent`         |
-| `image.pullSecrets` | Osclass image pull secrets                         | `[]`                   |
-| `image.debug`       | Enable Bitnami debug mode in Osclass image         | `false`                |
+| Name                | Description                                                                                             | Value                 |
+| ------------------- | ------------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`    | Osclass image registry                                                                                  | `docker.io`           |
+| `image.repository`  | Osclass image repository                                                                                | `bitnami/osclass`     |
+| `image.tag`         | Osclass image tag (immutable tags are recommended)                                                      | `8.0.2-debian-11-r22` |
+| `image.digest`      | Osclass image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `image.pullPolicy`  | Osclass image pull policy                                                                               | `IfNotPresent`        |
+| `image.pullSecrets` | Osclass image pull secrets                                                                              | `[]`                  |
+| `image.debug`       | Enable Bitnami debug mode in Osclass image                                                              | `false`               |
 
 
 ### Osclass Configuration parameters
@@ -107,85 +108,86 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Osclass deployment parameters
 
-| Name                                                 | Description                                                                               | Value                                    |
-| ---------------------------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------- |
-| `hostAliases`                                        | Osclass pod host aliases                                                                  | `[]`                                     |
-| `podSecurityContext.enabled`                         | Enabled Osclass pods' Security Context                                                    | `true`                                   |
-| `podSecurityContext.fsGroup`                         | Set Osclass pod's Security Context fsGroup                                                | `1001`                                   |
-| `containerSecurityContext.enabled`                   | Enabled Osclass containers' Security Context                                              | `true`                                   |
-| `containerSecurityContext.runAsUser`                 | Set Osclass container's Security Context runAsUser                                        | `1001`                                   |
-| `containerSecurityContext.runAsNonRoot`              | Set Osclass container's Security Context runAsNonRoot                                     | `true`                                   |
-| `startupProbe.enabled`                               | Enable startupProbe                                                                       | `false`                                  |
-| `startupProbe.path`                                  | Path for the HTTP probe                                                                   | `/oc-admin`                              |
-| `startupProbe.initialDelaySeconds`                   | Initial delay seconds for startupProbe                                                    | `600`                                    |
-| `startupProbe.periodSeconds`                         | Period seconds for startupProbe                                                           | `10`                                     |
-| `startupProbe.timeoutSeconds`                        | Timeout seconds for startupProbe                                                          | `5`                                      |
-| `startupProbe.failureThreshold`                      | Failure threshold for startupProbe                                                        | `5`                                      |
-| `startupProbe.successThreshold`                      | Success threshold for startupProbe                                                        | `1`                                      |
-| `livenessProbe.enabled`                              | Enable livenessProbe                                                                      | `true`                                   |
-| `livenessProbe.path`                                 | Path for the HTTP probe                                                                   | `/oc-admin`                              |
-| `livenessProbe.initialDelaySeconds`                  | Initial delay seconds for livenessProbe                                                   | `600`                                    |
-| `livenessProbe.periodSeconds`                        | Period seconds for livenessProbe                                                          | `10`                                     |
-| `livenessProbe.timeoutSeconds`                       | Timeout seconds for livenessProbe                                                         | `5`                                      |
-| `livenessProbe.failureThreshold`                     | Failure threshold for livenessProbe                                                       | `5`                                      |
-| `livenessProbe.successThreshold`                     | Success threshold for livenessProbe                                                       | `1`                                      |
-| `readinessProbe.enabled`                             | Enable readinessProbe                                                                     | `true`                                   |
-| `readinessProbe.path`                                | Path for the HTTP probe                                                                   | `/oc-admin`                              |
-| `readinessProbe.initialDelaySeconds`                 | Initial delay seconds for readinessProbe                                                  | `30`                                     |
-| `readinessProbe.periodSeconds`                       | Period seconds for readinessProbe                                                         | `5`                                      |
-| `readinessProbe.timeoutSeconds`                      | Timeout seconds for readinessProbe                                                        | `1`                                      |
-| `readinessProbe.failureThreshold`                    | Failure threshold for readinessProbe                                                      | `5`                                      |
-| `readinessProbe.successThreshold`                    | Success threshold for readinessProbe                                                      | `1`                                      |
-| `customStartupProbe`                                 | Custom livenessProbe that overrides the default one                                       | `{}`                                     |
-| `customLivenessProbe`                                | Custom livenessProbe that overrides the default one                                       | `{}`                                     |
-| `customReadinessProbe`                               | Custom readinessProbe that overrides the default one                                      | `{}`                                     |
-| `certificates.customCertificate.certificateSecret`   | name of the secret with custom certificates                                               | `""`                                     |
-| `certificates.customCertificate.chainSecret.name`    | name of the secret with the chain                                                         | `""`                                     |
-| `certificates.customCertificate.chainSecret.key`     | key of the secret with the chain                                                          | `""`                                     |
-| `certificates.customCertificate.certificateLocation` | Location of the certificate inside the container                                          | `/etc/ssl/certs/ssl-cert-snakeoil.pem`   |
-| `certificates.customCertificate.keyLocation`         | Location of the certificate key inside the container                                      | `/etc/ssl/private/ssl-cert-snakeoil.key` |
-| `certificates.customCertificate.chainLocation`       | Location of the certificate chain inside the container                                    | `/etc/ssl/certs/mychain.pem`             |
-| `certificates.customCAs`                             | Array with custom CAs                                                                     | `[]`                                     |
-| `certificates.command`                               | Override certificate container command                                                    | `[]`                                     |
-| `certificates.args`                                  | Override certificate container args                                                       | `[]`                                     |
-| `certificates.extraEnvVars`                          | An array to add extra env vars                                                            | `[]`                                     |
-| `certificates.extraEnvVarsCM`                        | ConfigMap with extra environment variables                                                | `""`                                     |
-| `certificates.extraEnvVarsSecret`                    | Secret with extra environment variables                                                   | `""`                                     |
-| `certificates.image.registry`                        | Apache Exporter image registry                                                            | `docker.io`                              |
-| `certificates.image.repository`                      | Apache Exporter image repository                                                          | `bitnami/bitnami-shell`                  |
-| `certificates.image.tag`                             | Apache Exporter image tag (immutable tags are recommended)                                | `10-debian-10-r426`                      |
-| `certificates.image.pullPolicy`                      | Apache Exporter image pull policy                                                         | `IfNotPresent`                           |
-| `certificates.image.pullSecrets`                     | Apache Exporter image pull secrets                                                        | `[]`                                     |
-| `lifecycleHooks`                                     | lifecycleHooks for the container to automate configuration before or after startup.       | `{}`                                     |
-| `podAnnotations`                                     | Annotations for Osclass pods                                                              | `{}`                                     |
-| `podLabels`                                          | Extra labels for Osclass pods                                                             | `{}`                                     |
-| `replicaCount`                                       | Number of Osclass replicas to deploy                                                      | `1`                                      |
-| `containerPorts.http`                                | Osclass HTTP container port                                                               | `8080`                                   |
-| `containerPorts.https`                               | Osclass HTTPS container port                                                              | `8443`                                   |
-| `command`                                            | Override default container command (useful when using custom images)                      | `[]`                                     |
-| `args`                                               | Override default container args (useful when using custom images)                         | `[]`                                     |
-| `updateStrategy.type`                                | Osclass deployment strategy type                                                          | `RollingUpdate`                          |
-| `updateStrategy.rollingUpdate`                       | Osclass deployment rolling update configuration parameters                                | `{}`                                     |
-| `extraEnvVars`                                       | Array with extra environment variables to add to the Osclass container                    | `[]`                                     |
-| `extraEnvVarsCM`                                     | Name of existing ConfigMap containing extra env vars                                      | `""`                                     |
-| `extraEnvVarsSecret`                                 | Name of existing Secret containing extra env vars                                         | `""`                                     |
-| `extraVolumes`                                       | Optionally specify extra list of additional volumes for Osclass pods                      | `[]`                                     |
-| `extraVolumeMounts`                                  | Optionally specify extra list of additional volumeMounts for Osclass container(s)         | `[]`                                     |
-| `initContainers`                                     | Add additional init containers to the Osclass pods                                        | `[]`                                     |
-| `sidecars`                                           | Add additional sidecar containers to the Osclass pod                                      | `[]`                                     |
-| `podAffinityPreset`                                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                     |
-| `podAntiAffinityPreset`                              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                                   |
-| `nodeAffinityPreset.type`                            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                     |
-| `nodeAffinityPreset.key`                             | Node label key to match. Ignored if `affinity` is set                                     | `""`                                     |
-| `nodeAffinityPreset.values`                          | Node label values to match. Ignored if `affinity` is set                                  | `[]`                                     |
-| `affinity`                                           | Affinity for pod assignment                                                               | `{}`                                     |
-| `nodeSelector`                                       | Node labels for pod assignment                                                            | `{}`                                     |
-| `resources.limits`                                   | The resources limits for the Osclass container                                            | `{}`                                     |
-| `resources.requests`                                 | The requested resources for the Osclass container                                         | `{}`                                     |
-| `tolerations`                                        | Tolerations for pod assignment                                                            | `[]`                                     |
-| `priorityClassName`                                  | Osclass pods' priorityClassName                                                           | `""`                                     |
-| `schedulerName`                                      | Name of the k8s scheduler (other than default)                                            | `""`                                     |
-| `topologySpreadConstraints`                          | Topology Spread Constraints for pod assignment                                            | `[]`                                     |
+| Name                                                 | Description                                                                                                     | Value                                    |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `hostAliases`                                        | Osclass pod host aliases                                                                                        | `[]`                                     |
+| `podSecurityContext.enabled`                         | Enabled Osclass pods' Security Context                                                                          | `true`                                   |
+| `podSecurityContext.fsGroup`                         | Set Osclass pod's Security Context fsGroup                                                                      | `1001`                                   |
+| `containerSecurityContext.enabled`                   | Enabled Osclass containers' Security Context                                                                    | `true`                                   |
+| `containerSecurityContext.runAsUser`                 | Set Osclass container's Security Context runAsUser                                                              | `1001`                                   |
+| `containerSecurityContext.runAsNonRoot`              | Set Osclass container's Security Context runAsNonRoot                                                           | `true`                                   |
+| `startupProbe.enabled`                               | Enable startupProbe                                                                                             | `false`                                  |
+| `startupProbe.path`                                  | Path for the HTTP probe                                                                                         | `/oc-admin`                              |
+| `startupProbe.initialDelaySeconds`                   | Initial delay seconds for startupProbe                                                                          | `600`                                    |
+| `startupProbe.periodSeconds`                         | Period seconds for startupProbe                                                                                 | `10`                                     |
+| `startupProbe.timeoutSeconds`                        | Timeout seconds for startupProbe                                                                                | `5`                                      |
+| `startupProbe.failureThreshold`                      | Failure threshold for startupProbe                                                                              | `5`                                      |
+| `startupProbe.successThreshold`                      | Success threshold for startupProbe                                                                              | `1`                                      |
+| `livenessProbe.enabled`                              | Enable livenessProbe                                                                                            | `true`                                   |
+| `livenessProbe.path`                                 | Path for the HTTP probe                                                                                         | `/oc-admin`                              |
+| `livenessProbe.initialDelaySeconds`                  | Initial delay seconds for livenessProbe                                                                         | `600`                                    |
+| `livenessProbe.periodSeconds`                        | Period seconds for livenessProbe                                                                                | `10`                                     |
+| `livenessProbe.timeoutSeconds`                       | Timeout seconds for livenessProbe                                                                               | `5`                                      |
+| `livenessProbe.failureThreshold`                     | Failure threshold for livenessProbe                                                                             | `5`                                      |
+| `livenessProbe.successThreshold`                     | Success threshold for livenessProbe                                                                             | `1`                                      |
+| `readinessProbe.enabled`                             | Enable readinessProbe                                                                                           | `true`                                   |
+| `readinessProbe.path`                                | Path for the HTTP probe                                                                                         | `/oc-admin`                              |
+| `readinessProbe.initialDelaySeconds`                 | Initial delay seconds for readinessProbe                                                                        | `30`                                     |
+| `readinessProbe.periodSeconds`                       | Period seconds for readinessProbe                                                                               | `5`                                      |
+| `readinessProbe.timeoutSeconds`                      | Timeout seconds for readinessProbe                                                                              | `1`                                      |
+| `readinessProbe.failureThreshold`                    | Failure threshold for readinessProbe                                                                            | `5`                                      |
+| `readinessProbe.successThreshold`                    | Success threshold for readinessProbe                                                                            | `1`                                      |
+| `customStartupProbe`                                 | Custom livenessProbe that overrides the default one                                                             | `{}`                                     |
+| `customLivenessProbe`                                | Custom livenessProbe that overrides the default one                                                             | `{}`                                     |
+| `customReadinessProbe`                               | Custom readinessProbe that overrides the default one                                                            | `{}`                                     |
+| `certificates.customCertificate.certificateSecret`   | name of the secret with custom certificates                                                                     | `""`                                     |
+| `certificates.customCertificate.chainSecret.name`    | name of the secret with the chain                                                                               | `""`                                     |
+| `certificates.customCertificate.chainSecret.key`     | key of the secret with the chain                                                                                | `""`                                     |
+| `certificates.customCertificate.certificateLocation` | Location of the certificate inside the container                                                                | `/etc/ssl/certs/ssl-cert-snakeoil.pem`   |
+| `certificates.customCertificate.keyLocation`         | Location of the certificate key inside the container                                                            | `/etc/ssl/private/ssl-cert-snakeoil.key` |
+| `certificates.customCertificate.chainLocation`       | Location of the certificate chain inside the container                                                          | `/etc/ssl/certs/mychain.pem`             |
+| `certificates.customCAs`                             | Array with custom CAs                                                                                           | `[]`                                     |
+| `certificates.command`                               | Override certificate container command                                                                          | `[]`                                     |
+| `certificates.args`                                  | Override certificate container args                                                                             | `[]`                                     |
+| `certificates.extraEnvVars`                          | An array to add extra env vars                                                                                  | `[]`                                     |
+| `certificates.extraEnvVarsCM`                        | ConfigMap with extra environment variables                                                                      | `""`                                     |
+| `certificates.extraEnvVarsSecret`                    | Secret with extra environment variables                                                                         | `""`                                     |
+| `certificates.image.registry`                        | Apache Exporter image registry                                                                                  | `docker.io`                              |
+| `certificates.image.repository`                      | Apache Exporter image repository                                                                                | `bitnami/bitnami-shell`                  |
+| `certificates.image.tag`                             | Apache Exporter image tag (immutable tags are recommended)                                                      | `11-debian-11-r23`                       |
+| `certificates.image.digest`                          | Apache Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                     |
+| `certificates.image.pullPolicy`                      | Apache Exporter image pull policy                                                                               | `IfNotPresent`                           |
+| `certificates.image.pullSecrets`                     | Apache Exporter image pull secrets                                                                              | `[]`                                     |
+| `lifecycleHooks`                                     | lifecycleHooks for the container to automate configuration before or after startup.                             | `{}`                                     |
+| `podAnnotations`                                     | Annotations for Osclass pods                                                                                    | `{}`                                     |
+| `podLabels`                                          | Extra labels for Osclass pods                                                                                   | `{}`                                     |
+| `replicaCount`                                       | Number of Osclass replicas to deploy                                                                            | `1`                                      |
+| `containerPorts.http`                                | Osclass HTTP container port                                                                                     | `8080`                                   |
+| `containerPorts.https`                               | Osclass HTTPS container port                                                                                    | `8443`                                   |
+| `command`                                            | Override default container command (useful when using custom images)                                            | `[]`                                     |
+| `args`                                               | Override default container args (useful when using custom images)                                               | `[]`                                     |
+| `updateStrategy.type`                                | Osclass deployment strategy type                                                                                | `RollingUpdate`                          |
+| `updateStrategy.rollingUpdate`                       | Osclass deployment rolling update configuration parameters                                                      | `{}`                                     |
+| `extraEnvVars`                                       | Array with extra environment variables to add to the Osclass container                                          | `[]`                                     |
+| `extraEnvVarsCM`                                     | Name of existing ConfigMap containing extra env vars                                                            | `""`                                     |
+| `extraEnvVarsSecret`                                 | Name of existing Secret containing extra env vars                                                               | `""`                                     |
+| `extraVolumes`                                       | Optionally specify extra list of additional volumes for Osclass pods                                            | `[]`                                     |
+| `extraVolumeMounts`                                  | Optionally specify extra list of additional volumeMounts for Osclass container(s)                               | `[]`                                     |
+| `initContainers`                                     | Add additional init containers to the Osclass pods                                                              | `[]`                                     |
+| `sidecars`                                           | Add additional sidecar containers to the Osclass pod                                                            | `[]`                                     |
+| `podAffinityPreset`                                  | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                                     |
+| `podAntiAffinityPreset`                              | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `soft`                                   |
+| `nodeAffinityPreset.type`                            | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                       | `""`                                     |
+| `nodeAffinityPreset.key`                             | Node label key to match. Ignored if `affinity` is set                                                           | `""`                                     |
+| `nodeAffinityPreset.values`                          | Node label values to match. Ignored if `affinity` is set                                                        | `[]`                                     |
+| `affinity`                                           | Affinity for pod assignment                                                                                     | `{}`                                     |
+| `nodeSelector`                                       | Node labels for pod assignment                                                                                  | `{}`                                     |
+| `resources.limits`                                   | The resources limits for the Osclass container                                                                  | `{}`                                     |
+| `resources.requests`                                 | The requested resources for the Osclass container                                                               | `{}`                                     |
+| `tolerations`                                        | Tolerations for pod assignment                                                                                  | `[]`                                     |
+| `priorityClassName`                                  | Osclass pods' priorityClassName                                                                                 | `""`                                     |
+| `schedulerName`                                      | Name of the k8s scheduler (other than default)                                                                  | `""`                                     |
+| `topologySpreadConstraints`                          | Topology Spread Constraints for pod assignment                                                                  | `[]`                                     |
 
 
 ### Traffic Exposure Parameters
@@ -222,39 +224,40 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Database Parameters
 
-| Name                                       | Description                                                                                     | Value                   |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------- | ----------------------- |
-| `externalDatabase.host`                    | External Database server host                                                                   | `""`                    |
-| `externalDatabase.port`                    | External Database server port                                                                   | `3306`                  |
-| `externalDatabase.user`                    | External Database username                                                                      | `bn_osclass`            |
-| `externalDatabase.password`                | External Database user password                                                                 | `""`                    |
-| `externalDatabase.database`                | External Database database name                                                                 | `bitnami_osclass`       |
-| `externalDatabase.existingSecret`          | Name of an existing secret resource containing the DB password                                  | `""`                    |
-| `mariadb.enabled`                          | Deploy a MariaDB server to satisfy the applications database requirements                       | `true`                  |
-| `mariadb.architecture`                     | MariaDB architecture. Allowed values: `standalone` or `replication`                             | `standalone`            |
-| `mariadb.auth.rootPassword`                | MariaDB root password                                                                           | `""`                    |
-| `mariadb.auth.database`                    | MariaDB custom database                                                                         | `bitnami_osclass`       |
-| `mariadb.auth.username`                    | MariaDB custom user name                                                                        | `bn_osclass`            |
-| `mariadb.auth.password`                    | MariaDB custom user password                                                                    | `""`                    |
-| `mariadb.primary.persistence.enabled`      | Enable persistence on MariaDB using PVC(s)                                                      | `true`                  |
-| `mariadb.primary.persistence.storageClass` | Persistent Volume storage class                                                                 | `""`                    |
-| `mariadb.primary.persistence.accessModes`  | Persistent Volume access modes                                                                  | `[]`                    |
-| `mariadb.primary.persistence.size`         | Persistent Volume size                                                                          | `8Gi`                   |
-| `persistence.enabled`                      | Enable persistence using Persistent Volume Claims                                               | `true`                  |
-| `persistence.storageClass`                 | Persistent Volume storage class                                                                 | `""`                    |
-| `persistence.accessModes`                  | Persistent Volume access modes                                                                  | `[]`                    |
-| `persistence.size`                         | Persistent Volume size                                                                          | `8Gi`                   |
-| `persistence.existingClaim`                | The name of an existing PVC to use for persistence                                              | `""`                    |
-| `persistence.hostPath`                     | If defined, the osclass-data volume will mount to the specified hostPath.                       | `""`                    |
-| `persistence.annotations`                  | Persistent Volume Claim annotations                                                             | `{}`                    |
-| `volumePermissions.enabled`                | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
-| `volumePermissions.image.registry`         | Bitnami Shell image registry                                                                    | `docker.io`             |
-| `volumePermissions.image.repository`       | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`              | Bitnami Shell image tag (immutable tags are recommended)                                        | `10-debian-10-r426`     |
-| `volumePermissions.image.pullPolicy`       | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`      | Bitnami Shell image pull secrets                                                                | `[]`                    |
-| `volumePermissions.resources.limits`       | The resources limits for the init container                                                     | `{}`                    |
-| `volumePermissions.resources.requests`     | The requested resources for the init container                                                  | `{}`                    |
+| Name                                       | Description                                                                                                   | Value                   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `externalDatabase.host`                    | External Database server host                                                                                 | `""`                    |
+| `externalDatabase.port`                    | External Database server port                                                                                 | `3306`                  |
+| `externalDatabase.user`                    | External Database username                                                                                    | `bn_osclass`            |
+| `externalDatabase.password`                | External Database user password                                                                               | `""`                    |
+| `externalDatabase.database`                | External Database database name                                                                               | `bitnami_osclass`       |
+| `externalDatabase.existingSecret`          | Name of an existing secret resource containing the DB password                                                | `""`                    |
+| `mariadb.enabled`                          | Deploy a MariaDB server to satisfy the applications database requirements                                     | `true`                  |
+| `mariadb.architecture`                     | MariaDB architecture. Allowed values: `standalone` or `replication`                                           | `standalone`            |
+| `mariadb.auth.rootPassword`                | MariaDB root password                                                                                         | `""`                    |
+| `mariadb.auth.database`                    | MariaDB custom database                                                                                       | `bitnami_osclass`       |
+| `mariadb.auth.username`                    | MariaDB custom user name                                                                                      | `bn_osclass`            |
+| `mariadb.auth.password`                    | MariaDB custom user password                                                                                  | `""`                    |
+| `mariadb.primary.persistence.enabled`      | Enable persistence on MariaDB using PVC(s)                                                                    | `true`                  |
+| `mariadb.primary.persistence.storageClass` | Persistent Volume storage class                                                                               | `""`                    |
+| `mariadb.primary.persistence.accessModes`  | Persistent Volume access modes                                                                                | `[]`                    |
+| `mariadb.primary.persistence.size`         | Persistent Volume size                                                                                        | `8Gi`                   |
+| `persistence.enabled`                      | Enable persistence using Persistent Volume Claims                                                             | `true`                  |
+| `persistence.storageClass`                 | Persistent Volume storage class                                                                               | `""`                    |
+| `persistence.accessModes`                  | Persistent Volume access modes                                                                                | `[]`                    |
+| `persistence.size`                         | Persistent Volume size                                                                                        | `8Gi`                   |
+| `persistence.existingClaim`                | The name of an existing PVC to use for persistence                                                            | `""`                    |
+| `persistence.hostPath`                     | If defined, the osclass-data volume will mount to the specified hostPath.                                     | `""`                    |
+| `persistence.annotations`                  | Persistent Volume Claim annotations                                                                           | `{}`                    |
+| `volumePermissions.enabled`                | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`               | `false`                 |
+| `volumePermissions.image.registry`         | Bitnami Shell image registry                                                                                  | `docker.io`             |
+| `volumePermissions.image.repository`       | Bitnami Shell image repository                                                                                | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`              | Bitnami Shell image tag (immutable tags are recommended)                                                      | `11-debian-11-r23`      |
+| `volumePermissions.image.digest`           | Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `volumePermissions.image.pullPolicy`       | Bitnami Shell image pull policy                                                                               | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`      | Bitnami Shell image pull secrets                                                                              | `[]`                    |
+| `volumePermissions.resources.limits`       | The resources limits for the init container                                                                   | `{}`                    |
+| `volumePermissions.resources.requests`     | The requested resources for the init container                                                                | `{}`                    |
 
 
 ### Other Parameters
@@ -273,30 +276,31 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics Parameters
 
-| Name                                       | Description                                                                       | Value                     |
-| ------------------------------------------ | --------------------------------------------------------------------------------- | ------------------------- |
-| `metrics.enabled`                          | Start a sidecar prometheus exporter to expose metrics                             | `false`                   |
-| `metrics.image.registry`                   | Apache Exporter image registry                                                    | `docker.io`               |
-| `metrics.image.repository`                 | Apache Exporter image repository                                                  | `bitnami/apache-exporter` |
-| `metrics.image.tag`                        | Apache Exporter image tag (immutable tags are recommended)                        | `0.11.0-debian-10-r145`   |
-| `metrics.image.pullPolicy`                 | Apache Exporter image pull policy                                                 | `IfNotPresent`            |
-| `metrics.image.pullSecrets`                | Apache Exporter image pull secrets                                                | `[]`                      |
-| `metrics.resources.limits`                 | The resources limits for the Prometheus exporter container                        | `{}`                      |
-| `metrics.resources.requests`               | The requested resources for the Prometheus exporter container                     | `{}`                      |
-| `metrics.podAnnotations`                   | Annotations to add                                                                | `{}`                      |
-| `metrics.service.type`                     | Metrics service type                                                              | `ClusterIP`               |
-| `metrics.service.port`                     | Metrics service port                                                              | `9117`                    |
-| `metrics.service.annotations`              | Additional custom annotations for Metrics service                                 | `{}`                      |
-| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator      | `false`                   |
-| `metrics.serviceMonitor.namespace`         | The namespace in which the ServiceMonitor will be created                         | `""`                      |
-| `metrics.serviceMonitor.interval`          | The interval at which metrics should be scraped                                   | `30s`                     |
-| `metrics.serviceMonitor.scrapeTimeout`     | The timeout after which the scrape is ended                                       | `""`                      |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                | `[]`                      |
-| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                         | `[]`                      |
-| `metrics.serviceMonitor.honorLabels`       | Labels to honor to add to the scrape endpoint                                     | `false`                   |
-| `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                                    | `{}`                      |
-| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                               | `{}`                      |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus. | `""`                      |
+| Name                                       | Description                                                                                                     | Value                     |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `metrics.enabled`                          | Start a sidecar prometheus exporter to expose metrics                                                           | `false`                   |
+| `metrics.image.registry`                   | Apache Exporter image registry                                                                                  | `docker.io`               |
+| `metrics.image.repository`                 | Apache Exporter image repository                                                                                | `bitnami/apache-exporter` |
+| `metrics.image.tag`                        | Apache Exporter image tag (immutable tags are recommended)                                                      | `0.11.0-debian-11-r28`    |
+| `metrics.image.digest`                     | Apache Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                      |
+| `metrics.image.pullPolicy`                 | Apache Exporter image pull policy                                                                               | `IfNotPresent`            |
+| `metrics.image.pullSecrets`                | Apache Exporter image pull secrets                                                                              | `[]`                      |
+| `metrics.resources.limits`                 | The resources limits for the Prometheus exporter container                                                      | `{}`                      |
+| `metrics.resources.requests`               | The requested resources for the Prometheus exporter container                                                   | `{}`                      |
+| `metrics.podAnnotations`                   | Annotations to add                                                                                              | `{}`                      |
+| `metrics.service.type`                     | Metrics service type                                                                                            | `ClusterIP`               |
+| `metrics.service.port`                     | Metrics service port                                                                                            | `9117`                    |
+| `metrics.service.annotations`              | Additional custom annotations for Metrics service                                                               | `{}`                      |
+| `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                    | `false`                   |
+| `metrics.serviceMonitor.namespace`         | The namespace in which the ServiceMonitor will be created                                                       | `""`                      |
+| `metrics.serviceMonitor.interval`          | The interval at which metrics should be scraped                                                                 | `30s`                     |
+| `metrics.serviceMonitor.scrapeTimeout`     | The timeout after which the scrape is ended                                                                     | `""`                      |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                              | `[]`                      |
+| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                                       | `[]`                      |
+| `metrics.serviceMonitor.honorLabels`       | Labels to honor to add to the scrape endpoint                                                                   | `false`                   |
+| `metrics.serviceMonitor.selector`          | ServiceMonitor selector labels                                                                                  | `{}`                      |
+| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                                             | `{}`                      |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                               | `""`                      |
 
 
 ### NetworkPolicy parameters

--- a/bitnami/osclass/values.yaml
+++ b/bitnami/osclass/values.yaml
@@ -47,6 +47,7 @@ extraDeploy: []
 ## @param image.registry Osclass image registry
 ## @param image.repository Osclass image repository
 ## @param image.tag Osclass image tag (immutable tags are recommended)
+## @param image.digest Osclass image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Osclass image pull policy
 ## @param image.pullSecrets Osclass image pull secrets
 ## @param image.debug Enable Bitnami debug mode in Osclass image
@@ -55,6 +56,7 @@ image:
   registry: docker.io
   repository: bitnami/osclass
   tag: 8.0.2-debian-11-r22
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -247,6 +249,7 @@ certificates:
   ## @param certificates.image.registry Apache Exporter image registry
   ## @param certificates.image.repository Apache Exporter image repository
   ## @param certificates.image.tag Apache Exporter image tag (immutable tags are recommended)
+  ## @param certificates.image.digest Apache Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param certificates.image.pullPolicy Apache Exporter image pull policy
   ## @param certificates.image.pullSecrets Apache Exporter image pull secrets
   ##
@@ -254,6 +257,7 @@ certificates:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -693,6 +697,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Bitnami Shell image registry
   ## @param volumePermissions.image.repository Bitnami Shell image repository
   ## @param volumePermissions.image.tag Bitnami Shell image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Bitnami Shell image pull policy
   ## @param volumePermissions.image.pullSecrets Bitnami Shell image pull secrets
   ##
@@ -700,6 +705,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -769,6 +775,7 @@ metrics:
   ## @param metrics.image.registry Apache Exporter image registry
   ## @param metrics.image.repository Apache Exporter image repository
   ## @param metrics.image.tag Apache Exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest Apache Exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy Apache Exporter image pull policy
   ## @param metrics.image.pullSecrets Apache Exporter image pull secrets
   ##
@@ -776,6 +783,7 @@ metrics:
     registry: docker.io
     repository: bitnami/apache-exporter
     tag: 0.11.0-debian-11-r28
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```