### PR TITLE
[bitnami/mongodb] Added variable for ipv6 in mongodb arbiter statefulset

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.1.2
+version: 13.1.3

--- a/bitnami/mongodb/templates/arbiter/statefulset.yaml
+++ b/bitnami/mongodb/templates/arbiter/statefulset.yaml
@@ -156,6 +156,8 @@ spec:
               value: "$(MY_POD_NAME).$(K8S_SERVICE_NAME).$(MY_POD_NAMESPACE).svc.{{ .Values.clusterDomain }}"
             - name: MONGODB_PORT_NUMBER
               value: {{ .Values.arbiter.containerPorts.mongodb | quote }}
+            - name: MONGODB_ENABLE_IPV6
+              value: {{ ternary "yes" "no" .Values.enableIPv6 | quote }}
             {{- if .Values.auth.enabled }}
             - name: MONGODB_INITIAL_PRIMARY_ROOT_USER
               value: {{ .Values.auth.rootUser | quote }}


### PR DESCRIPTION
MongoDB chart in `architecture=replicaset` doesn't work properly in ipv6 clusters, because `mongodb-arbiter` don't start in ipv6 [mode](https://github.com/bitnami/charts/issues/12411). So there is commit that added that ability.

### Description of the change

Added variable `MONGODB_ENABLE_IPV6` in arbiter statefulset, similar to data node 
https://github.com/bitnami/charts/blob/master/bitnami/mongodb/templates/replicaset/statefulset.yaml#L284

### Benefits

MongoDB will be able to work in `architecture=replicaset` in ipv6 clusters

### Possible drawbacks

\-

### Applicable issues

  - fixes [12411](https://github.com/bitnami/charts/issues/12411)

### Additional information

#### Testing notes

Install chart with changes:
```bash
helm3 install my-mongo ./ --set "architecture=replicaset,image.pullPolicy=Always,enableIPv6=true" -n mongo-test
```
```bash
k get all -n mongo-test
```
```bash
NAME                             READY   STATUS    RESTARTS   AGE
pod/my-mongo-mongodb-0           1/1     Running   0          110s
pod/my-mongo-mongodb-1           1/1     Running   0          93s
pod/my-mongo-mongodb-arbiter-0   1/1     Running   0          110s

NAME                                        TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)     AGE
service/my-mongo-mongodb-arbiter-headless   ClusterIP   None         <none>        27017/TCP   111s
service/my-mongo-mongodb-headless           ClusterIP   None         <none>        27017/TCP   111s

NAME                                        READY   AGE
statefulset.apps/my-mongo-mongodb           2/2     114s
statefulset.apps/my-mongo-mongodb-arbiter   1/1     114s
```
check arbiter config
```bash
k exec -it pod/my-mongo-mongodb-arbiter-0 -- cat /opt/bitnami/mongodb/conf/mongodb.conf | yq -y .net
```
```yaml
port: 27017
unixDomainSocket:
  enabled: true
  pathPrefix: /opt/bitnami/mongodb/tmp
ipv6: true
bindIpAll: true
```


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in Chart.yaml according to [semver](http://semver.org/). This is not necessary when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
