### PR TITLE
[bitnami/etcd] Add Helm Chart tests

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -11,6 +11,7 @@ on: # rebuild any PRs and main branch changes
       - 'bitnami/discourse/**'
       - 'bitnami/dokuwiki/**'
       - 'bitnami/elasticsearch/**'
+      - 'bitnami/etcd/**'
       - 'bitnami/external-dns/**'
       - 'bitnami/fluentd/**'
       - 'bitnami/ghost/**'

--- a/.vib/etcd/goss/goss.yaml
+++ b/.vib/etcd/goss/goss.yaml
@@ -1,0 +1,34 @@
+http:
+  http://etcd:{{ .Vars.service.ports.peer }}:
+    status: 404
+    allow-insecure: true
+file:
+  /bitnami/etcd:
+    exists: true
+    filetype: directory
+    mode: "2775"
+command:
+  {{- $auth := printf "--user=root --password=%s" .Vars.auth.rbac.rootPassword }}
+  {{- $svc_endpoint := printf "--endpoints=etcd:%s" .Vars.service.ports.client }}
+  cluster-members:
+    exec: etcdctl {{ $auth }} {{ $svc_endpoint }} member list
+    exit-status: 0
+    stdout:
+    {{- range $e, $i := until .Vars.replicaCount }}
+      - etcd-{{ $i }}
+    {{- end }}
+  {{- range $e, $i := until .Vars.replicaCount }}
+  {{- $key := printf "key_%s" (randAlpha 5) }}
+  {{- $value := printf "value_%s" (randAlpha 5) }}
+  manage-db-{{ $i }}:
+    exec: etcdctl {{ $auth }} {{ $svc_endpoint }} put {{ $key }} {{ $value }} && etcdctl {{ $auth }} --endpoints=etcd-{{ $i }}.etcd-headless:{{ $.Vars.containerPorts.client }} get {{ $key }}
+    exit-status: 0
+    stdout:
+    - {{ $key }}
+  {{- end }}
+  check-user-info:
+    exec: id
+    exit-status: 0
+    stdout:
+      - uid={{ .Vars.containerSecurityContext.runAsUser }}
+      - /groups=.*{{ .Vars.podSecurityContext.fsGroup }}/

--- a/.vib/etcd/goss/goss.yaml
+++ b/.vib/etcd/goss/goss.yaml
@@ -1,7 +1,6 @@
 http:
-  http://etcd:{{ .Vars.service.ports.peer }}:
-    status: 404
-    allow-insecure: true
+  http://etcd:{{ .Vars.service.ports.peer }}/version:
+    status: 200
 file:
   /bitnami/etcd:
     exists: true
@@ -9,7 +8,7 @@ file:
     mode: "2775"
 command:
   {{- $auth := printf "--user=root --password=%s" .Vars.auth.rbac.rootPassword }}
-  {{- $svc_endpoint := printf "--endpoints=etcd:%s" .Vars.service.ports.client }}
+  {{- $svc_endpoint := printf "--endpoints=etcd:%d" .Vars.service.ports.client }}
   cluster-members:
     exec: etcdctl {{ $auth }} {{ $svc_endpoint }} member list
     exit-status: 0

--- a/.vib/etcd/goss/vars.yaml
+++ b/.vib/etcd/goss/vars.yaml
@@ -1,0 +1,14 @@
+auth:
+  rbac:
+    rootPassword: 'ComplicatedPassword123!4'
+replicaCount: 3
+containerPorts:
+  client: 2378
+podSecurityContext:
+  fsGroup: 1002
+containerSecurityContext:
+  runAsUser: 1002
+service:
+  ports:
+    client: '80'
+    peer: 2381

--- a/.vib/etcd/goss/vars.yaml
+++ b/.vib/etcd/goss/vars.yaml
@@ -1,6 +1,6 @@
 auth:
   rbac:
-    rootPassword: 'ComplicatedPassword123!4'
+    rootPassword: ComplicatedPassword123!4
 replicaCount: 3
 containerPorts:
   client: 2378
@@ -10,5 +10,5 @@ containerSecurityContext:
   runAsUser: 1002
 service:
   ports:
-    client: '80'
+    client: 80
     peer: 2381

--- a/.vib/etcd/vib-publish.json
+++ b/.vib/etcd/vib-publish.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/etcd"
         },
-        "runtime_parameters": "ImF1dGgiOgogICJyYmFjIjoKICAgICJyb290UGFzc3dvcmQiOiAiQ3YzdzliTmRjcW1wIgoic2VydmljZSI6CiAgInBvcnRzIjoKICAgICJjbGllbnQiOiA4MAogICJ0eXBlIjogIkxvYWRCYWxhbmNlciI=",
+        "runtime_parameters": "YXV0aDoKICByYmFjOgogICAgcm9vdFBhc3N3b3JkOiBDb21wbGljYXRlZFBhc3N3b3JkMTIzITQKcmVwbGljYUNvdW50OiAzCmNvbnRhaW5lclBvcnRzOgogIGNsaWVudDogMjM3OAogIHBlZXI6IDIzODEKcG9kU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBmc0dyb3VwOiAxMDAyCmNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICBlbmFibGVkOiB0cnVlCiAgcnVuQXNVc2VyOiAxMDAyCnNlcnZpY2U6CiAgdHlwZTogTG9hZEJhbGFuY2VyCiAgcG9ydHM6CiAgICBjbGllbnQ6IDgwCiAgICBwZWVyOiAyMzgx",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -36,6 +36,18 @@
           "params": {
             "endpoint": "lb-etcd-client",
             "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/etcd/goss"
+            },
+            "remote": {
+              "workload": "sts-etcd"
+            },
+            "vars_file": "vars.yaml"
           }
         }
       ]

--- a/.vib/etcd/vib-verify.json
+++ b/.vib/etcd/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/etcd"
         },
-        "runtime_parameters": "ImF1dGgiOgogICJyYmFjIjoKICAgICJyb290UGFzc3dvcmQiOiAiQ3YzdzliTmRjcW1wIgoic2VydmljZSI6CiAgInBvcnRzIjoKICAgICJjbGllbnQiOiA4MAogICJ0eXBlIjogIkxvYWRCYWxhbmNlciI=",
+        "runtime_parameters": "YXV0aDoKICByYmFjOgogICAgcm9vdFBhc3N3b3JkOiBDb21wbGljYXRlZFBhc3N3b3JkMTIzITQKcmVwbGljYUNvdW50OiAzCmNvbnRhaW5lclBvcnRzOgogIGNsaWVudDogMjM3OAogIHBlZXI6IDIzODEKcG9kU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBmc0dyb3VwOiAxMDAyCmNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICBlbmFibGVkOiB0cnVlCiAgcnVuQXNVc2VyOiAxMDAyCnNlcnZpY2U6CiAgdHlwZTogTG9hZEJhbGFuY2VyCiAgcG9ydHM6CiAgICBjbGllbnQ6IDgwCiAgICBwZWVyOiAyMzgx",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -36,6 +36,18 @@
           "params": {
             "endpoint": "lb-etcd-client",
             "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/etcd/goss"
+            },
+            "remote": {
+              "workload": "sts-etcd"
+            },
+            "vars_file": "vars.yaml"
           }
         }
       ]


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Cassandra Helm Chart using VMware Image Builder. In order to do that, several changes are included:

- Adding the asset to the publishing workflow
- Increasing the existing test coverage of the asset by adding GOSS tests.

### Benefits

- Ensuring higher quality of the Helm charts.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could show to be potentially flaky. 

### Applicable issues

NA

### Additional information

Tested in https://github.com/FraPazGal/charts/pull/83

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)