### PR TITLE
[bitnami/grafana] Fix tests for version 9.1.1

### DIFF
--- a/.vib/grafana/cypress/cypress/integration/grafana_spec.js
+++ b/.vib/grafana/cypress/cypress/integration/grafana_spec.js
@@ -49,6 +49,9 @@ it('checks if it is possible to upload a dashboard as JSON file', () => {
       .type(`${dashboard.newDashboard.uploadedTitle} ${random}`);
     cy.get('[data-testid*="data-testid-import-dashboard-submit"]').click();
     cy.visit('dashboards');
+    cy.get(
+      'input[aria-label*="View as list"]'
+    ).click({ force: true });
     cy.contains('div', `${dashboard.newDashboard.uploadedTitle} ${random}`);
   });
 });


### PR DESCRIPTION
### Description of the change

This PR fixes #12127 failing tests.

The cypress tests have been adapted for the new version of Grafana 9.1.1 which introduced changes in the `/dashboards` view, no longer showing the 'General' folder's content by default.

To fix this issue, the /dashboards view has been changed to list view.

Error log from the tests:
```
    <testcase name="checks if it is possible to upload a dashboard as JSON file" time="0.0000" classname="checks if it is possible to upload a dashboard as JSON file">
      <failure message="Timed out retrying after 50000ms: Expected to find content: &apos;New Uploaded Dashboard 12c1y&apos; within the selector: &apos;div&apos; but never did." type="AssertionError"><![CDATA[AssertionError: Timed out retrying after 50000ms: Expected to find content: 'New Uploaded Dashboard 12c1y' within the selector: 'div' but never did.
    at Context.eval (http://34.75.226.235/__cypress/tests?p=cypress/integration/grafana_spec.js:136:8)]]></failure>
    </testcase>
```

Tested in my fork: https://github.com/migruiz4/charts/pull/2

### Checklist

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
