### PR TITLE
[bitnami/argo-cd] Use custom probes if given

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/containers/tree/main/bitnami/dex
   - https://github.com/dexidp/dex
-version: 4.1.4
+version: 4.1.5

--- a/bitnami/argo-cd/templates/application-controller/deployment.yaml
+++ b/bitnami/argo-cd/templates/application-controller/deployment.yaml
@@ -176,7 +176,9 @@ spec:
           {{- if .Values.controller.resources }}
           resources: {{- toYaml .Values.controller.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.controller.startupProbe.enabled }}
+          {{- if .Values.controller.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controller.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.controller.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /healthz
@@ -186,10 +188,10 @@ spec:
             timeoutSeconds: {{ .Values.controller.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.controller.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.controller.startupProbe.failureThreshold }}
-          {{- else if .Values.controller.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controller.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.controller.livenessProbe.enabled }}
+          {{- if .Values.controller.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controller.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.controller.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -199,10 +201,10 @@ spec:
             timeoutSeconds: {{ .Values.controller.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.controller.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.controller.livenessProbe.failureThreshold }}
-          {{- else if .Values.controller.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controller.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.controller.readinessProbe.enabled }}
+          {{- if .Values.controller.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controller.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.controller.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.controller.containerPorts.controller }}
@@ -211,8 +213,6 @@ spec:
             timeoutSeconds: {{ .Values.controller.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.controller.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.controller.readinessProbe.failureThreshold }}
-          {{- else if .Values.controller.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.controller.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             # Mounting into a path that will be read by Argo CD.

--- a/bitnami/argo-cd/templates/dex/deployment.yaml
+++ b/bitnami/argo-cd/templates/dex/deployment.yaml
@@ -160,7 +160,9 @@ spec:
           {{- if .Values.dex.resources }}
           resources: {{- toYaml .Values.dex.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.dex.startupProbe.enabled }}
+          {{- if .Values.dex.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dex.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.dex.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /healthz
@@ -170,10 +172,10 @@ spec:
             timeoutSeconds: {{ .Values.dex.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.dex.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.dex.startupProbe.failureThreshold }}
-          {{- else if .Values.dex.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dex.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.dex.livenessProbe.enabled }}
+          {{- if .Values.dex.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dex.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.dex.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -183,10 +185,10 @@ spec:
             timeoutSeconds: {{ .Values.dex.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.dex.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.dex.livenessProbe.failureThreshold }}
-          {{- else if .Values.dex.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dex.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.dex.readinessProbe.enabled }}
+          {{- if .Values.dex.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dex.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.dex.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /healthz
@@ -196,8 +198,6 @@ spec:
             timeoutSeconds: {{ .Values.dex.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.dex.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.dex.readinessProbe.failureThreshold }}
-          {{- else if .Values.dex.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dex.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: static-files

--- a/bitnami/argo-cd/templates/repo-server/deployment.yaml
+++ b/bitnami/argo-cd/templates/repo-server/deployment.yaml
@@ -185,7 +185,9 @@ spec:
           {{- if .Values.repoServer.resources }}
           resources: {{- toYaml .Values.repoServer.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.repoServer.startupProbe.enabled }}
+          {{- if .Values.repoServer.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.repoServer.startupProbe.enabled }}
           startupProbe:
             tcpSocket:
               port: {{ .Values.repoServer.containerPorts.repoServer }}
@@ -194,10 +196,10 @@ spec:
             timeoutSeconds: {{ .Values.repoServer.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.repoServer.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.repoServer.startupProbe.failureThreshold }}
-          {{- else if .Values.repoServer.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.repoServer.livenessProbe.enabled }}
+          {{- if .Values.repoServer.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.repoServer.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
               port: {{ .Values.repoServer.containerPorts.repoServer }}
@@ -206,10 +208,10 @@ spec:
             timeoutSeconds: {{ .Values.repoServer.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.repoServer.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.repoServer.livenessProbe.failureThreshold }}
-          {{- else if .Values.repoServer.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.repoServer.readinessProbe.enabled }}
+          {{- if .Values.repoServer.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.repoServer.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.repoServer.containerPorts.repoServer }}
@@ -218,8 +220,6 @@ spec:
             timeoutSeconds: {{ .Values.repoServer.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.repoServer.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.repoServer.readinessProbe.failureThreshold }}
-          {{- else if .Values.repoServer.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.repoServer.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             # Mounting into a path that will be read by Argo CD

--- a/bitnami/argo-cd/templates/server/deployment.yaml
+++ b/bitnami/argo-cd/templates/server/deployment.yaml
@@ -197,7 +197,9 @@ spec:
           {{- if .Values.server.resources }}
           resources: {{- toYaml .Values.server.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.startupProbe.enabled }}
+          {{- if .Values.server.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /healthz
@@ -207,10 +209,10 @@ spec:
             timeoutSeconds: {{ .Values.server.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.server.startupProbe.failureThreshold }}
-          {{- else if .Values.server.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.livenessProbe.enabled }}
+          {{- if .Values.server.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -220,10 +222,10 @@ spec:
             timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
-          {{- else if .Values.server.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.readinessProbe.enabled }}
+          {{- if .Values.server.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /healthz
@@ -233,8 +235,6 @@ spec:
             timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
-          {{- else if .Values.server.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             # Mounting into a path that will be read by Argo CD


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354