### PR TITLE
[bitnami/*] Fixing stale behaviour and assignation to internal contributions

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -53,3 +53,8 @@ jobs:
         with:
           add-labels: "triage"
           remove-labels: "solved"
+      - name: Removing the stale label
+        if: ${{ contains(github.event.issue.labels.*.name, 'stale') }}
+        uses: andymckay/labeler@1.0.4
+        with:
+          remove-labels: "stale"

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   send_to_solved:
+    if: ${{ github.actor != 'bitnami-bot' || (github.actor = 'bitnami-bot' && github.event.issue && (!contains(github.event.issue.labels.*.name, 'stale'))) }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout

--- a/.github/workflows/move-closed-issues.yml
+++ b/.github/workflows/move-closed-issues.yml
@@ -18,7 +18,6 @@ concurrency:
 
 jobs:
   send_to_solved:
-    if: ${{ github.actor != 'bitnami-bot' }}
     runs-on: ubuntu-latest
     steps:
       - name: Repo checkout

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.BITNAMI_BOT_TOKEN }}
           stale-issue-message: 'This Issue has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thanks for the feedback.'
           stale-pr-message: 'This Pull Request has been automatically marked as "stale" because it has not had recent activity (for 15 days). It will be closed if no further activity occurs. Thank you for your contribution.'
           close-issue-message: 'Due to the lack of activity in the last 5 days since it was marked as "stale", we proceed to close this Issue. Do not hesitate to reopen it later if necessary.'

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           numOfAssignee: 1
           removePreviousAssignees: false
-          teams: ${{ env.TRIAGE_TEAM_NAME }}
+          # If it's an internal issue, assign directly to the support team. Otherwise, to the triage one.
+          teams: ${{ (contains(fromJson(env.BITNAMI_TEAM), github.actor)) && env.SUPPORT_TEAM_NAME || env.TRIAGE_TEAM_NAME }}
           repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
       - name: Send to the board
         uses: peter-evans/create-or-update-project-card@v2


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Changes related to the stale bot and its behaviour. The action was being raised by using the _GITHUB_TOKEN_ than doesn't raise any event. After changing into the _BITNAMI_BOT_TOKEN_, will raise events as usual and removing the if condition in the `move-closed-issues.yml`, the issue will be moved directly into the solved column **without removing the stale label** to know was moved there because of the stale bot.

On the other hand, adding the possibility to assign internal PRs to the support team without doing triage (it's not needed).

Finally, adding the step to remove the _stale_ label when a comment is done to ensure the stale bot doesn't archive it as happened in https://github.com/bitnami/charts/issues/11404.

### Benefits

* Ensuring closed issues by the stale bot are properly moved into the Solved column.
* Ensuring internal PRs are assigned directly to the support team.
* Ensuring if a comment is done in the issue the _stale_ label is removed.

### Possible drawbacks

None detected during the tests.

### Applicable issues

- Will avoid the kind of behaviour of https://github.com/bitnami/charts/issues/11404

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
