### PR TITLE
[bitnami/schema-registry] Add support for image digest apart from tag

### DIFF
--- a/bitnami/schema-registry/Chart.lock
+++ b/bitnami/schema-registry/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.17.1
+  version: 2.0.0
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
   version: 18.0.8
-digest: sha256:21804b17cf2db99bdaadda1e9ced9ac94e41059d3d77fcbed0f4e4ccadf3e288
-generated: "2022-08-18T20:02:26.953683233Z"
+digest: sha256:1cbab0c27caf828977d311a0456a6510f32cf0d7b5480bf96d5a2b9a992d2d8b
+generated: "2022-08-20T11:01:14.690282192Z"

--- a/bitnami/schema-registry/Chart.lock
+++ b/bitnami/schema-registry/Chart.lock
@@ -6,4 +6,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 18.0.8
 digest: sha256:1cbab0c27caf828977d311a0456a6510f32cf0d7b5480bf96d5a2b9a992d2d8b
-generated: "2022-08-20T11:01:14.690282192Z"
+generated: "2022-08-22T14:27:22.325232247Z"

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -7,7 +7,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - condition: kafka.enabled
     name: kafka
     repository: https://charts.bitnami.com/bitnami
@@ -28,4 +28,4 @@ maintainers:
 name: schema-registry
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/schema-registry
-version: 5.0.0
+version: 5.1.0

--- a/bitnami/schema-registry/README.md
+++ b/bitnami/schema-registry/README.md
@@ -81,37 +81,38 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Schema Registry parameters
 
-| Name                                            | Description                                                                                                 | Value                     |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------- |
-| `image.registry`                                | Schema Registry image registry                                                                              | `docker.io`               |
-| `image.repository`                              | Schema Registry image repository                                                                            | `bitnami/schema-registry` |
-| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                  | `7.2.1-debian-11-r0`      |
-| `image.pullPolicy`                              | Schema Registry image pull policy                                                                           | `IfNotPresent`            |
-| `image.pullSecrets`                             | Schema Registry image pull secrets                                                                          | `[]`                      |
-| `image.debug`                                   | Enable image debug mode                                                                                     | `false`                   |
-| `command`                                       | Override default container command (useful when using custom images)                                        | `[]`                      |
-| `args`                                          | Override default container args (useful when using custom images)                                           | `[]`                      |
-| `hostAliases`                                   | Schema Registry pods host aliases                                                                           | `[]`                      |
-| `podLabels`                                     | Extra labels for Schema Registry pods                                                                       | `{}`                      |
-| `configuration`                                 | Specify content for schema-registry.properties. Auto-generated based on other parameters when not specified | `{}`                      |
-| `existingConfigmap`                             | Name of existing ConfigMap with Schema Registry configuration                                               | `""`                      |
-| `log4j`                                         | Schema Registry Log4J Configuration (optional)                                                              | `{}`                      |
-| `existingLog4jConfigMap`                        | Name of existing ConfigMap containing a custom log4j.properties file.                                       | `""`                      |
-| `auth.tls.enabled`                              | Enable TLS configuration to provide to be used when a listener uses HTTPS                                   | `false`                   |
-| `auth.tls.jksSecret`                            | Existing secret containing the truststore and one keystore per Schema Registry replica                      | `""`                      |
-| `auth.tls.keystorePassword`                     | Password to access the keystore when it's password-protected                                                | `""`                      |
-| `auth.tls.truststorePassword`                   | Password to access the truststore when it's password-protected                                              | `""`                      |
-| `auth.tls.clientAuthentication`                 | Client authentication configuration.                                                                        | `NONE`                    |
-| `auth.kafka.jksSecret`                          | Existing secret containing the truststore and one keystore per Schema Registry replica                      | `""`                      |
-| `auth.kafka.tlsEndpointIdentificationAlgorithm` | The endpoint identification algorithm used validate brokers hostnames                                       | `https`                   |
-| `auth.kafka.keystorePassword`                   | Password to access the keystore when it's password-protected                                                | `""`                      |
-| `auth.kafka.truststorePassword`                 | Password to access the truststore when it's password-protected                                              | `""`                      |
-| `auth.kafka.saslMechanism`                      | Mechanism that schema registry will use to connect to kafka. Allowed: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512   | `PLAIN`                   |
-| `listeners`                                     | Comma-separated list of listeners that listen for API requests over either HTTP or HTTPS                    | `http://0.0.0.0:8081`     |
-| `avroCompatibilityLevel`                        | Avro compatibility type                                                                                     | `backward`                |
-| `extraEnvVars`                                  | Extra environment variables to be set on Schema Registry container                                          | `[]`                      |
-| `extraEnvVarsCM`                                | Name of existing ConfigMap containing extra env vars                                                        | `""`                      |
-| `extraEnvVarsSecret`                            | Name of existing Secret containing extra env vars                                                           | `""`                      |
+| Name                                            | Description                                                                                                     | Value                     |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `image.registry`                                | Schema Registry image registry                                                                                  | `docker.io`               |
+| `image.repository`                              | Schema Registry image repository                                                                                | `bitnami/schema-registry` |
+| `image.tag`                                     | Schema Registry image tag (immutable tags are recommended)                                                      | `7.2.1-debian-11-r0`      |
+| `image.digest`                                  | Schema Registry image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                      |
+| `image.pullPolicy`                              | Schema Registry image pull policy                                                                               | `IfNotPresent`            |
+| `image.pullSecrets`                             | Schema Registry image pull secrets                                                                              | `[]`                      |
+| `image.debug`                                   | Enable image debug mode                                                                                         | `false`                   |
+| `command`                                       | Override default container command (useful when using custom images)                                            | `[]`                      |
+| `args`                                          | Override default container args (useful when using custom images)                                               | `[]`                      |
+| `hostAliases`                                   | Schema Registry pods host aliases                                                                               | `[]`                      |
+| `podLabels`                                     | Extra labels for Schema Registry pods                                                                           | `{}`                      |
+| `configuration`                                 | Specify content for schema-registry.properties. Auto-generated based on other parameters when not specified     | `{}`                      |
+| `existingConfigmap`                             | Name of existing ConfigMap with Schema Registry configuration                                                   | `""`                      |
+| `log4j`                                         | Schema Registry Log4J Configuration (optional)                                                                  | `{}`                      |
+| `existingLog4jConfigMap`                        | Name of existing ConfigMap containing a custom log4j.properties file.                                           | `""`                      |
+| `auth.tls.enabled`                              | Enable TLS configuration to provide to be used when a listener uses HTTPS                                       | `false`                   |
+| `auth.tls.jksSecret`                            | Existing secret containing the truststore and one keystore per Schema Registry replica                          | `""`                      |
+| `auth.tls.keystorePassword`                     | Password to access the keystore when it's password-protected                                                    | `""`                      |
+| `auth.tls.truststorePassword`                   | Password to access the truststore when it's password-protected                                                  | `""`                      |
+| `auth.tls.clientAuthentication`                 | Client authentication configuration.                                                                            | `NONE`                    |
+| `auth.kafka.jksSecret`                          | Existing secret containing the truststore and one keystore per Schema Registry replica                          | `""`                      |
+| `auth.kafka.tlsEndpointIdentificationAlgorithm` | The endpoint identification algorithm used validate brokers hostnames                                           | `https`                   |
+| `auth.kafka.keystorePassword`                   | Password to access the keystore when it's password-protected                                                    | `""`                      |
+| `auth.kafka.truststorePassword`                 | Password to access the truststore when it's password-protected                                                  | `""`                      |
+| `auth.kafka.saslMechanism`                      | Mechanism that schema registry will use to connect to kafka. Allowed: PLAIN, SCRAM-SHA-256, SCRAM-SHA-512       | `PLAIN`                   |
+| `listeners`                                     | Comma-separated list of listeners that listen for API requests over either HTTP or HTTPS                        | `http://0.0.0.0:8081`     |
+| `avroCompatibilityLevel`                        | Avro compatibility type                                                                                         | `backward`                |
+| `extraEnvVars`                                  | Extra environment variables to be set on Schema Registry container                                              | `[]`                      |
+| `extraEnvVarsCM`                                | Name of existing ConfigMap containing extra env vars                                                            | `""`                      |
+| `extraEnvVarsSecret`                            | Name of existing Secret containing extra env vars                                                               | `""`                      |
 
 
 ### Schema Registry statefulset parameters

--- a/bitnami/schema-registry/values.yaml
+++ b/bitnami/schema-registry/values.yaml
@@ -62,6 +62,7 @@ diagnosticMode:
 ## @param image.registry Schema Registry image registry
 ## @param image.repository Schema Registry image repository
 ## @param image.tag Schema Registry image tag (immutable tags are recommended)
+## @param image.digest Schema Registry image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
 ## @param image.pullPolicy Schema Registry image pull policy
 ## @param image.pullSecrets Schema Registry image pull secrets
 ## @param image.debug Enable image debug mode
@@ -70,6 +71,7 @@ image:
   registry: docker.io
   repository: bitnami/schema-registry
   tag: 7.2.1-debian-11-r0
+  digest: ""
   ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
### Description of the change

From now on it will be possible to set an `image.digest` instead of `image.tag` to pull the container image. Please note it is needed to release a bitnami/common version with those changes (see https://github.com/bitnami/charts/pull/11830).

Once applied the changes, this is the result when setting the `image.digest` parameter in the _values.yaml_:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd@sha256:507bc997779af5f0419ad917167ba1c9a2ceb936f2c1e82fb0f687e6c1296897
```
In the same way, when the `image.digest` is empty (default value), this is the result:
```yaml
## Bitnami etcd image version
## ref: https://hub.docker.com/r/bitnami/etcd/tags/
## @param image.registry etcd image registry
## @param image.repository etcd image name
## @param image.tag etcd image tag
## @param image.digest etcd image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
##
image:    
  registry: docker.io
  repository: bitnami/etcd
  tag: 3.5.4-debian-11-r22
  digest: ""
```
```console
$ helm template . -s templates/statefulset.yaml | grep 'image:'
          image: docker.io/bitnami/etcd:3.5.4-debian-11-r22
```