### PR TITLE
[bitnami/wavefront] Use custom probes if given

### DIFF
--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wavefront-proxy
   - https://github.com/wavefrontHQ/wavefront-collector-for-kubernetes
   - https://github.com/wavefrontHQ/wavefront-proxy
-version: 4.2.3
+version: 4.2.4

--- a/bitnami/wavefront/templates/proxy-deployment.yaml
+++ b/bitnami/wavefront/templates/proxy-deployment.yaml
@@ -172,7 +172,9 @@ spec:
           {{- if .Values.proxy.resources }}
           resources: {{- toYaml .Values.proxy.resources | nindent 12 }}
           {{- end }}
-          {{- if .Values.proxy.livenessProbe.enabled }}
+          {{- if .Values.proxy.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.proxy.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
               port: {{ .Values.proxy.port }}
@@ -181,10 +183,10 @@ spec:
             timeoutSeconds: {{ .Values.proxy.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.proxy.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.proxy.livenessProbe.failureThreshold }}
-          {{- else if .Values.proxy.customLivenessProbe }}
-          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.proxy.readinessProbe.enabled }}
+          {{- if .Values.proxy.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.proxy.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.proxy.port }}
@@ -193,10 +195,10 @@ spec:
             timeoutSeconds: {{ .Values.proxy.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.proxy.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.proxy.readinessProbe.failureThreshold }}
-          {{- else if .Values.proxy.customReadinessProbe }}
-          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
-          {{- if .Values.proxy.startupProbe.enabled }}
+          {{- if .Values.proxy.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.proxy.startupProbe.enabled }}
           startupProbe:
             tcpSocket:
               port: {{ .Values.proxy.port }}
@@ -205,8 +207,6 @@ spec:
             timeoutSeconds: {{ .Values.proxy.startupProbe.timeoutSeconds }}
             successThreshold: {{ .Values.proxy.startupProbe.successThreshold }}
             failureThreshold: {{ .Values.proxy.startupProbe.failureThreshold }}
-          {{- else if .Values.proxy.customStartupProbe }}
-          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.proxy.customStartupProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             {{- if .Values.proxy.preprocessor }}


### PR DESCRIPTION
Without this change, in order to use a custom probe, the user has to
specify the probe parameters, and also must specify for the original
probe "enabled: false".

Issue: #12354