### PR TITLE
[bitnami/jupyterhub] Fix test existence nested key

### DIFF
--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -26,4 +26,4 @@ name: jupyterhub
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/jupyterhub
   - https://github.com/jupyterhub/jupyterhub
-version: 2.0.0
+version: 2.0.1

--- a/bitnami/jupyterhub/templates/_helpers.tpl
+++ b/bitnami/jupyterhub/templates/_helpers.tpl
@@ -35,9 +35,9 @@ Return the cookie_secret value
 */}}
 {{- define "jupyterhub.hub.config.JupyterHub.cookie_secret" -}}
     {{ $hubConfiguration := include "common.tplvalues.render" ( dict "value" .Values.hub.configuration "context" $ ) | fromYaml }}
-    {{- if hasKey $hubConfiguration "hub.config.JupyterHub.cookie_secret" }}
+    {{- if ($hubConfiguration | dig "hub" "config" "JupyterHub" "cookie_secret" "") }}
         {{- $hubConfiguration.hub.config.JupyterHub.cookie_secret }}
-    {{- else if hasKey $hubConfiguration "hub.cookieSecret" }}
+    {{- else if ($hubConfiguration | dig "hub" "cookieSecret" "") }}
         {{- $hubConfiguration.hub.cookieSecret }}
     {{- else }}
         {{- $secretData := (lookup "v1" "Secret" $.Release.Namespace ( include "jupyterhub.hub.name" . )).data }}
@@ -54,7 +54,7 @@ Return the CryptKeeper value
 */}}
 {{- define "jupyterhub.hub.config.CryptKeeper.keys" -}}
     {{ $hubConfiguration := include "common.tplvalues.render" ( dict "value" .Values.hub.configuration "context" $ ) | fromYaml }}
-    {{- if hasKey $hubConfiguration "hub.config.CryptKeeper.keys" }}
+    {{- if ($hubConfiguration | dig "hub" "config" "CryptKeeper" "keys" "") }}
         {{- $hubConfiguration.hub.config.CryptKeeper.keys | join ";" }}
     {{- else }}
         {{- $secretData := (lookup "v1" "Secret" $.Release.Namespace ( include "jupyterhub.hub.name" . )).data }}


### PR DESCRIPTION
### Name and Version
bitnami/jupyterhub 2.0.0

### What steps will reproduce the bug?

Set `hub.config.CryptKeeper.keys` and `hub.config.JupyterHub.cookie_secret` in `hub.configuration`. E.g:

```yaml
hub:
  config:
    CryptKeeper:
      keys: XXXXXXXXXXXXXXXXXXX
    JupyterHub:
      cookie_secret: YYYYYYYYYYYYYYY
```

### What do you see instead?

The provided values are not used in the hub secret, instead a random value is generated (or value in existing secret if available)

### Root cause

The template function `hasKey` doesn't support test of nested keys.

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
