### PR TITLE
[bitnami/nginx-ingress-controller] Add support for image digest apart from tag

### DIFF
--- a/bitnami/nginx-ingress-controller/Chart.lock
+++ b/bitnami/nginx-ingress-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-22T01:28:38.433335029Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:59:53.413734975Z"

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: NGINX Ingress Controller is an Ingress controller that manages external access to HTTP services in a Kubernetes cluster using NGINX.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/nginx-ingress-controller
@@ -27,4 +27,4 @@ name: nginx-ingress-controller
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/nginx-ingress-controller
   - https://github.com/kubernetes/ingress-nginx
-version: 9.2.28
+version: 9.3.0

--- a/bitnami/nginx-ingress-controller/README.md
+++ b/bitnami/nginx-ingress-controller/README.md
@@ -81,7 +81,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
 | `image.registry`                       | Nginx Ingress Controller image registry                                                                                                            | `docker.io`                        |
 | `image.repository`                     | Nginx Ingress Controller image repository                                                                                                          | `bitnami/nginx-ingress-controller` |
-| `image.tag`                            | Nginx Ingress Controller image tag (immutable tags are recommended)                                                                                | `1.3.0-debian-11-r6`               |
+| `image.tag`                            | Nginx Ingress Controller image tag (immutable tags are recommended)                                                                                | `1.3.0-debian-11-r9`               |
+| `image.digest`                         | Nginx Ingress Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                           | `""`                               |
 | `image.pullPolicy`                     | Nginx Ingress Controller image pull policy                                                                                                         | `IfNotPresent`                     |
 | `image.pullSecrets`                    | Specify docker-registry secret names as an array                                                                                                   | `[]`                               |
 | `containerPorts`                       | Controller container ports to open                                                                                                                 | `{}`                               |
@@ -187,77 +188,78 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Default backend parameters
 
-| Name                                                   | Description                                                                                           | Value                 |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- | --------------------- |
-| `defaultBackend.enabled`                               | Enable a default backend based on NGINX                                                               | `true`                |
-| `defaultBackend.hostAliases`                           | Add deployment host aliases                                                                           | `[]`                  |
-| `defaultBackend.image.registry`                        | Default backend image registry                                                                        | `docker.io`           |
-| `defaultBackend.image.repository`                      | Default backend image repository                                                                      | `bitnami/nginx`       |
-| `defaultBackend.image.tag`                             | Default backend image tag (immutable tags are recommended)                                            | `1.23.1-debian-11-r3` |
-| `defaultBackend.image.pullPolicy`                      | Image pull policy                                                                                     | `IfNotPresent`        |
-| `defaultBackend.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                      | `[]`                  |
-| `defaultBackend.extraArgs`                             | Additional command line arguments to pass to Nginx container                                          | `{}`                  |
-| `defaultBackend.containerPort`                         | HTTP container port number                                                                            | `8080`                |
-| `defaultBackend.serverBlockConfig`                     | NGINX backend default server block configuration                                                      | `""`                  |
-| `defaultBackend.replicaCount`                          | Desired number of default backend pods                                                                | `1`                   |
-| `defaultBackend.podSecurityContext.enabled`            | Enable Default backend pods' Security Context                                                         | `true`                |
-| `defaultBackend.podSecurityContext.fsGroup`            | Group ID for the container filesystem                                                                 | `1001`                |
-| `defaultBackend.containerSecurityContext.enabled`      | Enable Default backend containers' Security Context                                                   | `true`                |
-| `defaultBackend.containerSecurityContext.runAsUser`    | User ID for the Default backend container                                                             | `1001`                |
-| `defaultBackend.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                                         | `true`                |
-| `defaultBackend.resources.limits`                      | The resources limits for the Default backend container                                                | `{}`                  |
-| `defaultBackend.resources.requests`                    | The requested resources for the Default backend container                                             | `{}`                  |
-| `defaultBackend.livenessProbe.enabled`                 | Enable livenessProbe                                                                                  | `true`                |
-| `defaultBackend.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                               | `30`                  |
-| `defaultBackend.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                      | `10`                  |
-| `defaultBackend.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                     | `5`                   |
-| `defaultBackend.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                   | `3`                   |
-| `defaultBackend.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                   | `1`                   |
-| `defaultBackend.readinessProbe.enabled`                | Enable readinessProbe                                                                                 | `true`                |
-| `defaultBackend.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                              | `0`                   |
-| `defaultBackend.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                     | `5`                   |
-| `defaultBackend.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                    | `5`                   |
-| `defaultBackend.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                  | `6`                   |
-| `defaultBackend.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                  | `1`                   |
-| `defaultBackend.startupProbe.enabled`                  | Enable startupProbe                                                                                   | `false`               |
-| `defaultBackend.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                | `0`                   |
-| `defaultBackend.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                       | `5`                   |
-| `defaultBackend.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                      | `5`                   |
-| `defaultBackend.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                    | `6`                   |
-| `defaultBackend.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                    | `1`                   |
-| `defaultBackend.customStartupProbe`                    | Custom liveness probe for the Web component                                                           | `{}`                  |
-| `defaultBackend.customLivenessProbe`                   | Custom liveness probe for the Web component                                                           | `{}`                  |
-| `defaultBackend.customReadinessProbe`                  | Custom readiness probe for the Web component                                                          | `{}`                  |
-| `defaultBackend.podLabels`                             | Extra labels for Controller pods                                                                      | `{}`                  |
-| `defaultBackend.podAnnotations`                        | Annotations for Controller pods                                                                       | `{}`                  |
-| `defaultBackend.priorityClassName`                     | priorityClassName                                                                                     | `""`                  |
-| `defaultBackend.schedulerName`                         | Name of the k8s scheduler (other than default)                                                        | `""`                  |
-| `defaultBackend.terminationGracePeriodSeconds`         | In seconds, time the given to the pod to terminate gracefully                                         | `60`                  |
-| `defaultBackend.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                        | `[]`                  |
-| `defaultBackend.podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                   | `""`                  |
-| `defaultBackend.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`              | `soft`                |
-| `defaultBackend.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`             | `""`                  |
-| `defaultBackend.nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                                | `""`                  |
-| `defaultBackend.nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                             | `[]`                  |
-| `defaultBackend.command`                               | Override default container command (useful when using custom images)                                  | `[]`                  |
-| `defaultBackend.args`                                  | Override default container args (useful when using custom images)                                     | `[]`                  |
-| `defaultBackend.lifecycleHooks`                        | for the %%MAIN_CONTAINER_NAME%% container(s) to automate configuration before or after startup        | `{}`                  |
-| `defaultBackend.extraEnvVars`                          | Array with extra environment variables to add to %%MAIN_CONTAINER_NAME%% nodes                        | `[]`                  |
-| `defaultBackend.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes                | `""`                  |
-| `defaultBackend.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes                   | `""`                  |
-| `defaultBackend.extraVolumes`                          | Optionally specify extra list of additional volumes for the %%MAIN_CONTAINER_NAME%% pod(s)            | `[]`                  |
-| `defaultBackend.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the %%MAIN_CONTAINER_NAME%% container(s) | `[]`                  |
-| `defaultBackend.sidecars`                              | Add additional sidecar containers to the %%MAIN_CONTAINER_NAME%% pod(s)                               | `[]`                  |
-| `defaultBackend.initContainers`                        | Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)                                  | `[]`                  |
-| `defaultBackend.affinity`                              | Affinity for pod assignment                                                                           | `{}`                  |
-| `defaultBackend.nodeSelector`                          | Node labels for pod assignment                                                                        | `{}`                  |
-| `defaultBackend.tolerations`                           | Tolerations for pod assignment                                                                        | `[]`                  |
-| `defaultBackend.service.type`                          | Kubernetes Service type for default backend                                                           | `ClusterIP`           |
-| `defaultBackend.service.ports.http`                    | Default backend service HTTP port                                                                     | `80`                  |
-| `defaultBackend.service.annotations`                   | Annotations for the default backend service                                                           | `{}`                  |
-| `defaultBackend.pdb.create`                            | Enable/disable a Pod Disruption Budget creation for Default backend                                   | `false`               |
-| `defaultBackend.pdb.minAvailable`                      | Minimum number/percentage of Default backend pods that should remain scheduled                        | `1`                   |
-| `defaultBackend.pdb.maxUnavailable`                    | Maximum number/percentage of Default backend pods that may be made unavailable                        | `""`                  |
+| Name                                                   | Description                                                                                                     | Value                 |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `defaultBackend.enabled`                               | Enable a default backend based on NGINX                                                                         | `true`                |
+| `defaultBackend.hostAliases`                           | Add deployment host aliases                                                                                     | `[]`                  |
+| `defaultBackend.image.registry`                        | Default backend image registry                                                                                  | `docker.io`           |
+| `defaultBackend.image.repository`                      | Default backend image repository                                                                                | `bitnami/nginx`       |
+| `defaultBackend.image.tag`                             | Default backend image tag (immutable tags are recommended)                                                      | `1.23.1-debian-11-r6` |
+| `defaultBackend.image.digest`                          | Default backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `defaultBackend.image.pullPolicy`                      | Image pull policy                                                                                               | `IfNotPresent`        |
+| `defaultBackend.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                | `[]`                  |
+| `defaultBackend.extraArgs`                             | Additional command line arguments to pass to Nginx container                                                    | `{}`                  |
+| `defaultBackend.containerPort`                         | HTTP container port number                                                                                      | `8080`                |
+| `defaultBackend.serverBlockConfig`                     | NGINX backend default server block configuration                                                                | `""`                  |
+| `defaultBackend.replicaCount`                          | Desired number of default backend pods                                                                          | `1`                   |
+| `defaultBackend.podSecurityContext.enabled`            | Enable Default backend pods' Security Context                                                                   | `true`                |
+| `defaultBackend.podSecurityContext.fsGroup`            | Group ID for the container filesystem                                                                           | `1001`                |
+| `defaultBackend.containerSecurityContext.enabled`      | Enable Default backend containers' Security Context                                                             | `true`                |
+| `defaultBackend.containerSecurityContext.runAsUser`    | User ID for the Default backend container                                                                       | `1001`                |
+| `defaultBackend.containerSecurityContext.runAsNonRoot` | Set container's Security Context runAsNonRoot                                                                   | `true`                |
+| `defaultBackend.resources.limits`                      | The resources limits for the Default backend container                                                          | `{}`                  |
+| `defaultBackend.resources.requests`                    | The requested resources for the Default backend container                                                       | `{}`                  |
+| `defaultBackend.livenessProbe.enabled`                 | Enable livenessProbe                                                                                            | `true`                |
+| `defaultBackend.livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                         | `30`                  |
+| `defaultBackend.livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                | `10`                  |
+| `defaultBackend.livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                               | `5`                   |
+| `defaultBackend.livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                             | `3`                   |
+| `defaultBackend.livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                             | `1`                   |
+| `defaultBackend.readinessProbe.enabled`                | Enable readinessProbe                                                                                           | `true`                |
+| `defaultBackend.readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                        | `0`                   |
+| `defaultBackend.readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                               | `5`                   |
+| `defaultBackend.readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                              | `5`                   |
+| `defaultBackend.readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                            | `6`                   |
+| `defaultBackend.readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                            | `1`                   |
+| `defaultBackend.startupProbe.enabled`                  | Enable startupProbe                                                                                             | `false`               |
+| `defaultBackend.startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                          | `0`                   |
+| `defaultBackend.startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                 | `5`                   |
+| `defaultBackend.startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                | `5`                   |
+| `defaultBackend.startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                              | `6`                   |
+| `defaultBackend.startupProbe.successThreshold`         | Success threshold for startupProbe                                                                              | `1`                   |
+| `defaultBackend.customStartupProbe`                    | Custom liveness probe for the Web component                                                                     | `{}`                  |
+| `defaultBackend.customLivenessProbe`                   | Custom liveness probe for the Web component                                                                     | `{}`                  |
+| `defaultBackend.customReadinessProbe`                  | Custom readiness probe for the Web component                                                                    | `{}`                  |
+| `defaultBackend.podLabels`                             | Extra labels for Controller pods                                                                                | `{}`                  |
+| `defaultBackend.podAnnotations`                        | Annotations for Controller pods                                                                                 | `{}`                  |
+| `defaultBackend.priorityClassName`                     | priorityClassName                                                                                               | `""`                  |
+| `defaultBackend.schedulerName`                         | Name of the k8s scheduler (other than default)                                                                  | `""`                  |
+| `defaultBackend.terminationGracePeriodSeconds`         | In seconds, time the given to the pod to terminate gracefully                                                   | `60`                  |
+| `defaultBackend.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                  | `[]`                  |
+| `defaultBackend.podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                  |
+| `defaultBackend.podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `soft`                |
+| `defaultBackend.nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                       | `""`                  |
+| `defaultBackend.nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set.                                                          | `""`                  |
+| `defaultBackend.nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                       | `[]`                  |
+| `defaultBackend.command`                               | Override default container command (useful when using custom images)                                            | `[]`                  |
+| `defaultBackend.args`                                  | Override default container args (useful when using custom images)                                               | `[]`                  |
+| `defaultBackend.lifecycleHooks`                        | for the %%MAIN_CONTAINER_NAME%% container(s) to automate configuration before or after startup                  | `{}`                  |
+| `defaultBackend.extraEnvVars`                          | Array with extra environment variables to add to %%MAIN_CONTAINER_NAME%% nodes                                  | `[]`                  |
+| `defaultBackend.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes                          | `""`                  |
+| `defaultBackend.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for %%MAIN_CONTAINER_NAME%% nodes                             | `""`                  |
+| `defaultBackend.extraVolumes`                          | Optionally specify extra list of additional volumes for the %%MAIN_CONTAINER_NAME%% pod(s)                      | `[]`                  |
+| `defaultBackend.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the %%MAIN_CONTAINER_NAME%% container(s)           | `[]`                  |
+| `defaultBackend.sidecars`                              | Add additional sidecar containers to the %%MAIN_CONTAINER_NAME%% pod(s)                                         | `[]`                  |
+| `defaultBackend.initContainers`                        | Add additional init containers to the %%MAIN_CONTAINER_NAME%% pod(s)                                            | `[]`                  |
+| `defaultBackend.affinity`                              | Affinity for pod assignment                                                                                     | `{}`                  |
+| `defaultBackend.nodeSelector`                          | Node labels for pod assignment                                                                                  | `{}`                  |
+| `defaultBackend.tolerations`                           | Tolerations for pod assignment                                                                                  | `[]`                  |
+| `defaultBackend.service.type`                          | Kubernetes Service type for default backend                                                                     | `ClusterIP`           |
+| `defaultBackend.service.ports.http`                    | Default backend service HTTP port                                                                               | `80`                  |
+| `defaultBackend.service.annotations`                   | Annotations for the default backend service                                                                     | `{}`                  |
+| `defaultBackend.pdb.create`                            | Enable/disable a Pod Disruption Budget creation for Default backend                                             | `false`               |
+| `defaultBackend.pdb.minAvailable`                      | Minimum number/percentage of Default backend pods that should remain scheduled                                  | `1`                   |
+| `defaultBackend.pdb.maxUnavailable`                    | Maximum number/percentage of Default backend pods that may be made unavailable                                  | `""`                  |
 
 
 ### Traffic exposure parameters

--- a/bitnami/nginx-ingress-controller/values.yaml
+++ b/bitnami/nginx-ingress-controller/values.yaml
@@ -48,6 +48,7 @@ clusterDomain: cluster.local
 ## @param image.registry Nginx Ingress Controller image registry
 ## @param image.repository Nginx Ingress Controller image repository
 ## @param image.tag Nginx Ingress Controller image tag (immutable tags are recommended)
+## @param image.digest Nginx Ingress Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Nginx Ingress Controller image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ##
@@ -55,6 +56,7 @@ image:
   registry: docker.io
   repository: bitnami/nginx-ingress-controller
   tag: 1.3.0-debian-11-r9
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -472,6 +474,7 @@ defaultBackend:
   ## @param defaultBackend.image.registry Default backend image registry
   ## @param defaultBackend.image.repository Default backend image repository
   ## @param defaultBackend.image.tag Default backend image tag (immutable tags are recommended)
+  ## @param defaultBackend.image.digest Default backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param defaultBackend.image.pullPolicy Image pull policy
   ## @param defaultBackend.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -479,6 +482,7 @@ defaultBackend:
     registry: docker.io
     repository: bitnami/nginx
     tag: 1.23.1-debian-11-r6
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```