### PR TITLE
[bitnami/spring-cloud-dataflow] Use custom probes if given

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-dataflow
   - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 12.1.6
+version: 12.1.7

--- a/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/deployment.yaml
@@ -193,7 +193,9 @@ spec:
               containerPort: {{ .Values.server.jdwp.port }}
               protocol: TCP
             {{- end }}
-          {{- if .Values.server.startupProbe.enabled }}
+          {{- if .Values.server.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /management/health
@@ -203,10 +205,10 @@ spec:
             timeoutSeconds: {{ .Values.server.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.server.startupProbe.failureThreshold }}
-          {{- else if .Values.server.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.livenessProbe.enabled }}
+          {{- if .Values.server.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /management/health
@@ -216,10 +218,10 @@ spec:
             timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
-          {{- else if .Values.server.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.server.readinessProbe.enabled }}
+          {{- if .Values.server.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.server.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /management/health
@@ -229,8 +231,6 @@ spec:
             timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
-          {{- else if .Values.server.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.server.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.server.resources }}
           resources: {{- include "common.tplvalues.render" (dict "value" .Values.server.resources "context" $) | nindent 12 }}

--- a/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/deployment.yaml
@@ -151,7 +151,9 @@ spec:
               containerPort: {{ .Values.skipper.jdwp.port }}
               protocol: TCP
             {{- end }}
-          {{- if .Values.skipper.startupProbe.enabled }}
+          {{- if .Values.skipper.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.skipper.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /actuator/health
@@ -161,10 +163,10 @@ spec:
             timeoutSeconds: {{ .Values.skipper.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.skipper.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.skipper.startupProbe.failureThreshold }}
-          {{- else if .Values.skipper.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.skipper.livenessProbe.enabled }}
+          {{- if .Values.skipper.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.skipper.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /actuator/health
@@ -174,10 +176,10 @@ spec:
             timeoutSeconds: {{ .Values.skipper.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.skipper.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.skipper.livenessProbe.failureThreshold }}
-          {{- else if .Values.skipper.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.skipper.readinessProbe.enabled }}
+          {{- if .Values.skipper.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.skipper.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /actuator/health
@@ -187,8 +189,6 @@ spec:
             timeoutSeconds: {{ .Values.skipper.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.skipper.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.skipper.readinessProbe.failureThreshold }}
-          {{- else if .Values.skipper.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.skipper.resources }}
           resources: {{- include "common.tplvalues.render" (dict "value" .Values.skipper.resources "context" $) | nindent 12 }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354