### PR TITLE
[bitnami/jupyterhub] Update Chart.lock

### DIFF
--- a/bitnami/jupyterhub/Chart.lock
+++ b/bitnami/jupyterhub/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.8.0
+  version: 11.8.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.0.0
-digest: sha256:e7b3a9104b4a4fffe02d5cce259535b49cca9b2af8fc4360a8fc4988d5debfe5
-generated: "2022-08-22T14:25:27.267231503Z"
+  version: 2.0.1
+digest: sha256:7d5f9f273366a7b9d005bb354fcdf05dacc4a4ffdfddc2d4f75e0ee5bae27f05
+generated: "2022-08-23T22:50:33.287691882Z"

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -26,4 +26,4 @@ name: jupyterhub
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/jupyterhub
   - https://github.com/jupyterhub/jupyterhub
-version: 1.4.0
+version: 1.4.1


### PR DESCRIPTION
Bump bitnami/common library chart version to include changes from https://github.com/bitnami/charts/pull/12029