### PR TITLE
[bitnami/kube-prometheus] Use custom probes if given

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
   - https://github.com/bitnami/containers/tree/main/bitnami/alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 8.1.7
+version: 8.1.8

--- a/bitnami/kube-prometheus/templates/blackbox-exporter/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/blackbox-exporter/deployment.yaml
@@ -105,26 +105,26 @@ spec:
           {{- if .Values.blackboxExporter.resources }}
           resources: {{- toYaml .Values.blackboxExporter.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.blackboxExporter.livenessProbe.enabled }}
+          {{- if .Values.blackboxExporter.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.blackboxExporter.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.blackboxExporter.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.blackboxExporter.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               port: http
-          {{- else if .Values.blackboxExporter.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.blackboxExporter.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.blackboxExporter.readinessProbe.enabled }}
+          {{- if .Values.blackboxExporter.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.blackboxExporter.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.blackboxExporter.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.blackboxExporter.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               port: http
-          {{- else if .Values.blackboxExporter.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.blackboxExporter.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.blackboxExporter.startupProbe.enabled }}
+          {{- if .Values.blackboxExporter.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.blackboxExporter.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.blackboxExporter.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.blackboxExporter.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               port: http
-          {{- else if .Values.blackboxExporter.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.blackboxExporter.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.blackboxExporter.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.blackboxExporter.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
+++ b/bitnami/kube-prometheus/templates/prometheus-operator/deployment.yaml
@@ -132,32 +132,32 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          {{- if .Values.operator.livenessProbe.enabled }}
+          {{- if .Values.operator.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.operator.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.operator.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.operator.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: http
               scheme: HTTP
-          {{- else if .Values.operator.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.operator.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.operator.readinessProbe.enabled }}
+          {{- if .Values.operator.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.operator.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.operator.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.operator.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: http
               scheme: HTTP
-          {{- else if .Values.operator.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.operator.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.operator.startupProbe.enabled }}
+          {{- if .Values.operator.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.operator.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.operator.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.operator.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /metrics
               port: http
               scheme: HTTP
-          {{- else if .Values.operator.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.operator.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.operator.resources }}
           resources: {{- toYaml .Values.operator.resources | nindent 12 }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354