### PR TITLE
[bitnami/ghost] cypress: Remove 'wait for save' during post creation test

### DIFF
--- a/.vib/ghost/cypress/cypress/integration/ghost_spec.js
+++ b/.vib/ghost/cypress/cypress/integration/ghost_spec.js
@@ -24,13 +24,7 @@ it('allows to create and publish a new post', () => {
     cy.get('textarea[placeholder="Post title"]').type(
       `${$posts.newPost.title}-${random}`
     );
-    // Clicking a different element to trigger save event
-    cy.get('article').click()
-    cy.contains('div[class=gh-editor-post-status]', 'Saved');
-    cy.get('article').type(`${$posts.newPost.content}-${random}`);
-    // Ensure content has been saved before publishing
-    cy.get('textarea[placeholder="Post title"]').click()
-    cy.contains('div[class=gh-editor-post-status]', 'Saved');
+    cy.get('article div[contenteditable="true"]').type(`${$posts.newPost.content}-${random}`, {force: true});
   });
   // Publishing a post needs 3 steps
   // Step 1: Open drop-down menu


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

### Description of the change

The changes introduced in https://github.com/bitnami/charts/pull/12478 are not enough for the tests to pass consistently.

Although the tests passed in the PR, during most executions the tests are failing because the Ghost post creation fails to wait for the 'Draft - Saved' status twice.

The timeout deadline is probably being exceeded because the post contains an image and the server size is not big enough to complete the test in under 60seconds. 
For reference, the 'create-page' test takes about 27 seconds and does not include an image.

Unlike the 'create-page' test, the 'create-post' test won't fail if a wait for 'Draft saved' status is not performed, therefore this PR removes them.
I initially added the wait to be consistent with the 'create-post'.

### Benefits

Ghost tests should pass consistently.

### Possible drawbacks

Differences between 'create-post' and 'create-page' tests.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes CI/CD action: https://github.com/bitnami/charts/actions/runs/3095644068/jobs/5010906908

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
