### PR TITLE
[bitnami/mariadb-galera] Add tests and publishing using VIB

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -28,6 +28,7 @@ on: # rebuild any PRs and main branch changes
       - 'bitnami/keycloak/**'
       - 'bitnami/kibana/**'
       - 'bitnami/magento/**'
+      - 'bitnami/mariadb-galera/**'
       - 'bitnami/mariadb/**'
       - 'bitnami/matomo/**'
       - 'bitnami/mediawiki/**'

--- a/.vib/mariadb-galera/goss/goss.yaml
+++ b/.vib/mariadb-galera/goss/goss.yaml
@@ -16,20 +16,22 @@ file:
       - /wsrep_provider=.*libgalera_smm.so/
       - "wsrep_cluster_name={{ .Vars.galera.name }}"
 command:
+  {{- $testValue := "1989" }}
+  {{- $conn_opts := printf "-P %d -u %s -p'%s' %s" .Vars.service.ports.mysql .Vars.rootUser.user .Vars.rootUser.password .Vars.db.name }}
   create-table-root:
-    exec: mariadb -h mariadb-galera -P {{ .Vars.service.ports.mysql }} -u {{ .Vars.rootUser.user }} -p'{{ .Vars.rootUser.password }}' {{ .Vars.db.name }} -e 'DROP TABLE IF EXISTS TEST; create table TEST(test_id int auto_increment, test_value int, primary key(test_id)); INSERT INTO TEST (TEST_VALUE) VALUES (1989);SELECT * FROM TEST'
+    exec: mariadb -h mariadb-galera {{ $conn_opts }} -e 'DROP TABLE IF EXISTS TEST; create table TEST(test_id int auto_increment, test_value int, primary key(test_id)); INSERT INTO TEST (TEST_VALUE) VALUES ({{ $testValue }});SELECT * FROM TEST'
     exit-status: 0
     stdout:
-    - 1989
+    - {{ $testValue }}
   {{- $numNodes := .Vars.replicaCount }}
+  {{- $testValue := "2022" }}
   {{- range $e, $i := until $numNodes }}
-  {{- $write_svc := printf "mariadb-galera-%d.mariadb-galera-headless" $i }}
   {{- $conn_opts := printf "-P %d -u %s -p'%s' %s" $.Vars.containerPorts.mysql $.Vars.db.user $.Vars.db.password $.Vars.db.name }}
   multimaster-write-{{ $i }}-read:
-    exec: mariadb -h mariadb-galera-{{ $i }}.mariadb-galera-headless {{ $conn_opts }} -e 'DROP TABLE IF EXISTS TEST_REP_{{ $i }}; create table TEST_REP_{{ $i }}(test_id int auto_increment, test_value varchar(4), primary key(test_id)); INSERT INTO TEST_REP_{{ $i }} (TEST_VALUE) VALUES (2022)' && sleep 2 {{ range $e, $j := until $numNodes }} && mariadb -h mariadb-galera-{{ $j }}.mariadb-galera-headless {{ $conn_opts }} -e 'SELECT * FROM TEST_REP_{{ $i }}'{{ end }}
+    exec: mariadb -h mariadb-galera-{{ $i }}.mariadb-galera-headless {{ $conn_opts }} -e 'DROP TABLE IF EXISTS TEST_REP_{{ $i }}; create table TEST_REP_{{ $i }}(test_id int auto_increment, test_value varchar(4), primary key(test_id)); INSERT INTO TEST_REP_{{ $i }} (TEST_VALUE) VALUES ({{ $testValue }})' && sleep 2 {{ range $e, $j := until $numNodes }} && mariadb -h mariadb-galera-{{ $j }}.mariadb-galera-headless {{ $conn_opts }} -e 'SELECT * FROM TEST_REP_{{ $i }}'{{ end }}
     exit-status: 0
     stdout:
-    - 2022
+    - {{ $testValue }}
     timeout: 9000
   {{- end }}
   check-user-info:

--- a/.vib/mariadb-galera/goss/goss.yaml
+++ b/.vib/mariadb-galera/goss/goss.yaml
@@ -1,0 +1,40 @@
+file:
+  /bitnami/mariadb/data/{{ .Vars.db.name }}:
+    mode: "2700"
+    filetype: directory
+    exists: true
+  /opt/bitnami/mariadb/.bootstrap:
+    mode: "2777"
+    filetype: directory
+    exists: true
+  /opt/bitnami/mariadb/conf/my.cnf:
+    mode: "0664"
+    filetype: file
+    exists: true
+    contains:
+      - "basedir=/opt/bitnami/mariadb"
+      - /wsrep_provider=.*libgalera_smm.so/
+      - "wsrep_cluster_name={{ .Vars.galera.name }}"
+command:
+  create-table-root:
+    exec: mariadb -h mariadb-galera -P {{ .Vars.service.ports.mysql }} -u {{ .Vars.rootUser.user }} -p'{{ .Vars.rootUser.password }}' {{ .Vars.db.name }} -e 'DROP TABLE IF EXISTS TEST; create table TEST(test_id int auto_increment, test_value int, primary key(test_id)); INSERT INTO TEST (TEST_VALUE) VALUES (1989);SELECT * FROM TEST'
+    exit-status: 0
+    stdout:
+    - 1989
+  {{- $numNodes := .Vars.replicaCount }}
+  {{- range $e, $i := until $numNodes }}
+  {{- $write_svc := printf "mariadb-galera-%d.mariadb-galera-headless" $i }}
+  {{- $conn_opts := printf "-P %d -u %s -p'%s' %s" $.Vars.containerPorts.mysql $.Vars.db.user $.Vars.db.password $.Vars.db.name }}
+  multimaster-write-{{ $i }}-read:
+    exec: mariadb -h mariadb-galera-{{ $i }}.mariadb-galera-headless {{ $conn_opts }} -e 'DROP TABLE IF EXISTS TEST_REP_{{ $i }}; create table TEST_REP_{{ $i }}(test_id int auto_increment, test_value varchar(4), primary key(test_id)); INSERT INTO TEST_REP_{{ $i }} (TEST_VALUE) VALUES (2022)' && sleep 2 {{ range $e, $j := until $numNodes }} && mariadb -h mariadb-galera-{{ $j }}.mariadb-galera-headless {{ $conn_opts }} -e 'SELECT * FROM TEST_REP_{{ $i }}'{{ end }}
+    exit-status: 0
+    stdout:
+    - 2022
+    timeout: 9000
+  {{- end }}
+  check-user-info:
+    exec: id
+    exit-status: 0
+    stdout:
+      - uid={{ .Vars.containerSecurityContext.runAsUser }}
+      - /groups=.*{{ .Vars.podSecurityContext.fsGroup }}/

--- a/.vib/mariadb-galera/goss/vars.yaml
+++ b/.vib/mariadb-galera/goss/vars.yaml
@@ -1,0 +1,19 @@
+replicaCount: 3
+service:
+  ports:
+    mysql: 80
+podSecurityContext:
+  fsGroup: 1002
+containerSecurityContext:
+  runAsUser: 1002
+rootUser:
+  user: bitnamiroot
+  password: "ComplicatedPassword123!4"
+db:
+  user: "bitnamiuser"
+  password: "BitnamiPassw0rd"
+  name: awesome_zoo_db
+galera:
+  name: bitnamigalera
+containerPorts:
+  mysql: 3306

--- a/.vib/mariadb-galera/vib-publish.json
+++ b/.vib/mariadb-galera/vib-publish.json
@@ -16,6 +16,42 @@
         }
       ]
     },
+    "verify": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/mariadb-galera"
+        },
+        "runtime_parameters": "cmVwbGljYUNvdW50OiAzCnNlcnZpY2U6CiAgdHlwZTogTG9hZEJhbGFuY2VyCiAgcG9ydHM6CiAgICBteXNxbDogODAKcG9kU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBmc0dyb3VwOiAxMDAyCiAgcnVuQXNVc2VyOiAxMDAyCmNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICBlbmFibGVkOiB0cnVlCiAgcnVuQXNVc2VyOiAxMDAyCnJvb3RVc2VyOgogIHVzZXI6IGJpdG5hbWlyb290CiAgcGFzc3dvcmQ6ICJDb21wbGljYXRlZFBhc3N3b3JkMTIzITQiCmRiOgogIHVzZXI6ICJiaXRuYW1pdXNlciIKICBwYXNzd29yZDogIkJpdG5hbWlQYXNzdzByZCIKICBuYW1lOiBhd2Vzb21lX3pvb19kYgpnYWxlcmE6CiAgbmFtZTogYml0bmFtaWdhbGVyYQpjb250YWluZXJQb3J0czoKICBteXNxbDogMzMwNgogIGdhbGVyYTogNDU2NwogIGlzdDogNDU2OAogIHNzdDogNDQ0NA==",
+        "target_platform": {
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
+          "size": {
+            "name": "S4"
+          }
+        }
+      },
+      "actions": [
+        {
+          "action_id": "health-check",
+          "params": {
+            "endpoint": "lb-mariadb-galera-mysql",
+            "app_protocol": "GENERIC"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/mariadb-galera/goss"
+            },
+            "vars_file": "vars.yaml",
+            "remote": {
+              "workload": "sts-mariadb-galera"
+            }
+          }
+        }
+      ]
+    },
     "publish": {
       "actions": [
         {

--- a/.vib/mariadb-galera/vib-verify.json
+++ b/.vib/mariadb-galera/vib-verify.json
@@ -15,6 +15,42 @@
           "action_id": "helm-lint"
         }
       ]
+    },
+    "verify": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/mariadb-galera"
+        },
+        "runtime_parameters": "cmVwbGljYUNvdW50OiAzCnNlcnZpY2U6CiAgdHlwZTogTG9hZEJhbGFuY2VyCiAgcG9ydHM6CiAgICBteXNxbDogODAKcG9kU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBmc0dyb3VwOiAxMDAyCiAgcnVuQXNVc2VyOiAxMDAyCmNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICBlbmFibGVkOiB0cnVlCiAgcnVuQXNVc2VyOiAxMDAyCnJvb3RVc2VyOgogIHVzZXI6IGJpdG5hbWlyb290CiAgcGFzc3dvcmQ6ICJDb21wbGljYXRlZFBhc3N3b3JkMTIzITQiCmRiOgogIHVzZXI6ICJiaXRuYW1pdXNlciIKICBwYXNzd29yZDogIkJpdG5hbWlQYXNzdzByZCIKICBuYW1lOiBhd2Vzb21lX3pvb19kYgpnYWxlcmE6CiAgbmFtZTogYml0bmFtaWdhbGVyYQpjb250YWluZXJQb3J0czoKICBteXNxbDogMzMwNgogIGdhbGVyYTogNDU2NwogIGlzdDogNDU2OAogIHNzdDogNDQ0NA==",
+        "target_platform": {
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
+          "size": {
+            "name": "S4"
+          }
+        }
+      },
+      "actions": [
+        {
+          "action_id": "health-check",
+          "params": {
+            "endpoint": "lb-mariadb-galera-mysql",
+            "app_protocol": "GENERIC"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/mariadb-galera/goss"
+            },
+            "vars_file": "vars.yaml",
+            "remote": {
+              "workload": "sts-mariadb-galera"
+            }
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami MariaDB-Galera Helm Chart using VMware Image Builder. In order to do that, several changes are included:

- Adding the asset to the publishing workflow
- Increasing the existing test coverage of the asset by adding GOSS tests.

### Benefits

- Ensuring higher quality of the Helm charts.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could show to be potentially flaky. 

### Applicable issues

NA

### Additional information

Tested in https://github.com/joancafom/charts/pull/78

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

