### PR TITLE
[bitnami/redis-cluster] Add support for image digest apart from tag

### DIFF
--- a/bitnami/redis-cluster/Chart.lock
+++ b/bitnami/redis-cluster/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-19T01:29:02.179555111Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T11:01:05.520385581Z"

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Redis(R) is an open source, scalable, distributed in-memory cache for applications. It can be used to store and serve data in the form of strings, hashes, lists, sets and sorted sets.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/redis-cluster
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
   - http://redis.io/
-version: 8.1.4
+version: 8.2.0

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -95,6 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.registry`                              | Redis&reg; cluster image registry                                                                                                                   | `docker.io`             |
 | `image.repository`                            | Redis&reg; cluster image repository                                                                                                                 | `bitnami/redis-cluster` |
 | `image.tag`                                   | Redis&reg; cluster image tag (immutable tags are recommended)                                                                                       | `7.0.4-debian-11-r4`    |
+| `image.digest`                                | Redis&reg; cluster image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                  | `""`                    |
 | `image.pullPolicy`                            | Redis&reg; cluster image pull policy                                                                                                                | `IfNotPresent`          |
 | `image.pullSecrets`                           | Specify docker-registry secret names as an array                                                                                                    | `[]`                    |
 | `image.debug`                                 | Enable image debug mode                                                                                                                             | `false`                 |
@@ -156,6 +157,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.image.registry`            | Init container volume-permissions image registry                                                                                                    | `docker.io`             |
 | `volumePermissions.image.repository`          | Init container volume-permissions image repository                                                                                                  | `bitnami/bitnami-shell` |
 | `volumePermissions.image.tag`                 | Init container volume-permissions image tag                                                                                                         | `11-debian-11-r23`      |
+| `volumePermissions.image.digest`              | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                   | `""`                    |
 | `volumePermissions.image.pullPolicy`          | Init container volume-permissions image pull policy                                                                                                 | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`         | Specify docker-registry secret names as an array                                                                                                    | `[]`                    |
 | `volumePermissions.resources.limits`          | The resources limits for the container                                                                                                              | `{}`                    |
@@ -283,6 +285,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.image.registry`                                    | Redis&reg; exporter image registry                                                                                                 | `docker.io`              |
 | `metrics.image.repository`                                  | Redis&reg; exporter image name                                                                                                     | `bitnami/redis-exporter` |
 | `metrics.image.tag`                                         | Redis&reg; exporter image tag                                                                                                      | `1.43.0-debian-11-r19`   |
+| `metrics.image.digest`                                      | Redis&reg; exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                | `""`                     |
 | `metrics.image.pullPolicy`                                  | Redis&reg; exporter image pull policy                                                                                              | `IfNotPresent`           |
 | `metrics.image.pullSecrets`                                 | Specify docker-registry secret names as an array                                                                                   | `[]`                     |
 | `metrics.resources`                                         | Metrics exporter resource requests and limits                                                                                      | `{}`                     |
@@ -315,18 +318,19 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Sysctl Image parameters
 
-| Name                             | Description                                        | Value                   |
-| -------------------------------- | -------------------------------------------------- | ----------------------- |
-| `sysctlImage.enabled`            | Enable an init container to modify Kernel settings | `false`                 |
-| `sysctlImage.command`            | sysctlImage command to execute                     | `[]`                    |
-| `sysctlImage.registry`           | sysctlImage Init container registry                | `docker.io`             |
-| `sysctlImage.repository`         | sysctlImage Init container repository              | `bitnami/bitnami-shell` |
-| `sysctlImage.tag`                | sysctlImage Init container tag                     | `11-debian-11-r23`      |
-| `sysctlImage.pullPolicy`         | sysctlImage Init container pull policy             | `IfNotPresent`          |
-| `sysctlImage.pullSecrets`        | Specify docker-registry secret names as an array   | `[]`                    |
-| `sysctlImage.mountHostSys`       | Mount the host `/sys` folder to `/host-sys`        | `false`                 |
-| `sysctlImage.resources.limits`   | The resources limits for the container             | `{}`                    |
-| `sysctlImage.resources.requests` | The requested resources for the container          | `{}`                    |
+| Name                             | Description                                                                                                          | Value                   |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `sysctlImage.enabled`            | Enable an init container to modify Kernel settings                                                                   | `false`                 |
+| `sysctlImage.command`            | sysctlImage command to execute                                                                                       | `[]`                    |
+| `sysctlImage.registry`           | sysctlImage Init container registry                                                                                  | `docker.io`             |
+| `sysctlImage.repository`         | sysctlImage Init container repository                                                                                | `bitnami/bitnami-shell` |
+| `sysctlImage.tag`                | sysctlImage Init container tag                                                                                       | `11-debian-11-r23`      |
+| `sysctlImage.digest`             | sysctlImage Init container digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `sysctlImage.pullPolicy`         | sysctlImage Init container pull policy                                                                               | `IfNotPresent`          |
+| `sysctlImage.pullSecrets`        | Specify docker-registry secret names as an array                                                                     | `[]`                    |
+| `sysctlImage.mountHostSys`       | Mount the host `/sys` folder to `/host-sys`                                                                          | `false`                 |
+| `sysctlImage.resources.limits`   | The resources limits for the container                                                                               | `{}`                    |
+| `sysctlImage.resources.requests` | The requested resources for the container                                                                            | `{}`                    |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -62,6 +62,7 @@ diagnosticMode:
 ## @param image.registry Redis&reg; cluster image registry
 ## @param image.repository Redis&reg; cluster image repository
 ## @param image.tag Redis&reg; cluster image tag (immutable tags are recommended)
+## @param image.digest Redis&reg; cluster image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Redis&reg; cluster image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Enable image debug mode
@@ -73,6 +74,7 @@ image:
   ## ref: https://github.com/bitnami/containers/tree/main/bitnami/redis#supported-tags-and-respective-dockerfile-links
   ##
   tag: 7.0.4-debian-11-r4
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -328,6 +330,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image repository
   ## @param volumePermissions.image.tag Init container volume-permissions image tag
+  ## @param volumePermissions.image.digest Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Init container volume-permissions image pull policy
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -335,6 +338,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r23
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -788,6 +792,7 @@ metrics:
   ## @param metrics.image.registry Redis&reg; exporter image registry
   ## @param metrics.image.repository Redis&reg; exporter image name
   ## @param metrics.image.tag Redis&reg; exporter image tag
+  ## @param metrics.image.digest Redis&reg; exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy Redis&reg; exporter image pull policy
   ## @param metrics.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -795,6 +800,7 @@ metrics:
     registry: docker.io
     repository: bitnami/redis-exporter
     tag: 1.43.0-debian-11-r19
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -949,12 +955,14 @@ sysctlImage:
   ## @param sysctlImage.registry sysctlImage Init container registry
   ## @param sysctlImage.repository sysctlImage Init container repository
   ## @param sysctlImage.tag sysctlImage Init container tag
+  ## @param sysctlImage.digest sysctlImage Init container digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param sysctlImage.pullPolicy sysctlImage Init container pull policy
   ## @param sysctlImage.pullSecrets Specify docker-registry secret names as an array
   ##
   registry: docker.io
   repository: bitnami/bitnami-shell
   tag: 11-debian-11-r23
+  digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```