### PR TITLE
[bitnami/cert-manager] Add missing webhooks to fix external plugin issues

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/cert-manager-webhook
   - https://github.com/bitnami/containers/tree/main/bitnami/cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.8.3
+version: 0.8.4

--- a/bitnami/cert-manager/templates/webhook/mutating-webhook.yaml
+++ b/bitnami/cert-manager/templates/webhook/mutating-webhook.yaml
@@ -1,0 +1,39 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "certmanager.webhook.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+  annotations:
+    cert-manager.io/inject-ca-from-secret: {{ printf "%s/%s-ca" (include "common.names.namespace" .) (include "certmanager.webhook.fullname" .) | quote }}
+  {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+webhooks:
+  - name: webhook.cert-manager.io
+    rules:
+      - apiGroups:
+          - "cert-manager.io"
+          - "acme.cert-manager.io"
+        apiVersions:
+          - "v1"
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - "*/*"
+    admissionReviewVersions: ["v1"]
+    # This webhook only accepts v1 cert-manager resources.
+    # Equivalent matchPolicy ensures that non-v1 resource requests are sent to
+    # this webhook (after the resources have been converted to v1).
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    # Only include 'sideEffects' field in Kubernetes 1.12+
+    sideEffects: None
+    clientConfig:
+      service:
+        name: {{ include "certmanager.webhook.fullname" . }}
+        namespace: {{ include "common.names.namespace" . }}
+        path: /mutate

--- a/bitnami/cert-manager/templates/webhook/validating-webhook.yaml
+++ b/bitnami/cert-manager/templates/webhook/validating-webhook.yaml
@@ -1,0 +1,48 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "certmanager.webhook.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: webhook
+  annotations:
+    cert-manager.io/inject-ca-from-secret: {{ printf "%s/%s-ca" (include "common.names.namespace" .) (include "certmanager.webhook.fullname" .) | quote }}
+  {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+webhooks:
+  - name: webhook.cert-manager.io
+    namespaceSelector:
+      matchExpressions:
+      - key: "cert-manager.io/disable-validation"
+        operator: "NotIn"
+        values:
+        - "true"
+      - key: "name"
+        operator: "NotIn"
+        values:
+        - {{ include "common.names.namespace" . }}
+    rules:
+      - apiGroups:
+          - "cert-manager.io"
+          - "acme.cert-manager.io"
+        apiVersions:
+          - "v1"
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - "*/*"
+    admissionReviewVersions: ["v1"]
+    # This webhook only accepts v1 cert-manager resources.
+    # Equivalent matchPolicy ensures that non-v1 resource requests are sent to
+    # this webhook (after the resources have been converted to v1).
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    sideEffects: None
+    clientConfig:
+      service:
+        name: {{ include "certmanager.webhook.fullname" . }}
+        namespace: {{ include "common.names.namespace" . }}
+        path: /validate


### PR DESCRIPTION
Signed-off-by: Benoit Pourre <benoit.pourre@gmail.com>

### Description of the change

Add missing mutating and validateing webooks to cert-manager.
These hooks exist in the official cert-manager Helm chart, but not in Bitnami's.

Without these webhooks, any external plugin for cert-manager will fail to approve its certificates.

### Benefits

Be able to use external plugins for cert-manager.

### Possible drawbacks

None

### Applicable issues

  - fixes #12235

### Additional information

NA

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
