### PR TITLE
[bitnami/schema-registry] external-kafka-secret required if externalKafka.auth.protocol is sasl

### DIFF
--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -28,4 +28,4 @@ maintainers:
 name: schema-registry
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/schema-registry
-version: 5.1.5
+version: 5.1.6

--- a/bitnami/schema-registry/templates/external-kafka-secrets.yaml
+++ b/bitnami/schema-registry/templates/external-kafka-secrets.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.kafka.enabled }}
+{{- if and (not .Values.kafka.enabled) (has .Values.externalKafka.auth.protocol (list "sasl" "sasl_tls")) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/schema-registry/templates/external-kafka-secrets.yaml
+++ b/bitnami/schema-registry/templates/external-kafka-secrets.yaml
@@ -1,4 +1,5 @@
-{{- if and (not .Values.kafka.enabled) (has .Values.externalKafka.auth.protocol (list "sasl" "sasl_tls")) }}
+{{- $kafkaProtocol := include "schema-registry.listenerType" ( dict "protocol" (ternary .Values.kafka.auth.clientProtocol .Values.externalKafka.auth.protocol .Values.kafka.enabled) ) -}}
+{{- if and (not .Values.kafka.enabled) (contains "SASL" $kafkaProtocol) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

`external-kafka-secrets.yaml` should skip creating the secret (and the password validation) if `externalKafka.auth.protocol` isn't sasl or sasl_tls. 

### Benefits

Fix issues during helm upgrades with `kafka.enable=false` and `externalKafka.auth.protocol=plaintext`

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #11762

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
