### PR TITLE
[bitnami/thanos] Use custom probes if given

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 11.5.0
+version: 11.5.1

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -128,7 +128,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-          {{- if .Values.bucketweb.livenessProbe.enabled }}
+          {{- if .Values.bucketweb.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.bucketweb.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.bucketweb.livenessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -139,10 +141,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.bucketweb.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.bucketweb.readinessProbe.enabled }}
+          {{- if .Values.bucketweb.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.bucketweb.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.bucketweb.readinessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -153,10 +155,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.bucketweb.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.bucketweb.startupProbe.enabled }}
+          {{- if .Values.bucketweb.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.bucketweb.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.bucketweb.startupProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -167,8 +169,6 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.bucketweb.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.bucketweb.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/compactor/deployment.yaml
+++ b/bitnami/thanos/templates/compactor/deployment.yaml
@@ -143,7 +143,9 @@ spec:
             - name: http
               containerPort: 10902
               protocol: TCP
-          {{- if .Values.compactor.livenessProbe.enabled }}
+          {{- if .Values.compactor.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.compactor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.livenessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -154,10 +156,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.compactor.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.compactor.readinessProbe.enabled }}
+          {{- if .Values.compactor.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.compactor.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.readinessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -168,10 +170,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.compactor.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.compactor.startupProbe.enabled }}
+          {{- if .Values.compactor.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.compactor.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.compactor.startupProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -182,8 +184,6 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.compactor.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.compactor.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/query-frontend/deployment.yaml
+++ b/bitnami/thanos/templates/query-frontend/deployment.yaml
@@ -128,7 +128,9 @@ spec:
             - name: http
               containerPort: 10902
               protocol: TCP
-          {{- if .Values.queryFrontend.livenessProbe.enabled }}
+          {{- if .Values.queryFrontend.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.queryFrontend.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.livenessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -139,10 +141,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.queryFrontend.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.queryFrontend.readinessProbe.enabled }}
+          {{- if .Values.queryFrontend.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.queryFrontend.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.readinessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -153,10 +155,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.queryFrontend.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.queryFrontend.startupProbe.enabled }}
+          {{- if .Values.queryFrontend.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.queryFrontend.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.queryFrontend.startupProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -167,8 +169,6 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.queryFrontend.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.queryFrontend.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -177,7 +177,9 @@ spec:
             - name: grpc
               containerPort: 10901
               protocol: TCP
-          {{- if .Values.query.livenessProbe.enabled }}
+          {{- if .Values.query.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.query.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.query.livenessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -188,10 +190,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.query.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.query.readinessProbe.enabled }}
+          {{- if .Values.query.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.query.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.query.readinessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -202,10 +204,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.query.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.query.startupProbe.enabled }}
+          {{- if .Values.query.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.query.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.query.startupProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -216,8 +218,6 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.query.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.query.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.query.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.query.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/receive-distributor/deployment.yaml
+++ b/bitnami/thanos/templates/receive-distributor/deployment.yaml
@@ -148,7 +148,9 @@ spec:
             - containerPort: {{ if .Values.receive.service.remoteWrite }}{{ coalesce .Values.receive.service.ports.remote .Values.receive.service.remoteWrite.port }}{{ else }}{{ .Values.receive.service.ports.remote }}{{ end }}
               name: remote-write
               protocol: TCP
-          {{- if .Values.receiveDistributor.livenessProbe.enabled }}
+          {{- if .Values.receiveDistributor.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.receiveDistributor.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.receiveDistributor.livenessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -159,10 +161,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.receiveDistributor.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.receiveDistributor.readinessProbe.enabled }}
+          {{- if .Values.receiveDistributor.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.receiveDistributor.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.receiveDistributor.readinessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -173,10 +175,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.receiveDistributor.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.receiveDistributor.startupProbe.enabled }}
+          {{- if .Values.receiveDistributor.customStartupProbe  }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.receiveDistributor.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.receiveDistributor.startupProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -187,8 +189,6 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.receiveDistributor.customStartupProbe  }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.receiveDistributor.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -188,7 +188,9 @@ spec:
             - containerPort: 19291
               name: remote-write
               protocol: TCP
-          {{- if .Values.receive.livenessProbe.enabled }}
+          {{- if .Values.receive.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receive.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.receive.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.receive.livenessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -199,10 +201,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.receive.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receive.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.receive.readinessProbe.enabled }}
+          {{- if .Values.receive.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receive.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.receive.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.receive.readinessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -213,10 +215,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.receive.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receive.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.receive.startupProbe.enabled }}
+          {{- if .Values.receive.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receive.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.receive.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.receive.startupProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -227,8 +229,6 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.receive.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.receive.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.receive.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.receive.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -170,7 +170,9 @@ spec:
             - name: grpc
               containerPort: 10901
               protocol: TCP
-          {{- if .Values.ruler.livenessProbe.enabled }}
+          {{- if .Values.ruler.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.ruler.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ruler.livenessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -181,10 +183,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.ruler.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.ruler.readinessProbe.enabled }}
+          {{- if .Values.ruler.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.ruler.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ruler.readinessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -195,10 +197,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.ruler.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.ruler.startupProbe.enabled }}
+          {{- if .Values.ruler.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.ruler.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.ruler.startupProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -209,8 +211,6 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.ruler.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.ruler.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -198,7 +198,9 @@ spec:
             - name: grpc
               containerPort: 10901
               protocol: TCP
-          {{- if $.Values.storegateway.livenessProbe.enabled }}
+          {{- if $.Values.storegateway.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if $.Values.storegateway.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $.Values.storegateway.livenessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not $.Values.auth.basicAuthUsers }}
             httpGet:
@@ -209,10 +211,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if $.Values.storegateway.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if $.Values.storegateway.readinessProbe.enabled }}
+          {{- if $.Values.storegateway.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if $.Values.storegateway.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit $.Values.storegateway.readinessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not $.Values.auth.basicAuthUsers }}
             httpGet:
@@ -223,10 +225,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if $.Values.storegateway.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if $.Values.storegateway.startupProbe.enabled }}
+          {{- if $.Values.storegateway.customReadinessProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if $.Values.storegateway.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit $.Values.storegateway.startupProbe "enabled") "context" $) | nindent 12 }}
             {{- if not $.Values.auth.basicAuthUsers }}
             httpGet:
@@ -237,8 +239,6 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if $.Values.storegateway.customReadinessProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if $.Values.storegateway.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.lifecycleHooks "context" $) | nindent 12 }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -163,7 +163,9 @@ spec:
             - name: grpc
               containerPort: 10901
               protocol: TCP
-          {{- if .Values.storegateway.livenessProbe.enabled }}
+          {{- if .Values.storegateway.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.storegateway.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.storegateway.livenessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -174,10 +176,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.storegateway.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.storegateway.readinessProbe.enabled }}
+          {{- if .Values.storegateway.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.storegateway.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.storegateway.readinessProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -188,10 +190,10 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.storegateway.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.storegateway.startupProbe.enabled }}
+          {{- if .Values.storegateway.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.storegateway.startupProbe.enabled }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.storegateway.startupProbe "enabled") "context" $) | nindent 12 }}
             {{- if not .Values.auth.basicAuthUsers }}
             httpGet:
@@ -202,8 +204,6 @@ spec:
             tcpSocket:
               port: http
             {{- end }}
-          {{- else if .Values.storegateway.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.storegateway.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.lifecycleHooks "context" $) | nindent 12 }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354