### PR TITLE
[bitnami/elasticsearch] Configurable servicenames

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 19.3.0
+version: 19.4.0

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -178,6 +178,7 @@ $ helm delete --purge my-release
 | `master.replicaCount`                                | Number of master-elegible replicas to deploy                                                                                                       | `2`                 |
 | `master.nameOverride`                                | String to partially override elasticsearch.master.fullname                                                                                         | `""`                |
 | `master.fullnameOverride`                            | String to fully override elasticsearch.master.fullname                                                                                             | `""`                |
+| `master.servicenameOverride`                         | String to fully override elasticsearch.master.servicename                                                                                          | `""`                |
 | `master.annotations`                                 | Annotations for the master statefulset                                                                                                             | `{}`                |
 | `master.updateStrategy.type`                         | Master-elegible nodes statefulset stategy type                                                                                                     | `RollingUpdate`     |
 | `master.resources.limits`                            | The resources limits for the master-elegible containers                                                                                            | `{}`                |
@@ -261,6 +262,7 @@ $ helm delete --purge my-release
 | `data.replicaCount`                                | Number of data-only replicas to deploy                                                                                                           | `2`                 |
 | `data.nameOverride`                                | String to partially override elasticsearch.data.fullname                                                                                         | `""`                |
 | `data.fullnameOverride`                            | String to fully override elasticsearch.data.fullname                                                                                             | `""`                |
+| `data.servicenameOverride`                         | String to fully override elasticsearch.data.servicename                                                                                          | `""`                |
 | `data.annotations`                                 | Annotations for the data statefulset                                                                                                             | `{}`                |
 | `data.updateStrategy.type`                         | Data-only nodes statefulset stategy type                                                                                                         | `RollingUpdate`     |
 | `data.resources.limits`                            | The resources limits for the data containers                                                                                                     | `{}`                |
@@ -344,6 +346,7 @@ $ helm delete --purge my-release
 | `coordinating.replicaCount`                                | Number of coordinating-only replicas to deploy                                                                            | `2`             |
 | `coordinating.nameOverride`                                | String to partially override elasticsearch.coordinating.fullname                                                          | `""`            |
 | `coordinating.fullnameOverride`                            | String to fully override elasticsearch.coordinating.fullname                                                              | `""`            |
+| `coordinating.servicenameOverride`                         | String to fully override elasticsearch.coordinating.servicename                                                           | `""`            |
 | `coordinating.annotations`                                 | Annotations for the coordinating-only statefulset                                                                         | `{}`            |
 | `coordinating.updateStrategy.type`                         | Coordinating-only nodes statefulset stategy type                                                                          | `RollingUpdate` |
 | `coordinating.resources.limits`                            | The resources limits for the coordinating-only containers                                                                 | `{}`            |
@@ -420,6 +423,7 @@ $ helm delete --purge my-release
 | `ingest.replicaCount`                                | Number of ingest-only replicas to deploy                                                                                         | `2`                          |
 | `ingest.nameOverride`                                | String to partially override elasticsearch.ingest.fullname                                                                       | `""`                         |
 | `ingest.fullnameOverride`                            | String to fully override elasticsearch.ingest.fullname                                                                           | `""`                         |
+| `ingest.servicenameOverride`                         | String to fully override ingest.master.servicename                                                                               | `""`                         |
 | `ingest.annotations`                                 | Annotations for the ingest statefulset                                                                                           | `{}`                         |
 | `ingest.containerPorts.restAPI`                      | Elasticsearch REST API port                                                                                                      | `9200`                       |
 | `ingest.containerPorts.transport`                    | Elasticsearch Transport port                                                                                                     | `9300`                       |

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -80,6 +80,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a default master service name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "elasticsearch.master.servicename" -}}
+{{- if .Values.master.servicenameOverride -}}
+{{- .Values.master.servicenameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-hl" (include "elasticsearch.master.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified coordinating name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -89,6 +101,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- .Values.coordinating.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" (include "common.names.fullname" .) $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default coordinating service name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "elasticsearch.coordinating.servicename" -}}
+{{- if .Values.coordinating.servicenameOverride -}}
+{{- .Values.coordinating.servicenameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-hl" (include "elasticsearch.coordinating.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -106,6 +130,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a default data service name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "elasticsearch.data.servicename" -}}
+{{- if .Values.data.servicenameOverride -}}
+{{- .Values.data.servicenameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-hl" (include "elasticsearch.data.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified ingest name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -115,6 +151,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- .Values.ingest.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" (include "common.names.fullname" .) $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default ingest service name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "elasticsearch.ingest.servicename" -}}
+{{- if .Values.ingest.servicenameOverride -}}
+{{- .Values.ingest.servicenameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-hl" (include "elasticsearch.ingest.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -174,19 +222,19 @@ Return the hostname of every ElasticSearch seed node
 {{- $clusterDomain := .Values.clusterDomain }}
 {{- $releaseNamespace := include "common.names.namespace" . }}
 {{- if (include "elasticsearch.master.enabled" .) -}}
-{{- $masterFullname := (printf "%s-hl" (include "elasticsearch.master.fullname" .) | trunc 63 | trimSuffix "-") }}
+{{- $masterFullname := include "elasticsearch.master.servicename" .}}
 {{- $masterFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
 {{- end -}}
 {{- if (include "elasticsearch.coordinating.enabled" .) -}}
-{{- $coordinatingFullname := (printf "%s-hl" (include "elasticsearch.coordinating.fullname" .) | trunc 63 | trimSuffix "-") }}
+{{- $coordinatingFullname := include "elasticsearch.coordinating.servicename" .}}
 {{- $coordinatingFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
 {{- end -}}
 {{- if (include "elasticsearch.data.enabled" .) -}}
-{{- $dataFullname := (printf "%s-hl" (include "elasticsearch.data.fullname" .) | trunc 63 | trimSuffix "-") }}
+{{- $dataFullname := include "elasticsearch.data.servicename" .}}
 {{- $dataFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
 {{- end -}}
 {{- if (include "elasticsearch.ingest.enabled" .) -}}
-{{- $ingestFullname := (printf "%s-hl" (include "elasticsearch.ingest.fullname" .) | trunc 63 | trimSuffix "-") }}
+{{- $ingestFullname := include "elasticsearch.ingest.servicename" .}}
 {{- $ingestFullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
 {{- end -}}
 {{- range .Values.extraHosts }}

--- a/bitnami/elasticsearch/templates/coordinating/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
   {{- if .Values.coordinating.updateStrategy }}
   updateStrategy: {{- toYaml .Values.coordinating.updateStrategy | nindent 4 }}
   {{- end }}
-  serviceName: {{ printf "%s-hl" (include "elasticsearch.coordinating.fullname" .) | trunc 63 | trimSuffix "-" }}
+  serviceName: {{ include "elasticsearch.coordinating.servicename" . }}
   podManagementPolicy: {{ .Values.coordinating.podManagementPolicy }}
   template:
     metadata:
@@ -158,7 +158,7 @@ spec:
             - name: ELASTICSEARCH_MINIMUM_MASTER_NODES
               value: {{ add (div (ternary .Values.master.autoscaling.minReplicas .Values.master.replicaCount .Values.master.autoscaling.enabled) 2) 1 | quote }}
             - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
-              value: "$(MY_POD_NAME).{{ printf "%s-hl" (include "elasticsearch.coordinating.fullname" .) | trunc 63 | trimSuffix "-" }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+              value: "$(MY_POD_NAME).{{ (include "elasticsearch.coordinating.servicename" .)}}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"                 
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}

--- a/bitnami/elasticsearch/templates/coordinating/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/svc-headless.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-hl" (include "elasticsearch.coordinating.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ include "elasticsearch.coordinating.servicename" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: coordinating-only
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: ""
   publishNotReadyAddresses: true
   ports:
     - name: tcp-rest-api

--- a/bitnami/elasticsearch/templates/data/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: data
-  serviceName: {{ printf "%s-hl" (include "elasticsearch.data.fullname" .) | trunc 63 | trimSuffix "-" }}
+  serviceName: {{ include "elasticsearch.data.servicename" . }}
   {{- if .Values.data.updateStrategy }}
   updateStrategy: {{- toYaml .Values.data.updateStrategy | nindent 4 }}
   {{- end }}
@@ -178,8 +178,8 @@ spec:
             - name: ELASTICSEARCH_MINIMUM_MASTER_NODES
               value: {{ add (div (ternary .Values.master.autoscaling.minReplicas .Values.master.replicaCount .Values.master.autoscaling.enabled) 2) 1 | quote }}
             - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
-              value: "$(MY_POD_NAME).{{ printf "%s-hl" (include "elasticsearch.data.fullname" .) | trunc 63 | trimSuffix "-" }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
-              {{- if .Values.plugins }}
+              value: "$(MY_POD_NAME).{{ (include "elasticsearch.data.servicename" .)}}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"                 
+            {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}
             {{- end }}

--- a/bitnami/elasticsearch/templates/data/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/data/svc-headless.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-hl" (include "elasticsearch.data.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ include "elasticsearch.data.servicename" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: data
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: ""
   publishNotReadyAddresses: true
   ports:
     - name: tcp-rest-api

--- a/bitnami/elasticsearch/templates/ingest/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: ingest
-  serviceName: {{ printf "%s-hl" (include "elasticsearch.ingest.fullname" .) | trunc 63 | trimSuffix "-" }}
+  serviceName: {{ include "elasticsearch.ingest.servicename" . }}
   {{- if .Values.ingest.updateStrategy }}
   updateStrategy: {{- toYaml .Values.ingest.updateStrategy | nindent 4 }}
   {{- end }}
@@ -158,7 +158,7 @@ spec:
             - name: ELASTICSEARCH_MINIMUM_MASTER_NODES
               value: {{ add (div (ternary .Values.master.autoscaling.minReplicas .Values.master.replicaCount .Values.master.autoscaling.enabled) 2) 1 | quote }}
             - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
-              value: "$(MY_POD_NAME).{{ printf "%s-hl" (include "elasticsearch.ingest.fullname" .) | trunc 63 | trimSuffix "-" }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+              value: "$(MY_POD_NAME).{{ (include "elasticsearch.ingest.servicename" .)}}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"            
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}

--- a/bitnami/elasticsearch/templates/ingest/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/ingest/svc-headless.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-hl" (include "elasticsearch.ingest.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ include "elasticsearch.ingest.servicename" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ingest
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: ""
   publishNotReadyAddresses: true
   ports:
     - name: tcp-rest-api

--- a/bitnami/elasticsearch/templates/master/statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: master
-  serviceName: {{ printf "%s-hl" (include "elasticsearch.master.fullname" .) | trunc 63 | trimSuffix "-" }}
+  serviceName: {{ include "elasticsearch.master.servicename" . }}
   {{- if .Values.master.updateStrategy }}
   updateStrategy: {{- toYaml .Values.master.updateStrategy | nindent 4 }}
   {{- end }}
@@ -178,7 +178,7 @@ spec:
             - name: ELASTICSEARCH_MINIMUM_MASTER_NODES
               value: {{ add (div (ternary .Values.master.autoscaling.minReplicas .Values.master.replicaCount .Values.master.autoscaling.enabled) 2) 1 | quote }}
             - name: ELASTICSEARCH_ADVERTISED_HOSTNAME
-              value: "$(MY_POD_NAME).{{ printf "%s-hl" (include "elasticsearch.master.fullname" .) | trunc 63 | trimSuffix "-" }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
+              value: "$(MY_POD_NAME).{{ (include "elasticsearch.master.servicename" .) | trunc 63 | trimSuffix "-" }}.{{ include "common.names.namespace" . }}.svc.{{ .Values.clusterDomain }}"
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}

--- a/bitnami/elasticsearch/templates/master/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/master/svc-headless.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ printf "%s-hl" (include "elasticsearch.master.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ include "elasticsearch.master.servicename" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{ include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: master
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
-  clusterIP: None
+  clusterIP: ""
   publishNotReadyAddresses: true
   ports:
     - name: tcp-rest-api

--- a/bitnami/elasticsearch/templates/tls-secret.yaml
+++ b/bitnami/elasticsearch/templates/tls-secret.yaml
@@ -5,7 +5,7 @@
 
 {{- if and (include "elasticsearch.master.enabled" .) (not .Values.security.tls.master.existingSecret) }}
 {{- $fullname := include "elasticsearch.master.fullname" . }}
-{{- $serviceName := printf "%s-hl" (include "elasticsearch.master.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $serviceName := include "elasticsearch.master.servicename" . }}
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) $fullname "127.0.0.1" "localhost" }}
 {{- if not (include "elasticsearch.coordinating.enabled" .) }}
 {{- $altNames = append $altNames (include "elasticsearch.service.name" .) }}
@@ -33,7 +33,7 @@ data:
 {{- end }}
 {{- if and (include "elasticsearch.data.enabled" .) (not .Values.security.tls.data.existingSecret) }}
 {{- $fullname := include "elasticsearch.data.fullname" . }}
-{{- $serviceName := printf "%s-hl" (include "elasticsearch.data.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $serviceName := include "elasticsearch.data.servicename" . }}
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) $fullname "127.0.0.1" "localhost" }}
 {{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
 ---
@@ -58,7 +58,7 @@ data:
 {{- end }}
 {{- if and (include "elasticsearch.coordinating.enabled" .) (not .Values.security.tls.coordinating.existingSecret) }}
 {{- $fullname := include "elasticsearch.coordinating.fullname" . }}
-{{- $serviceName := printf "%s-hl" (include "elasticsearch.coordinating.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $serviceName := include "elasticsearch.coordinating.servicename" . }}
 {{- $altNames := list (include "elasticsearch.service.name" .) (printf "%s.%s.svc.%s" (include "elasticsearch.service.name" .) $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) $fullname "127.0.0.1" "localhost" }}
 {{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
 ---
@@ -83,7 +83,7 @@ data:
 {{- end }}
 {{- if and (include "elasticsearch.ingest.enabled" .) (not .Values.security.tls.ingest.existingSecret) }}
 {{- $fullname := include "elasticsearch.ingest.fullname" . }}
-{{- $serviceName := printf "%s-hl" (include "elasticsearch.ingest.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $serviceName := include "elasticsearch.ingest.servicename" . }}
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) $fullname "127.0.0.1" "localhost" }}
 {{- if .Values.ingest.service.enabled }}
 {{- $altNames = append $altNames (include "elasticsearch.ingest.fullname" .) }}

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -465,6 +465,9 @@ master:
   ## @param master.fullnameOverride String to fully override elasticsearch.master.fullname
   ##
   fullnameOverride: ""
+  ## @param master.servicenameOverride String to fully override elasticsearch.master.servicename
+  ##
+  servicenameOverride: ""
   ## @param master.annotations [object] Annotations for the master statefulset
   ##
   annotations: {}
@@ -757,6 +760,9 @@ data:
   ## @param data.fullnameOverride String to fully override elasticsearch.data.fullname
   ##
   fullnameOverride: ""
+  ## @param data.servicenameOverride String to fully override elasticsearch.data.servicename
+  ##
+  servicenameOverride: ""
   ## @param data.annotations [object] Annotations for the data statefulset
   ##
   annotations: {}
@@ -1049,6 +1055,9 @@ coordinating:
   ## @param coordinating.fullnameOverride String to fully override elasticsearch.coordinating.fullname
   ##
   fullnameOverride: ""
+  ## @param coordinating.servicenameOverride String to fully override elasticsearch.coordinating.servicename
+  ##
+  servicenameOverride: ""
   ## @param coordinating.annotations [object] Annotations for the coordinating-only statefulset
   ##
   annotations: {}
@@ -1305,6 +1314,9 @@ ingest:
   ## @param ingest.fullnameOverride String to fully override elasticsearch.ingest.fullname
   ##
   fullnameOverride: ""
+  ## @param ingest.servicenameOverride String to fully override ingest.master.servicename
+  ##
+  servicenameOverride: ""
   ## @param ingest.annotations [object] Annotations for the ingest statefulset
   ##
   annotations: {}


### PR DESCRIPTION
### Description of the change

Since chart version 18.0.0 the naming of the node services changed **from**: 
```{{ include "elasticsearch.coordinating.fullname" . }}```  
**to:** 
```{{ printf "%s-hl" (include "elasticsearch.coordinating.fullname" .) | trunc 63 | trimSuffix "-" }}```
If one has a cluster running with the latest 17.x.x chart he will not be able to perform a rolling cluster upgrade to chart version >=18.0.0. This is because of kubernetes does not allow to change the servicename in a statefulset once set. Adressed in this issue #11505

This change intruduces the value ```servicenameOverride``` for each node section (**coordinating**, **data**, **master**, **ingest**) which could be used to override the *-hl* suffix.

### Benefits
You can run a rolling cluster upgrade  to elasticserach version >= 8 without any problems now.

### Possible drawbacks
No drawbacks as the defaults are the same

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #11505

### Additional information

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
