### PR TITLE
[bitnami/influxdb] Add chown for data dir, not only children

### DIFF
--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -24,4 +24,4 @@ name: influxdb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/influxdb
   - https://www.influxdata.com/products/influxdb-overview/
-version: 5.4.5
+version: 5.4.6

--- a/bitnami/influxdb/templates/deployment.yaml
+++ b/bitnami/influxdb/templates/deployment.yaml
@@ -70,11 +70,10 @@ spec:
             - |
               mkdir -p /bitnami/influxdb/{data,meta,wal}
               chmod 700 /bitnami/influxdb/{data,meta,wal}
-              find /bitnami/influxdb/{data,meta,wal} -mindepth 0 -maxdepth 1 | \
               {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
-                xargs -r chown -R `id -u`:`id -G | cut -d " " -f2`
+              chown -R `id -u`:`id -G | cut -d " " -f2` /bitnami/influxdb
               {{- else }}
-                xargs -r chown -R {{ .Values.influxdb.containerSecurityContext.runAsUser }}:{{ .Values.influxdb.podSecurityContext.fsGroup }}
+              chown -R {{ .Values.influxdb.containerSecurityContext.runAsUser }}:{{ .Values.influxdb.podSecurityContext.fsGroup }} /bitnami/influxdb
               {{- end }}
           {{- if eq ( toString ( .Values.volumePermissions.securityContext.runAsUser )) "auto" }}
           securityContext:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change improves volume permissions container behavior and adds feature of changing permission to `/bitnami/influxdb`.

### Benefits

Just adding one more chmod and not touching other code

### Possible drawbacks

No

### Applicable issues

Not opened an issue, providing PR instead of issue opening :)
Generally it fixes the bug with initial starting influxdb even with volume permissions container enabled. Reproduced it on EKS with EBS CSI driver storage class.
```
influxdb 13:05:31.76 
influxdb 13:05:31.76 Welcome to the Bitnami influxdb container
influxdb 13:05:31.77 Subscribe to project updates by watching https://github.com/bitnami/bitnami-docker-influxdb
influxdb 13:05:31.77 Submit issues and feature requests at https://github.com/bitnami/bitnami-docker-influxdb/issues
influxdb 13:05:31.77 
influxdb 13:05:31.77 INFO  ==> ** Starting InfluxDB setup **
influxdb 13:05:31.79 DEBUG ==> Validating settings in INFLUXDB_* env vars...
influxdb 13:05:31.80 INFO  ==> No injected configuration files found. Creating default config files...
influxdb 13:05:31.80 INFO  ==> Starting InfluxDB in background...
ts=2022-09-23T13:05:31.945437Z lvl=info msg="Welcome to InfluxDB" log_id=0d6c5eAG000 version=v2.2.0 commit=a2f8538 build_date=2022-09-23T13:05:31Z
ts=2022-09-23T13:05:31.945646Z lvl=error msg="Failed opening bolt" log_id=0d6c5eAG000 error="unable to open boltdb: open /bitnami/influxdb/influxd.bolt: permission denied"
Error: unable to open boltdb: open /bitnami/influxdb/influxd.bolt: permission denied
See 'influxd -h' for help
```

### Additional information

Similar to #9884

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
