### PR TITLE
[bitnami/fluentd] Use custom probes if given

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/fluentd
   - https://www.fluentd.org/
-version: 5.5.0
+version: 5.5.1

--- a/bitnami/fluentd/templates/aggregator-statefulset.yaml
+++ b/bitnami/fluentd/templates/aggregator-statefulset.yaml
@@ -133,7 +133,9 @@ spec:
               protocol: TCP
             {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.aggregator.startupProbe.enabled }}
+          {{- if .Values.aggregator.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.aggregator.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.aggregator.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: {{ .Values.aggregator.startupProbe.httpGet.path }}
@@ -143,10 +145,10 @@ spec:
             timeoutSeconds: {{ .Values.aggregator.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.aggregator.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.aggregator.startupProbe.failureThreshold }}
-          {{- else if .Values.aggregator.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.aggregator.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.aggregator.livenessProbe.enabled }}
+          {{- if .Values.aggregator.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.aggregator.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.aggregator.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: {{ .Values.aggregator.livenessProbe.httpGet.path }}
@@ -156,10 +158,10 @@ spec:
             timeoutSeconds: {{ .Values.aggregator.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.aggregator.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.aggregator.livenessProbe.failureThreshold }}
-          {{- else if .Values.aggregator.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.aggregator.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.aggregator.readinessProbe.enabled }}
+          {{- if .Values.aggregator.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.aggregator.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.aggregator.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: {{ .Values.aggregator.readinessProbe.httpGet.path }}
@@ -169,8 +171,6 @@ spec:
             timeoutSeconds: {{ .Values.aggregator.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.aggregator.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.aggregator.readinessProbe.failureThreshold }}
-          {{- else if .Values.aggregator.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.aggregator.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           volumeMounts:

--- a/bitnami/fluentd/templates/forwarder-daemonset.yaml
+++ b/bitnami/fluentd/templates/forwarder-daemonset.yaml
@@ -131,7 +131,9 @@ spec:
               protocol: TCP
             {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.forwarder.startupProbe.enabled }}
+          {{- if .Values.forwarder.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.forwarder.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.forwarder.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: {{ .Values.forwarder.startupProbe.httpGet.path }}
@@ -141,10 +143,10 @@ spec:
             timeoutSeconds: {{ .Values.forwarder.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.forwarder.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.forwarder.startupProbe.failureThreshold }}
-          {{- else if .Values.forwarder.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.forwarder.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.forwarder.livenessProbe.enabled }}
+          {{- if .Values.forwarder.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.forwarder.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.forwarder.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: {{ .Values.forwarder.livenessProbe.httpGet.path }}
@@ -154,10 +156,10 @@ spec:
             timeoutSeconds: {{ .Values.forwarder.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.forwarder.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.forwarder.livenessProbe.failureThreshold }}
-          {{- else if .Values.forwarder.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.forwarder.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.forwarder.readinessProbe.enabled }}
+          {{- if .Values.forwarder.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.forwarder.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.forwarder.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: {{ .Values.forwarder.readinessProbe.httpGet.path }}
@@ -167,8 +169,6 @@ spec:
             timeoutSeconds: {{ .Values.forwarder.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.forwarder.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.forwarder.readinessProbe.failureThreshold }}
-          {{- else if .Values.forwarder.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.forwarder.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           volumeMounts:


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354