### PR TITLE
[bitnami/rabbitmq] Bump chart version

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq
   - https://www.rabbitmq.com
-version: 10.3.3
+version: 10.3.4


### PR DESCRIPTION
The Helm chart version was bumped to the same number (`1.3.3`) in two different PRs:
- https://github.com/bitnami/charts/pull/12227
- https://github.com/bitnami/charts/pull/12303

Once merged, GitHub doesn't detect any conflict so the commit from the second one doesn't contain the chart version bump, see https://github.com/bitnami/charts/commit/99e9d0c93ea11c2d70d90f1fb2f50860dfd70d0c

The aim of this PR is to bump the chart version in a new patch (`1.3.4`) so there is a new chart released including changes from both PRs