### PR TITLE
[bitnami/discourse] Update Chart.lock

### DIFF
--- a/bitnami/discourse/Chart.lock
+++ b/bitnami/discourse/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.1.0
+  version: 17.1.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.8.0
+  version: 11.8.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.0.0
-digest: sha256:d9a6f0c7619c28679ad80abf5dda6b17db4653acef6f7b0f513b62bef52d7ea9
-generated: "2022-08-22T14:24:38.15074374Z"
+  version: 2.0.1
+digest: sha256:52f0da46e90c7f33c70734cbf1cd86801d792ffde69a0bc33027b6acc64ec479
+generated: "2022-08-23T22:49:09.9541787Z"

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 8.1.1
+version: 8.1.2


### PR DESCRIPTION
Bump bitnami/common library chart version to include changes from https://github.com/bitnami/charts/pull/12029