### PR TITLE
[bitnami/metrics-server] Use custom probes if given

### DIFF
--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -23,4 +23,4 @@ name: metrics-server
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/metrics-server
   - https://github.com/kubernetes-incubator/metrics-server
-version: 6.1.2
+version: 6.1.3

--- a/bitnami/metrics-server/templates/deployment.yaml
+++ b/bitnami/metrics-server/templates/deployment.yaml
@@ -117,30 +117,30 @@ spec:
             - name: https
               containerPort: {{ .Values.containerPorts.https }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.livenessProbe.enabled }}
+          {{- if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /livez
               port: https
               scheme: HTTPS
-          {{- else if .Values.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
+          {{- if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /readyz
               port: https
               scheme: HTTPS
-          {{- else if .Values.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.startupProbe.enabled }}
+          {{- if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: https
-          {{- else if .Values.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.extraVolumeMounts }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354