### PR TITLE
[bitnami/mxnet] Use custom probes if given

### DIFF
--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -24,4 +24,4 @@ name: mxnet
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mxnet
   - https://mxnet.apache.org/
-version: 3.1.2
+version: 3.1.3

--- a/bitnami/mxnet/templates/distributed/scheduler/deployment.yaml
+++ b/bitnami/mxnet/templates/distributed/scheduler/deployment.yaml
@@ -156,26 +156,26 @@ spec:
             - name: mxnet
               containerPort: {{ .Values.scheduler.containerPorts.mxnet }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.scheduler.livenessProbe.enabled }}
+          {{- if .Values.scheduler.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.scheduler.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.scheduler.livenessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: mxnet
-          {{- else if .Values.scheduler.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.scheduler.readinessProbe.enabled }}
+          {{- if .Values.scheduler.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.scheduler.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.scheduler.readinessProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: mxnet
-          {{- else if .Values.scheduler.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.scheduler.startupProbe.enabled }}
+          {{- if .Values.scheduler.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.scheduler.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.scheduler.startupProbe "enabled") "context" $) | nindent 12 }}
             tcpSocket:
               port: mxnet
-          {{- else if .Values.scheduler.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.scheduler.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.scheduler.resources }}

--- a/bitnami/mxnet/templates/distributed/server/statefulset.yaml
+++ b/bitnami/mxnet/templates/distributed/server/statefulset.yaml
@@ -184,35 +184,35 @@ spec:
           resources: {{- toYaml .Values.server.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.server.livenessProbe.enabled }}
+          {{- if .Values.server.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.server.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - python3
                 - -c
                 - import os; os.environ["DMLC_PS_ROOT_URI"] = "127.0.0.1"; os.environ["DMLC_ROLE"] = "worker"; import mxnet; print(mxnet.__version__)
-          {{- else if .Values.server.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.readinessProbe.enabled }}
+          {{- if .Values.server.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.server.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - python3
                 - -c
                 - import os; os.environ["DMLC_PS_ROOT_URI"] = "127.0.0.1"; os.environ["DMLC_ROLE"] = "worker"; import mxnet; print(mxnet.__version__)
-          {{- else if .Values.server.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.startupProbe.enabled }}
+          {{- if .Values.server.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.server.startupProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - python3
                 - -c
                 - import os; os.environ["DMLC_PS_ROOT_URI"] = "127.0.0.1"; os.environ["DMLC_ROLE"] = "worker"; import mxnet; print(mxnet.__version__)
-          {{- else if .Values.server.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           volumeMounts:

--- a/bitnami/mxnet/templates/distributed/worker/statefulset.yaml
+++ b/bitnami/mxnet/templates/distributed/worker/statefulset.yaml
@@ -182,35 +182,35 @@ spec:
           resources: {{- toYaml .Values.worker.resources | nindent 12 }}
           {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.worker.livenessProbe.enabled }}
+          {{- if .Values.worker.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.worker.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - python3
                 - -c
                 - import mxnet; print(mxnet.__version__)
-          {{- else if .Values.worker.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.worker.readinessProbe.enabled }}
+          {{- if .Values.worker.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.worker.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - python3
                 - -c
                 - import mxnet; print(mxnet.__version__)
-          {{- else if .Values.worker.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.worker.startupProbe.enabled }}
+          {{- if .Values.worker.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.worker.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.worker.startupProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - python3
                 - -c
                 - import mxnet; print(mxnet.__version__)
-          {{- else if .Values.worker.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.worker.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           volumeMounts:

--- a/bitnami/mxnet/templates/standalone/deployment.yaml
+++ b/bitnami/mxnet/templates/standalone/deployment.yaml
@@ -165,35 +165,35 @@ spec:
             - name: mxnet
               containerPort: {{ .Values.standalone.containerPorts.mxnet }}
           {{- if not .Values.diagnosticMode.enabled }}
-          {{- if .Values.standalone.livenessProbe.enabled }}
+          {{- if .Values.standalone.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.standalone.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.standalone.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.standalone.livenessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - python3
                 - -c
                 - import mxnet; print(mxnet.__version__)
-          {{- else if .Values.standalone.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.standalone.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.standalone.readinessProbe.enabled }}
+          {{- if .Values.standalone.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.standalone.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.standalone.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.standalone.readinessProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - python3
                 - -c
                 - import mxnet; print(mxnet.__version__)
-          {{- else if .Values.standalone.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.standalone.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.standalone.startupProbe.enabled }}
+          {{- if .Values.standalone.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.standalone.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.standalone.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.standalone.startupProbe "enabled") "context" $) | nindent 12 }}
             exec:
               command:
                 - python3
                 - -c
                 - import mxnet; print(mxnet.__version__)
-          {{- else if .Values.standalone.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.standalone.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- end }}
           {{- if .Values.standalone.resources }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354