### PR TITLE
[bitnami/*] Retrieve new list for packages before installing

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -168,7 +168,8 @@ jobs:
       - name: Install and configure aws-cli and helm
         run: |
           # AWS CLI
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y awscli
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update && sudo apt-get install -y awscli
           aws configure set region us-east-1
           aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
### Description of the change

When using system packages, it is desirable to update the list of packages before installing any component to ensure the index is updated. 

### Benefits

No failed jobs due to references to old packages in the list.

### Possible drawbacks

None

### Applicable issues

Failed publishing job executions, such like https://github.com/bitnami/charts/actions/runs/3157267471/jobs/5138068485

### Additional information

Tested in https://github.com/joancafom/charts/actions/runs/3157395326/jobs/5138216430

![Screenshot 2022-09-30 at 10 47 04](https://user-images.githubusercontent.com/24253844/193231298-a184131e-1b11-4827-a52b-01d224e27c56.png)


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
