### PR TITLE
[bitnami/common] Digest/Tag new approach backward compatible

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.0.0
+appVersion: 2.0.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/master/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - https://www.bitnami.com/
 type: library
-version: 2.0.0
+version: 2.0.1

--- a/bitnami/common/templates/_images.tpl
+++ b/bitnami/common/templates/_images.tpl
@@ -6,18 +6,18 @@ Return the proper image name
 {{- define "common.images.image" -}}
 {{- $registryName := .imageRoot.registry -}}
 {{- $repositoryName := .imageRoot.repository -}}
-{{- $tag := .imageRoot.tag | toString -}}
-{{- $digest := .imageRoot.digest | toString -}}
+{{- $separator := ":" -}}
+{{- $termination := .imageRoot.tag | toString -}}
 {{- if .global }}
     {{- if .global.imageRegistry }}
      {{- $registryName = .global.imageRegistry -}}
     {{- end -}}
 {{- end -}}
-{{- if $digest }}
-    {{- printf "%s/%s@%s" $registryName $repositoryName $digest -}}
-{{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- if .imageRoot.digest }}
+    {{- $separator = "@" -}}
+    {{- $termination = .imageRoot.digest | toString -}}
 {{- end -}}
+{{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Current behavior
#### 1.- Default values
```console
$ cat values.yaml
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
   tag: 3.10.7-debian-11-r4
   digest: ""
$ helm template . | grep 'image:'
          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
```
#### 2.- Setting the image.digest
```console
$ cat values.yaml
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
   tag: 3.10.7-debian-11-r4
   digest: "sha256:aaa"
$ helm template . | grep 'image:'
          image: docker.io/bitnami/rabbitmq@sha256:aaa
```
#### 3.- Removing the image.digest (old default)
```console
$ cat values.yaml
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
   tag: 3.10.7-debian-11-r4
$ helm template . | grep 'image:'
          image: docker.io/bitnami/rabbitmq@<nil>
```

### Behavior with changes in this PR
#### 1.- Default values
```console
$ cat values.yaml
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
   tag: 3.10.7-debian-11-r4
   digest: ""
$ helm template . | grep 'image:'
          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
```
#### 2.- Setting the image.digest
```console
$ cat values.yaml
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
   tag: 3.10.7-debian-11-r4
   digest: "sha256:bbb"
$ helm template . | grep 'image:'
          image: docker.io/bitnami/rabbitmq@sha256:bbb
```
#### 3.- Removing the image.digest (old default)
```console
$ cat values.yaml
 image:
   registry: docker.io
   repository: bitnami/rabbitmq
   tag: 3.10.7-debian-11-r4
$ helm template . | grep 'image:'
          image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4
```

Note the difference in the third case. With the current approach (bitnami/common@2.0.0), when `image.digest` doesn't exist in the _values.yaml_ it returns `image: docker.io/bitnami/rabbitmq@<nil>`. With the changes in this PR (bitnami/common@2.0.1), when the `image.digest` doesn't exist in the _values.yaml_ a valid image is returned `image: docker.io/bitnami/rabbitmq:3.10.7-debian-11-r4` using the `image.tag` as usual.

This is what it's behind the issue described at https://github.com/bitnami/charts/issues/12026

Once merged this PR, we should release a new version of the different Helm charts bundling bitnami/common@2.0.1