### PR TITLE
[bitnami/cassandra] ReadinessProbes Timeouts for Metrics Container are now configurable

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -23,4 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/cassandra
   - http://cassandra.apache.org
-version: 9.4.2
+version: 9.5.0

--- a/bitnami/cassandra/README.md
+++ b/bitnami/cassandra/README.md
@@ -244,31 +244,36 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Metrics parameters
 
-| Name                                       | Description                                                                                                        | Value                        |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
-| `metrics.enabled`                          | Start a side-car prometheus exporter                                                                               | `false`                      |
-| `metrics.image.registry`                   | Cassandra exporter image registry                                                                                  | `docker.io`                  |
-| `metrics.image.repository`                 | Cassandra exporter image name                                                                                      | `bitnami/cassandra-exporter` |
-| `metrics.image.tag`                        | Cassandra exporter image tag                                                                                       | `2.3.8-debian-11-r34`        |
-| `metrics.image.digest`                     | Cassandra exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                         |
-| `metrics.image.pullPolicy`                 | image pull policy                                                                                                  | `IfNotPresent`               |
-| `metrics.image.pullSecrets`                | Specify docker-registry secret names as an array                                                                   | `[]`                         |
-| `metrics.resources.limits`                 | The resources limits for the container                                                                             | `{}`                         |
-| `metrics.resources.requests`               | The requested resources for the container                                                                          | `{}`                         |
-| `metrics.extraVolumeMounts`                | Optionally specify extra list of additional volumeMounts for cassandra-exporter container                          | `[]`                         |
-| `metrics.podAnnotations`                   | Metrics exporter pod Annotation and Labels                                                                         | `{}`                         |
-| `metrics.serviceMonitor.enabled`           | If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)             | `false`                      |
-| `metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                                           | `monitoring`                 |
-| `metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                                       | `""`                         |
-| `metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                            | `""`                         |
-| `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                                | `{}`                         |
-| `metrics.serviceMonitor.metricRelabelings` | Specify Metric Relabelings to add to the scrape endpoint                                                           | `[]`                         |
-| `metrics.serviceMonitor.relabelings`       | RelabelConfigs to apply to samples before scraping                                                                 | `[]`                         |
-| `metrics.serviceMonitor.honorLabels`       | Specify honorLabels parameter to add the scrape endpoint                                                           | `false`                      |
-| `metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in prometheus.                                  | `""`                         |
-| `metrics.serviceMonitor.labels`            | Used to pass Labels that are required by the installed Prometheus Operator                                         | `{}`                         |
-| `metrics.containerPorts.http`              | HTTP Port on the Host and Container                                                                                | `8080`                       |
-| `metrics.containerPorts.jmx`               | JMX Port on the Host and Container                                                                                 | `5555`                       |
+| Name                                         | Description                                                                                                        | Value                        |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------- |
+| `metrics.enabled`                            | Start a side-car prometheus exporter                                                                               | `false`                      |
+| `metrics.image.registry`                     | Cassandra exporter image registry                                                                                  | `docker.io`                  |
+| `metrics.image.repository`                   | Cassandra exporter image name                                                                                      | `bitnami/cassandra-exporter` |
+| `metrics.image.tag`                          | Cassandra exporter image tag                                                                                       | `2.3.8-debian-11-r34`        |
+| `metrics.image.digest`                       | Cassandra exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                         |
+| `metrics.image.pullPolicy`                   | image pull policy                                                                                                  | `IfNotPresent`               |
+| `metrics.image.pullSecrets`                  | Specify docker-registry secret names as an array                                                                   | `[]`                         |
+| `metrics.resources.limits`                   | The resources limits for the container                                                                             | `{}`                         |
+| `metrics.resources.requests`                 | The requested resources for the container                                                                          | `{}`                         |
+| `metrics.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                           | `20`                         |
+| `metrics.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                  | `10`                         |
+| `metrics.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                 | `45`                         |
+| `metrics.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                               | `3`                          |
+| `metrics.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                               | `1`                          |
+| `metrics.extraVolumeMounts`                  | Optionally specify extra list of additional volumeMounts for cassandra-exporter container                          | `[]`                         |
+| `metrics.podAnnotations`                     | Metrics exporter pod Annotation and Labels                                                                         | `{}`                         |
+| `metrics.serviceMonitor.enabled`             | If `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)             | `false`                      |
+| `metrics.serviceMonitor.namespace`           | Namespace in which Prometheus is running                                                                           | `monitoring`                 |
+| `metrics.serviceMonitor.interval`            | Interval at which metrics should be scraped.                                                                       | `""`                         |
+| `metrics.serviceMonitor.scrapeTimeout`       | Timeout after which the scrape is ended                                                                            | `""`                         |
+| `metrics.serviceMonitor.selector`            | Prometheus instance selector labels                                                                                | `{}`                         |
+| `metrics.serviceMonitor.metricRelabelings`   | Specify Metric Relabelings to add to the scrape endpoint                                                           | `[]`                         |
+| `metrics.serviceMonitor.relabelings`         | RelabelConfigs to apply to samples before scraping                                                                 | `[]`                         |
+| `metrics.serviceMonitor.honorLabels`         | Specify honorLabels parameter to add the scrape endpoint                                                           | `false`                      |
+| `metrics.serviceMonitor.jobLabel`            | The name of the label on the target service to use as the job name in prometheus.                                  | `""`                         |
+| `metrics.serviceMonitor.labels`              | Used to pass Labels that are required by the installed Prometheus Operator                                         | `{}`                         |
+| `metrics.containerPorts.http`                | HTTP Port on the Host and Container                                                                                | `8080`                       |
+| `metrics.containerPorts.jmx`                 | JMX Port on the Host and Container                                                                                 | `5555`                       |
 
 
 ### TLS/SSL parameters

--- a/bitnami/cassandra/templates/statefulset.yaml
+++ b/bitnami/cassandra/templates/statefulset.yaml
@@ -484,8 +484,11 @@ spec:
             httpGet:
               path: /metrics
               port: metrics
-            initialDelaySeconds: 20
-            timeoutSeconds: 45
+            initialDelaySeconds: {{ .Values.metrics.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.metrics.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.metrics.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.metrics.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.metrics.readinessProbe.successThreshold }}
           {{- end }}
           {{- if .Values.metrics.extraVolumeMounts }}
           volumeMounts:

--- a/bitnami/cassandra/values.yaml
+++ b/bitnami/cassandra/values.yaml
@@ -692,6 +692,18 @@ metrics:
     ##    memory: 128Mi
     ##
     requests: {}
+  ## @param metrics.readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  ## @param metrics.readinessProbe.periodSeconds Period seconds for readinessProbe
+  ## @param metrics.readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  ## @param metrics.readinessProbe.failureThreshold Failure threshold for readinessProbe
+  ## @param metrics.readinessProbe.successThreshold Success threshold for readinessProbe
+  ##
+  readinessProbe:
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 45
+    failureThreshold: 3
+    successThreshold: 1
   ## @param metrics.extraVolumeMounts Optionally specify extra list of additional volumeMounts for cassandra-exporter container
   ##
   extraVolumeMounts: []


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
ReadinessProbes Timeouts for Metrics Container are now configurable
<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits
On Cassandras with a huge amount of Keyspace the metrics container needs a lot of time and gets often killed by OOM.
No more unnecessary restarts.
<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
