### PR TITLE
[bitnami/phpmyadmin] Add support for image digest apart from tag

### DIFF
--- a/bitnami/phpmyadmin/Chart.lock
+++ b/bitnami/phpmyadmin/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.6
+  version: 11.1.8
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:d82c41c31ead0266356a4eadddebba43fea03872fdde521b7cf4068208d3597e
-generated: "2022-08-09T06:31:46.971995182Z"
+  version: 2.0.0
+digest: sha256:4c83f55f0c155f143779c1bc08d3b6c78646679c26c4e5e15714e803af74de73
+generated: "2022-08-20T11:00:37.117338438Z"

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: phpMyAdmin is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/phpmyadmin
@@ -29,4 +29,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/phpmyadmin
   - https://www.phpmyadmin.net/
-version: 10.2.4
+version: 10.3.0

--- a/bitnami/phpmyadmin/values.yaml
+++ b/bitnami/phpmyadmin/values.yaml
@@ -45,6 +45,7 @@ extraDeploy: []
 ## @param image.registry phpMyAdmin image registry
 ## @param image.repository phpMyAdmin image repository
 ## @param image.tag phpMyAdmin image tag (immutable tags are recommended)
+## @param image.digest phpMyAdmin image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Enable phpmyadmin image debug mode
@@ -53,6 +54,7 @@ image:
   registry: docker.io
   repository: bitnami/phpmyadmin
   tag: 5.2.0-debian-11-r26
+  digest: ""
   ## Specify a imagePullPolicy
   ##
   pullPolicy: IfNotPresent
@@ -441,8 +443,8 @@ ingress:
   ##   secretName: phpmyadmin.local-tls
   ##
   extraTls: []
-  ## @param ingress.secrets If you're providing your own certificates and want to manage the secret via helm, 
-  ## please use this to add the certificates as secrets key and certificate should start with 
+  ## @param ingress.secrets If you're providing your own certificates and want to manage the secret via helm,
+  ## please use this to add the certificates as secrets key and certificate should start with
   ## -----BEGIN CERTIFICATE----- or -----BEGIN RSA PRIVATE KEY-----
   ## name should line up with a secretName set further up
   ##
@@ -461,7 +463,7 @@ ingress:
   ## @param ingress.existingSecretName If you're providing your own certificate and want to manage the secret yourself,
   ## please provide the name of the secret with this parameter. This secret will then be used for tls termination.
   ## It has higher priority than the cert-manager or the generation of the certificate from the chart.
-  ## 
+  ##
   ## Example:
   ## existingSecretName: "byo-phpmyadmin-tls"
   ##
@@ -478,7 +480,7 @@ ingress:
   ## - host: phpmyadmin.local
   ##     http:
   ##       path: /
-  ##       backend: 
+  ##       backend:
   ##         service:
   ##           name: phpmyadmin-svc
   ##           port:
@@ -549,6 +551,7 @@ metrics:
   ## @param metrics.image.registry Apache exporter image registry
   ## @param metrics.image.repository Apache exporter image repository
   ## @param metrics.image.tag Apache exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy Image pull policy
   ## @param metrics.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -556,6 +559,7 @@ metrics:
     registry: docker.io
     repository: bitnami/apache-exporter
     tag: 0.11.0-debian-11-r28
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```