### PR TITLE
[bitnami/mysql] Add custom annotations to headless services

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mysql
   - https://mysql.com
-version: 9.3.5
+version: 9.4.0

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -184,6 +184,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `primary.service.annotations`                   | Additional custom annotations for MySQL primary service                                                         | `{}`                |
 | `primary.service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                            | `None`              |
 | `primary.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                     | `{}`                |
+| `primary.service.headless.annotations`          | Additional custom annotations for headless MySQL primary service                                                | `{}`                |
 | `primary.pdb.create`                            | Enable/disable a Pod Disruption Budget creation for MySQL primary pods                                          | `false`             |
 | `primary.pdb.minAvailable`                      | Minimum number/percentage of MySQL primary pods that should remain scheduled                                    | `1`                 |
 | `primary.pdb.maxUnavailable`                    | Maximum number/percentage of MySQL primary pods that may be made unavailable                                    | `""`                |
@@ -270,6 +271,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.service.annotations`                   | Additional custom annotations for MySQL secondary service                                                           | `{}`                |
 | `secondary.service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                | `None`              |
 | `secondary.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                         | `{}`                |
+| `secondary.service.headless.annotations`          | Additional custom annotations for headless MySQL secondary service                                                  | `{}`                |
 | `secondary.pdb.create`                            | Enable/disable a Pod Disruption Budget creation for MySQL secondary pods                                            | `false`             |
 | `secondary.pdb.minAvailable`                      | Minimum number/percentage of MySQL secondary pods that should remain scheduled                                      | `1`                 |
 | `secondary.pdb.maxUnavailable`                    | Maximum number/percentage of MySQL secondary pods that may be made unavailable                                      | `""`                |

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -184,7 +184,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `primary.service.annotations`                   | Additional custom annotations for MySQL primary service                                                         | `{}`                |
 | `primary.service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                            | `None`              |
 | `primary.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                     | `{}`                |
-| `primary.service.headless.annotations`          | Additional custom annotations for headless MySQL primary service                                                | `{}`                |
+| `primary.service.headless.annotations`          | Additional custom annotations for headless MySQL primary service.                                               | `{}`                |
 | `primary.pdb.create`                            | Enable/disable a Pod Disruption Budget creation for MySQL primary pods                                          | `false`             |
 | `primary.pdb.minAvailable`                      | Minimum number/percentage of MySQL primary pods that should remain scheduled                                    | `1`                 |
 | `primary.pdb.maxUnavailable`                    | Maximum number/percentage of MySQL primary pods that may be made unavailable                                    | `""`                |
@@ -271,7 +271,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.service.annotations`                   | Additional custom annotations for MySQL secondary service                                                           | `{}`                |
 | `secondary.service.sessionAffinity`               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                | `None`              |
 | `secondary.service.sessionAffinityConfig`         | Additional settings for the sessionAffinity                                                                         | `{}`                |
-| `secondary.service.headless.annotations`          | Additional custom annotations for headless MySQL secondary service                                                  | `{}`                |
+| `secondary.service.headless.annotations`          | Additional custom annotations for headless MySQL secondary service.                                                 | `{}`                |
 | `secondary.pdb.create`                            | Enable/disable a Pod Disruption Budget creation for MySQL secondary pods                                            | `false`             |
 | `secondary.pdb.minAvailable`                      | Minimum number/percentage of MySQL secondary pods that should remain scheduled                                      | `1`                 |
 | `secondary.pdb.maxUnavailable`                    | Maximum number/percentage of MySQL secondary pods that may be made unavailable                                      | `""`                |

--- a/bitnami/mysql/templates/primary/svc-headless.yaml
+++ b/bitnami/mysql/templates/primary/svc-headless.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations or .Values.primary.service.headless.annotations }}
+  {{- if or .Values.primary.service.headless.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.primary.service.headless.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.primary.service.headless.annotations "context" $) | nindent 4 }}

--- a/bitnami/mysql/templates/primary/svc-headless.yaml
+++ b/bitnami/mysql/templates/primary/svc-headless.yaml
@@ -8,10 +8,15 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- if .Values.commonAnnotations or .Values.primary.service.headless.annotations }}
   annotations:
+    {{- if .Values.primary.service.headless.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.primary.service.headless.annotations "context" $) | nindent 4 }}
+    {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/bitnami/mysql/templates/secondary/svc-headless.yaml
+++ b/bitnami/mysql/templates/secondary/svc-headless.yaml
@@ -9,10 +9,15 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- if .Values.commonAnnotations or .Values.secondary.service.headless.annotations }}
   annotations:
+    {{- if .Values.secondary.service.headless.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.secondary.service.headless.annotations "context" $) | nindent 4 }}
+    {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/bitnami/mysql/templates/secondary/svc-headless.yaml
+++ b/bitnami/mysql/templates/secondary/svc-headless.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations or .Values.secondary.service.headless.annotations }}
+  {{- if or .Values.secondary.service.headless.annotations .Values.commonAnnotations }}
   annotations:
     {{- if .Values.secondary.service.headless.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.secondary.service.headless.annotations "context" $) | nindent 4 }}

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -491,6 +491,13 @@ primary:
     ##     timeoutSeconds: 300
     ##
     sessionAffinityConfig: {}
+    ## Headless service properties
+    ##
+    headless:
+      ## @param primary.service.headless.annotations Additional custom annotations for headless MySQL primary service.
+      ##
+      annotations: {}
+
   ## MySQL primary Pod Disruption Budget configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##
@@ -848,6 +855,13 @@ secondary:
     ##     timeoutSeconds: 300
     ##
     sessionAffinityConfig: {}
+    ## Headless service properties
+    ##
+    headless:
+      ## @param secondary.service.headless.annotations Additional custom annotations for headless MySQL secondary service.
+      ##
+      annotations: {}
+
   ## MySQL secondary Pod Disruption Budget configuration
   ## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   ##


### PR DESCRIPTION
### Description of the change

Adds the ability to annotate the headless services. This is useful for a specific use case around externaldns for us.

### Benefits

More flexibility, in our case to add an externaldns annotation.

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information


### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
