### PR TITLE
[bitnami/haproxy-intel] Update Chart.lock

### DIFF
--- a/bitnami/haproxy-intel/Chart.lock
+++ b/bitnami/haproxy-intel/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: haproxy
   repository: https://charts.bitnami.com/bitnami
-  version: 0.5.0
+  version: 0.5.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.0.0
-digest: sha256:643bb13008e07306835d5aef6549a467e4876f8c91d2dd0f4078c0599d4c4aeb
-generated: "2022-08-22T16:34:30.252226947Z"
+  version: 2.0.1
+digest: sha256:5a98276a973c798652d75c8872492bdf69e0dfb429763285c98f0f111a9c8863
+generated: "2022-08-23T22:50:07.984067679Z"

--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -26,4 +26,4 @@ name: haproxy-intel
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/haproxy-intel
   - https://github.com/haproxytech/haproxy
-version: 0.2.2
+version: 0.2.3


### PR DESCRIPTION
Bump bitnami/common library chart version to include changes from https://github.com/bitnami/charts/pull/12029