### PR TITLE
[bitnami/cassandra] Update Chart.lock

### DIFF
--- a/bitnami/cassandra/Chart.lock
+++ b/bitnami/cassandra/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.0.0
-digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
-generated: "2022-08-20T10:56:34.700781854Z"
+  version: 2.0.1
+digest: sha256:46553c7194313fd9ce2e1e86422eef4dab3defb450e20c692f865924eacb8fb1
+generated: "2022-08-23T21:16:34.762105499Z"

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -23,4 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/cassandra
   - http://cassandra.apache.org
-version: 9.3.0
+version: 9.3.1


### PR DESCRIPTION
Bump bitnami/common library chart version to include changes from https://github.com/bitnami/charts/pull/12029