### PR TITLE
[bitnami/geode] Use custom probes if given

### DIFF
--- a/bitnami/geode/Chart.yaml
+++ b/bitnami/geode/Chart.yaml
@@ -22,4 +22,4 @@ name: geode
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/geode
   - https://github.com/apache/geode
-version: 1.1.2
+version: 1.1.3

--- a/bitnami/geode/templates/locator/statefulset.yaml
+++ b/bitnami/geode/templates/locator/statefulset.yaml
@@ -319,7 +319,9 @@ spec:
             - name: rmi
               containerPort: {{ .Values.locator.containerPorts.rmi }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.locator.livenessProbe.enabled }}
+          {{- if .Values.locator.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.locator.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.locator.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.locator.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
@@ -328,10 +330,10 @@ spec:
                 - |
                   . /opt/bitnami/scripts/geode-env.sh
                   gfsh -e "connect --locator=$GEODE_NODE_NAME[$GEODE_LOCATOR_PORT_NUMBER]{{if .Values.auth.tls.enabled }} --use-ssl{{ end }}{{ if or .Values.auth.enabled .Values.auth.tls.enabled }} --security-properties-file=$GEODE_SEC_CONF_FILE{{ end }}" || exit 1
-          {{- else if .Values.locator.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.locator.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.locator.readinessProbe.enabled }}
+          {{- if .Values.locator.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.locator.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.locator.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.locator.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
@@ -340,15 +342,13 @@ spec:
                 - |
                   . /opt/bitnami/scripts/geode-env.sh
                   gfsh -e "connect --locator=$GEODE_NODE_NAME[$GEODE_LOCATOR_PORT_NUMBER]{{if .Values.auth.tls.enabled }} --use-ssl{{ end }}{{ if or .Values.auth.enabled .Values.auth.tls.enabled }} --security-properties-file=$GEODE_SEC_CONF_FILE{{ end }}" || exit 1
-          {{- else if .Values.locator.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.locator.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.locator.startupProbe.enabled }}
+          {{- if .Values.locator.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.locator.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.locator.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.locator.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: locator
-          {{- else if .Values.locator.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.locator.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.locator.lifecycleHooks }}
@@ -386,23 +386,23 @@ spec:
             - name: haproxy-configuration
               mountPath: /bitnami/haproxy/conf/haproxy.cfg
               subPath: haproxy.cfg
-          {{- if .Values.metrics.livenessProbe.enabled }}
+          {{- if .Values.metrics.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - pgrep
                 - haproxy
-          {{- else if .Values.metrics.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.metrics.readinessProbe.enabled }}
+          {{- if .Values.metrics.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - pgrep
                 - haproxy
-          {{- else if .Values.metrics.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           ports:
             - name: metrics

--- a/bitnami/geode/templates/server/statefulset.yaml
+++ b/bitnami/geode/templates/server/statefulset.yaml
@@ -380,7 +380,9 @@ spec:
             - name: rmi
               containerPort: {{ .Values.server.containerPorts.rmi }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.server.livenessProbe.enabled }}
+          {{- if .Values.server.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.server.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
@@ -388,10 +390,10 @@ spec:
                 - -c
                 - |
                   (cd /bitnami/geode/data && gfsh status server)
-          {{- else if .Values.server.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.readinessProbe.enabled }}
+          {{- if .Values.server.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.server.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
@@ -399,15 +401,13 @@ spec:
                 - -c
                 - |
                   (cd /bitnami/geode/data && gfsh status server)
-          {{- else if .Values.server.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.startupProbe.enabled }}
+          {{- if .Values.server.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.server.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: server
-          {{- else if .Values.server.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.server.lifecycleHooks }}
@@ -450,23 +450,23 @@ spec:
           {{- if .Values.metrics.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.metrics.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if .Values.metrics.livenessProbe.enabled }}
+          {{- if .Values.metrics.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - pgrep
                 - haproxy
-          {{- else if .Values.metrics.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.metrics.readinessProbe.enabled }}
+          {{- if .Values.metrics.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.metrics.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - pgrep
                 - haproxy
-          {{- else if .Values.metrics.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metrics.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: haproxy-configuration


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354