### PR TITLE
[bitnami/sealed-secrets] Add support for image digest apart from tag

### DIFF
--- a/bitnami/sealed-secrets/Chart.lock
+++ b/bitnami/sealed-secrets/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.16.1
-digest: sha256:bcc717c6a14262fac51e6434020ee5dd6148b864fe6cff6266c1d481df4a0c91
-generated: "2022-07-14T21:15:46.438671729Z"
+  version: 2.0.0
+digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
+generated: "2022-08-20T11:01:18.288992049Z"

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
 description: Sealed Secrets are "one-way" encrypted K8s Secrets that can be created by anyone, but can only be decrypted by the controller running in the target cluster recovering the original object.
 engine: gotpl
 home: https://github.com/bitnami-labs/sealed-secrets
@@ -23,4 +23,4 @@ name: sealed-secrets
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/sealed-secrets
   - https://github.com/bitnami-labs/sealed-secrets
-version: 1.0.12
+version: 1.1.0

--- a/bitnami/sealed-secrets/README.md
+++ b/bitnami/sealed-secrets/README.md
@@ -82,6 +82,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `image.registry`                                  | Sealed Secrets image registry                                                                                            | `docker.io`              |
 | `image.repository`                                | Sealed Secrets image repository                                                                                          | `bitnami/sealed-secrets` |
 | `image.tag`                                       | Sealed Secrets image tag (immutable tags are recommended)                                                                | `0.18.1-scratch-r3`      |
+| `image.digest`                                    | Sealed Secrets image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag           | `""`                     |
 | `image.pullPolicy`                                | Sealed Secrets image pull policy                                                                                         | `IfNotPresent`           |
 | `image.pullSecrets`                               | Sealed Secrets image pull secrets                                                                                        | `[]`                     |
 | `image.debug`                                     | Enable Sealed Secrets image debug mode                                                                                   | `false`                  |

--- a/bitnami/sealed-secrets/values.yaml
+++ b/bitnami/sealed-secrets/values.yaml
@@ -53,6 +53,7 @@ extraDeploy: []
 ## @param image.registry Sealed Secrets image registry
 ## @param image.repository Sealed Secrets image repository
 ## @param image.tag Sealed Secrets image tag (immutable tags are recommended)
+## @param image.digest Sealed Secrets image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Sealed Secrets image pull policy
 ## @param image.pullSecrets [array]  Sealed Secrets image pull secrets
 ## @param image.debug Enable Sealed Secrets image debug mode
@@ -61,6 +62,7 @@ image:
   registry: docker.io
   repository: bitnami/sealed-secrets
   tag: 0.18.1-scratch-r3
+  digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```