### PR TITLE
[bitnami/wavefront] Add support for image digest apart from tag

### DIFF
--- a/bitnami/wavefront/Chart.lock
+++ b/bitnami/wavefront/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 3.1.6
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:058c4dc434206d9030a728d743fd37323e06a9a8e800d0d772508af5988cc950
-generated: "2022-08-09T07:59:22.796387536Z"
+  version: 2.0.0
+digest: sha256:fc581ee6cf29f9d45b82111f80c74ac0d2349d51023234eeb447b2d781d5d0e6
+generated: "2022-08-20T11:01:54.465126865Z"

--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Wavefront is a high-performance streaming analytics platform for monitoring and optimizing your environment and applications.
 engine: gotpl
 home: https://www.wavefront.com
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 4.1.1
+version: 4.2.0

--- a/bitnami/wavefront/values.yaml
+++ b/bitnami/wavefront/values.yaml
@@ -124,16 +124,18 @@ collector:
   ## @param collector.enabled Setup and enable the Wavefront collector to gather metrics
   ##
   enabled: true
-  ## @param collector.image.registry Wavefront collector Image registry
-  ## @param collector.image.repository Wavefront collector Image repository
-  ## @param collector.image.tag Wavefront collector Image tag (immutable tags are recommended)
-  ## @param collector.image.pullPolicy Image pull policy
+  ## @param collector.image.registry Wavefront collector image registry
+  ## @param collector.image.repository Wavefront collector image repository
+  ## @param collector.image.tag Wavefront collector image tag (immutable tags are recommended)
+  ## @param collector.image.digest Wavefront collector image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+  ## @param collector.image.pullPolicy image pull policy
   ## @param collector.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
     registry: docker.io
     repository: bitnami/wavefront-kubernetes-collector
     tag: 1.11.0-scratch-r10
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -207,6 +209,7 @@ collector:
   ##
   apiServerMetrics: false
   ## @param collector.tags Map of tags to apply to all metrics collected by the collector
+## @param petete.digest Petete image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## Sample tags to include (env, region)
   ## tags:
   ##   env: production
@@ -219,6 +222,7 @@ collector:
   ## Filters to apply towards all metrics collected by the collector
   ## @param collector.filters.metricDenyList [array] Optimized metrics collection to omit peripheral metrics.
   ## @param collector.filters.tagExclude [array] Filter out generated labels
+## @param petete.digest Petete image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## e.g:
   ##   filters:
   ##     tagWhilelistSets:
@@ -523,6 +527,7 @@ proxy:
   ## @param proxy.image.registry Wavefront proxy image registry
   ## @param proxy.image.repository Wavefront proxy image repository
   ## @param proxy.image.tag Wavefront proxy image tag (immutable tags are recommended)
+  ## @param proxy.image.digest Wavefront proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
   ## @param proxy.image.pullPolicy Wavefront proxy image pull policy
   ## @param proxy.image.pullSecrets Specify docker-registry secret names as an array
   ##
@@ -530,6 +535,7 @@ proxy:
     registry: docker.io
     repository: bitnami/wavefront-proxy
     tag: 11.3.0-debian-11-r15
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```