### PR TITLE
[bitnami/wavefront-hpa-adapter] Add support for image digest apart from tag

### DIFF
--- a/bitnami/wavefront-hpa-adapter/Chart.lock
+++ b/bitnami/wavefront-hpa-adapter/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-21T14:22:21.780083665Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T11:01:58.032915428Z"

--- a/bitnami/wavefront-hpa-adapter/Chart.yaml
+++ b/bitnami/wavefront-hpa-adapter/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Wavefront HPA Adapter for Kubernetes is a Kubernetes Horizontal Pod Autoscaler adapter. It allows to scale your Kubernetes workloads based on Wavefront metrics.
 engine: gotpl
 home: https://github.com/wavefrontHQ/wavefront-kubernetes-adapter
@@ -25,4 +25,4 @@ maintainers:
 name: wavefront-hpa-adapter
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wavefront-hpa-adapter
-version: 1.2.7
+version: 1.3.0

--- a/bitnami/wavefront-hpa-adapter/README.md
+++ b/bitnami/wavefront-hpa-adapter/README.md
@@ -72,78 +72,79 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Wavefront HPA Adapter for Kubernetes deployment parameters
 
-| Name                                              | Description                                                                               | Value                                |
-| ------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------ |
-| `image.registry`                                  | Adapter image registry                                                                    | `docker.io`                          |
-| `image.repository`                                | Adapter image repository                                                                  | `bitnami/wavefront-hpa-adapter`      |
-| `image.tag`                                       | Adapter image tag (immutabe tags are recommended)                                         | `0.9.8-scratch-r21`                  |
-| `image.pullPolicy`                                | Adapter image pull policy                                                                 | `IfNotPresent`                       |
-| `image.pullSecrets`                               | Adapter image pull secrets                                                                | `[]`                                 |
-| `image.debug`                                     | Enable image debug mode                                                                   | `false`                              |
-| `livenessProbe.enabled`                           | Enable livenessProbe                                                                      | `true`                               |
-| `livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                   | `10`                                 |
-| `livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                          | `10`                                 |
-| `livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                         | `1`                                  |
-| `livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                       | `3`                                  |
-| `livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                       | `1`                                  |
-| `readinessProbe.enabled`                          | Enable readinessProbe                                                                     | `true`                               |
-| `readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                  | `10`                                 |
-| `readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                         | `10`                                 |
-| `readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                        | `1`                                  |
-| `readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                      | `3`                                  |
-| `readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                      | `1`                                  |
-| `startupProbe.enabled`                            | Enable startupProbe                                                                       | `false`                              |
-| `startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                    | `10`                                 |
-| `startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                           | `10`                                 |
-| `startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                          | `1`                                  |
-| `startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                        | `3`                                  |
-| `startupProbe.successThreshold`                   | Success threshold for startupProbe                                                        | `1`                                  |
-| `command`                                         | Override default container command (useful when using custom images)                      | `[]`                                 |
-| `args`                                            | Override default container args (useful when using custom images)                         | `[]`                                 |
-| `hostAliases`                                     | Add deployment host aliases                                                               | `[]`                                 |
-| `resources.limits`                                | The resources limits for the Adapter container                                            | `{}`                                 |
-| `resources.requests`                              | The requested resourcesc for the Adapter container                                        | `{}`                                 |
-| `containerSecurityContext.enabled`                | Enabled Adapter containers' Security Context                                              | `true`                               |
-| `containerSecurityContext.runAsUser`              | Set Adapter container's Security Context runAsUser                                        | `1001`                               |
-| `containerSecurityContext.runAsNonRoot`           | Set Adapter container's Security Context runAsNonRoot                                     | `true`                               |
-| `containerSecurityContext.readOnlyRootFilesystem` | mount / (root) as a readonly filesystem on Adapter container                              | `true`                               |
-| `podSecurityContext.enabled`                      | Enabled Adapter pods' Security Context                                                    | `true`                               |
-| `podSecurityContext.fsGroup`                      | Set Adapter pod's Security Context fsGroup                                                | `1001`                               |
-| `podAffinityPreset`                               | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`       | `""`                                 |
-| `podAntiAffinityPreset`                           | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                               |
-| `nodeAffinityPreset.type`                         | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                                 |
-| `nodeAffinityPreset.key`                          | Node label key to match. Ignored if `affinity` is set                                     | `""`                                 |
-| `nodeAffinityPreset.values`                       | Node label values to match. Ignored if `affinity` is set                                  | `[]`                                 |
-| `affinity`                                        | Affinity for pod assignment                                                               | `{}`                                 |
-| `nodeSelector`                                    | Node labels for pod assignment                                                            | `{}`                                 |
-| `tolerations`                                     | Tolerations for pod assignment                                                            | `[]`                                 |
-| `podLabels`                                       | Extra labels for Adapter pods                                                             | `{}`                                 |
-| `podAnnotations`                                  | Annotations for Adapter pods                                                              | `{}`                                 |
-| `priorityClassName`                               | Adapter pod priority                                                                      | `""`                                 |
-| `lifecycleHooks`                                  | Add lifecycle hooks to the Adapter deployment                                             | `{}`                                 |
-| `schedulerName`                                   | Alternative scheduler                                                                     | `""`                                 |
-| `topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment                                            | `[]`                                 |
-| `customLivenessProbe`                             | Override default liveness probe                                                           | `{}`                                 |
-| `customReadinessProbe`                            | Override default readiness probe                                                          | `{}`                                 |
-| `customStartupProbe`                              | Override default startup probe                                                            | `{}`                                 |
-| `updateStrategy.type`                             | Adapter deployment update strategy                                                        | `RollingUpdate`                      |
-| `containerPorts.https`                            | Adapter container port                                                                    | `6443`                               |
-| `extraEnvVars`                                    | Add extra environment variables to the Adapter container                                  | `[]`                                 |
-| `extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars                                      | `""`                                 |
-| `extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars                                         | `""`                                 |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for Adapter pods                      | `[]`                                 |
-| `extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for Adapter container(s)         | `[]`                                 |
-| `initContainers`                                  | Add additional init containers to the Adapter pods                                        | `[]`                                 |
-| `sidecars`                                        | Add additional sidecar containers to the Adapter pod                                      | `[]`                                 |
-| `adapterMetricPrefix`                             | Adapter metric `prefix` parameter                                                         | `kubernetes`                         |
-| `adapterAPIClientTimeout`                         | Adapter API timeout                                                                       | `10s`                                |
-| `adapterMetricRelistInterval`                     | Adapter metric relist interval                                                            | `10m`                                |
-| `adapterLogLevel`                                 | Adapter log level                                                                         | `info`                               |
-| `adapterRules`                                    | Adapter array of rules                                                                    | `[]`                                 |
-| `adapterSSLCertDir`                               | Adapter SSL Certs directory                                                               | `/etc/ssl/certs`                     |
-| `adapterSSLCertsSecret`                           | Adapter SSL Certs secret (will use autogenerated if empty)                                | `""`                                 |
-| `wavefront.url`                                   | External Wavefront URL                                                                    | `https://YOUR_CLUSTER.wavefront.com` |
-| `wavefront.token`                                 | External Wavefront Token                                                                  | `YOUR_API_TOKEN`                     |
+| Name                                              | Description                                                                                             | Value                                |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `image.registry`                                  | Adapter image registry                                                                                  | `docker.io`                          |
+| `image.repository`                                | Adapter image repository                                                                                | `bitnami/wavefront-hpa-adapter`      |
+| `image.tag`                                       | Adapter image tag (immutable tags are recommended)                                                      | `0.9.9-scratch-r4`                   |
+| `image.digest`                                    | Adapter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                 |
+| `image.pullPolicy`                                | Adapter image pull policy                                                                               | `IfNotPresent`                       |
+| `image.pullSecrets`                               | Specify docker-registry secret names as an array                                                        | `[]`                                 |
+| `image.debug`                                     | Enable image debug mode                                                                                 | `false`                              |
+| `livenessProbe.enabled`                           | Enable livenessProbe                                                                                    | `true`                               |
+| `livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                 | `10`                                 |
+| `livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                        | `10`                                 |
+| `livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                                       | `1`                                  |
+| `livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                                     | `3`                                  |
+| `livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                                     | `1`                                  |
+| `readinessProbe.enabled`                          | Enable readinessProbe                                                                                   | `true`                               |
+| `readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                                | `10`                                 |
+| `readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                                       | `10`                                 |
+| `readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                                      | `1`                                  |
+| `readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                                    | `3`                                  |
+| `readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                                    | `1`                                  |
+| `startupProbe.enabled`                            | Enable startupProbe                                                                                     | `false`                              |
+| `startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                                  | `10`                                 |
+| `startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                                         | `10`                                 |
+| `startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                                        | `1`                                  |
+| `startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                                      | `3`                                  |
+| `startupProbe.successThreshold`                   | Success threshold for startupProbe                                                                      | `1`                                  |
+| `command`                                         | Override default container command (useful when using custom images)                                    | `[]`                                 |
+| `args`                                            | Override default container args (useful when using custom images)                                       | `[]`                                 |
+| `hostAliases`                                     | Add deployment host aliases                                                                             | `[]`                                 |
+| `resources.limits`                                | The resources limits for the Adapter container                                                          | `{}`                                 |
+| `resources.requests`                              | The requested resourcesc for the Adapter container                                                      | `{}`                                 |
+| `containerSecurityContext.enabled`                | Enabled Adapter containers' Security Context                                                            | `true`                               |
+| `containerSecurityContext.runAsUser`              | Set Adapter container's Security Context runAsUser                                                      | `1001`                               |
+| `containerSecurityContext.runAsNonRoot`           | Set Adapter container's Security Context runAsNonRoot                                                   | `true`                               |
+| `containerSecurityContext.readOnlyRootFilesystem` | mount / (root) as a readonly filesystem on Adapter container                                            | `true`                               |
+| `podSecurityContext.enabled`                      | Enabled Adapter pods' Security Context                                                                  | `true`                               |
+| `podSecurityContext.fsGroup`                      | Set Adapter pod's Security Context fsGroup                                                              | `1001`                               |
+| `podAffinityPreset`                               | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                     | `""`                                 |
+| `podAntiAffinityPreset`                           | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                | `soft`                               |
+| `nodeAffinityPreset.type`                         | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`                                 |
+| `nodeAffinityPreset.key`                          | Node label key to match. Ignored if `affinity` is set                                                   | `""`                                 |
+| `nodeAffinityPreset.values`                       | Node label values to match. Ignored if `affinity` is set                                                | `[]`                                 |
+| `affinity`                                        | Affinity for pod assignment                                                                             | `{}`                                 |
+| `nodeSelector`                                    | Node labels for pod assignment                                                                          | `{}`                                 |
+| `tolerations`                                     | Tolerations for pod assignment                                                                          | `[]`                                 |
+| `podLabels`                                       | Extra labels for Adapter pods                                                                           | `{}`                                 |
+| `podAnnotations`                                  | Annotations for Adapter pods                                                                            | `{}`                                 |
+| `priorityClassName`                               | Adapter pod priority                                                                                    | `""`                                 |
+| `lifecycleHooks`                                  | Add lifecycle hooks to the Adapter deployment                                                           | `{}`                                 |
+| `schedulerName`                                   | Alternative scheduler                                                                                   | `""`                                 |
+| `topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment                                                          | `[]`                                 |
+| `customLivenessProbe`                             | Override default liveness probe                                                                         | `{}`                                 |
+| `customReadinessProbe`                            | Override default readiness probe                                                                        | `{}`                                 |
+| `customStartupProbe`                              | Override default startup probe                                                                          | `{}`                                 |
+| `updateStrategy.type`                             | Adapter deployment update strategy                                                                      | `RollingUpdate`                      |
+| `containerPorts.https`                            | Adapter container port                                                                                  | `6443`                               |
+| `extraEnvVars`                                    | Add extra environment variables to the Adapter container                                                | `[]`                                 |
+| `extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars                                                    | `""`                                 |
+| `extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars                                                       | `""`                                 |
+| `extraVolumes`                                    | Optionally specify extra list of additional volumes for Adapter pods                                    | `[]`                                 |
+| `extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for Adapter container(s)                       | `[]`                                 |
+| `initContainers`                                  | Add additional init containers to the Adapter pods                                                      | `[]`                                 |
+| `sidecars`                                        | Add additional sidecar containers to the Adapter pod                                                    | `[]`                                 |
+| `adapterMetricPrefix`                             | Adapter metric `prefix` parameter                                                                       | `kubernetes`                         |
+| `adapterAPIClientTimeout`                         | Adapter API timeout                                                                                     | `10s`                                |
+| `adapterMetricRelistInterval`                     | Adapter metric relist interval                                                                          | `10m`                                |
+| `adapterLogLevel`                                 | Adapter log level                                                                                       | `info`                               |
+| `adapterRules`                                    | Adapter array of rules                                                                                  | `[]`                                 |
+| `adapterSSLCertDir`                               | Adapter SSL Certs directory                                                                             | `/etc/ssl/certs`                     |
+| `adapterSSLCertsSecret`                           | Adapter SSL Certs secret (will use autogenerated if empty)                                              | `""`                                 |
+| `wavefront.url`                                   | External Wavefront URL                                                                                  | `https://YOUR_CLUSTER.wavefront.com` |
+| `wavefront.token`                                 | External Wavefront Token                                                                                | `YOUR_API_TOKEN`                     |
 
 
 ### Traffic Exposure Parameters

--- a/bitnami/wavefront-hpa-adapter/values.yaml
+++ b/bitnami/wavefront-hpa-adapter/values.yaml
@@ -50,31 +50,29 @@ extraDeploy: []
 
 ## @section Wavefront HPA Adapter for Kubernetes deployment parameters
 ##
+
+## @param image.registry Adapter image registry
+## @param image.repository Adapter image repository
+## @param image.tag Adapter image tag (immutable tags are recommended)
+## @param image.digest Adapter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+## @param image.pullPolicy Adapter image pull policy
+## @param image.pullSecrets Specify docker-registry secret names as an array
+##
 image:
-  ## @param image.registry Adapter image registry
-  ##
   registry: docker.io
-  ## @param image.repository Adapter image repository
-  ##
   repository: bitnami/wavefront-hpa-adapter
-  ## @param image.tag Adapter image tag (immutabe tags are recommended)
-  ##
   tag: 0.9.9-scratch-r4
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
-  ##
-  ## @param image.pullPolicy Adapter image pull policy
   ##
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
-  ## @param image.pullSecrets Adapter image pull secrets
-  ##
   pullSecrets: []
-  #   - myRegistryKeySecretName
   ## Enable debug mode
   ## @param image.debug Enable image debug mode
   ##


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```