### PR TITLE
[bitnami/harbor] Use custom probes if given

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -36,4 +36,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registry
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registryctl
   - https://goharbor.io/
-version: 15.2.2
+version: 15.2.3

--- a/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
+++ b/bitnami/harbor/templates/chartmuseum/chartmuseum-dpl.yaml
@@ -139,30 +139,30 @@ spec:
             - containerPort: {{ ternary .Values.chartmuseum.containerPorts.https .Values.chartmuseum.containerPorts.http .Values.internalTLS.enabled }}
               name: {{ ternary "https" "http" .Values.internalTLS.enabled }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.chartmuseum.startupProbe.enabled }}
+          {{- if .Values.chartmuseum.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.chartmuseum.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.chartmuseum.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.chartmuseum.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-          {{- else if .Values.chartmuseum.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.chartmuseum.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.chartmuseum.livenessProbe.enabled }}
+          {{- if .Values.chartmuseum.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.chartmuseum.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.chartmuseum.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.chartmuseum.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /health
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
-          {{- else if .Values.chartmuseum.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.chartmuseum.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.chartmuseum.readinessProbe.enabled }}
+          {{- if .Values.chartmuseum.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.chartmuseum.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.chartmuseum.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.chartmuseum.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /health
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
-          {{- else if .Values.chartmuseum.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.chartmuseum.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.chartmuseum.lifecycleHooks }}

--- a/bitnami/harbor/templates/core/core-dpl.yaml
+++ b/bitnami/harbor/templates/core/core-dpl.yaml
@@ -147,32 +147,32 @@ spec:
               name: metrics
             {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.core.startupProbe.enabled }}
+          {{- if .Values.core.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.core.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.core.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.core.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /api/v2.0/ping
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-          {{- else if .Values.core.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.core.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.core.livenessProbe.enabled }}
+          {{- if .Values.core.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.core.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.core.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.core.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /api/v2.0/ping
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-          {{- else if .Values.core.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.core.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.core.readinessProbe.enabled }}
+          {{- if .Values.core.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.core.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.core.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.core.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /api/v2.0/ping
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-          {{- else if .Values.core.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.core.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.core.lifecycleHooks }}

--- a/bitnami/harbor/templates/exporter/exporter-dpl.yaml
+++ b/bitnami/harbor/templates/exporter/exporter-dpl.yaml
@@ -119,33 +119,33 @@ spec:
             - containerPort: {{ .Values.exporter.containerPorts.metrics }}
               name: metrics
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.exporter.startupProbe.enabled }}
+          {{- if .Values.exporter.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.exporter.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.exporter.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.exporter.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: {{ .Values.metrics.path | quote }}
               port: metrics
               # Metrics are exposed only though HTTP https://github.com/goharbor/harbor/issues/16252
               scheme: HTTP
-          {{- else if .Values.exporter.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.exporter.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.exporter.livenessProbe.enabled }}
+          {{- if .Values.exporter.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.exporter.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.exporter.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.exporter.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: {{ .Values.metrics.path | quote }}
               port: metrics
               scheme: HTTP
-          {{- else if .Values.exporter.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.exporter.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.exporter.readinessProbe.enabled }}
+          {{- if .Values.exporter.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.exporter.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.exporter.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.exporter.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: {{ .Values.metrics.path | quote }}
               port: metrics
               scheme: HTTP
-          {{- else if .Values.exporter.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.exporter.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.exporter.lifecycleHooks }}

--- a/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
+++ b/bitnami/harbor/templates/jobservice/jobservice-dpl.yaml
@@ -163,30 +163,30 @@ spec:
               name: metrics
             {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.jobservice.startupProbe.enabled }}
+          {{- if .Values.jobservice.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.jobservice.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.jobservice.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.jobservice.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-          {{- else if .Values.jobservice.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.jobservice.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.jobservice.livenessProbe.enabled }}
+          {{- if .Values.jobservice.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.jobservice.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.jobservice.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.jobservice.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /api/v1/stats
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
-          {{- else if .Values.jobservice.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.jobservice.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.jobservice.readinessProbe.enabled }}
+          {{- if .Values.jobservice.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.jobservice.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.jobservice.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.jobservice.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /api/v1/stats
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
-          {{- else if .Values.jobservice.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.jobservice.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.jobservice.lifecycleHooks }}

--- a/bitnami/harbor/templates/nginx/deployment.yaml
+++ b/bitnami/harbor/templates/nginx/deployment.yaml
@@ -119,30 +119,30 @@ spec:
             - containerPort: {{ .Values.nginx.containerPorts.notary }}
               name: notary
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.nginx.startupProbe.enabled }}
+          {{- if .Values.nginx.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.nginx.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.nginx.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.nginx.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: {{ ternary "https" "http" .Values.nginx.tls.enabled }}
-          {{- else if .Values.nginx.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.nginx.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.nginx.livenessProbe.enabled }}
+          {{- if .Values.nginx.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.nginx.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.nginx.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.nginx.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
               port: {{ ternary "https" "http" .Values.nginx.tls.enabled }}
               scheme: {{ ternary "https" "http" .Values.nginx.tls.enabled  | upper }}
-          {{- else if .Values.nginx.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.nginx.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.nginx.readinessProbe.enabled }}
+          {{- if .Values.nginx.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.nginx.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.nginx.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.nginx.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
               port: {{ ternary "https" "http" .Values.nginx.tls.enabled }}
               scheme: {{ ternary "https" "http" .Values.nginx.tls.enabled  | upper }}
-          {{- else if .Values.nginx.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.nginx.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.nginx.resources }}

--- a/bitnami/harbor/templates/notary/notary-server.yaml
+++ b/bitnami/harbor/templates/notary/notary-server.yaml
@@ -114,26 +114,26 @@ spec:
             - containerPort: {{ .Values.notary.server.containerPorts.server }}
               name: notary-server
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.notary.server.startupProbe.enabled }}
+          {{- if .Values.notary.server.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.server.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.notary.server.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.notary.server.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: notary-server
-          {{- else if .Values.notary.server.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.server.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.notary.server.livenessProbe.enabled }}
+          {{- if .Values.notary.server.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.server.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.notary.server.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.notary.server.livenessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: notary-server
-          {{- else if .Values.notary.server.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.server.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.notary.server.readinessProbe.enabled }}
+          {{- if .Values.notary.server.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.server.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.notary.server.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.notary.server.readinessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: notary-server
-          {{- else if .Values.notary.server.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.server.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.notary.server.lifecycleHooks }}

--- a/bitnami/harbor/templates/notary/notary-signer.yaml
+++ b/bitnami/harbor/templates/notary/notary-signer.yaml
@@ -115,26 +115,26 @@ spec:
             - containerPort: {{ .Values.notary.signer.containerPorts.signer }}
               name: notary-signer
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.notary.signer.startupProbe.enabled }}
+          {{- if .Values.notary.signer.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.signer.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.notary.signer.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.notary.signer.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: notary-signer
-          {{- else if .Values.notary.signer.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.signer.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.notary.signer.livenessProbe.enabled }}
+          {{- if .Values.notary.signer.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.signer.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.notary.signer.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.notary.signer.livenessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: notary-signer
-          {{- else if .Values.notary.signer.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.signer.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.notary.signer.readinessProbe.enabled }}
+          {{- if .Values.notary.signer.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.signer.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.notary.signer.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.notary.signer.readinessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: notary-signer
-          {{- else if .Values.notary.signer.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.notary.signer.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.notary.signer.lifecycleHooks }}

--- a/bitnami/harbor/templates/portal/portal-dpl.yaml
+++ b/bitnami/harbor/templates/portal/portal-dpl.yaml
@@ -107,30 +107,30 @@ spec:
             - containerPort: {{ ternary .Values.portal.containerPorts.https .Values.portal.containerPorts.http .Values.internalTLS.enabled }}
               name: {{ ternary "https" "http" .Values.internalTLS.enabled }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.portal.startupProbe.enabled }}
+          {{- if .Values.portal.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.portal.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.portal.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.portal.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-          {{- else if .Values.portal.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.portal.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.portal.livenessProbe.enabled }}
+          {{- if .Values.portal.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.portal.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.portal.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.portal.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
-          {{- else if .Values.portal.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.portal.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.portal.readinessProbe.enabled }}
+          {{- if .Values.portal.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.portal.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.portal.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.portal.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
-          {{- else if .Values.portal.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.portal.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.portal.lifecycleHooks }}

--- a/bitnami/harbor/templates/registry/registry-dpl.yaml
+++ b/bitnami/harbor/templates/registry/registry-dpl.yaml
@@ -160,30 +160,30 @@ spec:
               name: metrics
             {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.registry.server.startupProbe.enabled }}
+          {{- if .Values.registry.server.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.server.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.registry.server.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.registry.server.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-          {{- else if .Values.registry.server.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.server.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.registry.server.livenessProbe.enabled }}
+          {{- if .Values.registry.server.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.server.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.registry.server.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.registry.server.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: registry
-          {{- else if .Values.registry.server.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.server.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.registry.server.readinessProbe.enabled }}
+          {{- if .Values.registry.server.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.server.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.registry.server.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.registry.server.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: registry
-          {{- else if .Values.registry.server.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.server.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.registry.server.lifecycleHooks }}
@@ -293,30 +293,30 @@ spec:
             - containerPort: {{ ternary .Values.registry.controller.containerPorts.https .Values.registry.controller.containerPorts.http .Values.internalTLS.enabled }}
               name: registryctl
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.registry.controller.startupProbe.enabled }}
+          {{- if .Values.registry.controller.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.controller.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.registry.controller.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.registry.controller.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: {{ ternary "https" "http" .Values.internalTLS.enabled }}
-          {{- else if .Values.registry.controller.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.controller.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.registry.controller.livenessProbe.enabled }}
+          {{- if .Values.registry.controller.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.controller.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.registry.controller.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.registry.controller.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /api/health
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: registryctl
-          {{- else if .Values.registry.controller.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.controller.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.registry.controller.readinessProbe.enabled }}
+          {{- if .Values.registry.controller.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.controller.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.registry.controller.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.registry.controller.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /api/health
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               port: registryctl
-          {{- else if .Values.registry.controller.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.registry.controller.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.registry.controller.lifecycleHooks }}

--- a/bitnami/harbor/templates/trivy/trivy-sts.yaml
+++ b/bitnami/harbor/templates/trivy/trivy-sts.yaml
@@ -135,30 +135,30 @@ spec:
             - name: api-server
               containerPort: {{ ternary .Values.trivy.containerPorts.https .Values.trivy.containerPorts.http .Values.internalTLS.enabled }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.trivy.startupProbe.enabled }}
+          {{- if .Values.trivy.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.trivy.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.trivy.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.trivy.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: api-server
-          {{- else if .Values.trivy.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.trivy.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.trivy.livenessProbe.enabled }}
+          {{- if .Values.trivy.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.trivy.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.trivy.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.trivy.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               path: /probe/healthy
               port: api-server
-          {{- else if .Values.trivy.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.trivy.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.trivy.readinessProbe.enabled }}
+          {{- if .Values.trivy.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.trivy.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.trivy.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.trivy.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               scheme: {{ ternary "https" "http" .Values.internalTLS.enabled | upper }}
               path: /probe/ready
               port: api-server
-          {{- else if .Values.trivy.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.trivy.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.trivy.lifecycleHooks }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354