### PR TITLE
[bitnami/spring-cloud-dataflow] Update Chart.lock

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.lock
+++ b/bitnami/spring-cloud-dataflow/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 11.2.1
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
-  version: 18.1.2
+  version: 18.1.3
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.1
-digest: sha256:f640b0284ea4b747ea1c4fcfef7374302d77718a9992062ad4a191ab31c1b343
-generated: "2022-08-23T22:53:57.484239958Z"
+digest: sha256:6956f4e854aff2f170351207e8e697ae81b861fba77e2b9b9ff31e8593945742
+generated: "2022-08-24T00:03:42.524134229Z"

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-dataflow
   - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 12.1.3
+version: 12.1.4


### PR DESCRIPTION
Bump bitnami/common library chart version to include changes from https://github.com/bitnami/charts/pull/12029