### PR TITLE
[bitnami/haproxy] Update Chart.lock

### DIFF
--- a/bitnami/haproxy/Chart.lock
+++ b/bitnami/haproxy/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.0.0
-digest: sha256:c66468d294c878acfb7cc6c082bc08d7105d139098bd42f88e6fe26903506c8f
-generated: "2022-08-20T10:57:47.872944168Z"
+  version: 2.0.1
+digest: sha256:46553c7194313fd9ce2e1e86422eef4dab3defb450e20c692f865924eacb8fb1
+generated: "2022-08-23T21:18:31.422780479Z"

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -23,4 +23,4 @@ name: haproxy
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/haproxy
   - https://github.com/haproxytech/haproxy
-version: 0.5.1
+version: 0.5.2


### PR DESCRIPTION
Bump bitnami/common library chart version to include changes from https://github.com/bitnami/charts/pull/12029