### PR TITLE
[bitnami/thanos] Fix http config encoding

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 11.5.1
+version: 11.5.2

--- a/bitnami/thanos/templates/httpconfig-secret.yaml
+++ b/bitnami/thanos/templates/httpconfig-secret.yaml
@@ -11,7 +11,7 @@ metadata:
 stringData:
   http-config.yml: |-
 {{- if .Values.httpConfig }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.httpConfig "context" $) | b64enc | nindent 4 }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.httpConfig "context" $) | nindent 4 }}
 {{- else }}
     {{- if .Values.https.enabled }}
     tls_server_config:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Remove erroneous base64 encoding from http config secret. Encoding is not required because stringData is used.

### Benefits

The httpConfig configuration will work properly, instead of causing an error.

### Possible drawbacks

None

### Applicable issues

None

### Additional information

None

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
