### PR TITLE
[bitnami/fluentd] Enforce verification on a single-node cluster

### DIFF
--- a/.vib/fluentd/vib-publish.json
+++ b/.vib/fluentd/vib-publish.json
@@ -26,7 +26,8 @@
         "target_platform": {
           "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
           "size": {
-            "name": "S4"
+            "name": "S4",
+            "worker_nodes_instance_count": "1"
           }
         }
       },

--- a/.vib/fluentd/vib-verify.json
+++ b/.vib/fluentd/vib-verify.json
@@ -26,7 +26,8 @@
         "target_platform": {
           "target_platform_id": "{VIB_ENV_ALTERNATIVE_TARGET_PLATFORM}",
           "size": {
-            "name": "S4"
+            "name": "S4",
+            "worker_nodes_instance_count": "1"
           }
         }
       },


### PR DESCRIPTION
### Description of the change

Enforce the provisioning of a single worker node cluster in the verification phase to ensure tests work correctly.

### Benefits

GOSS tests to verify the integration of _forwarders_ and _aggregators_ do not produce false failures.

### Possible drawbacks

None. There's really no need to have more than one node for these tests.

### Applicable issues

  - https://github.com/bitnami/charts/pull/12175

### Additional information

See https://github.com/bitnami/charts/pull/12175#issuecomment-1248003907 for further info

Tested in https://github.com/joancafom/charts/actions/runs/3059036095/jobs/4935943285

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
