### PR TITLE
[bitnami/odoo] Add support for image digest apart from tag

### DIFF
--- a/bitnami/odoo/Chart.lock
+++ b/bitnami/odoo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.6.26
+  version: 11.7.4
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:a32b7dfa32a64e4ccc28dcd1b8d959a03a6d9918cd57101103687d2bf94b04f8
-generated: "2022-08-10T08:07:47.244915233Z"
+  version: 2.0.0
+digest: sha256:20703cc32b9c610fc57e644b539c93120d7e935dd95950597fc833e919db59ee
+generated: "2022-08-20T11:00:11.425012085Z"

--- a/bitnami/odoo/Chart.lock
+++ b/bitnami/odoo/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.7.4
+  version: 11.8.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
-digest: sha256:20703cc32b9c610fc57e644b539c93120d7e935dd95950597fc833e919db59ee
-generated: "2022-08-20T11:00:11.425012085Z"
+digest: sha256:e7b3a9104b4a4fffe02d5cce259535b49cca9b2af8fc4360a8fc4988d5debfe5
+generated: "2022-08-22T14:26:42.661822419Z"

--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -9,7 +9,9 @@ dependencies:
     version: 11.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: 1.x.x
+    tags:
+      - bitnami-common
+    version: 2.x.x
 description: Odoo is an open source ERP and CRM platform, formerly known as OpenERP, that can connect a wide variety of business operations such as sales, supply chain, finance, and project management.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/odoo
@@ -27,4 +29,4 @@ name: odoo
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/odoo
   - https://www.odoo.com/
-version: 21.5.5
+version: 21.6.0

--- a/bitnami/odoo/README.md
+++ b/bitnami/odoo/README.md
@@ -68,24 +68,25 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                     | Description                                                                             | Value                        |
-| ------------------------ | --------------------------------------------------------------------------------------- | ---------------------------- |
-| `kubeVersion`            | Override Kubernetes version                                                             | `""`                         |
-| `nameOverride`           | String to partially override common.names.fullname                                      | `""`                         |
-| `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`                         |
-| `commonLabels`           | Labels to add to all deployed objects                                                   | `{}`                         |
-| `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`                         |
-| `clusterDomain`          | Default Kubernetes cluster domain                                                       | `cluster.local`              |
-| `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`                         |
-| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`                      |
-| `diagnosticMode.command` | Command to override all containers in the the statefulset                               | `["sleep"]`                  |
-| `diagnosticMode.args`    | Args to override all containers in the the statefulset                                  | `["infinity"]`               |
-| `image.registry`         | Odoo image registry                                                                     | `docker.io`                  |
-| `image.repository`       | Odoo image repository                                                                   | `bitnami/odoo`               |
-| `image.tag`              | Odoo image tag (immutable tags are recommended)                                         | `15.0.20220810-debian-11-r0` |
-| `image.pullPolicy`       | Odoo image pull policy                                                                  | `IfNotPresent`               |
-| `image.pullSecrets`      | Odoo image pull secrets                                                                 | `[]`                         |
-| `image.debug`            | Enable image debug mode                                                                 | `false`                      |
+| Name                     | Description                                                                                          | Value                        |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | ---------------------------- |
+| `kubeVersion`            | Override Kubernetes version                                                                          | `""`                         |
+| `nameOverride`           | String to partially override common.names.fullname                                                   | `""`                         |
+| `fullnameOverride`       | String to fully override common.names.fullname                                                       | `""`                         |
+| `commonLabels`           | Labels to add to all deployed objects                                                                | `{}`                         |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                                           | `{}`                         |
+| `clusterDomain`          | Default Kubernetes cluster domain                                                                    | `cluster.local`              |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                                    | `[]`                         |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden)              | `false`                      |
+| `diagnosticMode.command` | Command to override all containers in the the statefulset                                            | `["sleep"]`                  |
+| `diagnosticMode.args`    | Args to override all containers in the the statefulset                                               | `["infinity"]`               |
+| `image.registry`         | Odoo image registry                                                                                  | `docker.io`                  |
+| `image.repository`       | Odoo image repository                                                                                | `bitnami/odoo`               |
+| `image.tag`              | Odoo image tag (immutable tags are recommended)                                                      | `15.0.20220810-debian-11-r0` |
+| `image.digest`           | Odoo image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                         |
+| `image.pullPolicy`       | Odoo image pull policy                                                                               | `IfNotPresent`               |
+| `image.pullSecrets`      | Odoo image pull secrets                                                                              | `[]`                         |
+| `image.debug`            | Enable image debug mode                                                                              | `false`                      |
 
 
 ### Odoo Configuration parameters

--- a/bitnami/odoo/values.yaml
+++ b/bitnami/odoo/values.yaml
@@ -61,6 +61,7 @@ diagnosticMode:
 ## @param image.registry Odoo image registry
 ## @param image.repository Odoo image repository
 ## @param image.tag Odoo image tag (immutable tags are recommended)
+## @param image.digest Odoo image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Odoo image pull policy
 ## @param image.pullSecrets Odoo image pull secrets
 ## @param image.debug Enable image debug mode
@@ -69,6 +70,7 @@ image:
   registry: docker.io
   repository: bitnami/odoo
   tag: 15.0.20220810-debian-11-r0
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```