### PR TITLE
[bitnami/fluentd] Fix image digest in secondary containers

### DIFF
--- a/bitnami/fluentd/Chart.lock
+++ b/bitnami/fluentd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.0.0
-digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
-generated: "2022-08-22T14:24:53.763209131Z"
+  version: 2.0.1
+digest: sha256:46553c7194313fd9ce2e1e86422eef4dab3defb450e20c692f865924eacb8fb1
+generated: "2022-08-23T21:17:52.499546705Z"

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/fluentd
   - https://www.fluentd.org/
-version: 5.4.0
+version: 5.4.1

--- a/bitnami/fluentd/templates/_helpers.tpl
+++ b/bitnami/fluentd/templates/_helpers.tpl
@@ -7,7 +7,8 @@ Return the proper Fluentd image name
 {{- $registryName := default .Values.image.registry .Values.forwarder.image.registry -}}
 {{- $repositoryName := default .Values.image.repository .Values.forwarder.image.repository -}}
 {{- $tag := default .Values.image.tag .Values.forwarder.image.tag -}}
-{{- $imageRoot := dict "registry" $registryName "repository" $repositoryName "tag" $tag -}}
+{{- $digest := default .Values.image.tag .Values.forwarder.image.digest -}}
+{{- $imageRoot := dict "registry" $registryName "repository" $repositoryName "tag" $tag "digest" $digest -}}
 {{ include "common.images.image" (dict "imageRoot" $imageRoot "global" .Values.global) }}
 {{- end -}}
 
@@ -15,7 +16,8 @@ Return the proper Fluentd image name
 {{- $registryName := default .Values.image.registry .Values.aggregator.image.registry -}}
 {{- $repositoryName := default .Values.image.repository .Values.aggregator.image.repository -}}
 {{- $tag := default .Values.image.tag .Values.aggregator.image.tag -}}
-{{- $imageRoot := dict "registry" $registryName "repository" $repositoryName "tag" $tag -}}
+{{- $digest := default .Values.image.tag .Values.aggregator.image.digest -}}
+{{- $imageRoot := dict "registry" $registryName "repository" $repositoryName "tag" $tag "digest" $digest -}}
 {{ include "common.images.image" (dict "imageRoot" $imageRoot "global" .Values.global) }}
 {{- end -}}
 


### PR DESCRIPTION
### Description of the change

Continuation of #11884. It's needed to modify the helpers.tpl template for the aggregator and forwarder containers.