### PR TITLE
[bitnami/rabbitmq] Improve error handling message when memoryHighWatermark.enabled=true

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq
   - https://www.rabbitmq.com
-version: 10.3.2
+version: 10.3.3

--- a/bitnami/rabbitmq/templates/NOTES.txt
+++ b/bitnami/rabbitmq/templates/NOTES.txt
@@ -150,6 +150,5 @@ Then, open the obtained URL in a browser.
 
 {{- include "common.warnings.rollingTag" .Values.image }}
 {{- include "common.warnings.rollingTag" .Values.volumePermissions.image }}
-{{- include "rabbitmq.validateValues" . -}}
 
 {{- end }}

--- a/bitnami/rabbitmq/templates/validation.yaml
+++ b/bitnami/rabbitmq/templates/validation.yaml
@@ -1,0 +1,2 @@
+{{- include "rabbitmq.validateValues" . }}
+


### PR DESCRIPTION
It will allow failing early with a human readable errors like

```bash
$ helm template --set memoryHighWatermark.enabled=true .
Error: execution error at (rabbitmq/templates/statefulset.yaml:35:28):
VALUES VALIDATION:

rabbitmq: memoryHighWatermark
    You enabled configuring memory high watermark using a relative limit. However,
    no memory limits were defined at POD level. Define your POD limits as shown below:

    $ helm install release-name bitnami/rabbitmq \
      --set memoryHighWatermark.enabled=true \
      --set memoryHighWatermark.type="relative" \
      --set memoryHighWatermark.value="0.4" \
      --set resources.limits.memory="2Gi"

    Altenatively, user an absolute value for the memory memory high watermark :

    $ helm install release-name bitnami/rabbitmq \
      --set memoryHighWatermark.enabled=true \
      --set memoryHighWatermark.type="absolute" \
      --set memoryHighWatermark.value="512MB"

Use --debug flag to render out invalid YAML
```

Close #12226 