### PR TITLE
[bitnami/nginx-intel] Add support for image digest apart from tag

### DIFF
--- a/bitnami/nginx-intel/Chart.lock
+++ b/bitnami/nginx-intel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-29T02:19:12.739213649Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:59:56.331352334Z"

--- a/bitnami/nginx-intel/Chart.yaml
+++ b/bitnami/nginx-intel/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: NGINX Open Source for Intel is a lightweight server, combined with cryptography acceleration for 3rd gen Xeon Scalable Processors (Ice Lake) to get a breakthrough performance improvement.
 home: https://github.com/bitnami/charts/tree/master/bitnami/nginx-intel
 icon: https://bitnami.com/assets/stacks/nginx/img/nginx-stack-220x234.png
@@ -24,4 +24,4 @@ name: nginx-intel
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/nginx-intel
   - https://github.com/intel/asynch_mode_nginx
-version: 2.0.16
+version: 2.1.0

--- a/bitnami/nginx-intel/README.md
+++ b/bitnami/nginx-intel/README.md
@@ -88,20 +88,21 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### NGINX parameters
 
-| Name                 | Description                                                          | Value                 |
-| -------------------- | -------------------------------------------------------------------- | --------------------- |
-| `image.registry`     | NGINX image registry                                                 | `docker.io`           |
-| `image.repository`   | NGINX image repository                                               | `bitnami/nginx-intel` |
-| `image.tag`          | NGINX image tag (immutable tags are recommended)                     | `0.4.7-debian-11-r0`  |
-| `image.pullPolicy`   | NGINX image pull policy                                              | `IfNotPresent`        |
-| `image.pullSecrets`  | Specify docker-registry secret names as an array                     | `[]`                  |
-| `image.debug`        | Set to true if you would like to see extra information on logs       | `false`               |
-| `hostAliases`        | Deployment pod host aliases                                          | `[]`                  |
-| `command`            | Override default container command (useful when using custom images) | `[]`                  |
-| `args`               | Override default container args (useful when using custom images)    | `[]`                  |
-| `extraEnvVars`       | Extra environment variables to be set on NGINX containers            | `[]`                  |
-| `extraEnvVarsCM`     | ConfigMap with extra environment variables                           | `""`                  |
-| `extraEnvVarsSecret` | Secret with extra environment variables                              | `""`                  |
+| Name                 | Description                                                                                           | Value                 |
+| -------------------- | ----------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`     | NGINX image registry                                                                                  | `docker.io`           |
+| `image.repository`   | NGINX image repository                                                                                | `bitnami/nginx-intel` |
+| `image.tag`          | NGINX image tag (immutable tags are recommended)                                                      | `0.4.7-debian-11-r25` |
+| `image.digest`       | NGINX image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `image.pullPolicy`   | NGINX image pull policy                                                                               | `IfNotPresent`        |
+| `image.pullSecrets`  | Specify docker-registry secret names as an array                                                      | `[]`                  |
+| `image.debug`        | Set to true if you would like to see extra information on logs                                        | `false`               |
+| `hostAliases`        | Deployment pod host aliases                                                                           | `[]`                  |
+| `command`            | Override default container command (useful when using custom images)                                  | `[]`                  |
+| `args`               | Override default container args (useful when using custom images)                                     | `[]`                  |
+| `extraEnvVars`       | Extra environment variables to be set on NGINX containers                                             | `[]`                  |
+| `extraEnvVarsCM`     | ConfigMap with extra environment variables                                                            | `""`                  |
+| `extraEnvVarsSecret` | Secret with extra environment variables                                                               | `""`                  |
 
 
 ### NGINX deployment parameters
@@ -177,27 +178,28 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Custom NGINX application parameters
 
-| Name                                       | Description                                                                                       | Value                 |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------- | --------------------- |
-| `cloneStaticSiteFromGit.enabled`           | Get the server static content from a Git repository                                               | `false`               |
-| `cloneStaticSiteFromGit.image.registry`    | Git image registry                                                                                | `docker.io`           |
-| `cloneStaticSiteFromGit.image.repository`  | Git image repository                                                                              | `bitnami/git`         |
-| `cloneStaticSiteFromGit.image.tag`         | Git image tag (immutable tags are recommended)                                                    | `2.36.1-debian-11-r0` |
-| `cloneStaticSiteFromGit.image.pullPolicy`  | Git image pull policy                                                                             | `IfNotPresent`        |
-| `cloneStaticSiteFromGit.image.pullSecrets` | Specify docker-registry secret names as an array                                                  | `[]`                  |
-| `cloneStaticSiteFromGit.repository`        | Git Repository to clone static content from                                                       | `""`                  |
-| `cloneStaticSiteFromGit.branch`            | Git branch to checkout                                                                            | `""`                  |
-| `cloneStaticSiteFromGit.interval`          | Interval for sidecar container pull from the Git repository                                       | `60`                  |
-| `cloneStaticSiteFromGit.gitClone.command`  | Override default container command for git-clone-repository                                       | `[]`                  |
-| `cloneStaticSiteFromGit.gitClone.args`     | Override default container args for git-clone-repository                                          | `[]`                  |
-| `cloneStaticSiteFromGit.gitSync.command`   | Override default container command for git-repo-syncer                                            | `[]`                  |
-| `cloneStaticSiteFromGit.gitSync.args`      | Override default container args for git-repo-syncer                                               | `[]`                  |
-| `cloneStaticSiteFromGit.extraEnvVars`      | Additional environment variables to set for the in the containers that clone static site from git | `[]`                  |
-| `cloneStaticSiteFromGit.extraVolumeMounts` | Add extra volume mounts for the Git containers                                                    | `[]`                  |
-| `serverBlock`                              | Custom server block to be added to NGINX configuration                                            | `""`                  |
-| `existingServerBlockConfigmap`             | ConfigMap with custom server block to be added to NGINX configuration                             | `""`                  |
-| `staticSiteConfigmap`                      | Name of existing ConfigMap with the server static site content                                    | `""`                  |
-| `staticSitePVC`                            | Name of existing PVC with the server static site content                                          | `""`                  |
+| Name                                       | Description                                                                                         | Value                 |
+| ------------------------------------------ | --------------------------------------------------------------------------------------------------- | --------------------- |
+| `cloneStaticSiteFromGit.enabled`           | Get the server static content from a Git repository                                                 | `false`               |
+| `cloneStaticSiteFromGit.image.registry`    | Git image registry                                                                                  | `docker.io`           |
+| `cloneStaticSiteFromGit.image.repository`  | Git image repository                                                                                | `bitnami/git`         |
+| `cloneStaticSiteFromGit.image.tag`         | Git image tag (immutable tags are recommended)                                                      | `2.37.1-debian-11-r8` |
+| `cloneStaticSiteFromGit.image.digest`      | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `cloneStaticSiteFromGit.image.pullPolicy`  | Git image pull policy                                                                               | `IfNotPresent`        |
+| `cloneStaticSiteFromGit.image.pullSecrets` | Specify docker-registry secret names as an array                                                    | `[]`                  |
+| `cloneStaticSiteFromGit.repository`        | Git Repository to clone static content from                                                         | `""`                  |
+| `cloneStaticSiteFromGit.branch`            | Git branch to checkout                                                                              | `""`                  |
+| `cloneStaticSiteFromGit.interval`          | Interval for sidecar container pull from the Git repository                                         | `60`                  |
+| `cloneStaticSiteFromGit.gitClone.command`  | Override default container command for git-clone-repository                                         | `[]`                  |
+| `cloneStaticSiteFromGit.gitClone.args`     | Override default container args for git-clone-repository                                            | `[]`                  |
+| `cloneStaticSiteFromGit.gitSync.command`   | Override default container command for git-repo-syncer                                              | `[]`                  |
+| `cloneStaticSiteFromGit.gitSync.args`      | Override default container args for git-repo-syncer                                                 | `[]`                  |
+| `cloneStaticSiteFromGit.extraEnvVars`      | Additional environment variables to set for the in the containers that clone static site from git   | `[]`                  |
+| `cloneStaticSiteFromGit.extraVolumeMounts` | Add extra volume mounts for the Git containers                                                      | `[]`                  |
+| `serverBlock`                              | Custom server block to be added to NGINX configuration                                              | `""`                  |
+| `existingServerBlockConfigmap`             | ConfigMap with custom server block to be added to NGINX configuration                               | `""`                  |
+| `staticSiteConfigmap`                      | Name of existing ConfigMap with the server static site content                                      | `""`                  |
+| `staticSitePVC`                            | Name of existing PVC with the server static site content                                            | `""`                  |
 
 
 ### Traffic Exposure parameters
@@ -248,32 +250,33 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics parameters
 
-| Name                                       | Description                                                                                 | Value                    |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------- | ------------------------ |
-| `metrics.enabled`                          | Start a Prometheus exporter sidecar container                                               | `false`                  |
-| `metrics.port`                             | NGINX Container Status Port scraped by Prometheus Exporter                                  | `""`                     |
-| `metrics.image.registry`                   | NGINX Prometheus exporter image registry                                                    | `docker.io`              |
-| `metrics.image.repository`                 | NGINX Prometheus exporter image repository                                                  | `bitnami/nginx-exporter` |
-| `metrics.image.tag`                        | NGINX Prometheus exporter image tag (immutable tags are recommended)                        | `0.10.0-debian-11-r0`    |
-| `metrics.image.pullPolicy`                 | NGINX Prometheus exporter image pull policy                                                 | `IfNotPresent`           |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                            | `[]`                     |
-| `metrics.podAnnotations`                   | Additional annotations for NGINX Prometheus exporter pod(s)                                 | `{}`                     |
-| `metrics.securityContext.enabled`          | Enabled NGINX Exporter containers' Security Context                                         | `false`                  |
-| `metrics.securityContext.runAsUser`        | Set NGINX Exporter container's Security Context runAsUser                                   | `1001`                   |
-| `metrics.service.ports.metrics`            | NGINX Prometheus exporter service port                                                      | `9113`                   |
-| `metrics.service.annotations`              | Annotations for the Prometheus exporter service                                             | `{}`                     |
-| `metrics.resources.limits`                 | The resources limits for the NGINX Prometheus exporter container                            | `{}`                     |
-| `metrics.resources.requests`               | The requested resources for the NGINX Prometheus exporter container                         | `{}`                     |
-| `metrics.serviceMonitor.enabled`           | Creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                  |
-| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                    | `""`                     |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.           | `""`                     |
-| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                | `""`                     |
-| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                     | `""`                     |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                         | `{}`                     |
-| `metrics.serviceMonitor.labels`            | Additional labels that can be used so PodMonitor will be discovered by Prometheus           | `{}`                     |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                          | `[]`                     |
-| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                   | `[]`                     |
-| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                    | `false`                  |
+| Name                                       | Description                                                                                                               | Value                    |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `metrics.enabled`                          | Start a Prometheus exporter sidecar container                                                                             | `false`                  |
+| `metrics.port`                             | NGINX Container Status Port scraped by Prometheus Exporter                                                                | `""`                     |
+| `metrics.image.registry`                   | NGINX Prometheus exporter image registry                                                                                  | `docker.io`              |
+| `metrics.image.repository`                 | NGINX Prometheus exporter image repository                                                                                | `bitnami/nginx-exporter` |
+| `metrics.image.tag`                        | NGINX Prometheus exporter image tag (immutable tags are recommended)                                                      | `0.10.0-debian-11-r21`   |
+| `metrics.image.digest`                     | NGINX Prometheus exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
+| `metrics.image.pullPolicy`                 | NGINX Prometheus exporter image pull policy                                                                               | `IfNotPresent`           |
+| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                                          | `[]`                     |
+| `metrics.podAnnotations`                   | Additional annotations for NGINX Prometheus exporter pod(s)                                                               | `{}`                     |
+| `metrics.securityContext.enabled`          | Enabled NGINX Exporter containers' Security Context                                                                       | `false`                  |
+| `metrics.securityContext.runAsUser`        | Set NGINX Exporter container's Security Context runAsUser                                                                 | `1001`                   |
+| `metrics.service.ports.metrics`            | NGINX Prometheus exporter service port                                                                                    | `9113`                   |
+| `metrics.service.annotations`              | Annotations for the Prometheus exporter service                                                                           | `{}`                     |
+| `metrics.resources.limits`                 | The resources limits for the NGINX Prometheus exporter container                                                          | `{}`                     |
+| `metrics.resources.requests`               | The requested resources for the NGINX Prometheus exporter container                                                       | `{}`                     |
+| `metrics.serviceMonitor.enabled`           | Creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                               | `false`                  |
+| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                                                  | `""`                     |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                                         | `""`                     |
+| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                                              | `""`                     |
+| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                                   | `""`                     |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                                       | `{}`                     |
+| `metrics.serviceMonitor.labels`            | Additional labels that can be used so PodMonitor will be discovered by Prometheus                                         | `{}`                     |
+| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                                        | `[]`                     |
+| `metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion                                                                 | `[]`                     |
+| `metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                                                  | `false`                  |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/nginx-intel/values.yaml
+++ b/bitnami/nginx-intel/values.yaml
@@ -63,6 +63,7 @@ diagnosticMode:
 ## @param image.registry NGINX image registry
 ## @param image.repository NGINX image repository
 ## @param image.tag NGINX image tag (immutable tags are recommended)
+## @param image.digest NGINX image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy NGINX image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Set to true if you would like to see extra information on logs
@@ -71,6 +72,7 @@ image:
   registry: docker.io
   repository: bitnami/nginx-intel
   tag: 0.4.7-debian-11-r25
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -397,6 +399,7 @@ cloneStaticSiteFromGit:
   ## @param cloneStaticSiteFromGit.image.registry Git image registry
   ## @param cloneStaticSiteFromGit.image.repository Git image repository
   ## @param cloneStaticSiteFromGit.image.tag Git image tag (immutable tags are recommended)
+  ## @param cloneStaticSiteFromGit.image.digest Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param cloneStaticSiteFromGit.image.pullPolicy Git image pull policy
   ## @param cloneStaticSiteFromGit.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -404,6 +407,7 @@ cloneStaticSiteFromGit:
     registry: docker.io
     repository: bitnami/git
     tag: 2.37.1-debian-11-r8
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -645,7 +649,7 @@ ingress:
   ## - host: nginx.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: nginx-svc
   ##           port:
@@ -743,7 +747,7 @@ healthIngress:
   ## - host: nginx.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: nginx-svc
   ##           port:
@@ -767,6 +771,7 @@ metrics:
   ## @param metrics.image.registry NGINX Prometheus exporter image registry
   ## @param metrics.image.repository NGINX Prometheus exporter image repository
   ## @param metrics.image.tag NGINX Prometheus exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest NGINX Prometheus exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy NGINX Prometheus exporter image pull policy
   ## @param metrics.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -774,6 +779,7 @@ metrics:
     registry: docker.io
     repository: bitnami/nginx-exporter
     tag: 0.10.0-debian-11-r21
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```