### PR TITLE
[bitnami/spark] Add support for image digest apart from tag

### DIFF
--- a/bitnami/spark/Chart.lock
+++ b/bitnami/spark/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-22T15:53:48.677584826Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T11:01:29.714184928Z"

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Apache Spark is a high-performance engine for large-scale computing tasks, such as data processing, machine learning and real-time data streaming. It includes APIs for Java, Python, Scala and R.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/master/bitnami/spark
@@ -22,4 +22,4 @@ name: spark
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/spark
   - https://spark.apache.org/
-version: 6.2.4
+version: 6.3.0

--- a/bitnami/spark/README.md
+++ b/bitnami/spark/README.md
@@ -84,15 +84,16 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Spark parameters
 
-| Name                | Description                                      | Value                |
-| ------------------- | ------------------------------------------------ | -------------------- |
-| `image.registry`    | Spark image registry                             | `docker.io`          |
-| `image.repository`  | Spark image repository                           | `bitnami/spark`      |
-| `image.tag`         | Spark image tag (immutable tags are recommended) | `3.3.0-debian-11-r7` |
-| `image.pullPolicy`  | Spark image pull policy                          | `IfNotPresent`       |
-| `image.pullSecrets` | Specify docker-registry secret names as an array | `[]`                 |
-| `image.debug`       | Enable image debug mode                          | `false`              |
-| `hostNetwork`       | Enable HOST Network                              | `false`              |
+| Name                | Description                                                                                           | Value                 |
+| ------------------- | ----------------------------------------------------------------------------------------------------- | --------------------- |
+| `image.registry`    | Spark image registry                                                                                  | `docker.io`           |
+| `image.repository`  | Spark image repository                                                                                | `bitnami/spark`       |
+| `image.tag`         | Spark image tag (immutable tags are recommended)                                                      | `3.3.0-debian-11-r16` |
+| `image.digest`      | Spark image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
+| `image.pullPolicy`  | Spark image pull policy                                                                               | `IfNotPresent`        |
+| `image.pullSecrets` | Specify docker-registry secret names as an array                                                      | `[]`                  |
+| `image.debug`       | Enable image debug mode                                                                               | `false`               |
+| `hostNetwork`       | Enable HOST Network                                                                                   | `false`               |
 
 
 ### Spark master parameters

--- a/bitnami/spark/values.yaml
+++ b/bitnami/spark/values.yaml
@@ -84,6 +84,7 @@ diagnosticMode:
 ## @param image.registry Spark image registry
 ## @param image.repository Spark image repository
 ## @param image.tag Spark image tag (immutable tags are recommended)
+## @param image.digest Spark image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Spark image pull policy
 ## @param image.pullSecrets Specify docker-registry secret names as an array
 ## @param image.debug Enable image debug mode
@@ -92,6 +93,7 @@ image:
   registry: docker.io
   repository: bitnami/spark
   tag: 3.3.0-debian-11-r16
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```