### PR TITLE
[bitnami/kube-prometheus] Fix Prometheus' storage annotations and initContainers for kubernetes 1.19

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
   - https://github.com/bitnami/containers/tree/main/bitnami/alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 8.1.2
+version: 8.1.3

--- a/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus/prometheus.yaml
@@ -143,6 +143,7 @@ spec:
   storage:
     volumeClaimTemplate:
       metadata:
+        {{- if or .Values.prometheus.persistence.annotations .Values.commonAnnotations }}
         annotations:
           {{- if .Values.prometheus.persistence.annotations }}
           {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.persistence.annotations "context" $) | nindent 10 }}
@@ -150,6 +151,7 @@ spec:
           {{- if .Values.commonAnnotations }}
           {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
           {{- end }}
+        {{- end }}
         {{- if .Values.commonLabels }}
         labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
         {{- end }}
@@ -226,10 +228,10 @@ spec:
   {{- end }}
 {{- include "kube-prometheus.imagePullSecrets" . | indent 2 }}
   {{- if or .Values.prometheus.containers .Values.prometheus.thanos.create .Values.prometheus.containerSecurityContext.enabled .Values.prometheus.containerSecurityContext.enabled .Values.operator.prometheusConfigReloader.containerSecurityContext.enabled }}
+  {{- if .Values.prometheus.initContainers }}
   initContainers:
-    {{- if .Values.prometheus.initContainers }}
-      {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.initContainers "context" $) | nindent 4 }}
-    {{- end }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.initContainers "context" $) | nindent 4 }}
+  {{- end }}
   containers:
     {{- if .Values.prometheus.thanos.create }}
     - name: thanos-sidecar


### PR DESCRIPTION
### Description of the change

Fix two errors while trying to create `Prometheus` resource using default values in kuberneres 1.19.

### Benefits

Kubernetes 1.19 supported 

### Possible drawbacks

None expected.

### Applicable issues

### Additional information

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
