### PR TITLE
[bitnami/kiam] Use custom probes if given

### DIFF
--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -23,4 +23,4 @@ name: kiam
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kiam
   - https://github.com/uswitch/kiam
-version: 1.1.2
+version: 1.1.3

--- a/bitnami/kiam/templates/agent/agent-daemonset.yaml
+++ b/bitnami/kiam/templates/agent/agent-daemonset.yaml
@@ -159,7 +159,9 @@ spec:
           resources: {{- toYaml .Values.agent.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.agent.startupProbe.enabled }}
+          {{- if .Values.agent.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.agent.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.agent.startupProbe.enabled }}
           startupProbe:
             tcpSocket:
               port: {{ .Values.agent.containerPort }}
@@ -168,10 +170,10 @@ spec:
             timeoutSeconds: {{ .Values.agent.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.agent.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.agent.startupProbe.failureThreshold }}
-          {{- else if .Values.agent.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.agent.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.agent.livenessProbe.enabled }}
+          {{- if .Values.agent.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.agent.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.agent.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               {{- if .Values.agent.enableDeepProbe }}
@@ -185,10 +187,10 @@ spec:
             timeoutSeconds: {{ .Values.agent.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.agent.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.agent.livenessProbe.failureThreshold }}
-          {{- else if .Values.agent.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.agent.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.agent.readinessProbe.enabled }}
+          {{- if .Values.agent.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.agent.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.agent.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               {{- if .Values.agent.enableDeepProbe }}
@@ -202,8 +204,6 @@ spec:
             timeoutSeconds: {{ .Values.agent.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.agent.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.agent.readinessProbe.failureThreshold }}
-          {{- else if .Values.agent.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.agent.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           volumeMounts:

--- a/bitnami/kiam/templates/server/server-daemonset.yaml
+++ b/bitnami/kiam/templates/server/server-daemonset.yaml
@@ -146,7 +146,9 @@ spec:
           resources: {{- toYaml .Values.server.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.server.startupProbe.enabled }}
+          {{- if .Values.server.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.startupProbe.enabled }}
           startupProbe:
             grpc:
               port: grpclb
@@ -155,10 +157,10 @@ spec:
             timeoutSeconds: {{ .Values.server.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.server.startupProbe.failureThreshold }}
-          {{- else if .Values.server.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.livenessProbe.enabled }}
+          {{- if .Values.server.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.livenessProbe.enabled }}
           livenessProbe:
             exec:
               command:
@@ -176,10 +178,10 @@ spec:
             timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
-          {{- else if .Values.server.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.readinessProbe.enabled }}
+          {{- if .Values.server.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.readinessProbe.enabled }}
           readinessProbe:
             exec:
               command:
@@ -197,8 +199,6 @@ spec:
             timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
-          {{- else if .Values.server.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           volumeMounts:

--- a/bitnami/kiam/templates/server/server-deployment.yaml
+++ b/bitnami/kiam/templates/server/server-deployment.yaml
@@ -147,7 +147,9 @@ spec:
           resources: {{- toYaml .Values.server.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.server.startupProbe.enabled }}
+          {{- if .Values.server.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.startupProbe.enabled }}
           startupProbe:
             grpc:
               port: grpclb
@@ -156,10 +158,10 @@ spec:
             timeoutSeconds: {{ .Values.server.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.server.startupProbe.failureThreshold }}
-          {{- else if .Values.server.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.livenessProbe.enabled }}
+          {{- if .Values.server.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.livenessProbe.enabled }}
           livenessProbe:
             exec:
               command:
@@ -177,10 +179,10 @@ spec:
             timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
-          {{- else if .Values.server.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.readinessProbe.enabled }}
+          {{- if .Values.server.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.readinessProbe.enabled }}
           readinessProbe:
             exec:
               command:
@@ -198,8 +200,6 @@ spec:
             timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
-          {{- else if .Values.server.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           volumeMounts:


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354