### PR TITLE
[bitnami/mysql]  change default bind-address to * in mysql configuration (for enabling ipv6)

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mysql
   - https://mysql.com
-version: 9.3.2
+version: 9.3.3

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -185,7 +185,7 @@ primary:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8
@@ -545,7 +545,7 @@ secondary:
     datadir=/bitnami/mysql/data
     tmpdir=/opt/bitnami/mysql/tmp
     max_allowed_packet=16M
-    bind-address=0.0.0.0
+    bind-address=*
     pid-file=/opt/bitnami/mysql/tmp/mysqld.pid
     log-error=/opt/bitnami/mysql/logs/mysqld.log
     character-set-server=UTF8


### PR DESCRIPTION
### Description of the change

Changed `bind-address` to * in helm values in primary/secondary.configuration

### Benefits

This allow us to run mysql in both ipv4 and ipv6 modes by default.

### Possible drawbacks

\-

### Applicable issues

  - fixes [12442](https://github.com/bitnami/charts/issues/12442)

### Additional information

I've tested changes in both EKS ipv4 and ipv6 clusters, it works well.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
