### PR TITLE
[bitnami/tensorflow-resnet] Add support for image digest apart from tag

### DIFF
--- a/bitnami/tensorflow-resnet/Chart.lock
+++ b/bitnami/tensorflow-resnet/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-31T23:57:29.320932532Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T11:01:43.675813681Z"

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: TensorFlow ResNet is a client utility for use with TensorFlow Serving and ResNet models.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/tensorflow-resnet
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/tensorflow-serving
   - https://github.com/bitnami/containers/tree/main/bitnami/tensorflow-resnet
   - https://www.tensorflow.org/serving/
-version: 3.5.22
+version: 3.6.0

--- a/bitnami/tensorflow-resnet/README.md
+++ b/bitnami/tensorflow-resnet/README.md
@@ -81,89 +81,91 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### TensorFlow parameters
 
-| Name                                    | Description                                                                                       | Value                        |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------- |
-| `server.image.registry`                 | TensorFlow Serving image registry                                                                 | `docker.io`                  |
-| `server.image.repository`               | TensorFlow Serving image repository                                                               | `bitnami/tensorflow-serving` |
-| `server.image.tag`                      | TensorFlow Serving Image tag (immutable tags are recommended)                                     | `2.8.0-debian-10-r7`         |
-| `server.image.pullPolicy`               | TensorFlow Serving image pull policy                                                              | `IfNotPresent`               |
-| `server.image.pullSecrets`              | Specify docker-registry secret names as an array                                                  | `[]`                         |
-| `client.image.registry`                 | TensorFlow ResNet image registry                                                                  | `docker.io`                  |
-| `client.image.repository`               | TensorFlow ResNet image repository                                                                | `bitnami/tensorflow-resnet`  |
-| `client.image.tag`                      | TensorFlow ResNet Image tag (immutable tags are recommended)                                      | `2.8.0-debian-10-r3`         |
-| `client.image.pullPolicy`               | TensorFlow ResNet image pull policy                                                               | `IfNotPresent`               |
-| `client.image.pullSecrets`              | Specify docker-registry secret names as an array                                                  | `[]`                         |
-| `hostAliases`                           | Deployment pod host aliases                                                                       | `[]`                         |
-| `containerPorts.server`                 | Tensorflow server port                                                                            | `8500`                       |
-| `containerPorts.restApi`                | TensorFlow Serving Rest API Port                                                                  | `8501`                       |
-| `replicaCount`                          | Number of replicas                                                                                | `1`                          |
-| `podAnnotations`                        | Pod annotations                                                                                   | `{}`                         |
-| `podLabels`                             | Pod labels                                                                                        | `{}`                         |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`               | `""`                         |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`          | `soft`                       |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`         | `""`                         |
-| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                             | `""`                         |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                         | `[]`                         |
-| `affinity`                              | Affinity for pod assignment. Evaluated as a template.                                             | `{}`                         |
-| `nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                          | `{}`                         |
-| `tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                          | `[]`                         |
-| `podSecurityContext.enabled`            | Enabled pod Security Context                                                                      | `true`                       |
-| `podSecurityContext.fsGroup`            | Set pod Security Context fsGroup                                                                  | `1001`                       |
-| `containerSecurityContext.enabled`      | Enabled container Security Context                                                                | `true`                       |
-| `containerSecurityContext.runAsUser`    | Set container Security Context runAsUser                                                          | `1001`                       |
-| `containerSecurityContext.runAsNonRoot` | Set container Security Context runAsNonRoot                                                       | `true`                       |
-| `command`                               | Override default container command (useful when using custom images)                              | `[]`                         |
-| `args`                                  | Override default container args (useful when using custom images)                                 | `[]`                         |
-| `lifecycleHooks`                        | for the container to automate configuration before or after startup                               | `{}`                         |
-| `extraEnvVars`                          | Array with extra environment variables for the Tensorflow Serving container(s)                    | `[]`                         |
-| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env variables for the Tensorflow Serving container(s) | `""`                         |
-| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env variables for the Tensorflow Serving container(s)    | `""`                         |
-| `extraVolumes`                          | Optionally specify extra list of additional volumes                                               | `[]`                         |
-| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Tensorflow Serving container(s)  | `[]`                         |
-| `sidecars`                              | Add additional sidecar containers to the pod                                                      | `[]`                         |
-| `initContainers`                        | Add additional init containers to the pod                                                         | `[]`                         |
-| `updateStrategy.type`                   | Deployment strategy type.                                                                         | `RollingUpdate`              |
-| `priorityClassName`                     | Pod's priorityClassName                                                                           | `""`                         |
-| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                    | `""`                         |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                    | `[]`                         |
-| `resources.limits`                      | The resources limits for the container                                                            | `{}`                         |
-| `resources.requests`                    | The requested resources for the container                                                         | `{}`                         |
-| `startupProbe.enabled`                  | Enable startupProbe                                                                               | `false`                      |
-| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                            | `30`                         |
-| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                   | `5`                          |
-| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                  | `5`                          |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                | `6`                          |
-| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                | `1`                          |
-| `livenessProbe.enabled`                 | Enable livenessProbe                                                                              | `true`                       |
-| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                           | `30`                         |
-| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                  | `5`                          |
-| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                 | `5`                          |
-| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                               | `6`                          |
-| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                               | `1`                          |
-| `readinessProbe.enabled`                | Enable readinessProbe                                                                             | `true`                       |
-| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                          | `15`                         |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                 | `5`                          |
-| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                | `5`                          |
-| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                              | `6`                          |
-| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                              | `1`                          |
-| `customStartupProbe`                    | Custom liveness probe                                                                             | `{}`                         |
-| `customLivenessProbe`                   | Custom liveness probe                                                                             | `{}`                         |
-| `customReadinessProbe`                  | Custom readiness probe                                                                            | `{}`                         |
-| `service.type`                          | Kubernetes Service type                                                                           | `LoadBalancer`               |
-| `service.ports.server`                  | TensorFlow Serving server port                                                                    | `8500`                       |
-| `service.ports.restApi`                 | TensorFlow Serving Rest API port                                                                  | `8501`                       |
-| `service.nodePorts.server`              | Kubernetes server node port                                                                       | `""`                         |
-| `service.nodePorts.restApi`             | Kubernetes Rest API node port                                                                     | `""`                         |
-| `service.clusterIP`                     | Service Cluster IP                                                                                | `""`                         |
-| `service.loadBalancerIP`                | Service Load Balancer IP                                                                          | `""`                         |
-| `service.loadBalancerSourceRanges`      | Service Load Balancer sources                                                                     | `[]`                         |
-| `service.externalTrafficPolicy`         | Service external traffic policy                                                                   | `Cluster`                    |
-| `service.extraPorts`                    | Extra ports to expose (normally used with the `sidecar` value)                                    | `[]`                         |
-| `service.annotations`                   | Additional custom annotations for Service                                                         | `{}`                         |
-| `service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                              | `None`                       |
-| `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                       | `{}`                         |
-| `metrics.enabled`                       | Enable Prometheus exporter to expose Tensorflow server metrics                                    | `false`                      |
-| `metrics.podAnnotations`                | Prometheus exporter pod annotations                                                               | `{}`                         |
+| Name                                    | Description                                                                                                        | Value                        |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| `server.image.registry`                 | TensorFlow Serving image registry                                                                                  | `docker.io`                  |
+| `server.image.repository`               | TensorFlow Serving image repository                                                                                | `bitnami/tensorflow-serving` |
+| `server.image.tag`                      | TensorFlow Serving Image tag (immutable tags are recommended)                                                      | `2.9.1-debian-11-r12`        |
+| `server.image.digest`                   | TensorFlow Serving image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                         |
+| `server.image.pullPolicy`               | TensorFlow Serving image pull policy                                                                               | `IfNotPresent`               |
+| `server.image.pullSecrets`              | Specify docker-registry secret names as an array                                                                   | `[]`                         |
+| `client.image.registry`                 | TensorFlow ResNet image registry                                                                                   | `docker.io`                  |
+| `client.image.repository`               | TensorFlow ResNet image repository                                                                                 | `bitnami/tensorflow-resnet`  |
+| `client.image.tag`                      | TensorFlow ResNet image tag (immutable tags are recommended)                                                       | `2.9.1-debian-11-r11`        |
+| `client.image.digest`                   | TensorFlow ResNet image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag  | `""`                         |
+| `client.image.pullPolicy`               | TensorFlow ResNet image pull policy                                                                                | `IfNotPresent`               |
+| `client.image.pullSecrets`              | Specify docker-registry secret names as an array                                                                   | `[]`                         |
+| `hostAliases`                           | Deployment pod host aliases                                                                                        | `[]`                         |
+| `containerPorts.server`                 | Tensorflow server port                                                                                             | `8500`                       |
+| `containerPorts.restApi`                | TensorFlow Serving Rest API Port                                                                                   | `8501`                       |
+| `replicaCount`                          | Number of replicas                                                                                                 | `1`                          |
+| `podAnnotations`                        | Pod annotations                                                                                                    | `{}`                         |
+| `podLabels`                             | Pod labels                                                                                                         | `{}`                         |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                         |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                           | `soft`                       |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                          | `""`                         |
+| `nodeAffinityPreset.key`                | Node label key to match Ignored if `affinity` is set.                                                              | `""`                         |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set.                                                          | `[]`                         |
+| `affinity`                              | Affinity for pod assignment. Evaluated as a template.                                                              | `{}`                         |
+| `nodeSelector`                          | Node labels for pod assignment. Evaluated as a template.                                                           | `{}`                         |
+| `tolerations`                           | Tolerations for pod assignment. Evaluated as a template.                                                           | `[]`                         |
+| `podSecurityContext.enabled`            | Enabled pod Security Context                                                                                       | `true`                       |
+| `podSecurityContext.fsGroup`            | Set pod Security Context fsGroup                                                                                   | `1001`                       |
+| `containerSecurityContext.enabled`      | Enabled container Security Context                                                                                 | `true`                       |
+| `containerSecurityContext.runAsUser`    | Set container Security Context runAsUser                                                                           | `1001`                       |
+| `containerSecurityContext.runAsNonRoot` | Set container Security Context runAsNonRoot                                                                        | `true`                       |
+| `command`                               | Override default container command (useful when using custom images)                                               | `[]`                         |
+| `args`                                  | Override default container args (useful when using custom images)                                                  | `[]`                         |
+| `lifecycleHooks`                        | for the container to automate configuration before or after startup                                                | `{}`                         |
+| `extraEnvVars`                          | Array with extra environment variables for the Tensorflow Serving container(s)                                     | `[]`                         |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env variables for the Tensorflow Serving container(s)                  | `""`                         |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env variables for the Tensorflow Serving container(s)                     | `""`                         |
+| `extraVolumes`                          | Optionally specify extra list of additional volumes                                                                | `[]`                         |
+| `extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Tensorflow Serving container(s)                   | `[]`                         |
+| `sidecars`                              | Add additional sidecar containers to the pod                                                                       | `[]`                         |
+| `initContainers`                        | Add additional init containers to the pod                                                                          | `[]`                         |
+| `updateStrategy.type`                   | Deployment strategy type.                                                                                          | `RollingUpdate`              |
+| `priorityClassName`                     | Pod's priorityClassName                                                                                            | `""`                         |
+| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                                     | `""`                         |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                     | `[]`                         |
+| `resources.limits`                      | The resources limits for the container                                                                             | `{}`                         |
+| `resources.requests`                    | The requested resources for the container                                                                          | `{}`                         |
+| `startupProbe.enabled`                  | Enable startupProbe                                                                                                | `false`                      |
+| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                             | `30`                         |
+| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                    | `5`                          |
+| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                   | `5`                          |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                 | `6`                          |
+| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                 | `1`                          |
+| `livenessProbe.enabled`                 | Enable livenessProbe                                                                                               | `true`                       |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                            | `30`                         |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                   | `5`                          |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                  | `5`                          |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                | `6`                          |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                | `1`                          |
+| `readinessProbe.enabled`                | Enable readinessProbe                                                                                              | `true`                       |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                           | `15`                         |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                  | `5`                          |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                 | `5`                          |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                               | `6`                          |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                               | `1`                          |
+| `customStartupProbe`                    | Custom liveness probe                                                                                              | `{}`                         |
+| `customLivenessProbe`                   | Custom liveness probe                                                                                              | `{}`                         |
+| `customReadinessProbe`                  | Custom readiness probe                                                                                             | `{}`                         |
+| `service.type`                          | Kubernetes Service type                                                                                            | `LoadBalancer`               |
+| `service.ports.server`                  | TensorFlow Serving server port                                                                                     | `8500`                       |
+| `service.ports.restApi`                 | TensorFlow Serving Rest API port                                                                                   | `8501`                       |
+| `service.nodePorts.server`              | Kubernetes server node port                                                                                        | `""`                         |
+| `service.nodePorts.restApi`             | Kubernetes Rest API node port                                                                                      | `""`                         |
+| `service.clusterIP`                     | Service Cluster IP                                                                                                 | `""`                         |
+| `service.loadBalancerIP`                | Service Load Balancer IP                                                                                           | `""`                         |
+| `service.loadBalancerSourceRanges`      | Service Load Balancer sources                                                                                      | `[]`                         |
+| `service.externalTrafficPolicy`         | Service external traffic policy                                                                                    | `Cluster`                    |
+| `service.extraPorts`                    | Extra ports to expose (normally used with the `sidecar` value)                                                     | `[]`                         |
+| `service.annotations`                   | Additional custom annotations for Service                                                                          | `{}`                         |
+| `service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                               | `None`                       |
+| `service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                        | `{}`                         |
+| `metrics.enabled`                       | Enable Prometheus exporter to expose Tensorflow server metrics                                                     | `false`                      |
+| `metrics.podAnnotations`                | Prometheus exporter pod annotations                                                                                | `{}`                         |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/tensorflow-resnet/values.yaml
+++ b/bitnami/tensorflow-resnet/values.yaml
@@ -56,6 +56,7 @@ diagnosticMode:
 ## @param server.image.registry TensorFlow Serving image registry
 ## @param server.image.repository TensorFlow Serving image repository
 ## @param server.image.tag TensorFlow Serving Image tag (immutable tags are recommended)
+## @param server.image.digest TensorFlow Serving image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param server.image.pullPolicy TensorFlow Serving image pull policy
 ## @param server.image.pullSecrets Specify docker-registry secret names as an array
 ##
@@ -64,6 +65,7 @@ server:
     registry: docker.io
     repository: bitnami/tensorflow-serving
     tag: 2.9.1-debian-11-r12
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -81,7 +83,8 @@ server:
 ## ref: https://hub.docker.com/r/bitnami/tensorflow-resnet/tags/
 ## @param client.image.registry TensorFlow ResNet image registry
 ## @param client.image.repository TensorFlow ResNet image repository
-## @param client.image.tag TensorFlow ResNet Image tag (immutable tags are recommended)
+## @param client.image.tag TensorFlow ResNet image tag (immutable tags are recommended)
+## @param client.image.digest TensorFlow ResNet image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param client.image.pullPolicy TensorFlow ResNet image pull policy
 ## @param client.image.pullSecrets Specify docker-registry secret names as an array
 ##
@@ -90,6 +93,7 @@ client:
     registry: docker.io
     repository: bitnami/tensorflow-resnet
     tag: 2.9.1-debian-11-r11
+    digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```