### PR TITLE
[bitnami/wordpress-intel] Add support for image digest apart from tag

### DIFF
--- a/bitnami/wordpress-intel/Chart.lock
+++ b/bitnami/wordpress-intel/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
 digest: sha256:b1a88d0d728f55057370900d20826005138b9a4d60a7bb22f5d01a9d04ae3843
-generated: "2022-08-22T14:17:49.85913293Z"
+generated: "2022-08-22T14:27:40.12042473Z"

--- a/bitnami/wordpress-intel/Chart.lock
+++ b/bitnami/wordpress-intel/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.1.11
+  version: 6.2.0
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 11.1.8
+  version: 11.2.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.0
-digest: sha256:1a68edf4b992d9eb9fa7c72723edd2f03e7ae8b7a77f7b2d0c4cef81874dd741
-generated: "2022-08-20T11:02:15.100968956Z"
+digest: sha256:b1a88d0d728f55057370900d20826005138b9a4d60a7bb22f5d01a9d04ae3843
+generated: "2022-08-22T14:17:49.85913293Z"

--- a/bitnami/wordpress-intel/Chart.lock
+++ b/bitnami/wordpress-intel/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 11.1.8
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:787780782ca292841fccbafe2f7eea89c06c0f30bc4edcde59511497f1ac537b
-generated: "2022-08-16T19:23:18.25115304Z"
+  version: 2.0.0
+digest: sha256:1a68edf4b992d9eb9fa7c72723edd2f03e7ae8b7a77f7b2d0c4cef81874dd741
+generated: "2022-08-20T11:02:15.100968956Z"

--- a/bitnami/wordpress-intel/Chart.yaml
+++ b/bitnami/wordpress-intel/Chart.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: WordPress for Intel is the most popular blogging application combined with cryptography acceleration for 3rd gen Xeon Scalable Processors (Ice Lake) to get a breakthrough performance improvement.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/wordpress-intel
@@ -35,4 +35,4 @@ name: wordpress-intel
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wordpress-intel
   - https://wordpress.org/
-version: 2.0.20
+version: 2.1.0

--- a/bitnami/wordpress-intel/README.md
+++ b/bitnami/wordpress-intel/README.md
@@ -89,14 +89,15 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### WordPress Image parameters
 
-| Name                | Description                                          | Value                     |
-| ------------------- | ---------------------------------------------------- | ------------------------- |
-| `image.registry`    | WordPress image registry                             | `docker.io`               |
-| `image.repository`  | WordPress image repository                           | `bitnami/wordpress-intel` |
-| `image.tag`         | WordPress image tag (immutable tags are recommended) | `6.0.0-debian-11-r4`      |
-| `image.pullPolicy`  | WordPress image pull policy                          | `IfNotPresent`            |
-| `image.pullSecrets` | WordPress image pull secrets                         | `[]`                      |
-| `image.debug`       | Enable image debug mode                              | `false`                   |
+| Name                | Description                                                                                               | Value                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `image.registry`    | WordPress image registry                                                                                  | `docker.io`               |
+| `image.repository`  | WordPress image repository                                                                                | `bitnami/wordpress-intel` |
+| `image.tag`         | WordPress image tag (immutable tags are recommended)                                                      | `6.0.1-debian-11-r17`     |
+| `image.digest`      | WordPress image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                      |
+| `image.pullPolicy`  | WordPress image pull policy                                                                               | `IfNotPresent`            |
+| `image.pullSecrets` | WordPress image pull secrets                                                                              | `[]`                      |
+| `image.debug`       | Enable image debug mode                                                                                   | `false`                   |
 
 
 ### WordPress Configuration parameters
@@ -228,25 +229,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Persistence Parameters
 
-| Name                                          | Description                                                                                     | Value                   |
-| --------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------- |
-| `persistence.enabled`                         | Enable persistence using Persistent Volume Claims                                               | `true`                  |
-| `persistence.storageClass`                    | Persistent Volume storage class                                                                 | `""`                    |
-| `persistence.accessModes`                     | Persistent Volume access modes                                                                  | `[]`                    |
-| `persistence.accessMode`                      | Persistent Volume access mode (DEPRECATED: use `persistence.accessModes` instead)               | `ReadWriteOnce`         |
-| `persistence.size`                            | Persistent Volume size                                                                          | `10Gi`                  |
-| `persistence.dataSource`                      | Custom PVC data source                                                                          | `{}`                    |
-| `persistence.existingClaim`                   | The name of an existing PVC to use for persistence                                              | `""`                    |
-| `persistence.annotations`                     | Persistent Volume Claim annotations                                                             | `{}`                    |
-| `volumePermissions.enabled`                   | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup` | `false`                 |
-| `volumePermissions.image.registry`            | Bitnami Shell image registry                                                                    | `docker.io`             |
-| `volumePermissions.image.repository`          | Bitnami Shell image repository                                                                  | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                        | `11-debian-11-r6`       |
-| `volumePermissions.image.pullPolicy`          | Bitnami Shell image pull policy                                                                 | `IfNotPresent`          |
-| `volumePermissions.image.pullSecrets`         | Bitnami Shell image pull secrets                                                                | `[]`                    |
-| `volumePermissions.resources.limits`          | The resources limits for the init container                                                     | `{}`                    |
-| `volumePermissions.resources.requests`        | The requested resources for the init container                                                  | `{}`                    |
-| `volumePermissions.securityContext.runAsUser` | Set init container's Security Context runAsUser                                                 | `0`                     |
+| Name                                          | Description                                                                                                   | Value                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| `persistence.enabled`                         | Enable persistence using Persistent Volume Claims                                                             | `true`                  |
+| `persistence.storageClass`                    | Persistent Volume storage class                                                                               | `""`                    |
+| `persistence.accessModes`                     | Persistent Volume access modes                                                                                | `[]`                    |
+| `persistence.accessMode`                      | Persistent Volume access mode (DEPRECATED: use `persistence.accessModes` instead)                             | `ReadWriteOnce`         |
+| `persistence.size`                            | Persistent Volume size                                                                                        | `10Gi`                  |
+| `persistence.dataSource`                      | Custom PVC data source                                                                                        | `{}`                    |
+| `persistence.existingClaim`                   | The name of an existing PVC to use for persistence                                                            | `""`                    |
+| `persistence.annotations`                     | Persistent Volume Claim annotations                                                                           | `{}`                    |
+| `volumePermissions.enabled`                   | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`               | `false`                 |
+| `volumePermissions.image.registry`            | Bitnami Shell image registry                                                                                  | `docker.io`             |
+| `volumePermissions.image.repository`          | Bitnami Shell image repository                                                                                | `bitnami/bitnami-shell` |
+| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                                      | `11-debian-11-r26`      |
+| `volumePermissions.image.digest`              | Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
+| `volumePermissions.image.pullPolicy`          | Bitnami Shell image pull policy                                                                               | `IfNotPresent`          |
+| `volumePermissions.image.pullSecrets`         | Bitnami Shell image pull secrets                                                                              | `[]`                    |
+| `volumePermissions.resources.limits`          | The resources limits for the init container                                                                   | `{}`                    |
+| `volumePermissions.resources.requests`        | The requested resources for the init container                                                                | `{}`                    |
+| `volumePermissions.securityContext.runAsUser` | Set init container's Security Context runAsUser                                                               | `0`                     |
 
 
 ### Other Parameters
@@ -265,26 +267,27 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics Parameters
 
-| Name                                      | Description                                                                  | Value                    |
-| ----------------------------------------- | ---------------------------------------------------------------------------- | ------------------------ |
-| `metrics.enabled`                         | Start a sidecar prometheus exporter to expose metrics                        | `false`                  |
-| `metrics.port`                            | NGINX Container Status Port scraped by Prometheus Exporter                   | `""`                     |
-| `metrics.image.registry`                  | NGINX Prometheus exporter image registry                                     | `docker.io`              |
-| `metrics.image.repository`                | NGINX Prometheus exporter image repository                                   | `bitnami/nginx-exporter` |
-| `metrics.image.tag`                       | NGINX Prometheus exporter image tag (immutable tags are recommended)         | `0.10.0-debian-11-r7`    |
-| `metrics.image.pullPolicy`                | NGINX Prometheus exporter image pull policy                                  | `IfNotPresent`           |
-| `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                             | `[]`                     |
-| `metrics.resources.limits`                | The resources limits for the Prometheus exporter container                   | `{}`                     |
-| `metrics.resources.requests`              | The requested resources for the Prometheus exporter container                | `{}`                     |
-| `metrics.service.port`                    | Metrics service port                                                         | `9113`                   |
-| `metrics.service.annotations`             | Additional custom annotations for Metrics service                            | `{}`                     |
-| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator | `false`                  |
-| `metrics.serviceMonitor.namespace`        | The namespace in which the ServiceMonitor will be created                    | `""`                     |
-| `metrics.serviceMonitor.interval`         | The interval at which metrics should be scraped                              | `30s`                    |
-| `metrics.serviceMonitor.scrapeTimeout`    | The timeout after which the scrape is ended                                  | `""`                     |
-| `metrics.serviceMonitor.relabellings`     | Metrics relabellings to add to the scrape endpoint                           | `[]`                     |
-| `metrics.serviceMonitor.honorLabels`      | Labels to honor to add to the scrape endpoint                                | `false`                  |
-| `metrics.serviceMonitor.additionalLabels` | Additional custom labels for the ServiceMonitor                              | `{}`                     |
+| Name                                      | Description                                                                                                               | Value                    |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `metrics.enabled`                         | Start a sidecar prometheus exporter to expose metrics                                                                     | `false`                  |
+| `metrics.port`                            | NGINX Container Status Port scraped by Prometheus Exporter                                                                | `""`                     |
+| `metrics.image.registry`                  | NGINX Prometheus exporter image registry                                                                                  | `docker.io`              |
+| `metrics.image.repository`                | NGINX Prometheus exporter image repository                                                                                | `bitnami/nginx-exporter` |
+| `metrics.image.tag`                       | NGINX Prometheus exporter image tag (immutable tags are recommended)                                                      | `0.10.0-debian-11-r26`   |
+| `metrics.image.digest`                    | NGINX Prometheus exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
+| `metrics.image.pullPolicy`                | NGINX Prometheus exporter image pull policy                                                                               | `IfNotPresent`           |
+| `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                                                                          | `[]`                     |
+| `metrics.resources.limits`                | The resources limits for the Prometheus exporter container                                                                | `{}`                     |
+| `metrics.resources.requests`              | The requested resources for the Prometheus exporter container                                                             | `{}`                     |
+| `metrics.service.port`                    | Metrics service port                                                                                                      | `9113`                   |
+| `metrics.service.annotations`             | Additional custom annotations for Metrics service                                                                         | `{}`                     |
+| `metrics.serviceMonitor.enabled`          | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator                                              | `false`                  |
+| `metrics.serviceMonitor.namespace`        | The namespace in which the ServiceMonitor will be created                                                                 | `""`                     |
+| `metrics.serviceMonitor.interval`         | The interval at which metrics should be scraped                                                                           | `30s`                    |
+| `metrics.serviceMonitor.scrapeTimeout`    | The timeout after which the scrape is ended                                                                               | `""`                     |
+| `metrics.serviceMonitor.relabellings`     | Metrics relabellings to add to the scrape endpoint                                                                        | `[]`                     |
+| `metrics.serviceMonitor.honorLabels`      | Labels to honor to add to the scrape endpoint                                                                             | `false`                  |
+| `metrics.serviceMonitor.additionalLabels` | Additional custom labels for the ServiceMonitor                                                                           | `{}`                     |
 
 
 ### NetworkPolicy parameters

--- a/bitnami/wordpress-intel/values.yaml
+++ b/bitnami/wordpress-intel/values.yaml
@@ -62,6 +62,7 @@ diagnosticMode:
 ## @param image.registry WordPress image registry
 ## @param image.repository WordPress image repository
 ## @param image.tag WordPress image tag (immutable tags are recommended)
+## @param image.digest WordPress image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy WordPress image pull policy
 ## @param image.pullSecrets WordPress image pull secrets
 ## @param image.debug Enable image debug mode
@@ -70,6 +71,7 @@ image:
   registry: docker.io
   repository: bitnami/wordpress-intel
   tag: 6.0.1-debian-11-r17
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -642,6 +644,7 @@ volumePermissions:
   ## @param volumePermissions.image.registry Bitnami Shell image registry
   ## @param volumePermissions.image.repository Bitnami Shell image repository
   ## @param volumePermissions.image.tag Bitnami Shell image tag (immutable tags are recommended)
+  ## @param volumePermissions.image.digest Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param volumePermissions.image.pullPolicy Bitnami Shell image pull policy
   ## @param volumePermissions.image.pullSecrets Bitnami Shell image pull secrets
   ##
@@ -649,6 +652,7 @@ volumePermissions:
     registry: docker.io
     repository: bitnami/bitnami-shell
     tag: 11-debian-11-r26
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -718,6 +722,7 @@ metrics:
   ## @param metrics.image.registry NGINX Prometheus exporter image registry
   ## @param metrics.image.repository NGINX Prometheus exporter image repository
   ## @param metrics.image.tag NGINX Prometheus exporter image tag (immutable tags are recommended)
+  ## @param metrics.image.digest NGINX Prometheus exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param metrics.image.pullPolicy NGINX Prometheus exporter image pull policy
   ## @param metrics.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -725,6 +730,7 @@ metrics:
     registry: docker.io
     repository: bitnami/nginx-exporter
     tag: 0.10.0-debian-11-r26
+    digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```