### PR TITLE
[bitnami/cert-manager] Use custom probes if given

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/cert-manager-webhook
   - https://github.com/bitnami/containers/tree/main/bitnami/cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.8.2
+version: 0.8.3

--- a/bitnami/cert-manager/templates/webhook/deployment.yaml
+++ b/bitnami/cert-manager/templates/webhook/deployment.yaml
@@ -123,7 +123,9 @@ spec:
           {{- if .Values.webhook.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.webhook.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.webhook.livenessProbe.enabled }}
+          {{- if .Values.webhook.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.webhook.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.webhook.livenessProbe.enabled }}
           livenessProbe:
              httpGet:
                path: {{ .Values.webhook.livenessProbe.path }}
@@ -134,10 +136,10 @@ spec:
              timeoutSeconds: {{ .Values.webhook.livenessProbe.timeoutSeconds }}
              successThreshold: {{ .Values.webhook.livenessProbe.successThreshold }}
              failureThreshold: {{ .Values.webhook.livenessProbe.failureThreshold }}
-          {{- else if .Values.webhook.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.webhook.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.webhook.readinessProbe.enabled }}
+          {{- if .Values.webhook.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.webhook.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.webhook.readinessProbe.enabled }}
           readinessProbe:
              httpGet:
                path: {{ .Values.webhook.readinessProbe.path }}
@@ -148,8 +150,6 @@ spec:
              timeoutSeconds: {{ .Values.webhook.readinessProbe.timeoutSeconds }}
              successThreshold: {{ .Values.webhook.readinessProbe.successThreshold }}
              failureThreshold: {{ .Values.webhook.readinessProbe.failureThreshold }}
-          {{- else if .Values.webhook.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.webhook.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.webhook.resources }}
           resources: {{- toYaml .Values.webhook.resources | nindent 12 }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354