### PR TITLE
[bitnami/mongodb] Fix probes when url connection contains 'true'

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.1.1
+version: 13.1.2

--- a/bitnami/mongodb/templates/common-scripts-cm.yaml
+++ b/bitnami/mongodb/templates/common-scripts-cm.yaml
@@ -17,7 +17,7 @@ data:
     {{- if .Values.tls.enabled }}
     TLS_OPTIONS='--tls --tlsCertificateKeyFile=/certs/mongodb.pem --tlsCAFile=/certs/mongodb-ca-cert'
     {{- end }}
-    mongosh  $TLS_OPTIONS --port $MONGODB_PORT_NUMBER --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true'
+    mongosh  $TLS_OPTIONS --port $MONGODB_PORT_NUMBER --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true$'
   readiness-probe.sh: |
     #!/bin/bash
     {{- if .Values.tls.enabled }}
@@ -30,9 +30,9 @@ data:
     VERSION_MINOR="$(get_sematic_version "$VERSION" 2)"
     VERSION_PATCH="$(get_sematic_version "$VERSION" 3)"
     if [[ ( "$VERSION_MAJOR" -ge 5 ) || ( "$VERSION_MAJOR" -ge 4 && "$VERSION_MINOR" -ge 4 && "$VERSION_PATCH" -ge 2 ) ]]; then
-        mongosh $TLS_OPTIONS --port $MONGODB_PORT_NUMBER --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true'
+        mongosh $TLS_OPTIONS --port $MONGODB_PORT_NUMBER --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep -q 'true$'
     else
-        mongosh  $TLS_OPTIONS --port $MONGODB_PORT_NUMBER --eval 'db.isMaster().ismaster || db.isMaster().secondary' | grep -q 'true'
+        mongosh  $TLS_OPTIONS --port $MONGODB_PORT_NUMBER --eval 'db.isMaster().ismaster || db.isMaster().secondary' | grep -q 'true$'
     fi
   ping-mongodb.sh: |
     #!/bin/bash


### PR DESCRIPTION
### Description of the change

Instead of just checking the presence of the 'true' value anywhere in the probes command result, after this fix the 'true' value must to be at the end.

### Benefits

Even if the connection contains parameters with 'true' value, the probe will failed when not primary/secondary are UP.

### Possible drawbacks

None

### Applicable issues
  - fixes #11607

### Additional information
You can verify with a mongodb with tls enabled:
**Before**:
```bash
$ mongosh  $TLS_OPTIONS --port $MONGODB_PORT_NUMBER --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep "true"
Connecting to:          mongodb://127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000&tls=true&tlsCertificateKeyFile=%2Fcerts%2Fmongodb.pem&tlsCAFile=%2Fcerts%2Fmongodb-ca-cert&appName=mongosh+1.5.1
true
```
=> when the status is 'false' the grep -q exit with 0 due to the first line match (`tls=true`)

**After**:
```bash
$ mongosh  $TLS_OPTIONS --port $MONGODB_PORT_NUMBER --eval 'db.hello().isWritablePrimary || db.hello().secondary' | grep "true$"
true
```


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
