### PR TITLE
[bitnami/cassandra] metrics Container - extraVolumeMounts option added

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -23,4 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/cassandra
   - http://cassandra.apache.org
-version: 9.3.2
+version: 9.4.0

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -255,6 +255,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                                   | `[]`                         |
 | `metrics.resources.limits`                 | The resources limits for the container                                                                             | `{}`                         |
 | `metrics.resources.requests`               | The requested resources for the container                                                                          | `{}`                         |
+| `metrics.extraVolumeMounts`                | Optionally specify extra list of additional volumeMounts for cassandra-exporter container                          | `[]`                         |
 | `metrics.podAnnotations`                   | Metrics exporter pod Annotation and Labels                                                                         | `{}`                         |
 | `metrics.serviceMonitor.enabled`           | If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)             | `false`                      |
 | `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                                           | `monitoring`                 |

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -461,13 +461,6 @@ spec:
           command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
           args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.hostNetwork }}
-          env:
-            - name: CASSANDRA_EXPORTER_CONFIG_listenPort
-              value: {{ .Values.metrics.containerPorts.http | quote }}
-            - name:  CASSANDRA_EXPORTER_CONFIG_host
-              value: localhost:{{ .Values.containerPorts.jmx }}
-          {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.metrics.containerPorts.http | default "8080" }}
@@ -493,6 +486,10 @@ spec:
               port: metrics
             initialDelaySeconds: 20
             timeoutSeconds: 45
+          {{- end }}
+          {{- if .Values.metrics.extraVolumeMounts }}
+          volumeMounts:
+            {{- include "common.tplvalues.render" (dict "value" .Values.metrics.extraVolumeMounts "context" $) | nindent 12 }}
           {{- end }}
         {{- end }}
         {{- if .Values.sidecars }}

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -692,6 +692,9 @@ metrics:
     ##    memory: 128Mi
     ##
     requests: {}
+  ## @param metrics.extraVolumeMounts Optionally specify extra list of additional volumeMounts for cassandra-exporter container
+  ##
+  extraVolumeMounts: []
   ## @param metrics.podAnnotations [object] Metrics exporter pod Annotation and Labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##


### PR DESCRIPTION
Signed-off-by: Jan Mederer <jan@mederer.it>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
The Metrics Container can now mount a Volume like the cassandra container.
So you can configure the config.yaml of the metrics container with a ConfigMaps for example. 

And also some old stuff is remove the ENVs from the metrics Container. Those were not used by the default Bitnami Image.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
You can use the Bitnami Metrics Container with hostNetwork: true

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
