### PR TITLE
[bitnami/apache] Improve start-stop #11770

### DIFF
--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 2.4.54
+appVersion: 2.4.55
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -26,4 +26,4 @@ name: apache
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/apache
   - https://httpd.apache.org
-version: 9.2.1
+version: 9.3.0

--- a/bitnami/apache/README.md
+++ b/bitnami/apache/README.md
@@ -78,95 +78,93 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Apache parameters
 
-| Name                                    | Description                                                                                                              | Value                  |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
-| `image.registry`                        | Apache image registry                                                                                                    | `docker.io`            |
-| `image.repository`                      | Apache image repository                                                                                                  | `bitnami/apache`       |
-| `image.tag`                             | Apache image tag (immutable tags are recommended)                                                                        | `2.4.54-debian-11-r23` |
-| `image.digest`                          | Apache image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                   | `""`                   |
-| `image.pullPolicy`                      | Apache image pull policy                                                                                                 | `IfNotPresent`         |
-| `image.pullSecrets`                     | Apache image pull secrets                                                                                                | `[]`                   |
-| `image.debug`                           | Enable image debug mode                                                                                                  | `false`                |
-| `git.registry`                          | Git image registry                                                                                                       | `docker.io`            |
-| `git.repository`                        | Git image name                                                                                                           | `bitnami/git`          |
-| `git.tag`                               | Git image tag (immutable tags are recommended)                                                                           | `2.37.1-debian-11-r11` |
-| `git.digest`                            | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                      | `""`                   |
-| `git.pullPolicy`                        | Git image pull policy                                                                                                    | `IfNotPresent`         |
-| `git.pullSecrets`                       | Specify docker-registry secret names as an array                                                                         | `[]`                   |
-| `replicaCount`                          | Number of replicas of the Apache deployment                                                                              | `1`                    |
-| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                   |
-| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                 |
-| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                   |
-| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set                                                                    | `""`                   |
-| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set                                                                 | `[]`                   |
-| `affinity`                              | Affinity for pod assignment                                                                                              | `{}`                   |
-| `nodeSelector`                          | Node labels for pod assignment                                                                                           | `{}`                   |
-| `tolerations`                           | Tolerations for pod assignment                                                                                           | `[]`                   |
-| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                   |
-| `extraPodSpec`                          | Optionally specify extra PodSpec                                                                                         | `{}`                   |
-| `cloneHtdocsFromGit.enabled`            | Get the server static content from a git repository                                                                      | `false`                |
-| `cloneHtdocsFromGit.repository`         | Repository to clone static content from                                                                                  | `""`                   |
-| `cloneHtdocsFromGit.branch`             | Branch inside the git repository                                                                                         | `""`                   |
-| `cloneHtdocsFromGit.enableAutoRefresh`  | Enables an automatic git pull with a sidecar container                                                                   | `true`                 |
-| `cloneHtdocsFromGit.interval`           | Interval for sidecar container pull from the repository                                                                  | `60`                   |
-| `cloneHtdocsFromGit.resources`          | Init container git resource requests                                                                                     | `{}`                   |
-| `cloneHtdocsFromGit.extraVolumeMounts`  | Add extra volume mounts for the GIT containers                                                                           | `[]`                   |
-| `htdocsConfigMap`                       | Name of a config map with the server static content                                                                      | `""`                   |
-| `htdocsPVC`                             | Name of a PVC with the server static content                                                                             | `""`                   |
-| `vhostsConfigMap`                       | Name of a config map with the virtual hosts content                                                                      | `""`                   |
-| `httpdConfConfigMap`                    | Name of a config map with the httpd.conf file contents                                                                   | `""`                   |
-| `podLabels`                             | Extra labels for Apache pods                                                                                             | `{}`                   |
-| `podAnnotations`                        | Pod annotations                                                                                                          | `{}`                   |
-| `hostAliases`                           | Add deployment host aliases                                                                                              | `[]`                   |
-| `priorityClassName`                     | Apache Server pods' priorityClassName                                                                                    | `""`                   |
-| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                                           | `""`                   |
-| `podSecurityContext.enabled`            | Enabled Apache Server pods' Security Context                                                                             | `true`                 |
-| `podSecurityContext.fsGroup`            | Set Apache Server pod's Security Context fsGroup                                                                         | `1001`                 |
-| `containerSecurityContext.enabled`      | Enabled Apache Server containers' Security Context                                                                       | `true`                 |
-| `containerSecurityContext.runAsUser`    | Set Apache Server containers' Security Context runAsUser                                                                 | `1001`                 |
-| `containerSecurityContext.runAsNonRoot` | Set Controller container's Security Context runAsNonRoot                                                                 | `true`                 |
-| `command`                               | Override default container command (useful when using custom images)                                                     | `[]`                   |
-| `args`                                  | Override default container args (useful when using custom images)                                                        | `[]`                   |
-| `lifecycleHooks`                        | for the Apache server container(s) to automate configuration before or after startup                                     | `{}`                   |
-| `resources.limits`                      | The resources limits for the container                                                                                   | `{}`                   |
-| `resources.requests`                    | The requested resources for the container                                                                                | `{}`                   |
-| `startupProbe.enabled`                  | Enable startupProbe                                                                                                      | `false`                |
-| `startupProbe.path`                     | Path to access on the HTTP server                                                                                        | `/`                    |
-| `startupProbe.port`                     | Port for startupProbe                                                                                                    | `http`                 |
-| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `180`                  |
-| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `20`                   |
-| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `5`                    |
-| `startupProbe.failureThreshold`         | Failure threshold for startupProbe                                                                                       | `6`                    |
-| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                    |
-| `livenessProbe.enabled`                 | Enable liveness probe                                                                                                    | `true`                 |
-| `livenessProbe.path`                    | Path to access on the HTTP server                                                                                        | `/`                    |
-| `livenessProbe.port`                    | Port for livenessProbe                                                                                                   | `http`                 |
-| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `180`                  |
-| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `20`                   |
-| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `5`                    |
-| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `6`                    |
-| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                    |
-| `readinessProbe.enabled`                | Enable readiness probe                                                                                                   | `true`                 |
-| `readinessProbe.path`                   | Path to access on the HTTP server                                                                                        | `/`                    |
-| `readinessProbe.port`                   | Port for readinessProbe                                                                                                  | `http`                 |
-| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `30`                   |
-| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                   |
-| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `5`                    |
-| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `6`                    |
-| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                    |
-| `customStartupProbe`                    | Custom liveness probe for the Web component                                                                              | `{}`                   |
-| `customLivenessProbe`                   | Custom liveness probe for the Web component                                                                              | `{}`                   |
-| `customReadinessProbe`                  | Custom rediness probe for the Web component                                                                              | `{}`                   |
-| `extraVolumes`                          | Array to add extra volumes (evaluated as a template)                                                                     | `[]`                   |
-| `extraVolumeMounts`                     | Array to add extra mounts (normally used with extraVolumes, evaluated as a template)                                     | `[]`                   |
-| `extraEnvVars`                          | Array to add extra environment variables                                                                                 | `[]`                   |
-| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for Apache server nodes                                             | `""`                   |
-| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for Apache server nodes                                                | `""`                   |
-| `containerPorts.http`                   | Apache server HTTP container port                                                                                        | `8080`                 |
-| `containerPorts.https`                  | Apache server HTTPS container port                                                                                       | `8443`                 |
-| `initContainers`                        | Add additional init containers to the Apache pods                                                                        | `[]`                   |
-| `sidecars`                              | Add additional sidecar containers to the Apache pods                                                                     | `[]`                   |
-| `updateStrategy.type`                   | Apache Server deployment strategy type.                                                                                  | `RollingUpdate`        |
+| Name                                    | Description                                                                                                              | Value                          |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------ |
+| `image.registry`                        | Apache image registry                                                                                                    | `docker.io`                    |
+| `image.repository`                      | Apache image repository                                                                                                  | `bitnami/apache`               |
+| `image.tag`                             | Apache image tag (immutable tags are recommended)                                                                        | `2.4.55-debian-11-r23`         |
+| `image.digest`                          | Apache image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                   | `""`                           |
+| `image.pullPolicy`                      | Apache image pull policy                                                                                                 | `IfNotPresent`                 |
+| `image.pullSecrets`                     | Apache image pull secrets                                                                                                | `[]`                           |
+| `image.debug`                           | Enable image debug mode                                                                                                  | `false`                        |
+| `git.registry`                          | Git image registry                                                                                                       | `docker.io`                    |
+| `git.repository`                        | Git image name                                                                                                           | `bitnami/git`                  |
+| `git.tag`                               | Git image tag (immutable tags are recommended)                                                                           | `2.37.1-debian-11-r11`         |
+| `git.digest`                            | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                      | `""`                           |
+| `git.pullPolicy`                        | Git image pull policy                                                                                                    | `IfNotPresent`                 |
+| `git.pullSecrets`                       | Specify docker-registry secret names as an array                                                                         | `[]`                           |
+| `replicaCount`                          | Number of replicas of the Apache deployment                                                                              | `1`                            |
+| `podAffinityPreset`                     | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                           |
+| `podAntiAffinityPreset`                 | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                         |
+| `nodeAffinityPreset.type`               | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                           |
+| `nodeAffinityPreset.key`                | Node label key to match. Ignored if `affinity` is set                                                                    | `""`                           |
+| `nodeAffinityPreset.values`             | Node label values to match. Ignored if `affinity` is set                                                                 | `[]`                           |
+| `affinity`                              | Affinity for pod assignment                                                                                              | `{}`                           |
+| `nodeSelector`                          | Node labels for pod assignment                                                                                           | `{}`                           |
+| `tolerations`                           | Tolerations for pod assignment                                                                                           | `[]`                           |
+| `topologySpreadConstraints`             | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                           |
+| `extraPodSpec`                          | Optionally specify extra PodSpec                                                                                         | `{}`                           |
+| `cloneHtdocsFromGit.enabled`            | Get the server static content from a git repository                                                                      | `false`                        |
+| `cloneHtdocsFromGit.repository`         | Repository to clone static content from                                                                                  | `""`                           |
+| `cloneHtdocsFromGit.branch`             | Branch inside the git repository                                                                                         | `""`                           |
+| `cloneHtdocsFromGit.enableAutoRefresh`  | Enables an automatic git pull with a sidecar container                                                                   | `true`                         |
+| `cloneHtdocsFromGit.interval`           | Interval for sidecar container pull from the repository                                                                  | `60`                           |
+| `cloneHtdocsFromGit.resources`          | Init container git resource requests                                                                                     | `{}`                           |
+| `cloneHtdocsFromGit.extraVolumeMounts`  | Add extra volume mounts for the GIT containers                                                                           | `[]`                           |
+| `htdocsConfigMap`                       | Name of a config map with the server static content                                                                      | `""`                           |
+| `htdocsPVC`                             | Name of a PVC with the server static content                                                                             | `""`                           |
+| `vhostsConfigMap`                       | Name of a config map with the virtual hosts content                                                                      | `""`                           |
+| `httpdConfConfigMap`                    | Name of a config map with the httpd.conf file contents                                                                   | `""`                           |
+| `podLabels`                             | Extra labels for Apache pods                                                                                             | `{}`                           |
+| `podAnnotations`                        | Pod annotations                                                                                                          | `{}`                           |
+| `hostAliases`                           | Add deployment host aliases                                                                                              | `[]`                           |
+| `priorityClassName`                     | Apache Server pods' priorityClassName                                                                                    | `""`                           |
+| `schedulerName`                         | Name of the k8s scheduler (other than default)                                                                           | `""`                           |
+| `podSecurityContext.enabled`            | Enabled Apache Server pods' Security Context                                                                             | `true`                         |
+| `podSecurityContext.fsGroup`            | Set Apache Server pod's Security Context fsGroup                                                                         | `1001`                         |
+| `containerSecurityContext.enabled`      | Enabled Apache Server containers' Security Context                                                                       | `true`                         |
+| `containerSecurityContext.runAsUser`    | Set Apache Server containers' Security Context runAsUser                                                                 | `1001`                         |
+| `containerSecurityContext.runAsNonRoot` | Set Controller container's Security Context runAsNonRoot                                                                 | `true`                         |
+| `command`                               | Override default container command (useful when using custom images)                                                     | `[]`                           |
+| `args`                                  | Override default container args (useful when using custom images)                                                        | `[]`                           |
+| `lifecycleHooks.preStop.exec.command`   | Override default apache preStop command                                                                                  | `["kill","-s","SIGWINCH","1"]` |
+| `resources.limits`                      | The resources limits for the container                                                                                   | `{}`                           |
+| `resources.requests`                    | The requested resources for the container                                                                                | `{}`                           |
+| `startupProbe.enabled`                  | Enable startupProbe                                                                                                      | `true`                         |
+| `startupProbe.initialDelaySeconds`      | Initial delay seconds for startupProbe                                                                                   | `0`                            |
+| `startupProbe.periodSeconds`            | Period seconds for startupProbe                                                                                          | `1`                            |
+| `startupProbe.timeoutSeconds`           | Timeout seconds for startupProbe                                                                                         | `1`                            |
+| `startupProbe.failureThreshold`         | Failure threshold for startupProbe (allow failureThreshold * periodSeconds seconds to complete the setup)                | `30`                           |
+| `startupProbe.successThreshold`         | Success threshold for startupProbe                                                                                       | `1`                            |
+| `livenessProbe.enabled`                 | Enable liveness probe                                                                                                    | `true`                         |
+| `livenessProbe.path`                    | Path to access on the HTTP server                                                                                        | `/`                            |
+| `livenessProbe.port`                    | Port for livenessProbe                                                                                                   | `http`                         |
+| `livenessProbe.initialDelaySeconds`     | Initial delay seconds for livenessProbe                                                                                  | `0`                            |
+| `livenessProbe.periodSeconds`           | Period seconds for livenessProbe                                                                                         | `20`                           |
+| `livenessProbe.timeoutSeconds`          | Timeout seconds for livenessProbe                                                                                        | `5`                            |
+| `livenessProbe.failureThreshold`        | Failure threshold for livenessProbe                                                                                      | `6`                            |
+| `livenessProbe.successThreshold`        | Success threshold for livenessProbe                                                                                      | `1`                            |
+| `readinessProbe.enabled`                | Enable readiness probe                                                                                                   | `true`                         |
+| `readinessProbe.path`                   | Path to access on the HTTP server                                                                                        | `/`                            |
+| `readinessProbe.port`                   | Port for readinessProbe                                                                                                  | `http`                         |
+| `readinessProbe.initialDelaySeconds`    | Initial delay seconds for readinessProbe                                                                                 | `0`                            |
+| `readinessProbe.periodSeconds`          | Period seconds for readinessProbe                                                                                        | `10`                           |
+| `readinessProbe.timeoutSeconds`         | Timeout seconds for readinessProbe                                                                                       | `5`                            |
+| `readinessProbe.failureThreshold`       | Failure threshold for readinessProbe                                                                                     | `6`                            |
+| `readinessProbe.successThreshold`       | Success threshold for readinessProbe                                                                                     | `1`                            |
+| `customStartupProbe`                    | Custom liveness probe for the Web component                                                                              | `{}`                           |
+| `customLivenessProbe`                   | Custom liveness probe for the Web component                                                                              | `{}`                           |
+| `customReadinessProbe`                  | Custom rediness probe for the Web component                                                                              | `{}`                           |
+| `extraVolumes`                          | Array to add extra volumes (evaluated as a template)                                                                     | `[]`                           |
+| `extraVolumeMounts`                     | Array to add extra mounts (normally used with extraVolumes, evaluated as a template)                                     | `[]`                           |
+| `extraEnvVars`                          | Array to add extra environment variables                                                                                 | `[]`                           |
+| `extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for Apache server nodes                                             | `""`                           |
+| `extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for Apache server nodes                                                | `""`                           |
+| `containerPorts.http`                   | Apache server HTTP container port                                                                                        | `8080`                         |
+| `containerPorts.https`                  | Apache server HTTPS container port                                                                                       | `8443`                         |
+| `initContainers`                        | Add additional init containers to the Apache pods                                                                        | `[]`                           |
+| `sidecars`                              | Add additional sidecar containers to the Apache pods                                                                     | `[]`                           |
+| `updateStrategy.type`                   | Apache Server deployment strategy type.                                                                                  | `RollingUpdate`                |
 
 
 ### Other Parameters

--- a/bitnami/apache/templates/deployment.yaml
+++ b/bitnami/apache/templates/deployment.yaml
@@ -149,9 +149,11 @@ spec:
               containerPort: {{ .Values.containerPorts.https }}
           {{- if .Values.startupProbe.enabled }}
           startupProbe:
-            httpGet:
-              path: {{ .Values.startupProbe.path }}
-              port: {{ .Values.startupProbe.port }}
+            exec:
+              command:
+                - test
+                - -f
+                - /tmp/bitnami-setup-done
             initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.startupProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -52,7 +52,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/apache
-  tag: 2.4.54-debian-11-r23
+  tag: 2.4.55-debian-11-r23
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -224,9 +224,18 @@ command: []
 ## @param args Override default container args (useful when using custom images)
 ##
 args: []
-## @param lifecycleHooks for the Apache server container(s) to automate configuration before or after startup
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+## ref: https://httpd.apache.org/docs/2.4/en/stopping.html#gracefulstop
+## @param lifecycleHooks.preStop.exec.command Override default apache preStop command
 ##
-lifecycleHooks: {}
+lifecycleHooks:
+  preStop:
+    exec:
+      command:
+        - kill
+        - -s
+        - SIGWINCH
+        - "1"
 ## Apache pods' resource requests and limits
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
 ## We usually recommend not to specify default resources and to leave this as a conscious
@@ -251,22 +260,18 @@ resources:
 ## Configure extra options for Apache server containers' liveness, readiness and startup probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
 ## @param startupProbe.enabled Enable startupProbe
-## @param startupProbe.path Path to access on the HTTP server
-## @param startupProbe.port Port for startupProbe
 ## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
 ## @param startupProbe.periodSeconds Period seconds for startupProbe
 ## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
-## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe (allow failureThreshold * periodSeconds seconds to complete the setup)
 ## @param startupProbe.successThreshold Success threshold for startupProbe
 ##
 startupProbe:
-  enabled: false
-  path: "/"
-  port: http
-  initialDelaySeconds: 180
-  periodSeconds: 20
-  timeoutSeconds: 5
-  failureThreshold: 6
+  enabled: true
+  initialDelaySeconds: 0
+  periodSeconds: 1
+  timeoutSeconds: 1
+  failureThreshold: 30
   successThreshold: 1
 ## @param livenessProbe.enabled Enable liveness probe
 ## @param livenessProbe.path Path to access on the HTTP server
@@ -281,7 +286,7 @@ livenessProbe:
   enabled: true
   path: "/"
   port: http
-  initialDelaySeconds: 180
+  initialDelaySeconds: 0
   periodSeconds: 20
   timeoutSeconds: 5
   failureThreshold: 6
@@ -299,7 +304,7 @@ readinessProbe:
   enabled: true
   path: "/"
   port: http
-  initialDelaySeconds: 30
+  initialDelaySeconds: 0
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6


### PR DESCRIPTION
### Description of the change

Set `initialDelaySeconds` to 0 in all probes

Set custom preStop to stop apache gracefully

### Benefits

Pod is ready early

Current processes won't be killed after a scale down (because of the graceful stop)

### Possible drawbacks

Using startupProbe=true and a custom path. This won't work because the startupProbe now runs a custom command (instead a http request)

### Applicable issues

  - fixes #11770

### Additional information

The PR created in bitnami/containers#4234 must be merged

Why the new startupProbe is using a custom command instead of checking if http port is open? Because sometimes the setup needs to restart the service to apply some changes. For example:
* https://github.com/bitnami/containers/blob/main/bitnami/mysql/8.0/debian-11/rootfs/opt/bitnami/scripts/mysql/setup.sh#L38
* https://github.com/bitnami/containers/blob/main/bitnami/rabbitmq/3.10/debian-11/rootfs/opt/bitnami/scripts/rabbitmq/setup.sh#L20

So the probe could be success (port open) but the service is not ready because needs a restart.

I think this change (enable startupProbe and be ensure when setup is done) should be applied in all bitnami charts.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
