### PR TITLE
[bitnami/redmine]  External MariaDB secret name is wrong (#12384)

### DIFF
--- a/bitnami/redmine/Chart.lock
+++ b/bitnami/redmine/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 11.9.1
+  version: 11.9.5
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 11.3.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.0.3
-digest: sha256:894f4ce445bfc952bd2ca1855c8fb9db862822bd3f7b43b044efaf7e75de0c11
-generated: "2022-09-21T13:56:04.98187475Z"
+digest: sha256:d5ac6c1e27c930532ac08168ad763c46dcb443777fd453b5d1e23cd5b5fa1c94
+generated: "2022-10-01T03:56:54.920386666Z"

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -36,4 +36,4 @@ name: redmine
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redmine
   - https://www.redmine.org/
-version: 20.3.4
+version: 20.3.5

--- a/bitnami/redmine/templates/_helpers.tpl
+++ b/bitnami/redmine/templates/_helpers.tpl
@@ -198,7 +198,11 @@ Add environment variables to configure database values
             {{- print "password" -}}
         {{- end -}}
     {{- else -}}
-        {{- print "password" -}}
+        {{- if eq .Values.databaseType "mariadb" -}}
+            {{- print "mariadb-password" -}}
+        {{- else -}}
+            {{- print "password" -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
### Name and Version

bitnami/redmine 20.3.3

### What steps will reproduce the bug?

Make deploy with external MariaDB/MySQL using:
```
databaseType: mariadb
mariadb:
  enabled: false
postgresql:
  enabled: false
externalDatabase:
  host: "XXX.XXX.XXX.XXX"
  port: 3306
  user: not_a_root
  database: Redmine
  password: "XXXX"
  existingSecret: ""
  existingSecretPasswordKey: ""
```

### What do you see instead?

Since bug in helpers it tries to use secret for PostgreSQL to MariaDB.
```
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Normal   Scheduled  74s                default-scheduler  Successfully assigned redmine/redmine-595849d98c-vq2nf to ubuntu-22-04-server-08
  Normal   Pulled     10s (x7 over 74s)  kubelet            Container image "docker.io/bitnami/redmine:5.0.2-debian-11-r23" already present on machine
  Warning  Failed     10s (x7 over 74s)  kubelet            Error: couldn't find key password in Secret redmine/redmine-externaldb
```