### PR TITLE
[bitnami/mariadb-galera] Generic README instructions related to the repo

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 7.4.3
+version: 7.4.4

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -11,11 +11,9 @@ Trademarks: This software listing is packaged by Bitnami. The respective tradema
 ## TL;DR
 
 ```bash
-$ helm repo add my-repo REPO
+$ helm repo add my-repo https://charts.bitnami.com/bitnami
 $ helm install my-release my-repo/mariadb-galera
 ```
-
-Remember to replace the `REPO` placeholder by the repository from where you would like to deploy this Helm chart.
 
 ## Introduction
 

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -7,13 +7,15 @@ MariaDB Galera is a multi-primary database cluster solution for synchronous repl
 [Overview of MariaDB Galera](https://mariadb.com/kb/en/library/galera-cluster/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/mariadb-galera
+$ helm repo add my-repo REPO
+$ helm install my-release my-repo/mariadb-galera
 ```
+
+Remember to replace the `REPO` placeholder by the repository from where you would like to deploy this Helm chart.
 
 ## Introduction
 
@@ -32,13 +34,13 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment
 Add the `bitnami` charts repo to Helm:
 
 ```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
+$ helm repo add my-repo REPO
 ```
 
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install my-release bitnami/mariadb-galera
+$ helm install my-release my-repo/mariadb-galera
 ```
 
 The command deploys MariaDB Galera on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -271,7 +273,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 $ helm install my-release \
   --set rootUser.password=secretpassword,
   --set db.user=app_database \
-    bitnami/mariadb-galera
+    my-repo/mariadb-galera
 ```
 
 The above command sets the MariaDB `root` account password to `secretpassword`. Additionally it creates a database named `my_database`.
@@ -281,7 +283,7 @@ The above command sets the MariaDB `root` account password to `secretpassword`. 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install my-release -f values.yaml bitnami/mariadb-galera
+$ helm install my-release -f values.yaml my-repo/mariadb-galera
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -295,7 +297,7 @@ For example, if you want to enable the PAM cleartext plugin, specify the command
 ```bash
 $ helm install my-release \
   --set extraFlags="--pam-use-cleartext-plugin=ON" \
-  bitnami/mariadb-galera
+  my-repo/mariadb-galera
 ```
 
 ## Configuration and installation details
@@ -517,7 +519,7 @@ There are two possible scenarios:
 In this case you will need the node number `N` and run:
 
 ```bash
-helm install my-release bitnami/mariadb-galera \
+helm install my-release my-repo/mariadb-galera \
 --set rootUser.password=XXXX \
 --set galera.mariabackup.password=YYYY \
 --set galera.bootstrap.forceBootstrap=true \
@@ -530,7 +532,7 @@ helm install my-release bitnami/mariadb-galera \
 In this case the cluster was not stopped cleanly and you need to pick one to force the bootstrap from. The one to be chosen in the one with the highest `seqno` in `/bitnami/mariadb/data/grastate.dat`. The following example shows how to force bootstrap from node 3.
 
 ```bash
-helm install my-release bitnami/mariadb-galera \
+helm install my-release my-repo/mariadb-galera \
 --set rootUser.password=XXXX \
 --set galera.mariabackup.password=YYYY \
 --set galera.bootstrap.forceBootstrap=true \
@@ -544,7 +546,7 @@ helm install my-release bitnami/mariadb-galera \
 After you have started the cluster by forcing the bootstraping on one of the nodes, you will need to remove the forcing so the node can restart with normality.
 
 ```
-helm upgrade my-release bitnami/mariadb-galera \
+helm upgrade my-release my-repo/mariadb-galera \
 --set rootUser.password=XXXX \
 --set galera.mariabackup.password=YYYY \
 --set podManagementPolicy=Parallel
@@ -571,7 +573,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 It's necessary to specify the existing passwords while performing a upgrade to ensure the secrets are not updated with invalid randomly generated passwords. Remember to specify the existing values of the `rootUser.password`, `db.password` and `galera.mariabackup.password` parameters when upgrading the chart:
 
 ```bash
-$ helm upgrade my-release bitnami/mariadb-galera \
+$ helm upgrade my-release my-repo/mariadb-galera \
     --set rootUser.password=[ROOT_PASSWORD] \
     --set db.password=[MARIADB_PASSWORD] \
     --set galera.mariabackup.password=[GALERA_MARIABACKUP_PASSWORD]

--- a/bitnami/mariadb-galera/README.md
+++ b/bitnami/mariadb-galera/README.md
@@ -32,7 +32,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment
 Add the `bitnami` charts repo to Helm:
 
 ```bash
-$ helm repo add my-repo REPO
+$ helm repo add my-repo https://charts.bitnami.com/bitnami
 ```
 
 To install the chart with the release name `my-release`:

--- a/bitnami/mariadb-galera/templates/NOTES.txt
+++ b/bitnami/mariadb-galera/templates/NOTES.txt
@@ -76,7 +76,7 @@ To access the MariaDB Prometheus metrics from outside the cluster execute the fo
 
 To upgrade this helm chart:
 
-    helm upgrade --namespace {{ include "common.names.namespace" . }} {{ .Release.Name }} bitnami/mariadb-galera \
+    helm upgrade --namespace {{ include "common.names.namespace" . }} {{ .Release.Name }} my-repo/mariadb-galera \
       --set rootUser.password=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-root-password}" | base64 -d) \
       {{ if .Values.db.user }}--set db.user={{ .Values.db.user }} --set db.password=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-password}" | base64 -d) {{ end }}--set db.name={{ .Values.db.name }} \
       --set galera.mariabackup.password=$(kubectl get secret --namespace {{ include "common.names.namespace" . }} {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ template "common.names.fullname" . }}{{ end }} -o jsonpath="{.data.mariadb-galera-mariabackup-password}" | base64 -d)

--- a/bitnami/mariadb-galera/templates/_helpers.tpl
+++ b/bitnami/mariadb-galera/templates/_helpers.tpl
@@ -133,7 +133,7 @@ mariadb-galera: LDAP
     Invalid LDAP configuration. When enabling LDAP support, the parameters "ldap.uri",
     "ldap.base", "ldap.binddn", and "ldap.bindpw" are mandatory. Please provide them:
 
-    $ helm install {{ .Release.Name }} bitnami/mariadb-galera \
+    $ helm install {{ .Release.Name }} my-repo/mariadb-galera \
       --set ldap.enabled=true \
       --set ldap.uri="ldap://my_ldap_server" \
       --set ldap.base="dc=example,dc=org" \


### PR DESCRIPTION
### Description of the change

There are no mentions of `bitnami/` when it's related to the Helm repo in the README. They are replaced by a generic `my-repo`

### Benefits

Readme instructions can be followed regardless of the repository used to deploy the Helm charts