### PR TITLE
[bitnami/thanos] Use VIB to publish Thanos

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -71,6 +71,7 @@ on: # rebuild any PRs and main branch changes
       - 'bitnami/spring-cloud-dataflow/**'
       - 'bitnami/suitecrm/**'
       - 'bitnami/tensorflow-resnet/**'
+      - 'bitnami/thanos/**'
       - 'bitnami/tomcat/**'
       - 'bitnami/wildfly/**'
       - 'bitnami/wordpress/**'


### PR DESCRIPTION
### Description of the change

Add Thanos to the list of assets published using VMware Image Builder.

### Benefits

Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

NA

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
