### PR TITLE
[bitnami/contour] Updates Contour CRDs to release 1.22 

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/containers/tree/main/bitnami/contour
   - https://projectcontour.io
-version: 9.1.1
+version: 9.1.2

--- a/bitnami/contour/resources/contourconfiguration.yaml
+++ b/bitnami/contour/resources/contourconfiguration.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   name: contourconfigurations.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -39,80 +39,23 @@ spec:
                 customized, the other remaining options being command line flags.
               properties:
                 debug:
-                  default:
-                    kubernetesLogLevel: 0
-                    logLevel: info
                   description: Debug contains parameters to enable debug logging and
                     debug interfaces inside Contour.
                   properties:
                     address:
-                      description: Defines the Contour debug address interface.
-                      type: string
-                    kubernetesLogLevel:
-                      default: 0
-                      description: "KubernetesDebugLogLevel defines the log level which
-                      Contour will use when outputting Kubernetes specific log information.
-                      \n Details: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md"
-                      maximum: 9
-                      minimum: 0
-                      type: integer
-                    logLevel:
-                      description: DebugLogLevel defines the log level which Contour
-                        will use when outputting log information.
-                      enum:
-                        - info
-                        - debug
+                      description: "Defines the Contour debug address interface. \n
+                      Contour's default is \"127.0.0.1\"."
                       type: string
                     port:
-                      description: Defines the Contour debug address port.
+                      description: "Defines the Contour debug address port. \n Contour's
+                      default is 6060."
                       type: integer
-                  required:
-                    - logLevel
                   type: object
                 enableExternalNameService:
-                  default: false
-                  description: EnableExternalNameService allows processing of ExternalNameServices
-                    Defaults to disabled for security reasons.
+                  description: "EnableExternalNameService allows processing of ExternalNameServices
+                  \n Contour's default is false for security reasons."
                   type: boolean
                 envoy:
-                  default:
-                    cluster:
-                      dnsLookupFamily: auto
-                    defaultHTTPVersions:
-                      - HTTP/1.1
-                      - HTTP/2
-                    health:
-                      address: 0.0.0.0
-                      port: 8002
-                    http:
-                      accessLog: /dev/stdout
-                      address: 0.0.0.0
-                      port: 8080
-                    https:
-                      accessLog: /dev/stdout
-                      address: 0.0.0.0
-                      port: 8443
-                    listener:
-                      connectionBalancer: ""
-                      disableAllowChunkedLength: false
-                      tls:
-                        cipherSuites:
-                          - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-                          - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
-                          - ECDHE-ECDSA-AES256-GCM-SHA384
-                          - ECDHE-RSA-AES256-GCM-SHA384
-                        minimumProtocolVersion: "1.2"
-                      useProxyProtocol: false
-                    logging:
-                      accessLogFormat: envoy
-                    metrics:
-                      address: 0.0.0.0
-                      port: 8002
-                    network:
-                      adminPort: 9001
-                    service:
-                      name: envoy
-                      namespace: projectcontour
                   description: Envoy contains parameters for Envoy as well as how to
                     optionally configure a managed Envoy fleet.
                   properties:
@@ -135,7 +78,6 @@ spec:
                         values that can be set in the config file.
                       properties:
                         dnsLookupFamily:
-                          default: auto
                           description: "DNSLookupFamily defines how external names are
                           looked up When configured as V4, the DNS resolver will only
                           perform a lookup for addresses in the IPv4 family. If V6
@@ -145,34 +87,25 @@ spec:
                           in the IPv6 family and fallback to a lookup for addresses
                           in the IPv4 family. Note: This only applies to externalName
                           clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                          for more information."
-                          enum:
-                            - auto
-                            - v4
-                            - v6
+                          for more information. \n Values: `auto` (default), `v4`,
+                          `v6`. \n Other values will produce an error."
                           type: string
-                      required:
-                        - dnsLookupFamily
                       type: object
                     defaultHTTPVersions:
-                      description: DefaultHTTPVersions defines the default set of HTTPS
-                        versions the proxy should accept. HTTP versions are strings
-                        of the form "HTTP/xx". Supported versions are "HTTP/1.1" and
-                        "HTTP/2".
+                      description: "DefaultHTTPVersions defines the default set of HTTPS
+                      versions the proxy should accept. HTTP versions are strings
+                      of the form \"HTTP/xx\". Supported versions are \"HTTP/1.1\"
+                      and \"HTTP/2\". \n Values: `HTTP/1.1`, `HTTP/2` (default: both).
+                      \n Other values will produce an error."
                       items:
                         description: HTTPVersionType is the name of a supported HTTP
                           version.
-                        enum:
-                          - HTTP/1.1
-                          - HTTP/2
                         type: string
                       type: array
                     health:
-                      default:
-                        address: 0.0.0.0
-                        port: 8002
-                      description: Health defines the endpoint Envoy uses to serve health
-                        checks.
+                      description: "Health defines the endpoint Envoy uses to serve
+                      health checks. \n Contour's default is { address: \"0.0.0.0\",
+                      port: 8002 }."
                       properties:
                         address:
                           description: Defines the health address interface.
@@ -181,16 +114,11 @@ spec:
                         port:
                           description: Defines the health port.
                           type: integer
-                      required:
-                        - address
-                        - port
                       type: object
                     http:
-                      default:
-                        accessLog: /dev/stdout
-                        address: 0.0.0.0
-                        port: 8080
-                      description: Defines the HTTP Listener for Envoy.
+                      description: "Defines the HTTP Listener for Envoy. \n Contour's
+                      default is { address: \"0.0.0.0\", port: 8080, accessLog: \"/dev/stdout\"
+                      }."
                       properties:
                         accessLog:
                           description: AccessLog defines where Envoy logs are outputted
@@ -203,17 +131,11 @@ spec:
                         port:
                           description: Defines an Envoy listener Port.
                           type: integer
-                      required:
-                        - accessLog
-                        - address
-                        - port
                       type: object
                     https:
-                      default:
-                        accessLog: /dev/stdout
-                        address: 0.0.0.0
-                        port: 8443
-                      description: Defines the HTTP Listener for Envoy.
+                      description: "Defines the HTTPS Listener for Envoy. \n Contour's
+                      default is { address: \"0.0.0.0\", port: 8443, accessLog: \"/dev/stdout\"
+                      }."
                       properties:
                         accessLog:
                           description: AccessLog defines where Envoy logs are outputted
@@ -226,29 +148,32 @@ spec:
                         port:
                           description: Defines an Envoy listener Port.
                           type: integer
-                      required:
-                        - accessLog
-                        - address
-                        - port
                       type: object
                     listener:
                       description: Listener hold various configurable Envoy listener
                         values.
                       properties:
                         connectionBalancer:
-                          description: ConnectionBalancer. If the value is exact, the
-                            listener will use the exact connection balancer See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
-                            for more information.
-                          enum:
-                            - ""
-                            - exact
+                          description: "ConnectionBalancer. If the value is exact, the
+                          listener will use the exact connection balancer See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
+                          for more information. \n Values: (empty string): use the
+                          default ConnectionBalancer, `exact`: use the Exact ConnectionBalancer.
+                          \n Other values will produce an error."
                           type: string
                         disableAllowChunkedLength:
-                          description: 'DisableAllowChunkedLength disables the RFC-compliant
-                          Envoy behavior to strip the "Content-Length" header if "Transfer-Encoding:
-                          chunked" is also set. This is an emergency off-switch to
-                          revert back to Envoy''s default behavior in case of failures.
-                          Please file an issue if failures are encountered. See: https://github.com/projectcontour/contour/issues/3221'
+                          description: "DisableAllowChunkedLength disables the RFC-compliant
+                          Envoy behavior to strip the \"Content-Length\" header if
+                          \"Transfer-Encoding: chunked\" is also set. This is an emergency
+                          off-switch to revert back to Envoy's default behavior in
+                          case of failures. Please file an issue if failures are encountered.
+                          See: https://github.com/projectcontour/contour/issues/3221
+                          \n Contour's default is false."
+                          type: boolean
+                        disableMergeSlashes:
+                          description: "DisableMergeSlashes disables Envoy's non-standard
+                          merge_slashes path transformation option which strips duplicate
+                          slashes from request URL paths. \n Contour's default is
+                          false."
                           type: boolean
                         tls:
                           description: TLS holds various configurable Envoy TLS listener
@@ -260,78 +185,68 @@ spec:
                               TLS 1.2. Ciphers are validated against the set that
                               Envoy supports by default. This parameter should only
                               be used by advanced users. Note that these will be ignored
-                              when TLS 1.3 is in use. \n See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                              when TLS 1.3 is in use. \n This field is optional; when
+                              it is undefined, a Contour-managed ciphersuite list
+                              will be used, which may be updated to keep it secure.
+                              \n Contour's default list is:   - \"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]\"
+                              \  - \"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]\"
+                              \  - \"ECDHE-ECDSA-AES256-GCM-SHA384\"   - \"ECDHE-RSA-AES256-GCM-SHA384\"
+                              \n Ciphers provided are validated against the following
+                              list:   - \"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]\"
+                              \  - \"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]\"
+                              \  - \"ECDHE-ECDSA-AES128-GCM-SHA256\"   - \"ECDHE-RSA-AES128-GCM-SHA256\"
+                              \  - \"ECDHE-ECDSA-AES128-SHA\"   - \"ECDHE-RSA-AES128-SHA\"
+                              \  - \"AES128-GCM-SHA256\"   - \"AES128-SHA\"   - \"ECDHE-ECDSA-AES256-GCM-SHA384\"
+                              \  - \"ECDHE-RSA-AES256-GCM-SHA384\"   - \"ECDHE-ECDSA-AES256-SHA\"
+                              \  - \"ECDHE-RSA-AES256-SHA\"   - \"AES256-GCM-SHA384\"
+                              \  - \"AES256-SHA\" \n Contour recommends leaving this
+                              undefined unless you are sure you must. \n See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
                               Note: This list is a superset of what is valid for stock
                               Envoy builds and those using BoringSSL FIPS."
                               items:
-                                enum:
-                                  - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-                                  - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
-                                  - ECDHE-ECDSA-AES128-GCM-SHA256
-                                  - ECDHE-RSA-AES128-GCM-SHA256
-                                  - ECDHE-ECDSA-AES128-SHA
-                                  - ECDHE-RSA-AES128-SHA
-                                  - AES128-GCM-SHA256
-                                  - AES128-SHA
-                                  - ECDHE-ECDSA-AES256-GCM-SHA384
-                                  - ECDHE-RSA-AES256-GCM-SHA384
-                                  - ECDHE-ECDSA-AES256-SHA
-                                  - ECDHE-RSA-AES256-SHA
-                                  - AES256-GCM-SHA384
-                                  - AES256-SHA
                                 type: string
                               type: array
                             minimumProtocolVersion:
-                              description: MinimumProtocolVersion is the minimum TLS
-                                version this vhost should negotiate. Valid options are
-                                `1.2` (default) and `1.3`.
-                              enum:
-                                - "1.2"
-                                - "1.3"
+                              description: "MinimumProtocolVersion is the minimum TLS
+                              version this vhost should negotiate. \n Values: `1.2`
+                              (default), `1.3`. \n Other values will produce an error."
                               type: string
-                          required:
-                            - cipherSuites
-                            - minimumProtocolVersion
                           type: object
                         useProxyProtocol:
-                          description: Use PROXY protocol for all listeners.
+                          description: "Use PROXY protocol for all listeners. \n Contour's
+                          default is false."
                           type: boolean
-                      required:
-                        - connectionBalancer
-                        - disableAllowChunkedLength
-                        - tls
-                        - useProxyProtocol
                       type: object
                     logging:
                       description: Logging defines how Envoy's logs can be configured.
                       properties:
                         accessLogFormat:
-                          description: AccessLogFormat sets the global access log format.
-                            Valid options are 'envoy' or 'json'
-                          enum:
-                            - envoy
-                            - json
+                          description: "AccessLogFormat sets the global access log format.
+                          \n Values: `envoy` (default), `json`. \n Other values will
+                          produce an error."
                           type: string
                         accessLogFormatString:
                           description: AccessLogFormatString sets the access log format
                             when format is set to `envoy`. When empty, Envoy's default
                             format is used.
                           type: string
-                        jsonFields:
-                          description: AccessLogFields sets the fields that JSON logging
-                            will output when AccessLogFormat is json.
+                        accessLogJSONFields:
+                          description: AccessLogJSONFields sets the fields that JSON
+                            logging will output when AccessLogFormat is json.
                           items:
                             type: string
                           type: array
-                      required:
-                        - accessLogFormat
+                        accessLogLevel:
+                          description: "AccessLogLevel sets the verbosity level of the
+                          access log. \n Values: `info` (default, meaning all requests
+                          are logged), `error` and `disabled`. \n Other values will
+                          produce an error."
+                          type: string
                       type: object
                     metrics:
-                      default:
-                        address: 0.0.0.0
-                        port: 8002
-                      description: Metrics defines the endpoint Envoy uses to serve
-                        metrics.
+                      description: "Metrics defines the endpoint Envoy uses to serve
+                      metrics. \n Contour's default is { address: \"0.0.0.0\", port:
+                      8002 }."
                       properties:
                         address:
                           description: Defines the metrics address interface.
@@ -356,37 +271,29 @@ spec:
                               description: Client key filename.
                               type: string
                           type: object
-                      required:
-                        - address
-                        - port
                       type: object
                     network:
                       description: Network holds various configurable Envoy network
                         values.
                       properties:
                         adminPort:
-                          default: 9001
-                          description: Configure the port used to access the Envoy Admin
-                            interface. If configured to port "0" then the admin interface
-                            is disabled.
+                          description: "Configure the port used to access the Envoy
+                          Admin interface. If configured to port \"0\" then the admin
+                          interface is disabled. \n Contour's default is 9001."
                           type: integer
                         numTrustedHops:
                           description: "XffNumTrustedHops defines the number of additional
                           ingress proxy hops from the right side of the x-forwarded-for
                           HTTP header to trust when determining the origin client’s
                           IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
-                          for more information."
+                          for more information. \n Contour's default is 0."
                           format: int32
                           type: integer
-                      required:
-                        - adminPort
                       type: object
                     service:
-                      default:
-                        name: envoy
-                        namespace: projectcontour
-                      description: Service holds Envoy service parameters for setting
-                        Ingress status.
+                      description: "Service holds Envoy service parameters for setting
+                      Ingress status. \n Contour's default is { namespace: \"projectcontour\",
+                      name: \"envoy\" }."
                       properties:
                         name:
                           type: string
@@ -400,6 +307,13 @@ spec:
                       description: Timeouts holds various configurable timeouts that
                         can be set in the config file.
                       properties:
+                        connectTimeout:
+                          description: "ConnectTimeout defines how long the proxy should
+                          wait when establishing connection to upstream service. If
+                          not set, a default value of 2 seconds will be used. \n See
+                          https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-connect-timeout
+                          for more information."
+                          type: string
                         connectionIdleTimeout:
                           description: "ConnectionIdleTimeout defines how long the proxy
                           should wait while there are no active requests (for HTTP/1.1)
@@ -452,37 +366,37 @@ spec:
                           for more information."
                           type: string
                       type: object
-                  required:
-                    - cluster
-                    - defaultHTTPVersions
-                    - http
-                    - https
-                    - listener
-                    - logging
-                    - metrics
-                    - network
-                    - service
                   type: object
                 gateway:
                   description: Gateway contains parameters for the gateway-api Gateway
                     that Contour is configured to serve traffic.
                   properties:
                     controllerName:
-                      default: projectcontour.io/projectcontour/contour
                       description: ControllerName is used to determine whether Contour
                         should reconcile a GatewayClass. The string takes the form of
                         "projectcontour.io/<namespace>/contour". If unset, the gatewayclass
-                        controller will not be started.
+                        controller will not be started. Exactly one of ControllerName
+                        or GatewayRef must be set.
                       type: string
-                  required:
-                    - controllerName
+                    gatewayRef:
+                      description: GatewayRef defines a specific Gateway that this Contour
+                        instance corresponds to. If set, Contour will reconcile only
+                        this gateway, and will not reconcile any gateway classes. Exactly
+                        one of ControllerName or GatewayRef must be set.
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
                   type: object
                 health:
-                  default:
-                    address: 0.0.0.0
-                    port: 8000
-                  description: Health defines the endpoints Contour uses to serve health
-                    checks.
+                  description: "Health defines the endpoints Contour uses to serve health
+                  checks. \n Contour's default is { address: \"0.0.0.0\", port: 8000
+                  }."
                   properties:
                     address:
                       description: Defines the health address interface.
@@ -491,18 +405,13 @@ spec:
                     port:
                       description: Defines the health port.
                       type: integer
-                  required:
-                    - address
-                    - port
                   type: object
                 httpproxy:
-                  default:
-                    disablePermitInsecure: false
                   description: HTTPProxy defines parameters on HTTPProxy.
                   properties:
                     disablePermitInsecure:
-                      description: DisablePermitInsecure disables the use of the permitInsecure
-                        field in HTTPProxy.
+                      description: "DisablePermitInsecure disables the use of the permitInsecure
+                      field in HTTPProxy. \n Contour's default is false."
                       type: boolean
                     fallbackCertificate:
                       description: FallbackCertificate defines the namespace/name of
@@ -523,24 +432,22 @@ spec:
                       items:
                         type: string
                       type: array
-                  required:
-                    - disablePermitInsecure
                   type: object
                 ingress:
                   description: Ingress contains parameters for ingress options.
                   properties:
-                    className:
-                      description: Ingress Class Name Contour should use.
-                      type: string
+                    classNames:
+                      description: Ingress Class Names Contour should use.
+                      items:
+                        type: string
+                      type: array
                     statusAddress:
                       description: Address to set in Ingress object status.
                       type: string
                   type: object
                 metrics:
-                  default:
-                    address: 0.0.0.0
-                    port: 8000
-                  description: Metrics defines the endpoint Contour uses to serve metrics.
+                  description: "Metrics defines the endpoint Contour uses to serve metrics.
+                  \n Contour's default is { address: \"0.0.0.0\", port: 8000 }."
                   properties:
                     address:
                       description: Defines the metrics address interface.
@@ -565,17 +472,14 @@ spec:
                           description: Client key filename.
                           type: string
                       type: object
-                  required:
-                    - address
-                    - port
                   type: object
                 policy:
                   description: Policy specifies default policy applied if not overridden
                     by the user
                   properties:
                     applyToIngress:
-                      description: ApplyToIngress determines if the Policies will apply
-                        to ingress objects
+                      description: "ApplyToIngress determines if the Policies will apply
+                      to ingress objects \n Contour's default is false."
                       type: boolean
                     requestHeaders:
                       description: RequestHeadersPolicy defines the request headers
@@ -636,33 +540,24 @@ spec:
                         limit decision within the timeout defined on the extension service.
                       type: boolean
                   required:
-                    - domain
-                    - enableXRateLimitHeaders
-                    - failOpen
+                    - extensionService
                   type: object
                 xdsServer:
-                  default:
-                    address: 0.0.0.0
-                    port: 8001
-                    tls:
-                      caFile: /certs/ca.crt
-                      certFile: /certs/tls.crt
-                      insecure: false
-                      keyFile: /certs/tls.key
-                    type: contour
                   description: XDSServer contains parameters for the xDS server.
                   properties:
                     address:
-                      description: Defines the xDS gRPC API address which Contour will
-                        serve.
+                      description: "Defines the xDS gRPC API address which Contour will
+                      serve. \n Contour's default is \"0.0.0.0\"."
                       minLength: 1
                       type: string
                     port:
-                      description: Defines the xDS gRPC API port which Contour will
-                        serve.
+                      description: "Defines the xDS gRPC API port which Contour will
+                      serve. \n Contour's default is 8001."
                       type: integer
                     tls:
-                      description: TLS holds TLS file config details.
+                      description: "TLS holds TLS file config details. \n Contour's
+                      default is { caFile: \"/certs/ca.crt\", certFile: \"/certs/tls.cert\",
+                      keyFile: \"/certs/tls.key\", insecure: false }."
                       properties:
                         caFile:
                           description: CA filename.
@@ -676,19 +571,12 @@ spec:
                         keyFile:
                           description: Client key filename.
                           type: string
-                      required:
-                        - insecure
                       type: object
                     type:
-                      description: Defines the XDSServer to use for `contour serve`.
-                      enum:
-                        - contour
-                        - envoy
+                      description: "Defines the XDSServer to use for `contour serve`.
+                      \n Values: `contour` (default), `envoy`. \n Other values will
+                      produce an error."
                       type: string
-                  required:
-                    - address
-                    - port
-                    - type
                   type: object
               type: object
             status:
@@ -718,7 +606,7 @@ spec:
                     be indicated in the Reason field. There must be zero entries in
                     the `errors` slice in this case. \n `Valid`, `status: false` means
                     that the object has had one or more fatal errors during processing
-                    into Contour.  The details of the errors will be present under
+                    into Contour. The details of the errors will be present under
                     the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`. \n For DetailedConditions of types
                     other than `Valid`, the Condition must be in the negative polarity.

--- a/bitnami/contour/resources/contourdeployments.yaml
+++ b/bitnami/contour/resources/contourdeployments.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.7.0
   name: contourdeployments.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -35,88 +34,218 @@ spec:
             metadata:
               type: object
             spec:
-              description: ContourDeploymentSpec defines the parameters of how a Contour
-                instance should be configured.
+              description: ContourDeploymentSpec specifies options for how a Contour
+                instance should be provisioned.
               properties:
-                config:
-                  description: Config is the config that the instances of Contour are
-                    to utilize.
+                contour:
+                  description: Contour specifies deployment-time settings for the Contour
+                    part of the installation, i.e. the xDS server/control plane and
+                    associated resources, including things like replica count for the
+                    Deployment, and node placement constraints for the pods.
+                  properties:
+                    nodePlacement:
+                      description: NodePlacement describes node scheduling configuration
+                        of Contour pods.
+                      properties:
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: "NodeSelector is the simplest recommended form
+                          of node selection constraint and specifies a map of key-value
+                          pairs. For the pod to be eligible to run on a node, the
+                          node must have each of the indicated key-value pairs as
+                          labels (it can have additional labels as well). \n If unset,
+                          the pod(s) will be scheduled to any available node."
+                          type: object
+                        tolerations:
+                          description: "Tolerations work with taints to ensure that
+                          pods are not scheduled onto inappropriate nodes. One or
+                          more taints are applied to a node; this marks that the node
+                          should not accept any pods that do not tolerate the taints.
+                          \n The default is an empty list. \n See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                          for additional details."
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect> using
+                              the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match.
+                                  Empty means match all taint effects. When specified,
+                                  allowed values are NoSchedule, PreferNoSchedule and
+                                  NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If the
+                                  key is empty, operator must be Exists; this combination
+                                  means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints of
+                                  a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect NoExecute,
+                                  otherwise this field is ignored) tolerates the taint.
+                                  By default, it is not set, which means tolerate the
+                                  taint forever (do not evict). Zero and negative values
+                                  will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value should
+                                  be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    replicas:
+                      description: Replicas is the desired number of Contour replicas.
+                        If unset, defaults to 2.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                  type: object
+                envoy:
+                  description: Envoy specifies deployment-time settings for the Envoy
+                    part of the installation, i.e. the xDS client/data plane and associated
+                    resources, including things like the workload type to use (DaemonSet
+                    or Deployment), node placement constraints for the pods, and various
+                    options for the Envoy service.
+                  properties:
+                    networkPublishing:
+                      description: NetworkPublishing defines how to expose Envoy to
+                        a network.
+                      properties:
+                        serviceAnnotations:
+                          additionalProperties:
+                            type: string
+                          description: ServiceAnnotations is the annotations to add
+                            to the provisioned Envoy service.
+                          type: object
+                        type:
+                          description: "NetworkPublishingType is the type of publishing
+                          strategy to use. Valid values are: \n * LoadBalancerService
+                          \n In this configuration, network endpoints for Envoy use
+                          container networking. A Kubernetes LoadBalancer Service
+                          is created to publish Envoy network endpoints. \n See: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+                          \n * NodePortService \n Publishes Envoy network endpoints
+                          using a Kubernetes NodePort Service. \n In this configuration,
+                          Envoy network endpoints use container networking. A Kubernetes
+                          NodePort Service is created to publish the network endpoints.
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
+                          \n * ClusterIPService \n Publishes Envoy network endpoints
+                          using a Kubernetes ClusterIP Service. \n In this configuration,
+                          Envoy network endpoints use container networking. A Kubernetes
+                          ClusterIP Service is created to publish the network endpoints.
+                          \n See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                          \n If unset, defaults to LoadBalancerService."
+                          type: string
+                      type: object
+                    nodePlacement:
+                      description: NodePlacement describes node scheduling configuration
+                        of Envoy pods.
+                      properties:
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: "NodeSelector is the simplest recommended form
+                          of node selection constraint and specifies a map of key-value
+                          pairs. For the pod to be eligible to run on a node, the
+                          node must have each of the indicated key-value pairs as
+                          labels (it can have additional labels as well). \n If unset,
+                          the pod(s) will be scheduled to any available node."
+                          type: object
+                        tolerations:
+                          description: "Tolerations work with taints to ensure that
+                          pods are not scheduled onto inappropriate nodes. One or
+                          more taints are applied to a node; this marks that the node
+                          should not accept any pods that do not tolerate the taints.
+                          \n The default is an empty list. \n See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+                          for additional details."
+                          items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect> using
+                              the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match.
+                                  Empty means match all taint effects. When specified,
+                                  allowed values are NoSchedule, PreferNoSchedule and
+                                  NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If the
+                                  key is empty, operator must be Exists; this combination
+                                  means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints of
+                                  a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect NoExecute,
+                                  otherwise this field is ignored) tolerates the taint.
+                                  By default, it is not set, which means tolerate the
+                                  taint forever (do not evict). Zero and negative values
+                                  will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value should
+                                  be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    replicas:
+                      description: Replicas is the desired number of Envoy replicas.
+                        If WorkloadType is not "Deployment", this field is ignored.
+                        Otherwise, if unset, defaults to 2.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    workloadType:
+                      description: WorkloadType is the type of workload to install Envoy
+                        as. Choices are DaemonSet and Deployment. If unset, defaults
+                        to DaemonSet.
+                      type: string
+                  type: object
+                runtimeSettings:
+                  description: RuntimeSettings is a ContourConfiguration spec to be
+                    used when provisioning a Contour instance that will influence aspects
+                    of the Contour instance's runtime behavior.
                   properties:
                     debug:
-                      default:
-                        kubernetesLogLevel: 0
-                        logLevel: info
                       description: Debug contains parameters to enable debug logging
                         and debug interfaces inside Contour.
                       properties:
                         address:
-                          description: Defines the Contour debug address interface.
-                          type: string
-                        kubernetesLogLevel:
-                          default: 0
-                          description: "KubernetesDebugLogLevel defines the log level
-                          which Contour will use when outputting Kubernetes specific
-                          log information. \n Details: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md"
-                          maximum: 9
-                          minimum: 0
-                          type: integer
-                        logLevel:
-                          description: DebugLogLevel defines the log level which Contour
-                            will use when outputting log information.
-                          enum:
-                            - info
-                            - debug
+                          description: "Defines the Contour debug address interface.
+                          \n Contour's default is \"127.0.0.1\"."
                           type: string
                         port:
-                          description: Defines the Contour debug address port.
+                          description: "Defines the Contour debug address port. \n Contour's
+                          default is 6060."
                           type: integer
-                      required:
-                        - logLevel
                       type: object
                     enableExternalNameService:
-                      default: false
-                      description: EnableExternalNameService allows processing of ExternalNameServices
-                        Defaults to disabled for security reasons.
+                      description: "EnableExternalNameService allows processing of ExternalNameServices
+                      \n Contour's default is false for security reasons."
                       type: boolean
                     envoy:
-                      default:
-                        cluster:
-                          dnsLookupFamily: auto
-                        defaultHTTPVersions:
-                          - HTTP/1.1
-                          - HTTP/2
-                        health:
-                          address: 0.0.0.0
-                          port: 8002
-                        http:
-                          accessLog: /dev/stdout
-                          address: 0.0.0.0
-                          port: 8080
-                        https:
-                          accessLog: /dev/stdout
-                          address: 0.0.0.0
-                          port: 8443
-                        listener:
-                          connectionBalancer: ""
-                          disableAllowChunkedLength: false
-                          tls:
-                            cipherSuites:
-                              - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-                              - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
-                              - ECDHE-ECDSA-AES256-GCM-SHA384
-                              - ECDHE-RSA-AES256-GCM-SHA384
-                            minimumProtocolVersion: "1.2"
-                          useProxyProtocol: false
-                        logging:
-                          accessLogFormat: envoy
-                        metrics:
-                          address: 0.0.0.0
-                          port: 8002
-                        network:
-                          adminPort: 9001
-                        service:
-                          name: envoy
-                          namespace: projectcontour
                       description: Envoy contains parameters for Envoy as well as how
                         to optionally configure a managed Envoy fleet.
                       properties:
@@ -139,7 +268,6 @@ spec:
                             values that can be set in the config file.
                           properties:
                             dnsLookupFamily:
-                              default: auto
                               description: "DNSLookupFamily defines how external names
                               are looked up When configured as V4, the DNS resolver
                               will only perform a lookup for addresses in the IPv4
@@ -149,34 +277,26 @@ spec:
                               a lookup for addresses in the IPv6 family and fallback
                               to a lookup for addresses in the IPv4 family. Note:
                               This only applies to externalName clusters. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto.html#envoy-v3-api-enum-config-cluster-v3-cluster-dnslookupfamily
-                              for more information."
-                              enum:
-                                - auto
-                                - v4
-                                - v6
+                              for more information. \n Values: `auto` (default), `v4`,
+                              `v6`. \n Other values will produce an error."
                               type: string
-                          required:
-                            - dnsLookupFamily
                           type: object
                         defaultHTTPVersions:
-                          description: DefaultHTTPVersions defines the default set of
-                            HTTPS versions the proxy should accept. HTTP versions are
-                            strings of the form "HTTP/xx". Supported versions are "HTTP/1.1"
-                            and "HTTP/2".
+                          description: "DefaultHTTPVersions defines the default set
+                          of HTTPS versions the proxy should accept. HTTP versions
+                          are strings of the form \"HTTP/xx\". Supported versions
+                          are \"HTTP/1.1\" and \"HTTP/2\". \n Values: `HTTP/1.1`,
+                          `HTTP/2` (default: both). \n Other values will produce an
+                          error."
                           items:
                             description: HTTPVersionType is the name of a supported
                               HTTP version.
-                            enum:
-                              - HTTP/1.1
-                              - HTTP/2
                             type: string
                           type: array
                         health:
-                          default:
-                            address: 0.0.0.0
-                            port: 8002
-                          description: Health defines the endpoint Envoy uses to serve
-                            health checks.
+                          description: "Health defines the endpoint Envoy uses to serve
+                          health checks. \n Contour's default is { address: \"0.0.0.0\",
+                          port: 8002 }."
                           properties:
                             address:
                               description: Defines the health address interface.
@@ -185,16 +305,11 @@ spec:
                             port:
                               description: Defines the health port.
                               type: integer
-                          required:
-                            - address
-                            - port
                           type: object
                         http:
-                          default:
-                            accessLog: /dev/stdout
-                            address: 0.0.0.0
-                            port: 8080
-                          description: Defines the HTTP Listener for Envoy.
+                          description: "Defines the HTTP Listener for Envoy. \n Contour's
+                          default is { address: \"0.0.0.0\", port: 8080, accessLog:
+                          \"/dev/stdout\" }."
                           properties:
                             accessLog:
                               description: AccessLog defines where Envoy logs are outputted
@@ -207,17 +322,11 @@ spec:
                             port:
                               description: Defines an Envoy listener Port.
                               type: integer
-                          required:
-                            - accessLog
-                            - address
-                            - port
                           type: object
                         https:
-                          default:
-                            accessLog: /dev/stdout
-                            address: 0.0.0.0
-                            port: 8443
-                          description: Defines the HTTP Listener for Envoy.
+                          description: "Defines the HTTPS Listener for Envoy. \n Contour's
+                          default is { address: \"0.0.0.0\", port: 8443, accessLog:
+                          \"/dev/stdout\" }."
                           properties:
                             accessLog:
                               description: AccessLog defines where Envoy logs are outputted
@@ -230,31 +339,34 @@ spec:
                             port:
                               description: Defines an Envoy listener Port.
                               type: integer
-                          required:
-                            - accessLog
-                            - address
-                            - port
                           type: object
                         listener:
                           description: Listener hold various configurable Envoy listener
                             values.
                           properties:
                             connectionBalancer:
-                              description: ConnectionBalancer. If the value is exact,
-                                the listener will use the exact connection balancer
-                                See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
-                                for more information.
-                              enum:
-                                - ""
-                                - exact
+                              description: "ConnectionBalancer. If the value is exact,
+                              the listener will use the exact connection balancer
+                              See https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener.proto#envoy-api-msg-listener-connectionbalanceconfig
+                              for more information. \n Values: (empty string): use
+                              the default ConnectionBalancer, `exact`: use the Exact
+                              ConnectionBalancer. \n Other values will produce an
+                              error."
                               type: string
                             disableAllowChunkedLength:
-                              description: 'DisableAllowChunkedLength disables the RFC-compliant
-                              Envoy behavior to strip the "Content-Length" header
-                              if "Transfer-Encoding: chunked" is also set. This is
-                              an emergency off-switch to revert back to Envoy''s default
-                              behavior in case of failures. Please file an issue if
-                              failures are encountered. See: https://github.com/projectcontour/contour/issues/3221'
+                              description: "DisableAllowChunkedLength disables the RFC-compliant
+                              Envoy behavior to strip the \"Content-Length\" header
+                              if \"Transfer-Encoding: chunked\" is also set. This
+                              is an emergency off-switch to revert back to Envoy's
+                              default behavior in case of failures. Please file an
+                              issue if failures are encountered. See: https://github.com/projectcontour/contour/issues/3221
+                              \n Contour's default is false."
+                              type: boolean
+                            disableMergeSlashes:
+                              description: "DisableMergeSlashes disables Envoy's non-standard
+                              merge_slashes path transformation option which strips
+                              duplicate slashes from request URL paths. \n Contour's
+                              default is false."
                               type: boolean
                             tls:
                               description: TLS holds various configurable Envoy TLS
@@ -266,79 +378,71 @@ spec:
                                   TLS 1.2. Ciphers are validated against the set that
                                   Envoy supports by default. This parameter should
                                   only be used by advanced users. Note that these
-                                  will be ignored when TLS 1.3 is in use. \n See:
-                                  https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
+                                  will be ignored when TLS 1.3 is in use. \n This
+                                  field is optional; when it is undefined, a Contour-managed
+                                  ciphersuite list will be used, which may be updated
+                                  to keep it secure. \n Contour's default list is:
+                                  \  - \"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]\"
+                                  \  - \"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]\"
+                                  \  - \"ECDHE-ECDSA-AES256-GCM-SHA384\"   - \"ECDHE-RSA-AES256-GCM-SHA384\"
+                                  \n Ciphers provided are validated against the following
+                                  list:   - \"[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]\"
+                                  \  - \"[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]\"
+                                  \  - \"ECDHE-ECDSA-AES128-GCM-SHA256\"   - \"ECDHE-RSA-AES128-GCM-SHA256\"
+                                  \  - \"ECDHE-ECDSA-AES128-SHA\"   - \"ECDHE-RSA-AES128-SHA\"
+                                  \  - \"AES128-GCM-SHA256\"   - \"AES128-SHA\"   -
+                                  \"ECDHE-ECDSA-AES256-GCM-SHA384\"   - \"ECDHE-RSA-AES256-GCM-SHA384\"
+                                  \  - \"ECDHE-ECDSA-AES256-SHA\"   - \"ECDHE-RSA-AES256-SHA\"
+                                  \  - \"AES256-GCM-SHA384\"   - \"AES256-SHA\" \n
+                                  Contour recommends leaving this undefined unless
+                                  you are sure you must. \n See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto#extensions-transport-sockets-tls-v3-tlsparameters
                                   Note: This list is a superset of what is valid for
                                   stock Envoy builds and those using BoringSSL FIPS."
                                   items:
-                                    enum:
-                                      - '[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]'
-                                      - '[ECDHE-RSA-AES128-GCM-SHA256|ECDHE-RSA-CHACHA20-POLY1305]'
-                                      - ECDHE-ECDSA-AES128-GCM-SHA256
-                                      - ECDHE-RSA-AES128-GCM-SHA256
-                                      - ECDHE-ECDSA-AES128-SHA
-                                      - ECDHE-RSA-AES128-SHA
-                                      - AES128-GCM-SHA256
-                                      - AES128-SHA
-                                      - ECDHE-ECDSA-AES256-GCM-SHA384
-                                      - ECDHE-RSA-AES256-GCM-SHA384
-                                      - ECDHE-ECDSA-AES256-SHA
-                                      - ECDHE-RSA-AES256-SHA
-                                      - AES256-GCM-SHA384
-                                      - AES256-SHA
                                     type: string
                                   type: array
                                 minimumProtocolVersion:
-                                  description: MinimumProtocolVersion is the minimum
-                                    TLS version this vhost should negotiate. Valid options
-                                    are `1.2` (default) and `1.3`.
-                                  enum:
-                                    - "1.2"
-                                    - "1.3"
+                                  description: "MinimumProtocolVersion is the minimum
+                                  TLS version this vhost should negotiate. \n Values:
+                                  `1.2` (default), `1.3`. \n Other values will produce
+                                  an error."
                                   type: string
-                              required:
-                                - cipherSuites
-                                - minimumProtocolVersion
                               type: object
                             useProxyProtocol:
-                              description: Use PROXY protocol for all listeners.
+                              description: "Use PROXY protocol for all listeners. \n
+                              Contour's default is false."
                               type: boolean
-                          required:
-                            - connectionBalancer
-                            - disableAllowChunkedLength
-                            - tls
-                            - useProxyProtocol
                           type: object
                         logging:
                           description: Logging defines how Envoy's logs can be configured.
                           properties:
                             accessLogFormat:
-                              description: AccessLogFormat sets the global access log
-                                format. Valid options are 'envoy' or 'json'
-                              enum:
-                                - envoy
-                                - json
+                              description: "AccessLogFormat sets the global access log
+                              format. \n Values: `envoy` (default), `json`. \n Other
+                              values will produce an error."
                               type: string
                             accessLogFormatString:
                               description: AccessLogFormatString sets the access log
                                 format when format is set to `envoy`. When empty, Envoy's
                                 default format is used.
                               type: string
-                            jsonFields:
-                              description: AccessLogFields sets the fields that JSON
-                                logging will output when AccessLogFormat is json.
+                            accessLogJSONFields:
+                              description: AccessLogJSONFields sets the fields that
+                                JSON logging will output when AccessLogFormat is json.
                               items:
                                 type: string
                               type: array
-                          required:
-                            - accessLogFormat
+                            accessLogLevel:
+                              description: "AccessLogLevel sets the verbosity level
+                              of the access log. \n Values: `info` (default, meaning
+                              all requests are logged), `error` and `disabled`. \n
+                              Other values will produce an error."
+                              type: string
                           type: object
                         metrics:
-                          default:
-                            address: 0.0.0.0
-                            port: 8002
-                          description: Metrics defines the endpoint Envoy uses to serve
-                            metrics.
+                          description: "Metrics defines the endpoint Envoy uses to serve
+                          metrics. \n Contour's default is { address: \"0.0.0.0\",
+                          port: 8002 }."
                           properties:
                             address:
                               description: Defines the metrics address interface.
@@ -363,37 +467,30 @@ spec:
                                   description: Client key filename.
                                   type: string
                               type: object
-                          required:
-                            - address
-                            - port
                           type: object
                         network:
                           description: Network holds various configurable Envoy network
                             values.
                           properties:
                             adminPort:
-                              default: 9001
-                              description: Configure the port used to access the Envoy
-                                Admin interface. If configured to port "0" then the
-                                admin interface is disabled.
+                              description: "Configure the port used to access the Envoy
+                              Admin interface. If configured to port \"0\" then the
+                              admin interface is disabled. \n Contour's default is
+                              9001."
                               type: integer
                             numTrustedHops:
                               description: "XffNumTrustedHops defines the number of
                               additional ingress proxy hops from the right side of
                               the x-forwarded-for HTTP header to trust when determining
                               the origin client’s IP address. \n See https://www.envoyproxy.io/docs/envoy/v1.17.0/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto?highlight=xff_num_trusted_hops
-                              for more information."
+                              for more information. \n Contour's default is 0."
                               format: int32
                               type: integer
-                          required:
-                            - adminPort
                           type: object
                         service:
-                          default:
-                            name: envoy
-                            namespace: projectcontour
-                          description: Service holds Envoy service parameters for setting
-                            Ingress status.
+                          description: "Service holds Envoy service parameters for setting
+                          Ingress status. \n Contour's default is { namespace: \"projectcontour\",
+                          name: \"envoy\" }."
                           properties:
                             name:
                               type: string
@@ -407,6 +504,13 @@ spec:
                           description: Timeouts holds various configurable timeouts
                             that can be set in the config file.
                           properties:
+                            connectTimeout:
+                              description: "ConnectTimeout defines how long the proxy
+                              should wait when establishing connection to upstream
+                              service. If not set, a default value of 2 seconds will
+                              be used. \n See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-field-config-cluster-v3-cluster-connect-timeout
+                              for more information."
+                              type: string
                             connectionIdleTimeout:
                               description: "ConnectionIdleTimeout defines how long the
                               proxy should wait while there are no active requests
@@ -462,37 +566,37 @@ spec:
                               for more information."
                               type: string
                           type: object
-                      required:
-                        - cluster
-                        - defaultHTTPVersions
-                        - http
-                        - https
-                        - listener
-                        - logging
-                        - metrics
-                        - network
-                        - service
                       type: object
                     gateway:
                       description: Gateway contains parameters for the gateway-api Gateway
                         that Contour is configured to serve traffic.
                       properties:
                         controllerName:
-                          default: projectcontour.io/projectcontour/contour
                           description: ControllerName is used to determine whether Contour
                             should reconcile a GatewayClass. The string takes the form
                             of "projectcontour.io/<namespace>/contour". If unset, the
-                            gatewayclass controller will not be started.
+                            gatewayclass controller will not be started. Exactly one
+                            of ControllerName or GatewayRef must be set.
                           type: string
-                      required:
-                        - controllerName
+                        gatewayRef:
+                          description: GatewayRef defines a specific Gateway that this
+                            Contour instance corresponds to. If set, Contour will reconcile
+                            only this gateway, and will not reconcile any gateway classes.
+                            Exactly one of ControllerName or GatewayRef must be set.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          required:
+                            - name
+                            - namespace
+                          type: object
                       type: object
                     health:
-                      default:
-                        address: 0.0.0.0
-                        port: 8000
-                      description: Health defines the endpoints Contour uses to serve
-                        health checks.
+                      description: "Health defines the endpoints Contour uses to serve
+                      health checks. \n Contour's default is { address: \"0.0.0.0\",
+                      port: 8000 }."
                       properties:
                         address:
                           description: Defines the health address interface.
@@ -501,18 +605,14 @@ spec:
                         port:
                           description: Defines the health port.
                           type: integer
-                      required:
-                        - address
-                        - port
                       type: object
                     httpproxy:
-                      default:
-                        disablePermitInsecure: false
                       description: HTTPProxy defines parameters on HTTPProxy.
                       properties:
                         disablePermitInsecure:
-                          description: DisablePermitInsecure disables the use of the
-                            permitInsecure field in HTTPProxy.
+                          description: "DisablePermitInsecure disables the use of the
+                          permitInsecure field in HTTPProxy. \n Contour's default
+                          is false."
                           type: boolean
                         fallbackCertificate:
                           description: FallbackCertificate defines the namespace/name
@@ -533,25 +633,23 @@ spec:
                           items:
                             type: string
                           type: array
-                      required:
-                        - disablePermitInsecure
                       type: object
                     ingress:
                       description: Ingress contains parameters for ingress options.
                       properties:
-                        className:
-                          description: Ingress Class Name Contour should use.
-                          type: string
+                        classNames:
+                          description: Ingress Class Names Contour should use.
+                          items:
+                            type: string
+                          type: array
                         statusAddress:
                           description: Address to set in Ingress object status.
                           type: string
                       type: object
                     metrics:
-                      default:
-                        address: 0.0.0.0
-                        port: 8000
-                      description: Metrics defines the endpoint Contour uses to serve
-                        metrics.
+                      description: "Metrics defines the endpoint Contour uses to serve
+                      metrics. \n Contour's default is { address: \"0.0.0.0\", port:
+                      8000 }."
                       properties:
                         address:
                           description: Defines the metrics address interface.
@@ -576,17 +674,14 @@ spec:
                               description: Client key filename.
                               type: string
                           type: object
-                      required:
-                        - address
-                        - port
                       type: object
                     policy:
                       description: Policy specifies default policy applied if not overridden
                         by the user
                       properties:
                         applyToIngress:
-                          description: ApplyToIngress determines if the Policies will
-                            apply to ingress objects
+                          description: "ApplyToIngress determines if the Policies will
+                          apply to ingress objects \n Contour's default is false."
                           type: boolean
                         requestHeaders:
                           description: RequestHeadersPolicy defines the request headers
@@ -648,33 +743,24 @@ spec:
                             the extension service.
                           type: boolean
                       required:
-                        - domain
-                        - enableXRateLimitHeaders
-                        - failOpen
+                        - extensionService
                       type: object
                     xdsServer:
-                      default:
-                        address: 0.0.0.0
-                        port: 8001
-                        tls:
-                          caFile: /certs/ca.crt
-                          certFile: /certs/tls.crt
-                          insecure: false
-                          keyFile: /certs/tls.key
-                        type: contour
                       description: XDSServer contains parameters for the xDS server.
                       properties:
                         address:
-                          description: Defines the xDS gRPC API address which Contour
-                            will serve.
+                          description: "Defines the xDS gRPC API address which Contour
+                          will serve. \n Contour's default is \"0.0.0.0\"."
                           minLength: 1
                           type: string
                         port:
-                          description: Defines the xDS gRPC API port which Contour will
-                            serve.
+                          description: "Defines the xDS gRPC API port which Contour
+                          will serve. \n Contour's default is 8001."
                           type: integer
                         tls:
-                          description: TLS holds TLS file config details.
+                          description: "TLS holds TLS file config details. \n Contour's
+                          default is { caFile: \"/certs/ca.crt\", certFile: \"/certs/tls.cert\",
+                          keyFile: \"/certs/tls.key\", insecure: false }."
                           properties:
                             caFile:
                               description: CA filename.
@@ -688,128 +774,34 @@ spec:
                             keyFile:
                               description: Client key filename.
                               type: string
-                          required:
-                            - insecure
                           type: object
                         type:
-                          description: Defines the XDSServer to use for `contour serve`.
-                          enum:
-                            - contour
-                            - envoy
+                          description: "Defines the XDSServer to use for `contour serve`.
+                          \n Values: `contour` (default), `envoy`. \n Other values
+                          will produce an error."
                           type: string
-                      required:
-                        - address
-                        - port
-                        - type
                       type: object
                   type: object
-                replicas:
-                  default: 2
-                  description: Replicas is the desired number of Contour replicas. If
-                    unset, defaults to 2.
-                  format: int32
-                  minimum: 0
-                  type: integer
-              required:
-                - config
               type: object
             status:
               description: ContourDeploymentStatus defines the observed state of a ContourDeployment
                 resource.
               properties:
                 conditions:
-                  description: "Conditions contains the current status of the Contour
-                  resource. \n Contour will update a single condition, `Valid`, that
-                  is in normal-true polarity. \n Contour will not modify any other
-                  Conditions set in this block, in case some other controller wants
-                  to add a Condition."
+                  description: Conditions describe the current conditions of the ContourDeployment
+                    resource.
                   items:
-                    description: "DetailedCondition is an extension of the normal Kubernetes
-                    conditions, with two extra fields to hold sub-conditions, which
-                    provide more detailed reasons for the state (True or False) of
-                    the condition. \n `errors` holds information about sub-conditions
-                    which are fatal to that condition and render its state False.
-                    \n `warnings` holds information about sub-conditions which are
-                    not fatal to that condition and do not force the state to be False.
-                    \n Remember that Conditions have a type, a status, and a reason.
-                    \n The type is the type of the condition, the most important one
-                    in this CRD set is `Valid`. `Valid` is a positive-polarity condition:
-                    when it is `status: true` there are no problems. \n In more detail,
-                    `status: true` means that the object is has been ingested into
-                    Contour with no errors. `warnings` may still be present, and will
-                    be indicated in the Reason field. There must be zero entries in
-                    the `errors` slice in this case. \n `Valid`, `status: false` means
-                    that the object has had one or more fatal errors during processing
-                    into Contour.  The details of the errors will be present under
-                    the `errors` field. There must be at least one error in the `errors`
-                    slice if `status` is `false`. \n For DetailedConditions of types
-                    other than `Valid`, the Condition must be in the negative polarity.
-                    When they have `status` `true`, there is an error. There must
-                    be at least one entry in the `errors` Subcondition slice. When
-                    they have `status` `false`, there are no serious errors, and there
-                    must be zero entries in the `errors` slice. In either case, there
-                    may be entries in the `warnings` slice. \n Regardless of the polarity,
-                    the `reason` and `message` fields must be updated with either
-                    the detail of the reason (if there is one and only one entry in
-                    total across both the `errors` and `warnings` slices), or `MultipleReasons`
-                    if there is more than one entry."
+                    description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
                     properties:
-                      errors:
-                        description: "Errors contains a slice of relevant error subconditions
-                        for this object. \n Subconditions are expected to appear when
-                        relevant (when there is a error), and disappear when not relevant.
-                        An empty slice here indicates no errors."
-                        items:
-                          description: "SubCondition is a Condition-like type intended
-                          for use as a subcondition inside a DetailedCondition. \n
-                          It contains a subset of the Condition fields. \n It is intended
-                          for warnings and errors, so `type` names should use abnormal-true
-                          polarity, that is, they should be of the form \"ErrorPresent:
-                          true\". \n The expected lifecycle for these errors is that
-                          they should only be present when the error or warning is,
-                          and should be removed when they are not relevant."
-                          properties:
-                            message:
-                              description: "Message is a human readable message indicating
-                              details about the transition. \n This may be an empty
-                              string."
-                              maxLength: 32768
-                              type: string
-                            reason:
-                              description: "Reason contains a programmatic identifier
-                              indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected
-                              values and meanings for this field, and whether the
-                              values are considered a guaranteed API. \n The value
-                              should be a CamelCase string. \n This field may not
-                              be empty."
-                              maxLength: 1024
-                              minLength: 1
-                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                              type: string
-                            status:
-                              description: Status of the condition, one of True, False,
-                                Unknown.
-                              enum:
-                                - "True"
-                                - "False"
-                                - Unknown
-                              type: string
-                            type:
-                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
-                              \n This must be in abnormal-true polarity, that is,
-                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
-                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                              maxLength: 316
-                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                              type: string
-                          required:
-                            - message
-                            - reason
-                            - status
-                            - type
-                          type: object
-                        type: array
                       lastTransitionTime:
                         description: lastTransitionTime is the last time the condition
                           transitioned from one status to another. This should be when
@@ -858,62 +850,6 @@ spec:
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
-                      warnings:
-                        description: "Warnings contains a slice of relevant warning
-                        subconditions for this object. \n Subconditions are expected
-                        to appear when relevant (when there is a warning), and disappear
-                        when not relevant. An empty slice here indicates no warnings."
-                        items:
-                          description: "SubCondition is a Condition-like type intended
-                          for use as a subcondition inside a DetailedCondition. \n
-                          It contains a subset of the Condition fields. \n It is intended
-                          for warnings and errors, so `type` names should use abnormal-true
-                          polarity, that is, they should be of the form \"ErrorPresent:
-                          true\". \n The expected lifecycle for these errors is that
-                          they should only be present when the error or warning is,
-                          and should be removed when they are not relevant."
-                          properties:
-                            message:
-                              description: "Message is a human readable message indicating
-                              details about the transition. \n This may be an empty
-                              string."
-                              maxLength: 32768
-                              type: string
-                            reason:
-                              description: "Reason contains a programmatic identifier
-                              indicating the reason for the condition's last transition.
-                              Producers of specific condition types may define expected
-                              values and meanings for this field, and whether the
-                              values are considered a guaranteed API. \n The value
-                              should be a CamelCase string. \n This field may not
-                              be empty."
-                              maxLength: 1024
-                              minLength: 1
-                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                              type: string
-                            status:
-                              description: Status of the condition, one of True, False,
-                                Unknown.
-                              enum:
-                                - "True"
-                                - "False"
-                                - Unknown
-                              type: string
-                            type:
-                              description: "Type of condition in `CamelCase` or in `foo.example.com/CamelCase`.
-                              \n This must be in abnormal-true polarity, that is,
-                              `ErrorFound` or `controller.io/ErrorFound`. \n The regex
-                              it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)"
-                              maxLength: 316
-                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                              type: string
-                          required:
-                            - message
-                            - reason
-                            - status
-                            - type
-                          type: object
-                        type: array
                     required:
                       - lastTransitionTime
                       - message

--- a/bitnami/contour/resources/extensionservices.yaml
+++ b/bitnami/contour/resources/extensionservices.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   name: extensionservices.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -73,6 +73,20 @@ spec:
                                   header that will be used to calculate the hash key.
                                   If the header specified is not present on a request,
                                   no hash will be produced.
+                                minLength: 1
+                                type: string
+                            type: object
+                          queryParameterHashOptions:
+                            description: QueryParameterHashOptions should be set when
+                              request query parameter hash based load balancing is desired.
+                              It must be the only hash option field set, otherwise this
+                              request hash policy object will be ignored.
+                            properties:
+                              parameterName:
+                                description: ParameterName is the name of the HTTP request
+                                  query parameter that will be used to calculate the
+                                  hash key. If the query parameter specified is not
+                                  present on a request, no hash will be produced.
                                 minLength: 1
                                 type: string
                             type: object
@@ -153,6 +167,12 @@ spec:
                         manager-wide stream_idle_timeout default of 5m still applies.
                       pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                       type: string
+                    idleConnection:
+                      description: Timeout for how long connection from the proxy to
+                        the upstream service is kept when there are no active requests.
+                        If not supplied, Envoy's default value of 1h applies.
+                      pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                      type: string
                     response:
                       description: Timeout for receiving a response from the server
                         after processing a request from client. If not supplied, Envoy's
@@ -166,11 +186,12 @@ spec:
                   properties:
                     caSecret:
                       description: Name or namespaced name of the Kubernetes secret
-                        used to validate the certificate presented by the backend
+                        used to validate the certificate presented by the backend. The
+                        secret must contain key named ca.crt.
                       type: string
                     subjectName:
                       description: Key which is expected to be present in the 'subjectAltName'
-                        of the presented certificate
+                        of the presented certificate.
                       type: string
                   required:
                     - caSecret
@@ -206,7 +227,7 @@ spec:
                     be indicated in the Reason field. There must be zero entries in
                     the `errors` slice in this case. \n `Valid`, `status: false` means
                     that the object has had one or more fatal errors during processing
-                    into Contour.  The details of the errors will be present under
+                    into Contour. The details of the errors will be present under
                     the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`. \n For DetailedConditions of types
                     other than `Valid`, the Condition must be in the negative polarity.

--- a/bitnami/contour/resources/httpproxies.yaml
+++ b/bitnami/contour/resources/httpproxies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   name: httpproxies.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -277,6 +277,26 @@ spec:
                             - name
                           type: object
                         type: array
+                      directResponsePolicy:
+                        description: DirectResponsePolicy returns an arbitrary HTTP
+                          response directly.
+                        properties:
+                          body:
+                            description: "Body is the content of the response body.
+                            If this setting is omitted, no body is included in the
+                            generated response. \n Note: Body is not recommended to
+                            set too long otherwise it can have significant resource
+                            usage impacts."
+                            type: string
+                          statusCode:
+                            description: StatusCode is the HTTP response status to be
+                              returned.
+                            maximum: 599
+                            minimum: 200
+                            type: integer
+                        required:
+                          - statusCode
+                        type: object
                       enableWebsockets:
                         description: Enables websocket support for the route.
                         type: boolean
@@ -347,6 +367,22 @@ spec:
                                         request header that will be used to calculate
                                         the hash key. If the header specified is not
                                         present on a request, no hash will be produced.
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                                queryParameterHashOptions:
+                                  description: QueryParameterHashOptions should be set
+                                    when request query parameter hash based load balancing
+                                    is desired. It must be the only hash option field
+                                    set, otherwise this request hash policy object will
+                                    be ignored.
+                                  properties:
+                                    parameterName:
+                                      description: ParameterName is the name of the
+                                        HTTP request query parameter that will be used
+                                        to calculate the hash key. If the query parameter
+                                        specified is not present on a request, no hash
+                                        will be produced.
                                       minLength: 1
                                       type: string
                                   type: object
@@ -971,11 +1007,12 @@ spec:
                                 caSecret:
                                   description: Name or namespaced name of the Kubernetes
                                     secret used to validate the certificate presented
-                                    by the backend
+                                    by the backend. The secret must contain key named
+                                    ca.crt.
                                   type: string
                                 subjectName:
                                   description: Key which is expected to be present in
-                                    the 'subjectAltName' of the presented certificate
+                                    the 'subjectAltName' of the presented certificate.
                                   type: string
                               required:
                                 - caSecret
@@ -1003,6 +1040,13 @@ spec:
                               consecutive requests. If not specified, there is no per-route
                               idle timeout, though a connection manager-wide stream_idle_timeout
                               default of 5m still applies.
+                            pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
+                            type: string
+                          idleConnection:
+                            description: Timeout for how long connection from the proxy
+                              to the upstream service is kept when there are no active
+                              requests. If not supplied, Envoy's default value of 1h
+                              applies.
                             pattern: ^(((\d*(\.\d*)?h)|(\d*(\.\d*)?m)|(\d*(\.\d*)?s)|(\d*(\.\d*)?ms)|(\d*(\.\d*)?us)|(\d*(\.\d*)?µs)|(\d*(\.\d*)?ns))+|infinity|infinite)$
                             type: string
                           response:
@@ -1104,6 +1148,21 @@ spec:
                                       request header that will be used to calculate
                                       the hash key. If the header specified is not present
                                       on a request, no hash will be produced.
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              queryParameterHashOptions:
+                                description: QueryParameterHashOptions should be set
+                                  when request query parameter hash based load balancing
+                                  is desired. It must be the only hash option field
+                                  set, otherwise this request hash policy object will
+                                  be ignored.
+                                properties:
+                                  parameterName:
+                                    description: ParameterName is the name of the HTTP
+                                      request query parameter that will be used to calculate
+                                      the hash key. If the query parameter specified
+                                      is not present on a request, no hash will be produced.
                                     minLength: 1
                                     type: string
                                 type: object
@@ -1290,11 +1349,12 @@ spec:
                               caSecret:
                                 description: Name or namespaced name of the Kubernetes
                                   secret used to validate the certificate presented
-                                  by the backend
+                                  by the backend. The secret must contain key named
+                                  ca.crt.
                                 type: string
                               subjectName:
                                 description: Key which is expected to be present in
-                                  the 'subjectAltName' of the presented certificate
+                                  the 'subjectAltName' of the presented certificate.
                                 type: string
                             required:
                               - caSecret
@@ -1698,10 +1758,25 @@ spec:
                           properties:
                             caSecret:
                               description: Name of a Kubernetes secret that contains
-                                a CA certificate bundle. The client certificate must
-                                validate against the certificates in the bundle. If
-                                specified and SkipClientCertValidation is true, client
-                                certificates will be required on requests.
+                                a CA certificate bundle. The secret must contain key
+                                named ca.crt. The client certificate must validate against
+                                the certificates in the bundle. If specified and SkipClientCertValidation
+                                is true, client certificates will be required on requests.
+                              minLength: 1
+                              type: string
+                            crlOnlyVerifyLeafCert:
+                              description: If this option is set to true, only the certificate
+                                at the end of the certificate chain will be subject
+                                to validation by CRL.
+                              type: boolean
+                            crlSecret:
+                              description: Name of a Kubernetes opaque secret that contains
+                                a concatenated list of PEM encoded CRLs. The secret
+                                must contain key named crl.pem. This field will be used
+                                to verify that a client certificate has not been revoked.
+                                CRLs must be available from all CAs, unless crlOnlyVerifyLeafCert
+                                is true. Large CRL lists are not supported since individual
+                                secrets are limited to 1MiB in size.
                               minLength: 1
                               type: string
                             skipClientCertValidation:
@@ -1779,7 +1854,7 @@ spec:
                     be indicated in the Reason field. There must be zero entries in
                     the `errors` slice in this case. \n `Valid`, `status: false` means
                     that the object has had one or more fatal errors during processing
-                    into Contour.  The details of the errors will be present under
+                    into Contour. The details of the errors will be present under
                     the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`. \n For DetailedConditions of types
                     other than `Valid`, the Condition must be in the negative polarity.

--- a/bitnami/contour/resources/tlscertificatedeligations.yaml
+++ b/bitnami/contour/resources/tlscertificatedeligations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.7.0
   name: tlscertificatedelegations.projectcontour.io
 spec:
   preserveUnknownFields: false
@@ -93,7 +93,7 @@ spec:
                     be indicated in the Reason field. There must be zero entries in
                     the `errors` slice in this case. \n `Valid`, `status: false` means
                     that the object has had one or more fatal errors during processing
-                    into Contour.  The details of the errors will be present under
+                    into Contour. The details of the errors will be present under
                     the `errors` field. There must be at least one error in the `errors`
                     slice if `status` is `false`. \n For DetailedConditions of types
                     other than `Valid`, the Condition must be in the negative polarity.


### PR DESCRIPTION
### Description of the change

Updates the CRDs for Contour to the [state released as 1.22](https://github.com/projectcontour/contour/blob/release-1.22/examples/contour/01-crds.yaml). 

### Benefits

Recently released features like the `directResponsePolicy` get accessible through Contour deployments made with the Bitnami helm charts.

### Possible drawbacks

I do not know of any.

### Applicable issues

  - fixes #11756

### Additional information

Keep up the good work folks.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
