### PR TITLE
[bitnami/contour] Add support for PDB on Contour and Envoy deployments

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/containers/tree/main/bitnami/contour
   - https://projectcontour.io
-version: 9.1.2
+version: 9.2.0

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -184,6 +184,9 @@ $ helm uninstall my-release
 | `contour.debug`                                               | Enable Contour debug log level                                                                                                     | `false`               |
 | `contour.kubernetesDebug`                                     | Contour kubernetes debug log level, Default 0, minimum 0, maximum 9.                                                               | `0`                   |
 | `contour.rootNamespaces`                                      | Restrict Contour to searching these namespaces for root ingress routes.                                                            | `""`                  |
+| `contour.pdb.create`                                          | Enable Pod Disruption Budget configuration                                                                                         | `false`               |
+| `contour.pdb.minAvailable`                                    | Minimum number/percentage of Contour pods that should remain scheduled                                                             | `1`                   |
+| `contour.pdb.maxUnavailable`                                  | Maximum number/percentage of Contour pods that should remain scheduled                                                             | `""`                  |
 
 
 ### Envoy parameters
@@ -298,6 +301,9 @@ $ helm uninstall my-release
 | `envoy.extraEnvVars`                                | Array containing extra env vars to be added to all Envoy containers                                                   | `[]`                  |
 | `envoy.extraEnvVarsCM`                              | ConfigMap containing extra env vars to be added to all Envoy containers                                               | `""`                  |
 | `envoy.extraEnvVarsSecret`                          | Secret containing extra env vars to be added to all Envoy containers                                                  | `""`                  |
+| `envoy.pdb.create`                                  | Enable Pod Disruption Budget configuration                                                                            | `false`               |
+| `envoy.pdb.minAvailable`                            | Minimum number/percentage of Envoy pods that should remain scheduled                                                  | `1`                   |
+| `envoy.pdb.maxUnavailable`                          | Maximum number/percentage of Envoy pods that should remain scheduled                                                  | `""`                  |
 
 
 ### Default backend parameters

--- a/bitnami/contour/templates/contour/poddisruptionbudget.yaml
+++ b/bitnami/contour/templates/contour/poddisruptionbudget.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.contour.enabled .Values.contour.pdb.create }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ printf "%s-contour" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: contour
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.contour.pdb.minAvailable }}
+  minAvailable: {{ .Values.contour.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.contour.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.contour.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: contour
+{{- end }}

--- a/bitnami/contour/templates/envoy/poddisruptionbudget.yaml
+++ b/bitnami/contour/templates/envoy/poddisruptionbudget.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.envoy.enabled (eq .Values.envoy.kind "deployment") .Values.envoy.pdb.create  }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ printf "%s-envoy" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: envoy
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.envoy.pdb.minAvailable }}
+  minAvailable: {{ .Values.envoy.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.envoy.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.envoy.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: envoy
+{{- end }}

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -449,6 +449,18 @@ contour:
   ##
   rootNamespaces: ""
 
+  ## PodDisruptionBudget for contour deployment
+  ## Contour deployment Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ## @param contour.pdb.create Enable Pod Disruption Budget configuration
+  ## @param contour.pdb.minAvailable Minimum number/percentage of Contour pods that should remain scheduled
+  ## @param contour.pdb.maxUnavailable Maximum number/percentage of Contour pods that should remain scheduled
+  ##
+  pdb:
+    create: false
+    minAvailable: 1
+    maxUnavailable: ""
+
 ## @section Envoy parameters
 ##
 
@@ -865,6 +877,18 @@ envoy:
   ## @param envoy.extraEnvVarsSecret Secret containing extra env vars to be added to all Envoy containers
   ##
   extraEnvVarsSecret: ""
+
+  ## PodDisruptionBudget for envoy when deployed in "deployment" mode, this doesn't do anything in "daemonset" mode
+  ## Envoy deployment Pod Disruption Budget configuration
+  ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  ## @param envoy.pdb.create Enable Pod Disruption Budget configuration
+  ## @param envoy.pdb.minAvailable Minimum number/percentage of Envoy pods that should remain scheduled
+  ## @param envoy.pdb.maxUnavailable Maximum number/percentage of Envoy pods that should remain scheduled
+  ##
+  pdb:
+    create: false
+    minAvailable: 1
+    maxUnavailable: ""
 
 ## @section Default backend parameters
 ##


### PR DESCRIPTION
### Description of the change

This PR add support for setting PDB on Contour deployment, and on Envoy if deployed in "deployment" mode (it's ignored in "daemonset" mode).

### Benefits

This PR allow a better availability of Contour when doing Kubernetes operations (ex: rolling upgrade).

### Possible drawbacks

No drawbacks identified as those PDB creations are disabled by default.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
