### PR TITLE
[bitnami/*] Refactor CI Pipeline for automated PRs to have specific workflow

### DIFF
--- a/.github/workflows/ci-automated-pipeline.yaml
+++ b/.github/workflows/ci-automated-pipeline.yaml
@@ -1,0 +1,144 @@
+name: '[CI/CD] CI Pipeline for automated PRs'
+on: # rebuild any PRs and main branch changes
+  pull_request_target:
+    types:
+      - opened
+    branches:
+      - master
+      - bitnami:master
+    paths:
+      - 'bitnami/**'
+env:
+  CSP_API_URL: https://console.cloud.vmware.com
+  CSP_API_TOKEN: ${{ secrets.CSP_API_TOKEN }}
+  VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
+jobs:
+  auto-pr-triage:
+    runs-on: ubuntu-latest
+    name: Triage for automated PRs
+    if: ${{ github.actor == 'bitnami-bot' }}
+    steps:
+      # Enables auto-merge and adds necessary labels for automated releases' PRs
+      - id: labeling
+        name: Label PR
+        uses: andymckay/labeler@1.0.4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          add-labels: "verify, auto-merge"
+      - id: auto-merge
+        name: Enable auto-merge
+        run: |
+          curl --request POST \
+          --url https://api.github.com/graphql \
+          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
+          --data '{
+            "query": "mutation { enablePullRequestAutoMerge(input: {pullRequestId: \"${{ github.event.pull_request.node_id }}\", mergeMethod: SQUASH}) { clientMutationId }}"
+            }' \
+          --fail
+  get-chart:
+    runs-on: ubuntu-latest
+    name: Get modified charts
+    needs: auto-pr-triage
+    outputs:
+      chart: ${{ steps.get-chart.outputs.chart }}
+    steps:
+      - id: get-chart
+        name: Get modified charts
+        run: |
+          # Using the Github API to detect the files changed as git merge-base stops working when the branch is behind
+          PR_URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
+          files_changed_data=$(curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -G "$PR_URL")
+          files_changed="$(echo $files_changed_data | jq -r '.[] | .filename')"
+          # Adding || true to avoid "Process exited with code 1" errors
+          charts_dirs_changed="$(echo "$files_changed" | xargs dirname | grep -o "bitnami/[^/]*" | sort | uniq || true)"
+          num_charts_changed="$(echo "$charts_dirs_changed" | grep -c "bitnami" || true)"
+          num_version_bumps="$(echo "$files_changed_data" | jq -r '[.[] | select(.filename|endswith("Chart.yaml")) | select(.patch|contains("+version")) ] | length' )"
+
+          if [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then
+            # Changes done in charts but version not bumped
+            echo -e "Detected changes in charts without version bump in Chart.yaml.\nCharts changed: ${num_charts_changed}\n${charts_dirs_changed}\nVersion bumps detected: ${num_version_bumps}"
+            exit 1
+          elif [[ "$num_charts_changed" -eq "1" ]]; then
+            # Changes done in only one chart -> OK
+            chart_name=$(echo "$charts_dirs_changed" | sed "s|bitnami/||g")
+            echo "::set-output name=chart::${chart_name}"
+          else
+            # Changes should only modify one chart
+            echo -e "Changes should modify no less and no more than one chart. The rest of the tests will be skipped."
+            exit 1
+          fi
+  vib-verify:
+    runs-on: ubuntu-latest
+    needs: get-chart
+    name: VIB Verify
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout Repository
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - uses: vmware-labs/vmware-image-builder-action@main
+        name: Verify ${{ needs.get-chart.outputs.chart }}
+        with:
+          pipeline: ${{ needs.get-chart.outputs.chart }}/vib-verify.json
+        env:
+          # Target-Platform used by default
+          VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
+          # Alternative Target-Platform to be used in case of incompatibilities
+          VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}
+  auto-pr-review:
+    runs-on: ubuntu-latest
+    needs: [get-chart, vib-verify]
+    name: Reviewal for automated PRs
+    if: |
+      always() &&
+      github.actor == 'bitnami-bot'
+    steps:
+      # Approves the CI's PR if the 'VIB Verify' job succeeded
+      # Approved by the 'github-actions' user. A PR can't be approved by its author
+      - name: Approval
+        if: ${{ needs.vib-verify.result == 'success' }}
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --data '{
+            "event": "APPROVE"
+            }' \
+          --fail
+      - name: Remove auto-merge label
+        if: ${{ needs.get-chart.result == 'failure' || needs.vib-verify.result == 'failure' }}
+        uses: andymckay/labeler@1.0.4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          remove-labels: "auto-merge"
+      - name: Disable auto-merge
+        if: ${{ needs.get-chart.result == 'failure' || needs.vib-verify.result == 'failure' }}
+        run: |
+          curl --request POST \
+          --url https://api.github.com/graphql \
+          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
+          --data '{
+            "query": "mutation { disablePullRequestAutoMerge(input: {pullRequestId: \"${{ github.event.pull_request.node_id }}\"}) { clientMutationId }}"
+            }' \
+          --fail
+      - name: Manual review required
+        if: ${{ needs.get-chart.result == 'failure' || needs.vib-verify.result == 'failure' }}
+        run: |
+          curl --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --data '{
+            "body": "There has been an error during the automated release process. Manual revision is now required."
+            }' \
+          --fail
+          curl --request POST \
+          --url https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
+          --header 'content-type: application/json' \
+          --data '{
+            "team_reviewers": ["build-maintainers"]
+            }' \
+          --fail

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -14,48 +14,18 @@ env:
   CSP_API_TOKEN: ${{ secrets.CSP_API_TOKEN }}
   VIB_PUBLIC_URL: https://cp.bromelia.vmware.com
 jobs:
-  auto-pr-triage:
-    runs-on: ubuntu-latest
-    name: Triage for automated PRs
-    if: |
-      contains(github.event.pull_request.title, 'Release') &&
-      github.event.action == 'opened' &&
-      github.actor == 'bitnami-bot'
-    steps:
-      # Enables auto-merge and adds necessary labels for automated releases' PRs
-      - id: labeling
-        name: Label PR
-        uses: andymckay/labeler@1.0.4
-        with:
-          # We can't use GITHUB_TOKEN because the labeling needs to trigger a new CI pipeline
-          repo-token: "${{ secrets.BITNAMI_BOT_TOKEN }}"
-          add-labels: "verify, auto-merge"
-      - id: auto-merge
-        name: Enable auto-merge
-        run: |
-          curl --request POST \
-          --url https://api.github.com/graphql \
-          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
-          --data '{
-            "query": "mutation { enablePullRequestAutoMerge(input: {pullRequestId: \"${{ github.event.pull_request.node_id }}\", mergeMethod: SQUASH}) { clientMutationId }}"
-            }' \
-          --fail
   get-chart:
     runs-on: ubuntu-latest
-    name: 'Get modified charts'
-    if: ${{ github.event.pull_request.state != 'closed' }}
+    name: Get modified charts
+    if: |
+      github.event.pull_request.state != 'closed' &&
+      !(github.event.action == 'opened' && github.actor == 'bitnami-bot')
     outputs:
       chart: ${{ steps.get-chart.outputs.chart }}
       result: ${{ steps.get-chart.outputs.result }}
     steps:
-      - uses: actions/checkout@v2
-        name: 'Checkout Repository'
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
       - id: get-chart
-        name: 'Get modified charts'
+        name: Get modified charts
         run: |
           # Check latest commit to skip pipeline if it contains changes from 'update-readme-metadata' action
           COMMIT_URL="https://api.github.com/repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.ref }}"
@@ -73,6 +43,7 @@ jobs:
           num_version_bumps="$(echo "$files_changed_data" | jq -r '[.[] | select(.filename|endswith("Chart.yaml")) | select(.patch|contains("+version")) ] | length' )"
           non_readme_files=$(echo "$files_changed" | grep -vc "\.md" || true)
 
+          # TODO: remove initial if when the readme workflow is integrated into the CI
           if [[ ${{ github.event.action }} == "synchronize" && ${{ github.actor }} == "bitnami-bot" && "$latest_commit_message" == *"readme-generator-for-helm"*  ]]; then
             echo "::set-output name=result::skip"
           elif [[ "$non_readme_files" -le "0" ]]; then
@@ -105,7 +76,7 @@ jobs:
       # Using actions/github-scripts because using exit 1 in the script above would not provide any output
       # Source: https://github.community/t/no-output-on-process-completed-with-exit-code-1/123821/3
       - id: show-error
-        name: 'Show error'
+        name: Show error
         if: ${{ steps.get-chart.outputs.result == 'fail' }}
         uses: actions/github-script@v3
         with:
@@ -116,12 +87,10 @@ jobs:
     needs: get-chart
     # Given performance issues of the action feature on GH's side, we need to be very restrictive in the job's triggers:
     # -> The 'Get modified charts' job suceededs AND
-    # -> The event is not opened (avoids running twice on consecutive opened and labeled events)  AND
     #  ( ---> The pipeline was triggered due to a label addition and said label was the 'verify' one OR
     #    ---> The pipeline was NOT triggered due to a label addition but the PR already contains the 'verify' one )
     if: |
         needs.get-chart.outputs.result == 'ok' &&
-        github.event.action != 'opened' &&
         (
           (github.event.action == 'labeled' && github.event.label.name == 'verify') ||
           (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'verify'))
@@ -129,7 +98,7 @@ jobs:
     name: VIB Verify
     steps:
       - uses: actions/checkout@v2
-        name: 'Checkout Repository'
+        name: Checkout Repository
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -142,60 +111,3 @@ jobs:
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
           # Alternative Target-Platform to be used in case of incompatibilities
           VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}
-  auto-pr-review:
-    runs-on: ubuntu-latest
-    needs: vib-verify
-    name: Reviewal for automated PRs
-    if: |
-      always() &&
-      github.actor == 'bitnami-bot' &&
-      contains(github.event.pull_request.labels.*.name, 'auto-merge')
-    steps:
-      # Approves the CI's PR if the 'VIB Verify' job succeeded
-      # Approved by the 'github-actions' user. A PR can't be approved by its author
-      - name: Approval
-        if: ${{ needs.vib-verify.result == 'success' }}
-        run: |
-          curl --request POST \
-          --url https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          --header 'content-type: application/json' \
-          --data '{
-            "event": "APPROVE"
-            }' \
-          --fail
-      - name: Remove auto-merge label
-        if: ${{ needs.vib-verify.result == 'failure' }}
-        uses: andymckay/labeler@1.0.4
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          remove-labels: "auto-merge"
-      - name: Disable auto-merge
-        if: ${{ needs.vib-verify.result == 'failure' }}
-        run: |
-          curl --request POST \
-          --url https://api.github.com/graphql \
-          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
-          --data '{
-            "query": "mutation { disablePullRequestAutoMerge(input: {pullRequestId: \"${{ github.event.pull_request.node_id }}\"}) { clientMutationId }}"
-            }' \
-          --fail
-      - name: Manual review required
-        if: ${{ needs.vib-verify.result == 'failure' }}
-        run: |
-          curl --request POST \
-          --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-          --header 'content-type: application/json' \
-          --data '{
-            "body": "There has been an error during the automated release process. Manual revision is now required."
-            }' \
-          --fail
-          curl --request POST \
-          --url https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-          --header 'authorization: Bearer ${{ secrets.BITNAMI_BOT_TOKEN }}' \
-          --header 'content-type: application/json' \
-          --data '{
-            "team_reviewers": ["build-maintainers"]
-            }' \
-          --fail


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This CI pipeline refactor aims to simplify the existing workflow complexity by dividing the existing workflow into 2 separate ones:

- CI Pipeline for users' contributions. Contains only `get-chart` and call to VIB.
- CI Pipeline for automated PRs. Contains triage and reviewal jobs in addition to the ones above.

### Benefits

- Removed unnecessary logic maintained due to legacy
- For labeled and synchronise events, removed non-related jobs for non-automated PRs 
- Improved code readability

### Possible drawbacks

Maintaining the `opened` trigger for both pipelines translates in having entries from both pipelines when the PR is created and for automated PRs without manual updates (see https://github.com/FraPazGal/charts/pull/95 and https://github.com/FraPazGal/charts/pull/89). 

Having the CI for automated PRs trigger in `opened` events is a must and although it is not necessary for the non-automated PRs, I think it's better to leave it. The drawbacks to remove the `opened` trigger from `ci-pipeline` are several:

- The non-automated PRs will still show the CI jobs of the `ci-automated-pipeline` when it is opened. They would be skipped, but not showing any jobs from the correct pipeline would be confusing.
- The initial checks done at `get-charts` (the chart version has to be bumped, only one chart should be modified, etc) won't be executed until a support agents labels the PR. That delays feedback the user could apply before an agent checks the PR.

### Additional information

Additional PRs created in fork:

- https://github.com/FraPazGal/charts/pull/94
- https://github.com/FraPazGal/charts/pull/90

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
