### PR TITLE
[bitnami/keycloak] Do not duplicate groups key in PrometheusRule

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 9.8.0
+version: 9.8.1

--- a/bitnami/keycloak/templates/prometheusrule.yaml
+++ b/bitnami/keycloak/templates/prometheusrule.yaml
@@ -16,9 +16,9 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- range $groupName, $group := .Values.metrics.prometheusRule.groups }}
   groups:
+    {{- range $groupName, $group := .Values.metrics.prometheusRule.groups }}
     - name: {{ $groupName }}
       rules: {{- tpl (toYaml $group.rules) $ | nindent 8 }}
-  {{- end }}
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Max Nitze <max.nitze@gmx.de>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

When using multiple groups in the PrometheusRule, that was introduced in #12268, the top level key `groups` was added multiple times to the resource.

### Benefits

_Bugfix, see description._

### Possible drawbacks

no limitations known

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
