### PR TITLE
[bitnami/nats] Add support for image digest apart from tag

### DIFF
--- a/bitnami/nats/Chart.lock
+++ b/bitnami/nats/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-08-01T08:32:59.681993633Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T10:59:47.446965132Z"

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: NATS is an open source, lightweight and high-performance messaging system. It is ideal for distributed systems and supports modern cloud architectures and pub-sub, request-reply and queuing models.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/nats
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/nats
   - https://nats.io/
-version: 7.3.12
+version: 7.4.0

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -76,41 +76,42 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### NATS parameters
 
-| Name                     | Description                                                                                           | Value                |
-| ------------------------ | ----------------------------------------------------------------------------------------------------- | -------------------- |
-| `image.registry`         | NATS image registry                                                                                   | `docker.io`          |
-| `image.repository`       | NATS image repository                                                                                 | `bitnami/nats`       |
-| `image.tag`              | NATS image tag (immutable tags are recommended)                                                       | `2.8.3-debian-10-r0` |
-| `image.pullPolicy`       | NATS image pull policy                                                                                | `IfNotPresent`       |
-| `image.pullSecrets`      | NATS image pull secrets                                                                               | `[]`                 |
-| `image.debug`            | Enable NATS image debug mode                                                                          | `false`              |
-| `auth.enabled`           | Switch to enable/disable client authentication                                                        | `true`               |
-| `auth.user`              | Client authentication user                                                                            | `nats_client`        |
-| `auth.password`          | Client authentication password                                                                        | `""`                 |
-| `auth.token`             | Client authentication token                                                                           | `""`                 |
-| `auth.timeout`           | Client authentication timeout (seconds)                                                               | `1`                  |
-| `auth.usersCredentials`  | Client authentication users credentials collection                                                    | `[]`                 |
-| `auth.noAuthUser`        | Client authentication username from auth.usersCredentials map to be used when no credentials provided | `""`                 |
-| `cluster.connectRetries` | Configure number of connect retries for implicit routes, otherwise leave blank                        | `""`                 |
-| `cluster.auth.enabled`   | Switch to enable/disable cluster authentication                                                       | `true`               |
-| `cluster.auth.user`      | Cluster authentication user                                                                           | `nats_cluster`       |
-| `cluster.auth.password`  | Cluster authentication password                                                                       | `""`                 |
-| `cluster.auth.token`     | Cluster authentication token                                                                          | `""`                 |
-| `debug.enabled`          | Switch to enable/disable debug on logging                                                             | `false`              |
-| `debug.trace`            | Switch to enable/disable trace debug level on logging                                                 | `false`              |
-| `debug.logtime`          | Switch to enable/disable logtime on logging                                                           | `false`              |
-| `maxConnections`         | Max. number of client connections                                                                     | `""`                 |
-| `maxControlLine`         | Max. protocol control line                                                                            | `""`                 |
-| `maxPayload`             | Max. payload                                                                                          | `""`                 |
-| `writeDeadline`          | Duration the server can block on a socket write to a client                                           | `""`                 |
-| `natsFilename`           | Filename used by several NATS files (binary, configuration file, and pid file)                        | `nats-server`        |
-| `configuration`          | Specify content for NATS configuration file (generated based on other parameters otherwise)           | `""`                 |
-| `existingSecret`         | The name of an existing Secret with your custom configuration for NATS                                | `""`                 |
-| `command`                | Override default container command (useful when using custom images)                                  | `[]`                 |
-| `args`                   | Override default container args (useful when using custom images)                                     | `[]`                 |
-| `extraEnvVars`           | Extra environment variables to be set on NATS container                                               | `[]`                 |
-| `extraEnvVarsCM`         | ConfigMap with extra environment variables                                                            | `""`                 |
-| `extraEnvVarsSecret`     | Secret with extra environment variables                                                               | `""`                 |
+| Name                     | Description                                                                                           | Value                 |
+| ------------------------ | ----------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`         | NATS image registry                                                                                   | `docker.io`           |
+| `image.repository`       | NATS image repository                                                                                 | `bitnami/nats`        |
+| `image.tag`              | NATS image tag (immutable tags are recommended)                                                       | `2.8.4-debian-11-r25` |
+| `image.digest`           | NATS image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag  | `""`                  |
+| `image.pullPolicy`       | NATS image pull policy                                                                                | `IfNotPresent`        |
+| `image.pullSecrets`      | NATS image pull secrets                                                                               | `[]`                  |
+| `image.debug`            | Enable NATS image debug mode                                                                          | `false`               |
+| `auth.enabled`           | Switch to enable/disable client authentication                                                        | `true`                |
+| `auth.user`              | Client authentication user                                                                            | `nats_client`         |
+| `auth.password`          | Client authentication password                                                                        | `""`                  |
+| `auth.token`             | Client authentication token                                                                           | `""`                  |
+| `auth.timeout`           | Client authentication timeout (seconds)                                                               | `1`                   |
+| `auth.usersCredentials`  | Client authentication users credentials collection                                                    | `[]`                  |
+| `auth.noAuthUser`        | Client authentication username from auth.usersCredentials map to be used when no credentials provided | `""`                  |
+| `cluster.connectRetries` | Configure number of connect retries for implicit routes, otherwise leave blank                        | `""`                  |
+| `cluster.auth.enabled`   | Switch to enable/disable cluster authentication                                                       | `true`                |
+| `cluster.auth.user`      | Cluster authentication user                                                                           | `nats_cluster`        |
+| `cluster.auth.password`  | Cluster authentication password                                                                       | `""`                  |
+| `cluster.auth.token`     | Cluster authentication token                                                                          | `""`                  |
+| `debug.enabled`          | Switch to enable/disable debug on logging                                                             | `false`               |
+| `debug.trace`            | Switch to enable/disable trace debug level on logging                                                 | `false`               |
+| `debug.logtime`          | Switch to enable/disable logtime on logging                                                           | `false`               |
+| `maxConnections`         | Max. number of client connections                                                                     | `""`                  |
+| `maxControlLine`         | Max. protocol control line                                                                            | `""`                  |
+| `maxPayload`             | Max. payload                                                                                          | `""`                  |
+| `writeDeadline`          | Duration the server can block on a socket write to a client                                           | `""`                  |
+| `natsFilename`           | Filename used by several NATS files (binary, configuration file, and pid file)                        | `nats-server`         |
+| `configuration`          | Specify content for NATS configuration file (generated based on other parameters otherwise)           | `""`                  |
+| `existingSecret`         | The name of an existing Secret with your custom configuration for NATS                                | `""`                  |
+| `command`                | Override default container command (useful when using custom images)                                  | `[]`                  |
+| `args`                   | Override default container args (useful when using custom images)                                     | `[]`                  |
+| `extraEnvVars`           | Extra environment variables to be set on NATS container                                               | `[]`                  |
+| `extraEnvVarsCM`         | ConfigMap with extra environment variables                                                            | `""`                  |
+| `extraEnvVarsSecret`     | Secret with extra environment variables                                                               | `""`                  |
 
 
 ### NATS deployment/statefulset parameters
@@ -212,31 +213,32 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics parameters
 
-| Name                                       | Description                                                                      | Value                   |
-| ------------------------------------------ | -------------------------------------------------------------------------------- | ----------------------- |
-| `metrics.enabled`                          | Enable Prometheus metrics via exporter side-car                                  | `false`                 |
-| `metrics.image.registry`                   | Prometheus metrics exporter image registry                                       | `docker.io`             |
-| `metrics.image.repository`                 | Prometheus metrics exporter image repository                                     | `bitnami/nats-exporter` |
-| `metrics.image.tag`                        | Prometheus metrics exporter image tag (immutable tags are recommended)           | `0.9.3-debian-10-r0`    |
-| `metrics.image.pullPolicy`                 | Prometheus metrics image pull policy                                             | `IfNotPresent`          |
-| `metrics.image.pullSecrets`                | Prometheus metrics image pull secrets                                            | `[]`                    |
-| `metrics.resources`                        | Metrics exporter resource requests and limits                                    | `{}`                    |
-| `metrics.containerPort`                    | Prometheus metrics exporter port                                                 | `7777`                  |
-| `metrics.flags`                            | Flags to be passed to Prometheus metrics                                         | `[]`                    |
-| `metrics.service.type`                     | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)              | `ClusterIP`             |
-| `metrics.service.port`                     | Prometheus metrics service port                                                  | `7777`                  |
-| `metrics.service.loadBalancerIP`           | Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank | `""`                    |
-| `metrics.service.annotations`              | Annotations for Prometheus metrics service                                       | `{}`                    |
-| `metrics.service.labels`                   | Labels for Prometheus metrics service                                            | `{}`                    |
-| `metrics.serviceMonitor.enabled`           | Specify if a ServiceMonitor will be deployed for Prometheus Operator             | `false`                 |
-| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                         | `monitoring`            |
-| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                              | `{}`                    |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus | `""`                    |
-| `metrics.serviceMonitor.interval`          | How frequently to scrape metrics                                                 | `""`                    |
-| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                          | `""`                    |
-| `metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                         | `[]`                    |
-| `metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                       | `[]`                    |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                              | `{}`                    |
+| Name                                       | Description                                                                                            | Value                   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------ | ----------------------- |
+| `metrics.enabled`                          | Enable Prometheus metrics via exporter side-car                                                        | `false`                 |
+| `metrics.image.registry`                   | Prometheus metrics exporter image registry                                                             | `docker.io`             |
+| `metrics.image.repository`                 | Prometheus metrics exporter image repository                                                           | `bitnami/nats-exporter` |
+| `metrics.image.tag`                        | Prometheus metrics exporter image tag (immutable tags are recommended)                                 | `0.9.3-debian-11-r25`   |
+| `metrics.image.digest`                     | Petete image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `metrics.image.pullPolicy`                 | Prometheus metrics image pull policy                                                                   | `IfNotPresent`          |
+| `metrics.image.pullSecrets`                | Prometheus metrics image pull secrets                                                                  | `[]`                    |
+| `metrics.resources`                        | Metrics exporter resource requests and limits                                                          | `{}`                    |
+| `metrics.containerPort`                    | Prometheus metrics exporter port                                                                       | `7777`                  |
+| `metrics.flags`                            | Flags to be passed to Prometheus metrics                                                               | `[]`                    |
+| `metrics.service.type`                     | Kubernetes service type (`ClusterIP`, `NodePort` or `LoadBalancer`)                                    | `ClusterIP`             |
+| `metrics.service.port`                     | Prometheus metrics service port                                                                        | `7777`                  |
+| `metrics.service.loadBalancerIP`           | Use serviceLoadBalancerIP to request a specific static IP, otherwise leave blank                       | `""`                    |
+| `metrics.service.annotations`              | Annotations for Prometheus metrics service                                                             | `{}`                    |
+| `metrics.service.labels`                   | Labels for Prometheus metrics service                                                                  | `{}`                    |
+| `metrics.serviceMonitor.enabled`           | Specify if a ServiceMonitor will be deployed for Prometheus Operator                                   | `false`                 |
+| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                               | `monitoring`            |
+| `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                                    | `{}`                    |
+| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus                       | `""`                    |
+| `metrics.serviceMonitor.interval`          | How frequently to scrape metrics                                                                       | `""`                    |
+| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                | `""`                    |
+| `metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                                               | `[]`                    |
+| `metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                                             | `[]`                    |
+| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                    | `{}`                    |
 
 
 ### Other parameters

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -56,6 +56,7 @@ diagnosticMode:
 ## @param image.registry NATS image registry
 ## @param image.repository NATS image repository
 ## @param image.tag NATS image tag (immutable tags are recommended)
+## @param image.digest NATS image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy NATS image pull policy
 ## @param image.pullSecrets NATS image pull secrets
 ## @param image.debug Enable NATS image debug mode
@@ -64,6 +65,7 @@ image:
   registry: docker.io
   repository: bitnami/nats
   tag: 2.8.4-debian-11-r25
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -666,6 +668,7 @@ metrics:
   ## @param metrics.image.registry Prometheus metrics exporter image registry
   ## @param metrics.image.repository Prometheus metrics exporter image repository
   ## @param metrics.image.tag Prometheus metrics exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest Petete image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy Prometheus metrics image pull policy
   ## @param metrics.image.pullSecrets Prometheus metrics image pull secrets
   ##
@@ -673,6 +676,7 @@ metrics:
     registry: docker.io
     repository: bitnami/nats-exporter
     tag: 0.9.3-debian-11-r25
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```