### PR TITLE
[bitnami/etcd] Fix pvc deletion when trying to restore from snapshot

### DIFF
--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -24,4 +24,4 @@ name: etcd
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/etcd
   - https://coreos.com/etcd/
-version: 8.4.3
+version: 8.4.4

--- a/bitnami/etcd/templates/_helpers.tpl
+++ b/bitnami/etcd/templates/_helpers.tpl
@@ -168,18 +168,18 @@ Compile all warnings into a single message, and call fail.
 
 {{/* Validate values of etcd - an existing claim must be provided when startFromSnapshot is enabled */}}
 {{- define "etcd.validateValues.startFromSnapshot.existingClaim" -}}
-{{- if and .Values.startFromSnapshot.enabled (not .Values.startFromSnapshot.existingClaim) -}}
+{{- if and .Values.startFromSnapshot.enabled (not .Values.startFromSnapshot.existingClaim) (not .Values.disasterRecovery.enabled) -}}
 etcd: startFromSnapshot.existingClaim
-    An existing claim must be provided when startFromSnapshot is enabled!!
+    An existing claim must be provided when startFromSnapshot is enabled and disasterRecovery is disabled!!
     Please provide it (--set startFromSnapshot.existingClaim="xxxx")
 {{- end -}}
 {{- end -}}
 
 {{/* Validate values of etcd - the snapshot filename must be provided when startFromSnapshot is enabled */}}
 {{- define "etcd.validateValues.startFromSnapshot.snapshotFilename" -}}
-{{- if and .Values.startFromSnapshot.enabled (not .Values.startFromSnapshot.snapshotFilename) -}}
+{{- if and .Values.startFromSnapshot.enabled (not .Values.startFromSnapshot.snapshotFilename) (not .Values.disasterRecovery.enabled) -}}
 etcd: startFromSnapshot.snapshotFilename
-    The snapshot filename must be provided when startFromSnapshot is enabled!!
+    The snapshot filename must be provided when startFromSnapshot is enabled and disasterRecovery is disabled!!
     Please provide it (--set startFromSnapshot.snapshotFilename="xxxx")
 {{- end -}}
 {{- end -}}

--- a/bitnami/etcd/templates/snapshot-pvc.yaml
+++ b/bitnami/etcd/templates/snapshot-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.disasterRecovery.enabled (not .Values.disasterRecovery.pvc.existingClaim) (not .Values.startFromSnapshot.enabled) -}}
+{{- if and .Values.disasterRecovery.enabled (not .Values.disasterRecovery.pvc.existingClaim) -}}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:


### PR DESCRIPTION
Signed-off-by: Jayson Reis <santosdosreis@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

If you have enabled disaster recovery, pvcs are created with nfs but, if you run an upgrade to try and restore from a specific file, the template removes the pvc definition, and it gets garbage collected by helm thus making the previously attached pvc invalid.
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
You can use helm upgrade to start from a snapshot

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks
I cannot foresee one

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- maybe helps #11697

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
