### PR TITLE
[bitnami/contour] Use custom probes if given

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/containers/tree/main/bitnami/contour
   - https://projectcontour.io
-version: 9.1.2
+version: 9.1.3

--- a/bitnami/contour/templates/contour/deployment.yaml
+++ b/bitnami/contour/templates/contour/deployment.yaml
@@ -132,7 +132,9 @@ spec:
           {{- if .Values.contour.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.contour.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.contour.livenessProbe.enabled }}
+          {{- if .Values.contour.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.contour.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.contour.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -142,10 +144,10 @@ spec:
             timeoutSeconds: {{ .Values.contour.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.contour.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.contour.livenessProbe.failureThreshold }}
-          {{- else if .Values.contour.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.contour.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.contour.readinessProbe.enabled }}
+          {{- if .Values.contour.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.contour.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.contour.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /healthz
@@ -155,10 +157,10 @@ spec:
             timeoutSeconds: {{ .Values.contour.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.contour.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.contour.readinessProbe.failureThreshold }}
-          {{- else if .Values.contour.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.contour.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.contour.startupProbe.enabled }}
+          {{- if .Values.contour.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.contour.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.contour.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /healthz
@@ -168,8 +170,6 @@ spec:
             timeoutSeconds: {{ .Values.contour.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.contour.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.contour.startupProbe.failureThreshold }}
-          {{- else if .Values.contour.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.contour.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           resources: {{ toYaml .Values.contour.resources | nindent 12 }}

--- a/bitnami/contour/templates/default-backend/deployment.yaml
+++ b/bitnami/contour/templates/default-backend/deployment.yaml
@@ -117,7 +117,9 @@ spec:
                 name: {{ include "common.tplvalues.render" ( dict "value" .Values.defaultBackend.extraEnvVarsSecret "context" $ ) }}
             {{- end }}
           {{- end }}
-          {{- if .Values.defaultBackend.livenessProbe.enabled }}
+          {{- if .Values.defaultBackend.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.defaultBackend.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.defaultBackend.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /
@@ -128,10 +130,10 @@ spec:
             timeoutSeconds: {{ .Values.defaultBackend.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.defaultBackend.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.defaultBackend.livenessProbe.failureThreshold }}
-          {{- else if .Values.defaultBackend.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.defaultBackend.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.defaultBackend.readinessProbe.enabled }}
+          {{- if .Values.defaultBackend.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.defaultBackend.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.defaultBackend.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /
@@ -142,10 +144,10 @@ spec:
             timeoutSeconds: {{ .Values.defaultBackend.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.defaultBackend.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.defaultBackend.readinessProbe.failureThreshold }}
-          {{- else if .Values.defaultBackend.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.defaultBackend.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.defaultBackend.startupProbe.enabled }}
+          {{- if .Values.defaultBackend.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.defaultBackend.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.defaultBackend.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /
@@ -156,8 +158,6 @@ spec:
             timeoutSeconds: {{ .Values.defaultBackend.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.defaultBackend.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.defaultBackend.startupProbe.failureThreshold }}
-          {{- else if .Values.defaultBackend.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.defaultBackend.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           ports:
             - name: http

--- a/bitnami/contour/templates/envoy/deployment.yaml
+++ b/bitnami/contour/templates/envoy/deployment.yaml
@@ -107,7 +107,9 @@ spec:
                   - contour
                   - envoy
                   - shutdown
-          {{- if .Values.contour.livenessProbe.enabled }}
+          {{- if .Values.envoy.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.envoy.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.contour.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -210,10 +212,10 @@ spec:
             timeoutSeconds: {{ .Values.envoy.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.envoy.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.envoy.readinessProbe.failureThreshold }}
-          {{- else if .Values.envoy.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.envoy.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.envoy.livenessProbe.enabled }}
+          {{- if .Values.envoy.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.envoy.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.envoy.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /ready
@@ -223,10 +225,10 @@ spec:
             timeoutSeconds: {{ .Values.envoy.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.envoy.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.envoy.livenessProbe.failureThreshold }}
-          {{- else if .Values.envoy.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.envoy.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.envoy.startupProbe.enabled }}
+          {{- if .Values.envoy.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.envoy.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.envoy.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /ready
@@ -236,8 +238,6 @@ spec:
             timeoutSeconds: {{ .Values.envoy.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.envoy.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.envoy.startupProbe.failureThreshold }}
-          {{- else if .Values.envoy.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.envoy.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           resources: {{- toYaml .Values.envoy.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354