### PR TITLE
[bitnami/mongodb-sharded] Force new version publishing

### DIFF
--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb-sharded
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb-sharded
   - https://mongodb.org
-version: 6.1.4
+version: 6.1.5


### PR DESCRIPTION
### Description of the change

Force changes in https://github.com/bitnami/charts/commit/7e73521cbb6fd948a018f983125f5154157ed3c0 to be published.

### Benefits

The asset is up-to-date in our helm index.

### Possible drawbacks

None

### Applicable issues

Related to https://github.com/bitnami/charts/pull/12748

### Additional information

We have been experiencing intermittent failures in our publishing pipelines, which made the index to miss some updates from charts.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
