### PR TITLE
[bitnami/wordpress] Remove rollingUpdate fixes bitnami/charts#12639

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wordpress
   - https://wordpress.org/
-version: 15.2.4
+version: 15.2.5

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -148,7 +148,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
 | `replicaCount`                                      | Number of WordPress replicas to deploy                                                                                   | `1`              |
 | `updateStrategy.type`                               | WordPress deployment strategy type                                                                                       | `RollingUpdate`  |
-| `updateStrategy.rollingUpdate`                      | WordPress deployment rolling update configuration parameters                                                             | `{}`             |
+| `updateStrategy.rollingUpdate`                      | WordPress deployment rolling update configuration parameters                                                             | `nil`            |
 | `schedulerName`                                     | Alternate scheduler                                                                                                      | `""`             |
 | `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`             |
 | `priorityClassName`                                 | Name of the existing priority class to be used by WordPress pods, priority class needs to be created beforehand          | `""`             |

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -148,7 +148,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
 | `replicaCount`                                      | Number of WordPress replicas to deploy                                                                                   | `1`              |
 | `updateStrategy.type`                               | WordPress deployment strategy type                                                                                       | `RollingUpdate`  |
-| `updateStrategy.rollingUpdate`                      | WordPress deployment rolling update configuration parameters                                                             | `nil`            |
 | `schedulerName`                                     | Alternate scheduler                                                                                                      | `""`             |
 | `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`             |
 | `priorityClassName`                                 | Name of the existing priority class to be used by WordPress pods, priority class needs to be created beforehand          | `""`             |

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -263,7 +263,7 @@ replicaCount: 1
 ## @param updateStrategy.type WordPress deployment strategy type
 ## @param updateStrategy.rollingUpdate WordPress deployment rolling update configuration parameters
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
-## NOTE: Set it to `Recreate` if you use a PV that cannot be mounted on multiple pods
+## NOTE: Set it to `Recreate` if you use a PV that cannot be mounted on multiple pods. Optionally specify rollingUpdate if using type RollingUpdate
 ## e.g:
 ## updateStrategy:
 ##  type: RollingUpdate
@@ -273,7 +273,6 @@ replicaCount: 1
 ##
 updateStrategy:
   type: RollingUpdate
-  rollingUpdate: {}
 ## @param schedulerName Alternate scheduler
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -261,7 +261,6 @@ multisite:
 ##
 replicaCount: 1
 ## @param updateStrategy.type WordPress deployment strategy type
-## @param updateStrategy.rollingUpdate WordPress deployment rolling update configuration parameters
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 ## NOTE: Set it to `Recreate` if you use a PV that cannot be mounted on multiple pods. Optionally specify rollingUpdate if using type RollingUpdate
 ## e.g:


### PR DESCRIPTION
Signed-off-by: Matthew Connley <matt@mattconnley.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Removes the rollingUpdate parameter from updateStrategy.

### Benefits

This allows the deployment strategy type to be set to Recreate.

### Possible drawbacks

None

### Applicable issues

  - fixes #12639
 
### Additional information

As described in #12639 including the `rollingUpdate` property in `values.yaml` prevents the use of the `Recreate` deployment strategy, as it is forbidden for that type.

This change is functionally identical to [#8678](https://github.com/bitnami/charts/pull/8678), thanks to @yardenshoham for paving the way. Just taking a quick look, it appears this issue may be widespread across many charts -- I'd be happy to fix and create individual PRs for them as well.

I'd additionally suggest, at least for the sake of discussion, that charts with PV(s) that default to `ReadWriteOnce` should default `updateStrategy` to `Recreate`. Upgrades of deployments that bind to `ReadWriteOnce` PVs fail when executed with `RollingUpdate` defaults.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
