### PR TITLE
[bitnami/redmine] Add support for image digest apart from tag

### DIFF
--- a/bitnami/redmine/Chart.lock
+++ b/bitnami/redmine/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.7.2
+  version: 11.7.4
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 11.1.8
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:725f50e0b87e989f60c41326f999011488e4b9d6da6a2a2f435bc949dbbade57
-generated: "2022-08-17T20:22:51.001411282Z"
+  version: 2.0.0
+digest: sha256:4bcbdb627cbf9e07991d13d78f2aeaf57cb2dafea2550507c2f3212e486db15a
+generated: "2022-08-20T11:01:09.748920457Z"

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Redmine is an open source management application. It includes a tracking issue system, Gantt charts for a visual view of projects and deadlines, and supports SCM integration for version control.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/redmine
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redmine
   - https://www.redmine.org/
-version: 20.2.20
+version: 20.3.0

--- a/bitnami/redmine/README.md
+++ b/bitnami/redmine/README.md
@@ -89,32 +89,33 @@ helm install my-release bitnami/redmine --set databaseType=postgresql
 
 ### Redmine Configuration parameters
 
-| Name                    | Description                                                            | Value                 |
-| ----------------------- | ---------------------------------------------------------------------- | --------------------- |
-| `image.registry`        | Redmine image registry                                                 | `docker.io`           |
-| `image.repository`      | Redmine image repository                                               | `bitnami/redmine`     |
-| `image.tag`             | Redmine image tag (immutable tags are recommended)                     | `5.0.2-debian-11-r20` |
-| `image.pullPolicy`      | Redmine image pull policy                                              | `IfNotPresent`        |
-| `image.pullSecrets`     | Redmine image pull secrets                                             | `[]`                  |
-| `image.debug`           | Enable image debug mode                                                | `false`               |
-| `redmineUsername`       | Redmine username                                                       | `user`                |
-| `redminePassword`       | Redmine user password                                                  | `""`                  |
-| `redmineEmail`          | Redmine user email                                                     | `user@example.com`    |
-| `redmineLanguage`       | Redmine default data language                                          | `en`                  |
-| `allowEmptyPassword`    | Allow the container to be started with blank passwords                 | `false`               |
-| `smtpHost`              | SMTP server host                                                       | `""`                  |
-| `smtpPort`              | SMTP server port                                                       | `""`                  |
-| `smtpUser`              | SMTP username                                                          | `""`                  |
-| `smtpPassword`          | SMTP user password                                                     | `""`                  |
-| `smtpProtocol`          | SMTP protocol                                                          | `""`                  |
-| `existingSecret`        | Name of existing secret containing Redmine credentials                 | `""`                  |
-| `smtpExistingSecret`    | The name of an existing secret with SMTP credentials                   | `""`                  |
-| `customPostInitScripts` | Custom post-init.d user scripts                                        | `{}`                  |
-| `command`               | Override default container command (useful when using custom images)   | `[]`                  |
-| `args`                  | Override default container args (useful when using custom images)      | `[]`                  |
-| `extraEnvVars`          | Array with extra environment variables to add to the Redmine container | `[]`                  |
-| `extraEnvVarsCM`        | Name of existing ConfigMap containing extra env vars                   | `""`                  |
-| `extraEnvVarsSecret`    | Name of existing Secret containing extra env vars                      | `""`                  |
+| Name                    | Description                                                                                             | Value                 |
+| ----------------------- | ------------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`        | Redmine image registry                                                                                  | `docker.io`           |
+| `image.repository`      | Redmine image repository                                                                                | `bitnami/redmine`     |
+| `image.tag`             | Redmine image tag (immutable tags are recommended)                                                      | `5.0.2-debian-11-r20` |
+| `image.digest`          | Redmine image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `image.pullPolicy`      | Redmine image pull policy                                                                               | `IfNotPresent`        |
+| `image.pullSecrets`     | Redmine image pull secrets                                                                              | `[]`                  |
+| `image.debug`           | Enable image debug mode                                                                                 | `false`               |
+| `redmineUsername`       | Redmine username                                                                                        | `user`                |
+| `redminePassword`       | Redmine user password                                                                                   | `""`                  |
+| `redmineEmail`          | Redmine user email                                                                                      | `user@example.com`    |
+| `redmineLanguage`       | Redmine default data language                                                                           | `en`                  |
+| `allowEmptyPassword`    | Allow the container to be started with blank passwords                                                  | `false`               |
+| `smtpHost`              | SMTP server host                                                                                        | `""`                  |
+| `smtpPort`              | SMTP server port                                                                                        | `""`                  |
+| `smtpUser`              | SMTP username                                                                                           | `""`                  |
+| `smtpPassword`          | SMTP user password                                                                                      | `""`                  |
+| `smtpProtocol`          | SMTP protocol                                                                                           | `""`                  |
+| `existingSecret`        | Name of existing secret containing Redmine credentials                                                  | `""`                  |
+| `smtpExistingSecret`    | The name of an existing secret with SMTP credentials                                                    | `""`                  |
+| `customPostInitScripts` | Custom post-init.d user scripts                                                                         | `{}`                  |
+| `command`               | Override default container command (useful when using custom images)                                    | `[]`                  |
+| `args`                  | Override default container args (useful when using custom images)                                       | `[]`                  |
+| `extraEnvVars`          | Array with extra environment variables to add to the Redmine container                                  | `[]`                  |
+| `extraEnvVarsCM`        | Name of existing ConfigMap containing extra env vars                                                    | `""`                  |
+| `extraEnvVarsSecret`    | Name of existing Secret containing extra env vars                                                       | `""`                  |
 
 
 ### Redmine deployment parameters
@@ -335,21 +336,22 @@ helm install my-release bitnami/redmine --set databaseType=postgresql
 
 ### Custom Certificates parameters
 
-| Name                                                 | Description                                                        | Value                                    |
-| ---------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------- |
-| `certificates.customCertificate.certificateSecret`   | Secret containing the certificate and key to add                   | `""`                                     |
-| `certificates.customCertificate.certificateLocation` | Location in the container to store the certificate                 | `/etc/ssl/certs/ssl-cert-snakeoil.pem`   |
-| `certificates.customCertificate.keyLocation`         | Location in the container to store the private key                 | `/etc/ssl/private/ssl-cert-snakeoil.key` |
-| `certificates.customCertificate.chainLocation`       | Location in the container to store the certificate chain           | `/etc/ssl/certs/mychain.pem`             |
-| `certificates.customCertificate.chainSecret.name`    | Name of the secret containing the certificate chain                | `""`                                     |
-| `certificates.customCertificate.chainSecret.key`     | Key of the certificate chain file inside the secret                | `""`                                     |
-| `certificates.customCA`                              | Defines a list of secrets to import into the container trust store | `[]`                                     |
-| `certificates.image.registry`                        | Redmine image registry                                             | `docker.io`                              |
-| `certificates.image.repository`                      | Redmine image repository                                           | `bitnami/bitnami-shell`                  |
-| `certificates.image.tag`                             | Redmine image tag (immutable tags are recommended)                 | `11-debian-11-r26`                       |
-| `certificates.image.pullPolicy`                      | Redmine image pull policy                                          | `IfNotPresent`                           |
-| `certificates.image.pullSecrets`                     | Redmine image pull secrets                                         | `[]`                                     |
-| `certificates.extraEnvVars`                          | Container sidecar extra environment variables (e.g. proxy)         | `[]`                                     |
+| Name                                                 | Description                                                                                             | Value                                    |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `certificates.customCertificate.certificateSecret`   | Secret containing the certificate and key to add                                                        | `""`                                     |
+| `certificates.customCertificate.certificateLocation` | Location in the container to store the certificate                                                      | `/etc/ssl/certs/ssl-cert-snakeoil.pem`   |
+| `certificates.customCertificate.keyLocation`         | Location in the container to store the private key                                                      | `/etc/ssl/private/ssl-cert-snakeoil.key` |
+| `certificates.customCertificate.chainLocation`       | Location in the container to store the certificate chain                                                | `/etc/ssl/certs/mychain.pem`             |
+| `certificates.customCertificate.chainSecret.name`    | Name of the secret containing the certificate chain                                                     | `""`                                     |
+| `certificates.customCertificate.chainSecret.key`     | Key of the certificate chain file inside the secret                                                     | `""`                                     |
+| `certificates.customCA`                              | Defines a list of secrets to import into the container trust store                                      | `[]`                                     |
+| `certificates.image.registry`                        | Redmine image registry                                                                                  | `docker.io`                              |
+| `certificates.image.repository`                      | Redmine image repository                                                                                | `bitnami/bitnami-shell`                  |
+| `certificates.image.tag`                             | Redmine image tag (immutable tags are recommended)                                                      | `11-debian-11-r26`                       |
+| `certificates.image.digest`                          | Redmine image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                     |
+| `certificates.image.pullPolicy`                      | Redmine image pull policy                                                                               | `IfNotPresent`                           |
+| `certificates.image.pullSecrets`                     | Redmine image pull secrets                                                                              | `[]`                                     |
+| `certificates.extraEnvVars`                          | Container sidecar extra environment variables (e.g. proxy)                                              | `[]`                                     |
 
 
 ### NetworkPolicy parameters

--- a/bitnami/redmine/values.yaml
+++ b/bitnami/redmine/values.yaml
@@ -65,6 +65,7 @@ diagnosticMode:
 ## @param image.registry Redmine image registry
 ## @param image.repository Redmine image repository
 ## @param image.tag Redmine image tag (immutable tags are recommended)
+## @param image.digest Redmine image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Redmine image pull policy
 ## @param image.pullSecrets [array] Redmine image pull secrets
 ## @param image.debug Enable image debug mode
@@ -73,6 +74,7 @@ image:
   registry: docker.io
   repository: bitnami/redmine
   tag: 5.0.2-debian-11-r20
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -933,6 +935,7 @@ certificates:
   ## @param certificates.image.registry Redmine image registry
   ## @param certificates.image.repository Redmine image repository
   ## @param certificates.image.tag Redmine image tag (immutable tags are recommended)
+  ## @param certificates.image.digest Redmine image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param certificates.image.pullPolicy Redmine image pull policy
   ## @param certificates.image.pullSecrets [array] Redmine image pull secrets
   ##
@@ -940,6 +943,7 @@ certificates:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r26
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```