### PR TITLE
[bitnami/kube-prometheus] update nindent values for alertmanager

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
   - https://github.com/bitnami/containers/tree/main/bitnami/alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 8.1.5
+version: 8.1.6

--- a/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/ingress.yaml
@@ -7,13 +7,13 @@ metadata:
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.alertmanager.ingress.annotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.alertmanager.ingress.annotations "context" $) | nindent 10 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.alertmanager.ingress.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonLabels }}
-  labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
+  labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.alertmanager.ingress.ingressClassName (include "common.ingress.supportsIngressClassname" .) }}

--- a/bitnami/kube-prometheus/templates/alertmanager/pdb.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/pdb.yaml
@@ -6,10 +6,10 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "kube-prometheus.alertmanager.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   selector:

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrole.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrole.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 rules:
   - apiGroups: ['extensions']

--- a/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp-clusterrolebinding.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bitnami/kube-prometheus/templates/alertmanager/psp.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/psp.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 spec:
   privileged: false

--- a/bitnami/kube-prometheus/templates/alertmanager/secrets.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/secrets.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
+  annotations: {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
   {{- end }}
 data:
   alertmanager.yaml: {{ toYaml .Values.alertmanager.config | b64enc | quote }}

--- a/bitnami/kube-prometheus/templates/alertmanager/service.yaml
+++ b/bitnami/kube-prometheus/templates/alertmanager/service.yaml
@@ -10,10 +10,10 @@ metadata:
     {{- end }}
   annotations:
     {{- if .Values.alertmanager.service.annotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.alertmanager.service.annotations "context" $) | nindent 10 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.alertmanager.service.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
   type: {{ .Values.alertmanager.service.type }}


### PR DESCRIPTION
Signed-off-by: Julian Muders <julian.muders@deliveryhero.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
Some `nindent` values in the alertmanager component of kube-prometheus had wrong values, breaking the use of `commonLabels` & `commonAnnotations`. This PR fixes these values.

### Benefits

<!-- What benefits will be realized by the code change? -->
`commonLabels` and `commonAnnotations` will work as expected and not fail to template.

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None, bugfix.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  None

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
