### PR TITLE
[bitnami/haproxy] Add tests and publish using VIB

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -16,6 +16,7 @@ on: # rebuild any PRs and main branch changes
       - 'bitnami/ghost/**'
       - 'bitnami/grafana-loki/**'
       - 'bitnami/grafana/**'
+      - 'bitnami/haproxy/**'
       - 'bitnami/haproxy-intel/**'
       - 'bitnami/harbor/**'
       - 'bitnami/influxdb/**'

--- a/.vib/haproxy/cypress/cypress.json
+++ b/.vib/haproxy/cypress/cypress.json
@@ -1,0 +1,3 @@
+{
+  "baseUrl": "http://localhost"
+}

--- a/.vib/haproxy/cypress/cypress/integration/haproxy_spec.js
+++ b/.vib/haproxy/cypress/cypress/integration/haproxy_spec.js
@@ -1,0 +1,6 @@
+/// <reference types="cypress" />
+
+it('can access backend server', () => {
+  cy.visit('/');
+  cy.contains('Welcome to nginx')
+});

--- a/.vib/haproxy/cypress/cypress/integration/haproxy_spec.js
+++ b/.vib/haproxy/cypress/cypress/integration/haproxy_spec.js
@@ -1,6 +1,9 @@
 /// <reference types="cypress" />
 
 it('can access backend server', () => {
+  // HAProxy is configured with an NGINX server deployed as a sidecar, which
+  // plays the role of backend. Successful access to NGINX means HAProxy is
+  // correctly routing!
   cy.visit('/');
   cy.contains('Welcome to nginx')
 });

--- a/.vib/haproxy/goss/goss.yaml
+++ b/.vib/haproxy/goss/goss.yaml
@@ -1,0 +1,12 @@
+file:
+  /var/run/secrets/kubernetes.io/serviceaccount:
+    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
+    filetype: directory
+    mode: "3777"
+command:
+  check-user-info:
+    exec: id
+    exit-status: 0
+    stdout:
+    - uid={{ .Vars.containerSecurityContext.runAsUser }}
+    - /groups=.*{{ .Vars.podSecurityContext.fsGroup }}/

--- a/.vib/haproxy/goss/vars.yaml
+++ b/.vib/haproxy/goss/vars.yaml
@@ -1,0 +1,6 @@
+podSecurityContext:
+  fsGroup: 1002
+containerSecurityContext:
+  runAsUser: 1002
+serviceAccount:
+  automountServiceAccountToken: true

--- a/.vib/haproxy/vib-publish.json
+++ b/.vib/haproxy/vib-publish.json
@@ -22,6 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/haproxy"
         },
+        "runtime_parameters": "Y29uZmlndXJhdGlvbjogfAogIGdsb2JhbAogICAgbG9nIHN0ZG91dCBmb3JtYXQgcmF3IGxvY2FsMAogICAgbWF4Y29ubiAxMDI0CiAgZGVmYXVsdHMKICAgIGxvZyBnbG9iYWwKICAgIHRpbWVvdXQgY2xpZW50IDYwcwogICAgdGltZW91dCBjb25uZWN0IDYwcwogICAgdGltZW91dCBzZXJ2ZXIgNjBzCiAgZnJvbnRlbmQgZmVfbWFpbgogICAgYmluZCA6ODA4MQogICAgZGVmYXVsdF9iYWNrZW5kIGJlX21haW4KICBiYWNrZW5kIGJlX21haW4KICAgIHNlcnZlciB3ZWIxIDEyNy4wLjAuMTo4MDgwIGNoZWNrCmNvbnRhaW5lclBvcnRzOgogIC0gbmFtZTogaHR0cAogICAgY29udGFpbmVyUG9ydDogODA4MQpwb2RTZWN1cml0eUNvbnRleHQ6CiAgZW5hYmxlZDogdHJ1ZQogIGZzR3JvdXA6IDEwMDIKY29udGFpbmVyU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBydW5Bc1VzZXI6IDEwMDIKc2VydmljZUFjY291bnQ6CiAgY3JlYXRlOiB0cnVlCiAgYXV0b21vdW50U2VydmljZUFjY291bnRUb2tlbjogdHJ1ZQpzZXJ2aWNlOgogIHR5cGU6IExvYWRCYWxhbmNlcgogIHBvcnRzOgogICAgLSBuYW1lOiBodHRwCiAgICAgIHByb3RvY29sOiBUQ1AKICAgICAgcG9ydDogODAKICAgICAgdGFyZ2V0UG9ydDogaHR0cApzaWRlY2FyczoKICAtIG5hbWU6IG5naW54CiAgICBpbWFnZTogZG9ja2VyLmlvL2JpdG5hbWkvbmdpbng6MS4yMi4wLWRlYmlhbi0xMS1yMzAKICAgIGltYWdlUHVsbFBvbGljeTogQWx3YXlzCiAgICBwb3J0czoKICAgICAgLSBuYW1lOiB3ZWIKICAgICAgICBjb250YWluZXJQb3J0OiA4MDgwCg==",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -34,6 +35,28 @@
           "action_id": "health-check",
           "params": {
             "endpoint": "lb-haproxy-http"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/haproxy/goss"
+            },
+            "remote": {
+              "workload": "deploy-haproxy"
+            },
+            "vars_file": "vars.yaml"
+          }
+        },
+        {
+          "action_id": "cypress",
+          "params": {
+            "resources": {
+              "path": "/.vib/haproxy/cypress"
+            },
+            "endpoint": "lb-haproxy-http",
+            "app_protocol": "HTTP"
           }
         }
       ]

--- a/.vib/haproxy/vib-verify.json
+++ b/.vib/haproxy/vib-verify.json
@@ -22,6 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/haproxy"
         },
+        "runtime_parameters": "Y29uZmlndXJhdGlvbjogfAogIGdsb2JhbAogICAgbG9nIHN0ZG91dCBmb3JtYXQgcmF3IGxvY2FsMAogICAgbWF4Y29ubiAxMDI0CiAgZGVmYXVsdHMKICAgIGxvZyBnbG9iYWwKICAgIHRpbWVvdXQgY2xpZW50IDYwcwogICAgdGltZW91dCBjb25uZWN0IDYwcwogICAgdGltZW91dCBzZXJ2ZXIgNjBzCiAgZnJvbnRlbmQgZmVfbWFpbgogICAgYmluZCA6ODA4MQogICAgZGVmYXVsdF9iYWNrZW5kIGJlX21haW4KICBiYWNrZW5kIGJlX21haW4KICAgIHNlcnZlciB3ZWIxIDEyNy4wLjAuMTo4MDgwIGNoZWNrCmNvbnRhaW5lclBvcnRzOgogIC0gbmFtZTogaHR0cAogICAgY29udGFpbmVyUG9ydDogODA4MQpwb2RTZWN1cml0eUNvbnRleHQ6CiAgZW5hYmxlZDogdHJ1ZQogIGZzR3JvdXA6IDEwMDIKY29udGFpbmVyU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBydW5Bc1VzZXI6IDEwMDIKc2VydmljZUFjY291bnQ6CiAgY3JlYXRlOiB0cnVlCiAgYXV0b21vdW50U2VydmljZUFjY291bnRUb2tlbjogdHJ1ZQpzZXJ2aWNlOgogIHR5cGU6IExvYWRCYWxhbmNlcgogIHBvcnRzOgogICAgLSBuYW1lOiBodHRwCiAgICAgIHByb3RvY29sOiBUQ1AKICAgICAgcG9ydDogODAKICAgICAgdGFyZ2V0UG9ydDogaHR0cApzaWRlY2FyczoKICAtIG5hbWU6IG5naW54CiAgICBpbWFnZTogZG9ja2VyLmlvL2JpdG5hbWkvbmdpbng6MS4yMi4wLWRlYmlhbi0xMS1yMzAKICAgIGltYWdlUHVsbFBvbGljeTogQWx3YXlzCiAgICBwb3J0czoKICAgICAgLSBuYW1lOiB3ZWIKICAgICAgICBjb250YWluZXJQb3J0OiA4MDgwCg==",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -34,6 +35,28 @@
           "action_id": "health-check",
           "params": {
             "endpoint": "lb-haproxy-http"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/haproxy/goss"
+            },
+            "remote": {
+              "workload": "deploy-haproxy"
+            },
+            "vars_file": "vars.yaml"
+          }
+        },
+        {
+          "action_id": "cypress",
+          "params": {
+            "resources": {
+              "path": "/.vib/haproxy/cypress"
+            },
+            "endpoint": "lb-haproxy-http",
+            "app_protocol": "HTTP"
           }
         }
       ]


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami HAProxy Helm Chart using VMware Image Builder. In order to do that, several changes are included:

- Adding the asset to the publishing workflow
- Increasing the existing test coverage of the asset by adding Cypress tests.
- Increasing the existing test coverage of the asset by adding GOSS tests.

### Benefits

- Ensuring higher quality of the Helm charts.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could show to be potentially flaky. 

### Applicable issues

NA

### Additional information

Tested in https://github.com/joancafom/charts/pull/71

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

