### PR TITLE
[bitnami/concourse] Force new version publishing

### DIFF
--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -30,4 +30,4 @@ name: concourse
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/concourse
   - https://github.com/concourse/concourse
-version: 1.5.1
+version: 1.5.2


### PR DESCRIPTION
### Description of the change

Force changes in https://github.com/bitnami/charts/commit/876854198ad92bcb60b4524c2660e4ba803a2733 to be published.

### Benefits

The asset is up-to-date in our helm index.

### Possible drawbacks

None

### Applicable issues

Related to https://github.com/bitnami/charts/pull/12748

### Additional information

We have been experiencing intermittent failures in our publishing pipelines, which made the index to miss some updates from charts.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
