### PR TITLE
[bitnami/opencart] Update OpenCart chart to version 4.x.x

### DIFF
--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: E-Commerce
 apiVersion: v2
-appVersion: 3.0.3-8
+appVersion: 4.0.1-1
 dependencies:
   - condition: mariadb.enabled
     name: mariadb
@@ -29,4 +29,4 @@ name: opencart
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/opencart
   - https://opencart.com/
-version: 12.4.2
+version: 13.0.0

--- a/bitnami/opencart/README.md
+++ b/bitnami/opencart/README.md
@@ -410,7 +410,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ### To 13.0.0
 
-OpenCart version was bumped to its latest major, `4.x.x`. The most remarkable chante is that the `/admin` folder has been moved to `/administration` for security requirements. Though no incompatibilities are expected while upgrading from previous versions, OpenCart recommends backing up your application first.
+OpenCart version was bumped to its latest major, `4.x.x`. The most remarkable change is that the `/admin` folder has been renamed to `/administration` for security requirements. Though no incompatibilities are expected while upgrading from previous versions, OpenCart recommends backing up your application first before upgrading.
 
 ### To 12.0.0
 

--- a/bitnami/opencart/README.md
+++ b/bitnami/opencart/README.md
@@ -408,6 +408,10 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 13.0.0
+
+OpenCart version was bumped to its latest major, `4.x.x`. The most remarkable chante is that the `/admin` folder has been moved to `/administration` for security requirements. Though no incompatibilities are expected while upgrading from previous versions, OpenCart recommends backing up your application first.
+
 ### To 12.0.0
 
 This major release bumps the MariaDB version to 10.6. Follow the [upstream instructions](https://mariadb.com/kb/en/upgrading-from-mariadb-105-to-mariadb-106/) for upgrading from MariaDB 10.5 to 10.6. No major issues are expected during the upgrade.


### PR DESCRIPTION
Signed-off-by: David Gomez <dgomezleon@vmware.com>

Update OpenCart chart to version 13.0.0 (app version 4.0.1-1)