### PR TITLE
[bitnami/node] Add support for image digest apart from tag

### DIFF
--- a/bitnami/node/Chart.lock
+++ b/bitnami/node/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 13.0.1
+  version: 13.0.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:217b8f7f0ee9b38b72964759a45440d99a54fddb10b29ec8d420f8a4cef5db48
-generated: "2022-08-16T13:19:26.913730145Z"
+  version: 2.0.0
+digest: sha256:2a2797770dc115f46936be5eaf16da3bac25ffc5611ef2a7283e0ecdb3e7f8db
+generated: "2022-08-20T10:59:59.898959715Z"

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Node.js is a runtime environment built on V8 JavaScript engine. Its event-driven, non-blocking I/O model enables the development of fast, scalable, and data-intensive server applications.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/node
@@ -28,4 +28,4 @@ name: node
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/node
   - http://nodejs.org/
-version: 19.0.3
+version: 19.1.0

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -126,6 +126,7 @@ externaldb:
 ## @param image.registry NodeJS image registry
 ## @param image.repository NodeJS image repository
 ## @param image.tag NodeJS image tag (immutable tags are recommended)
+## @param image.digest NodeJS image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy NodeJS image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Set to true if you would like to see extra information on logs
@@ -134,6 +135,7 @@ image:
   registry: docker.io
   repository: bitnami/node
   tag: 16.17.0-debian-11-r0
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -408,6 +410,7 @@ git:
   ## @param git.image.registry Git image registry
   ## @param git.image.repository Git image repository
   ## @param git.image.tag Git image tag (immutable tags are recommended)
+  ## @param git.image.digest Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param git.image.pullPolicy Git image pull policy
   ## @param git.image.pullSecrets Specify docker-registry secret names as an array
   ## @param git.image.debug Set to true if you would like to see extra information on logs
@@ -416,6 +419,7 @@ git:
     registry: docker.io
     repository: bitnami/git
     tag: 2.37.2-debian-11-r1
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -463,6 +467,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image repository
   ## @param volumePermissions.image.tag Init container volume-permissions image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -470,6 +475,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r26
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```