### PR TITLE
[bitnami/grafana-tempo] Use custom probes if given

### DIFF
--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -28,4 +28,4 @@ name: grafana-tempo
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/grafana-tempo
   - https://github.com/grafana/tempo/
-version: 1.4.2
+version: 1.4.3

--- a/bitnami/grafana-tempo/templates/compactor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/compactor/deployment.yaml
@@ -112,28 +112,28 @@ spec:
           resources: {{- toYaml .Values.compactor.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.compactor.livenessProbe.enabled }}
+          {{- if .Values.compactor.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.compactor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: {{ .Values.tempo.containerPorts.web }}
-          {{- else if .Values.compactor.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.compactor.readinessProbe.enabled }}
+          {{- if .Values.compactor.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.compactor.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: {{ .Values.tempo.containerPorts.web }}
-          {{- else if .Values.compactor.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.compactor.startupProbe.enabled }}
+          {{- if .Values.compactor.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.compactor.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.compactor.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.compactor.lifecycleHooks }}

--- a/bitnami/grafana-tempo/templates/distributor/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/distributor/deployment.yaml
@@ -153,28 +153,28 @@ spec:
           resources: {{- toYaml .Values.distributor.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.distributor.livenessProbe.enabled }}
+          {{- if .Values.distributor.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.distributor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.distributor.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: {{ .Values.tempo.containerPorts.web }}
-          {{- else if .Values.distributor.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.distributor.readinessProbe.enabled }}
+          {{- if .Values.distributor.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.distributor.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.distributor.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: {{ .Values.tempo.containerPorts.web }}
-          {{- else if .Values.distributor.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.distributor.startupProbe.enabled }}
+          {{- if .Values.distributor.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.distributor.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.distributor.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.distributor.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.distributor.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.distributor.lifecycleHooks }}

--- a/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
+++ b/bitnami/grafana-tempo/templates/ingester/statefulset.yaml
@@ -139,26 +139,26 @@ spec:
           resources: {{- toYaml .Values.ingester.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.ingester.livenessProbe.enabled }}
+          {{- if .Values.ingester.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.ingester.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.livenessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.ingester.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.ingester.readinessProbe.enabled }}
+          {{- if .Values.ingester.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.ingester.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.readinessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.ingester.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.ingester.startupProbe.enabled }}
+          {{- if .Values.ingester.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.ingester.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ingester.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.ingester.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ingester.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.ingester.lifecycleHooks }}

--- a/bitnami/grafana-tempo/templates/metrics-generator/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/metrics-generator/deployment.yaml
@@ -114,28 +114,28 @@ spec:
           resources: {{- toYaml .Values.metricsGenerator.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.metricsGenerator.livenessProbe.enabled }}
+          {{- if .Values.metricsGenerator.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metricsGenerator.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.metricsGenerator.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metricsGenerator.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: {{ .Values.tempo.containerPorts.http }}
-          {{- else if .Values.metricsGenerator.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metricsGenerator.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.metricsGenerator.readinessProbe.enabled }}
+          {{- if .Values.metricsGenerator.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metricsGenerator.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.metricsGenerator.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metricsGenerator.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: {{ .Values.tempo.containerPorts.http }}
-          {{- else if .Values.metricsGenerator.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metricsGenerator.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.metricsGenerator.startupProbe.enabled }}
+          {{- if .Values.metricsGenerator.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metricsGenerator.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.metricsGenerator.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metricsGenerator.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.metricsGenerator.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.metricsGenerator.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.metricsGenerator.lifecycleHooks }}

--- a/bitnami/grafana-tempo/templates/querier/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/querier/deployment.yaml
@@ -113,28 +113,28 @@ spec:
           resources: {{- toYaml .Values.querier.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.querier.livenessProbe.enabled }}
+          {{- if .Values.querier.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.querier.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.querier.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: {{ .Values.tempo.containerPorts.web }}
-          {{- else if .Values.querier.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.querier.readinessProbe.enabled }}
+          {{- if .Values.querier.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.querier.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.querier.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: {{ .Values.tempo.containerPorts.web }}
-          {{- else if .Values.querier.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.querier.startupProbe.enabled }}
+          {{- if .Values.querier.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.querier.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.querier.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.querier.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.querier.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.querier.lifecycleHooks }}

--- a/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/query-frontend/deployment.yaml
@@ -113,28 +113,28 @@ spec:
           resources: {{- toYaml .Values.queryFrontend.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.queryFrontend.livenessProbe.enabled }}
+          {{- if .Values.queryFrontend.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.queryFrontend.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: {{ .Values.tempo.containerPorts.web }}
-          {{- else if .Values.queryFrontend.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.queryFrontend.readinessProbe.enabled }}
+          {{- if .Values.queryFrontend.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.queryFrontend.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: {{ .Values.tempo.containerPorts.web }}
-          {{- else if .Values.queryFrontend.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.queryFrontend.startupProbe.enabled }}
+          {{- if .Values.queryFrontend.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.queryFrontend.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.queryFrontend.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.queryFrontend.lifecycleHooks }}
@@ -192,26 +192,26 @@ spec:
           resources: {{- toYaml .Values.queryFrontend.query.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.queryFrontend.query.livenessProbe.enabled }}
+          {{- if .Values.queryFrontend.query.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.queryFrontend.query.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.livenessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: jaeger-ui
-          {{- else if .Values.queryFrontend.query.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.queryFrontend.query.readinessProbe.enabled }}
+          {{- if .Values.queryFrontend.query.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.queryFrontend.query.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.readinessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: jaeger-ui
-          {{- else if .Values.queryFrontend.query.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.queryFrontend.query.startupProbe.enabled }}
+          {{- if .Values.queryFrontend.query.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.queryFrontend.query.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.query.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: jaeger-ui
-          {{- else if .Values.queryFrontend.query.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.query.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.queryFrontend.query.lifecycleHooks }}

--- a/bitnami/grafana-tempo/templates/vulture/deployment.yaml
+++ b/bitnami/grafana-tempo/templates/vulture/deployment.yaml
@@ -109,28 +109,28 @@ spec:
           resources: {{- toYaml .Values.vulture.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.vulture.livenessProbe.enabled }}
+          {{- if .Values.vulture.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.vulture.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: {{ .Values.vulture.containerPorts.http }}
-          {{- else if .Values.vulture.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.vulture.readinessProbe.enabled }}
+          {{- if .Values.vulture.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.vulture.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: {{ .Values.vulture.containerPorts.http }}
-          {{- else if .Values.vulture.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.vulture.startupProbe.enabled }}
+          {{- if .Values.vulture.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.vulture.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.vulture.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.vulture.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.vulture.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.vulture.lifecycleHooks }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354