### PR TITLE
[bitnami/pinniped] Add support for image digest apart from tag

### DIFF
--- a/bitnami/pinniped/Chart.lock
+++ b/bitnami/pinniped/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-16T15:40:10.238781773Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T11:00:40.775579321Z"

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Pinniped is an identity service provider for Kubernetes. Provides a consistent, unified login experience across all your clusters, allowing enteprise IDP protocols.
 engine: gotpl
 home: https://pinniped.dev/
@@ -22,4 +22,4 @@ name: pinniped
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/pinniped
   - https://github.com/vmware-tanzu/pinniped/
-version: 0.1.8
+version: 0.2.0

--- a/bitnami/pinniped/README.md
+++ b/bitnami/pinniped/README.md
@@ -65,21 +65,22 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Common parameters
 
-| Name                | Description                                         | Value               |
-| ------------------- | --------------------------------------------------- | ------------------- |
-| `kubeVersion`       | Override Kubernetes version                         | `""`                |
-| `nameOverride`      | String to partially override common.names.name      | `""`                |
-| `fullnameOverride`  | String to fully override common.names.fullname      | `""`                |
-| `namespaceOverride` | String to fully override common.names.namespace     | `""`                |
-| `commonLabels`      | Labels to add to all deployed objects               | `{}`                |
-| `commonAnnotations` | Annotations to add to all deployed objects          | `{}`                |
-| `clusterDomain`     | Kubernetes cluster domain name                      | `cluster.local`     |
-| `extraDeploy`       | Array of extra objects to deploy with the release   | `[]`                |
-| `image.registry`    | Pinniped image registry                             | `docker.io`         |
-| `image.repository`  | Pinniped image repository                           | `bitnami/pinniped`  |
-| `image.tag`         | Pinniped image tag (immutable tags are recommended) | `0.18.0-scratch-r8` |
-| `image.pullPolicy`  | Pinniped image pull policy                          | `IfNotPresent`      |
-| `image.pullSecrets` | Pinniped image pull secrets                         | `[]`                |
+| Name                | Description                                                                                              | Value               |
+| ------------------- | -------------------------------------------------------------------------------------------------------- | ------------------- |
+| `kubeVersion`       | Override Kubernetes version                                                                              | `""`                |
+| `nameOverride`      | String to partially override common.names.name                                                           | `""`                |
+| `fullnameOverride`  | String to fully override common.names.fullname                                                           | `""`                |
+| `namespaceOverride` | String to fully override common.names.namespace                                                          | `""`                |
+| `commonLabels`      | Labels to add to all deployed objects                                                                    | `{}`                |
+| `commonAnnotations` | Annotations to add to all deployed objects                                                               | `{}`                |
+| `clusterDomain`     | Kubernetes cluster domain name                                                                           | `cluster.local`     |
+| `extraDeploy`       | Array of extra objects to deploy with the release                                                        | `[]`                |
+| `image.registry`    | Pinniped image registry                                                                                  | `docker.io`         |
+| `image.repository`  | Pinniped image repository                                                                                | `bitnami/pinniped`  |
+| `image.tag`         | Pinniped image tag (immutable tags are recommended)                                                      | `0.18.0-scratch-r8` |
+| `image.digest`      | Pinniped image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                |
+| `image.pullPolicy`  | Pinniped image pull policy                                                                               | `IfNotPresent`      |
+| `image.pullSecrets` | Pinniped image pull secrets                                                                              | `[]`                |
 
 
 ### Concierge Parameters

--- a/bitnami/pinniped/values.yaml
+++ b/bitnami/pinniped/values.yaml
@@ -50,6 +50,7 @@ extraDeploy: []
 ## @param image.registry Pinniped image registry
 ## @param image.repository Pinniped image repository
 ## @param image.tag Pinniped image tag (immutable tags are recommended)
+## @param image.digest Pinniped image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Pinniped image pull policy
 ## @param image.pullSecrets Pinniped image pull secrets
 ##
@@ -57,6 +58,7 @@ image:
   registry: docker.io
   repository: bitnami/pinniped
   tag: 0.18.0-scratch-r8
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```