### PR TITLE
[bitnami/nginx-intel] Force new version publishing

### DIFF
--- a/bitnami/nginx-intel/Chart.yaml
+++ b/bitnami/nginx-intel/Chart.yaml
@@ -24,4 +24,4 @@ name: nginx-intel
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/nginx-intel
   - https://github.com/intel/asynch_mode_nginx
-version: 2.1.7
+version: 2.1.8


### PR DESCRIPTION
### Description of the change

Force changes in https://github.com/bitnami/charts/commit/2c1af791d03ec80827585e09f2b2e25c2509d794 to be published.

### Benefits

The asset is up-to-date in our helm index.

### Possible drawbacks

None

### Applicable issues

Related to https://github.com/bitnami/charts/pull/12748

### Additional information

We have been experiencing intermittent failures in our publishing pipelines, which made the index to miss some updates from charts.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
