### PR TITLE
[bitnami/pinniped] Use custom probes if given

### DIFF
--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -22,4 +22,4 @@ name: pinniped
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/pinniped
   - https://github.com/vmware-tanzu/pinniped/
-version: 0.3.1
+version: 0.3.2

--- a/bitnami/pinniped/templates/concierge/deployment.yaml
+++ b/bitnami/pinniped/templates/concierge/deployment.yaml
@@ -118,32 +118,32 @@ spec:
               containerPort: {{ .Values.concierge.containerPorts.proxy }}
             - name: https-api
               containerPort: {{ .Values.concierge.containerPorts.api }}
-          {{- if .Values.concierge.livenessProbe.enabled }}
+          {{- if .Values.concierge.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.concierge.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.concierge.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.concierge.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /healthz
               port: https-api
               scheme: HTTPS
-          {{- else if .Values.concierge.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.concierge.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.concierge.readinessProbe.enabled }}
+          {{- if .Values.concierge.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.concierge.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.concierge.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.concierge.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /healthz
               port: https-api
               scheme: HTTPS
-          {{- else if .Values.concierge.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.concierge.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.concierge.startupProbe.enabled }}
+          {{- if .Values.concierge.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.concierge.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.concierge.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.concierge.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /healthz
               port: https-api
               scheme: HTTPS
-          {{- else if .Values.concierge.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.concierge.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.concierge.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.concierge.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/pinniped/templates/supervisor/deployment.yaml
+++ b/bitnami/pinniped/templates/supervisor/deployment.yaml
@@ -110,32 +110,32 @@ spec:
           ports:
             - name: https
               containerPort: {{ .Values.supervisor.containerPorts.https }}
-          {{- if .Values.supervisor.livenessProbe.enabled }}
+          {{- if .Values.supervisor.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.supervisor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.supervisor.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /healthz
               port: https
               scheme: HTTPS
-          {{- else if .Values.supervisor.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.supervisor.readinessProbe.enabled }}
+          {{- if .Values.supervisor.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.supervisor.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.supervisor.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /healthz
               port: https
               scheme: HTTPS
-          {{- else if .Values.supervisor.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.supervisor.startupProbe.enabled }}
+          {{- if .Values.supervisor.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.supervisor.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.supervisor.startupProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
               path: /healthz
               port: https
               scheme: HTTPS
-          {{- else if .Values.supervisor.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.supervisor.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.lifecycleHooks "context" $) | nindent 12 }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354