### PR TITLE
[bitnami/geode] Update Chart.lock

### DIFF
--- a/bitnami/geode/Chart.lock
+++ b/bitnami/geode/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.0.0
-digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
-generated: "2022-08-22T14:24:58.142581404Z"
+  version: 2.0.1
+digest: sha256:46553c7194313fd9ce2e1e86422eef4dab3defb450e20c692f865924eacb8fb1
+generated: "2022-08-23T21:18:00.942389348Z"

--- a/bitnami/geode/Chart.yaml
+++ b/bitnami/geode/Chart.yaml
@@ -22,4 +22,4 @@ name: geode
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/geode
   - https://github.com/apache/geode
-version: 1.1.0
+version: 1.1.1


### PR DESCRIPTION
Bump bitnami/common library chart version to include changes from https://github.com/bitnami/charts/pull/12029