### PR TITLE
[bitnami/mediawiki] Don't generate certificates if cert-manager annotation is found

### DIFF
--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -32,4 +32,4 @@ name: mediawiki
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mediawiki
   - https://www.mediawiki.org/
-version: 14.3.1
+version: 14.3.2

--- a/bitnami/mediawiki/templates/tls-secrets.yaml
+++ b/bitnami/mediawiki/templates/tls-secrets.yaml
@@ -19,7 +19,7 @@ data:
   tls.key: {{ .key | b64enc }}
 ---
 {{- end }}
-{{- else if and .Values.ingress.tls (not .Values.ingress.certManager) }}
+{{- else if and .Values.ingress.tls (not (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.certManager)) }}
 {{- $ca := genCA "mediawiki-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
 apiVersion: v1


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This change detects (using the bitnami common chart) the
cert-manager annotation(s) to prevent creation of the self-signed cert
and helps users follow the deprecation guidelines of using their own
annotations instead of relying on `ingress.certManager`.

The deprecated behavior is retained if `ingress.certManager` is
specified.

### Benefits

<!-- What benefits will be realized by the code change? -->

`ingress.certManager` is deprecated, yet ~~required to use cert-manager~~
needed to prevent creation of an unused self-signed certificate.

When `ingress.certManager` used it prevents creation of an unused self
signed certificate and places an optional annotation
`kubernetes.io/tls-acme: "true"` on the ingress.

While users may need this annotation for their setup, it is not required
for cert-manager to function (I didn't need it in my setup).

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None, this is backward compatible with the deprecated `ingress.certManager`.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #12266

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
