### PR TITLE
[bitnami/external-dns] add PodMonitor to support Google Managed Prome…

### DIFF
--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -24,4 +24,4 @@ sources:
   - https://github.com/kubernetes-sigs/external-dns
   - https://github.com/bitnami/containers/tree/main/bitnami/external-dns
   - https://github.com/kubernetes-sigs/external-dns
-version: 6.9.0
+version: 6.10.0

--- a/bitnami/external-dns/README.md
+++ b/bitnami/external-dns/README.md
@@ -329,6 +329,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.serviceMonitor.honorLabels`          | Specify honorLabels parameter to add the scrape endpoint                                                                                                                     | `false`                   |
 | `metrics.serviceMonitor.labels`               | Used to pass Labels that are required by the installed Prometheus Operator                                                                                                   | `{}`                      |
 | `metrics.serviceMonitor.jobLabel`             | The name of the label on the target service to use as the job name in prometheus.                                                                                            | `""`                      |
+| `metrics.googlePodMonitor.enabled`            | Create Google Managed Prometheus PodMonitoring object                                                                                                                        | `false`                   |
+| `metrics.googlePodMonitor.namespace`          | Namespace in which PodMonitoring created                                                                                                                                     | `""`                      |
+| `metrics.googlePodMonitor.interval`           | Interval at which metrics should be scraped by Google Managed Prometheus                                                                                                     | `60s`                     |
+| `metrics.googlePodMonitor.endpoint`           | The endpoint for Google Managed Prometheus scraping the metrics                                                                                                              | `/metrics`                |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/external-dns/templates/podmonitor.yaml
+++ b/bitnami/external-dns/templates/podmonitor.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.metrics.enabled .Values.metrics.googlePodMonitor.enabled }}
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ template "external-dns.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.metrics.googlePodMonitor.namespace | quote }}
+  labels: {{ include "external-dns.labels" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: http
+      {{- with .Values.metrics.googlePodMonitor.endpoint }}
+      path: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.googlePodMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+  selector:
+    matchLabels: {{ include "external-dns.matchLabels" . | nindent 6 }}
+{{- end }}

--- a/bitnami/external-dns/values.yaml
+++ b/bitnami/external-dns/values.yaml
@@ -1029,3 +1029,18 @@ metrics:
     ## @param metrics.serviceMonitor.jobLabel The name of the label on the target service to use as the job name in prometheus.
     ##
     jobLabel: ""
+  ## Google Managed Prometheus PodMonitor configuration
+  ##
+  googlePodMonitor:
+    ## @param metrics.googlePodMonitor.enabled Create Google Managed Prometheus PodMonitoring object
+    ##
+    enabled: false
+    ## @param metrics.googlePodMonitor.namespace Namespace in which PodMonitoring created
+    ##
+    namespace: ""
+    ## @param metrics.googlePodMonitor.interval Interval at which metrics should be scraped by Google Managed Prometheus
+    ##
+    interval: "60s"
+    ## @param  metrics.googlePodMonitor.endpoint The endpoint for Google Managed Prometheus scraping the metrics
+    ##
+    endpoint: /metrics


### PR DESCRIPTION
…theus

Signed-off-by: Chuyen Pham <pkchuyen@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Add PodMonitor resource for Google Managed Prometheus.
It will generate Prometheus scraping config for external-dns to scrape the metrics and store by Google Managed Prometheus.

### Benefits

It will enable external-dns to monitor by GMP

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
