### PR TITLE
[bitnami/fluentd] fix: add target port on vib-verify runtime parameters

### DIFF
--- a/.vib/fluentd/vib-verify.json
+++ b/.vib/fluentd/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/fluentd"
         },
-        "runtime_parameters": "YWdncmVnYXRvcjoKICBlbmFibGVkOiB0cnVlCmZvcndhcmRlcjoKICBlbmFibGVkOiB0cnVlCiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6CiAgICAgICAgcG9ydDogODA=",
+        "runtime_parameters": "YWdncmVnYXRvcjoKICBlbmFibGVkOiB0cnVlCmZvcndhcmRlcjoKICBlbmFibGVkOiB0cnVlCiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6CiAgICAgICAgcG9ydDogODAKICAgICAgICB0YXJnZXRQb3J0OiA5ODgw",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
           "size": {


### PR DESCRIPTION
Signed-off-by: Paul Joshua Robles <joshuahrobles@gmail.com>

### Description of the change

Updates the runtime parameters for the vib-verify action for fluentd from:
```yaml
aggregator:
  enabled: true
forwarder:
  enabled: true
  service:
    type: LoadBalancer
    ports:
      http:
        port: 80
```
to 
```yaml
aggregator:
  enabled: true
forwarder:
  enabled: true
  service:
    type: LoadBalancer
    ports:
      http:
        port: 80
        targetPort: 9880
```

### Benefits

Fixes the verify action for fluentd chart

### Possible drawbacks

The test is already broken (?) so what else could possibly go wrong? 🤠 

### Applicable issues

  - fixes #12213 
  - unblocks #12175 

### Additional information

The forwarder does not expose port 80.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
