### PR TITLE
[bitnami/kubeapps] Use custom probes if given

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 10.3.3
+version: 10.3.4

--- a/bitnami/kubeapps/templates/dashboard/deployment.yaml
+++ b/bitnami/kubeapps/templates/dashboard/deployment.yaml
@@ -104,28 +104,28 @@ spec:
             - name: http
               containerPort: {{ .Values.dashboard.containerPorts.http }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.dashboard.livenessProbe.enabled }}
+          {{- if .Values.dashboard.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.dashboard.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dashboard.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
               port: http
-          {{- else if .Values.dashboard.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.dashboard.readinessProbe.enabled }}
+          {{- if .Values.dashboard.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.dashboard.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dashboard.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
               port: http
-          {{- else if .Values.dashboard.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.dashboard.startupProbe.enabled }}
+          {{- if .Values.dashboard.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.dashboard.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.dashboard.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.dashboard.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.dashboard.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.dashboard.resources }}

--- a/bitnami/kubeapps/templates/frontend/deployment.yaml
+++ b/bitnami/kubeapps/templates/frontend/deployment.yaml
@@ -104,28 +104,28 @@ spec:
             - name: http
               containerPort: {{ .Values.frontend.containerPorts.http }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.frontend.livenessProbe.enabled }}
+          {{- if .Values.frontend.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.frontend.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.frontend.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /healthz
               port: http
-          {{- else if .Values.frontend.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.frontend.readinessProbe.enabled }}
+          {{- if .Values.frontend.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.frontend.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.frontend.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /
               port: http
-          {{- else if .Values.frontend.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.frontend.startupProbe.enabled }}
+          {{- if .Values.frontend.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.frontend.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.frontend.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.frontend.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.frontend.resources }}

--- a/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -174,28 +174,28 @@ spec:
             - name: grpc-http
               containerPort: {{ .Values.kubeappsapis.containerPorts.http }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.kubeappsapis.livenessProbe.enabled }}
+          {{- if .Values.kubeappsapis.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.kubeappsapis.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /core/plugins/v1alpha1/configured-plugins
               port: grpc-http
-          {{- else if .Values.kubeappsapis.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.kubeappsapis.readinessProbe.enabled }}
+          {{- if .Values.kubeappsapis.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.kubeappsapis.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /core/plugins/v1alpha1/configured-plugins
               port: grpc-http
-          {{- else if .Values.kubeappsapis.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.kubeappsapis.startupProbe.enabled }}
+          {{- if .Values.kubeappsapis.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.kubeappsapis.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeappsapis.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: grpc-http
-          {{- else if .Values.kubeappsapis.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeappsapis.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.kubeappsapis.resources }}

--- a/bitnami/kubeapps/templates/kubeops/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeops/deployment.yaml
@@ -136,28 +136,28 @@ spec:
             - name: http
               containerPort: {{ .Values.kubeops.containerPorts.http }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.kubeops.livenessProbe.enabled }}
+          {{- if .Values.kubeops.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.kubeops.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeops.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /live
               port: http
-          {{- else if .Values.kubeops.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.kubeops.readinessProbe.enabled }}
+          {{- if .Values.kubeops.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.kubeops.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeops.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /ready
               port: http
-          {{- else if .Values.kubeops.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.kubeops.startupProbe.enabled }}
+          {{- if .Values.kubeops.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.kubeops.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.kubeops.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: http
-          {{- else if .Values.kubeops.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.kubeops.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.kubeops.resources }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354