### PR TITLE
[bitnami/nginx-intel] Fix reference to staticSiteConfigmap in README.md

### DIFF
--- a/bitnami/nginx-intel/README.md
+++ b/bitnami/nginx-intel/README.md
@@ -314,7 +314,7 @@ To modify the application version used in this chart, specify a different versio
 The NGINX chart allows you to deploy a custom web application using one of the following methods:
 
 - Cloning from a git repository: Set `cloneStaticSiteFromGit.enabled` to `true` and set the repository and branch using the `cloneStaticSiteFromGit.repository` and  `cloneStaticSiteFromGit.branch` parameters. A sidecar will also pull the latest changes in an interval set by `cloneStaticSitesFromGit.interval`.
-- Providing a ConfigMap: Set the `staticSiteConfigMap` value to mount a ConfigMap in the NGINX html folder.
+- Providing a ConfigMap: Set the `staticSiteConfigmap` value to mount a ConfigMap in the NGINX html folder.
 - Using an existing PVC: Set the `staticSitePVC` value to mount an PersistentVolumeClaim with the static site content.
 
 You can deploy a example web application using git deploying the chart with the following parameters:


### PR DESCRIPTION
Copied from https://github.com/bitnami/charts/pull/12212

There is a typo in the README for the `nginx-intel` chart.

The capitalization for `staticSiteConfigmap` in one case is incorrect.

### Description of the change

Fix reference to `staticSiteConfigmap` in README.md

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
