### PR TITLE
[bitnami/oauth2-proxy] Fix PDB default values

### DIFF
--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -30,4 +30,4 @@ name: oauth2-proxy
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/oauth2-proxy
   - https://github.com/oauth2-proxy/oauth2-proxy
-version: 3.2.1
+version: 3.2.2

--- a/bitnami/oauth2-proxy/README.md
+++ b/bitnami/oauth2-proxy/README.md
@@ -178,7 +178,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `resources.requests`                          | The requested resources for the OAuth2 Proxy containers                                          | `{}`            |
 | `pdb.create`                                  | Enable a Pod Disruption Budget creation                                                          | `false`         |
 | `pdb.minAvailable`                            | Minimum number/percentage of pods that should remain scheduled                                   | `1`             |
-| `pdb.maxUnavailable`                          | Maximum number/percentage of pods that may be made unavailable                                   | `1`             |
+| `pdb.maxUnavailable`                          | Maximum number/percentage of pods that may be made unavailable                                   | `""`            |
 | `podSecurityContext.enabled`                  | Enabled OAuth2 Proxy pods' Security Context                                                      | `true`          |
 | `podSecurityContext.fsGroup`                  | Set OAuth2 Proxy pod's Security Context fsGroup                                                  | `1001`          |
 | `containerSecurityContext.enabled`            | Enabled OAuth2 Proxy containers' Security Context                                                | `true`          |

--- a/bitnami/oauth2-proxy/values.yaml
+++ b/bitnami/oauth2-proxy/values.yaml
@@ -435,7 +435,7 @@ resources:
 pdb:
   create: false
   minAvailable: 1
-  maxUnavailable: 1
+  maxUnavailable: ""
 
 ## Configure Pods Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod


### PR DESCRIPTION
### Description of the change

This PR fixes the Oauth2 Proxy default values for Pod Disruption Budget since both `pdb.minAvailable` & `pdb.maxUnavailable` are set.

### Benefits

Users that enable Pod Disruption Budget creation won't find the error below:

```
The PodDisruptionBudget "oauth2-proxy" is invalid: spec: Invalid value: policy.PodDisruptionBudgetSpec{MinAvailable:(*intstr.IntOrString)(0xc01ef241a0), Selector:(*v1.LabelSelector)(0xc01ef241c0), MaxUnavailable:(*intstr.IntOrString)(0xc01ef24180)}: minAvailable and maxUnavailable cannot be both set
```


### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
