### PR TITLE
[bitnami/oauth2-proxy] Add support for image digest apart from tag

### DIFF
--- a/bitnami/oauth2-proxy/Chart.lock
+++ b/bitnami/oauth2-proxy/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.0.11
+  version: 17.1.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
-digest: sha256:da74b8fa464320406082fa24f3dce935e3a06212482b8b648404296b0e229526
-generated: "2022-08-20T11:00:07.172300169Z"
+digest: sha256:ca7ca7dd997532396f0c05189d7282c5959df7f05d61f3fcff68b20e176b1e67
+generated: "2022-08-22T14:26:37.047018608Z"

--- a/bitnami/oauth2-proxy/Chart.lock
+++ b/bitnami/oauth2-proxy/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.0.9
+  version: 17.0.11
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:531a6460b26fbf5cfecbc7de23de651d7b206cc6a507c9649028c1dfdca7cde4
-generated: "2022-08-09T10:27:35.887272416Z"
+  version: 2.0.0
+digest: sha256:da74b8fa464320406082fa24f3dce935e3a06212482b8b648404296b0e229526
+generated: "2022-08-20T11:00:07.172300169Z"

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: A reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/oauth2-proxy
@@ -30,4 +30,4 @@ name: oauth2-proxy
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/oauth2-proxy
   - https://github.com/oauth2-proxy/oauth2-proxy
-version: 3.1.0
+version: 3.2.0

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -113,13 +113,14 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### OAuth2 Proxy Image parameters
 
-| Name                | Description                                             | Value                  |
-| ------------------- | ------------------------------------------------------- | ---------------------- |
-| `image.registry`    | OAuth2 Proxy image registry                             | `docker.io`            |
-| `image.repository`  | OAuth2 Proxy image repository                           | `bitnami/oauth2-proxy` |
-| `image.tag`         | OAuth2 Proxy image tag (immutable tags are recommended) | `7.3.0-debian-11-r23`  |
-| `image.pullPolicy`  | OAuth2 Proxy image pull policy                          | `IfNotPresent`         |
-| `image.pullSecrets` | OAuth2 Proxy image pull secrets                         | `[]`                   |
+| Name                | Description                                                                                                  | Value                  |
+| ------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| `image.registry`    | OAuth2 Proxy image registry                                                                                  | `docker.io`            |
+| `image.repository`  | OAuth2 Proxy image repository                                                                                | `bitnami/oauth2-proxy` |
+| `image.tag`         | OAuth2 Proxy image tag (immutable tags are recommended)                                                      | `7.3.0-debian-11-r23`  |
+| `image.digest`      | OAuth2 Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
+| `image.pullPolicy`  | OAuth2 Proxy image pull policy                                                                               | `IfNotPresent`         |
+| `image.pullSecrets` | OAuth2 Proxy image pull secrets                                                                              | `[]`                   |
 
 
 ### OAuth2 Proxy configuration parameters

--- a/bitnami/oauth2-proxy/values.yaml
+++ b/bitnami/oauth2-proxy/values.yaml
@@ -219,7 +219,7 @@ ingress:
   ## - host: example.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: example-svc
   ##           port:
@@ -235,6 +235,7 @@ ingress:
 ## @param image.registry OAuth2 Proxy image registry
 ## @param image.repository OAuth2 Proxy image repository
 ## @param image.tag OAuth2 Proxy image tag (immutable tags are recommended)
+## @param image.digest OAuth2 Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy OAuth2 Proxy image pull policy
 ## @param image.pullSecrets OAuth2 Proxy image pull secrets
 ##
@@ -242,6 +243,7 @@ image:
   registry: docker.io
   repository: bitnami/oauth2-proxy
   tag: 7.3.0-debian-11-r23
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```