### PR TITLE
[bitnami/postgresql-ha] Generic README instructions related to the repo

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -29,4 +29,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
-version: 9.4.6
+version: 9.4.7

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -7,13 +7,15 @@ This PostgreSQL cluster solution includes the PostgreSQL replication manager, an
 [Overview of PostgreSQL HA](https://www.postgresql.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/postgresql-ha
+$ helm repo add my-repo REPO
+$ helm install my-release my-repo/postgresql-ha
 ```
+
+Remember to replace the `REPO` placeholder by the repository from where you would like to deploy this Helm chart.
 
 ## Introduction
 
@@ -36,8 +38,8 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment
 Install the PostgreSQL HA helm chart with a release name `my-release`:
 
 ```console
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/postgresql-ha
+$ helm repo add my-repo REPO
+$ helm install my-release my-repo/postgresql-ha
 ```
 
 ## Uninstalling the Chart
@@ -484,7 +486,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```console
 $ helm install my-release \
     --set postgresql.password=password \
-    bitnami/postgresql-ha
+    my-repo/postgresql-ha
 ```
 
 The above command sets the password for user `postgres` to `password`.
@@ -666,7 +668,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 It's necessary to specify the existing passwords while performing a upgrade to ensure the secrets are not updated with invalid randomly generated passwords. Remember to specify the existing values of the `postgresql.password` and `postgresql.repmgrPassword` parameters when upgrading the chart:
 
 ```bash
-$ helm upgrade my-release bitnami/postgresql-ha \
+$ helm upgrade my-release my-repo/postgresql-ha \
     --set postgresql.password=[POSTGRES_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD]
 ```
@@ -704,7 +706,7 @@ A new major version of repmgr (5.3) was included. To upgrade to this major versi
 - Reduce your PostgreSQL setup to one replica (primary node) and upgrade to `8.0.0`, enabling the repmgr extension upgrade:
 
 ```bash
-$ helm upgrade my-release --version 8.0.0 bitnami/postgresql-ha \
+$ helm upgrade my-release --version 8.0.0 my-repo/postgresql-ha \
     --set postgresql.password=[POSTGRESQL_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
     --set postgresql.replicaCount=1 \
@@ -714,7 +716,7 @@ $ helm upgrade my-release --version 8.0.0 bitnami/postgresql-ha \
 - Scale your PostgreSQL setup to the original number of replicas:
 
 ```bash
-$ helm upgrade my-release --version 8.0.0 bitnami/postgresql-ha \
+$ helm upgrade my-release --version 8.0.0 my-repo/postgresql-ha \
     --set postgresql.password=[POSTGRESQL_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
     --set postgresql.replicaCount=[NUMBER_OF_REPLICAS]
@@ -757,7 +759,7 @@ A new  version of repmgr (5.2.0) was included. To upgrade to this version, it's 
 - Reduce your PostgreSQL setup to one replica (primary node) and upgrade to `5.2.0`, enabling the repmgr extension upgrade:
 
 ```bash
-$ helm upgrade my-release --version 5.2.0 bitnami/postgresql-ha \
+$ helm upgrade my-release --version 5.2.0 my-repo/postgresql-ha \
     --set postgresql.password=[POSTGRESQL_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
     --set postgresql.replicaCount=1 \
@@ -767,7 +769,7 @@ $ helm upgrade my-release --version 5.2.0 bitnami/postgresql-ha \
 - Scale your PostgreSQL setup to the original number of replicas:
 
 ```bash
-$ helm upgrade my-release --version 5.2.0 bitnami/postgresql-ha \
+$ helm upgrade my-release --version 5.2.0 my-repo/postgresql-ha \
     --set postgresql.password=[POSTGRESQL_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
     --set postgresql.replicaCount=[NUMBER_OF_REPLICAS]
@@ -787,7 +789,7 @@ $ # e.g. Previous deployment v3.9.1
 $ helm install my-release \
     --set postgresql.password=[POSTGRESQL_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
-    bitnami/postgresql-ha --version 3.9.1
+    my-repo/postgresql-ha --version 3.9.1
 
 $ # Update repository information
 $ helm repo update
@@ -797,7 +799,7 @@ $ helm delete my-release
 $ helm install my-release \
     --set postgresql.password=[POSTGRESQL_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
-    bitnami/postgresql-ha --version 5.0.0
+    my-repo/postgresql-ha --version 5.0.0
 ```
 
 ### To 4.0.x
@@ -811,7 +813,7 @@ A new major version of repmgr (5.1.0) was included. To upgrade to this major ver
 - Reduce your PostgreSQL setup to one replica (primary node) and upgrade to `3.0.0`, enabling the repmgr extension upgrade:
 
 ```bash
-$ helm upgrade my-release --version 3.0.0 bitnami/postgresql-ha \
+$ helm upgrade my-release --version 3.0.0 my-repo/postgresql-ha \
     --set postgresql.password=[POSTGRESQL_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
     --set postgresql.replicaCount=1 \
@@ -821,7 +823,7 @@ $ helm upgrade my-release --version 3.0.0 bitnami/postgresql-ha \
 - Scale your PostgreSQL setup to the original number of replicas:
 
 ```bash
-$ helm upgrade my-release --version 3.0.0 bitnami/postgresql-ha \
+$ helm upgrade my-release --version 3.0.0 my-repo/postgresql-ha \
     --set postgresql.password=[POSTGRESQL_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
     --set postgresql.replicaCount=[NUMBER_OF_REPLICAS]
@@ -845,7 +847,7 @@ A new major version of repmgr (5.0.0) was included. To upgrade to this major ver
 - Reduce your PostgreSQL setup to one replica (primary node) and upgrade to `1.0.0`, enabling the repmgr extension upgrade:
 
 ```bash
-$ helm upgrade my-release --version 1.0.0 bitnami/postgresql-ha \
+$ helm upgrade my-release --version 1.0.0 my-repo/postgresql-ha \
     --set postgresql.password=[POSTGRESQL_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
     --set postgresql.replicaCount=1 \
@@ -855,7 +857,7 @@ $ helm upgrade my-release --version 1.0.0 bitnami/postgresql-ha \
 - Scale your PostgreSQL setup to the original number of replicas:
 
 ```bash
-$ helm upgrade my-release --version 1.0.0 bitnami/postgresql-ha \
+$ helm upgrade my-release --version 1.0.0 my-repo/postgresql-ha \
     --set postgresql.password=[POSTGRESQL_PASSWORD] \
     --set postgresql.repmgrPassword=[REPMGR_PASSWORD] \
     --set postgresql.replicaCount=[NUMBER_OF_REPLICAS]

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -36,7 +36,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment
 Install the PostgreSQL HA helm chart with a release name `my-release`:
 
 ```console
-$ helm repo add my-repo REPO
+$ helm repo add my-repo https://charts.bitnami.com/bitnami
 $ helm install my-release my-repo/postgresql-ha
 ```
 

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -11,11 +11,9 @@ Trademarks: This software listing is packaged by Bitnami. The respective tradema
 ## TL;DR
 
 ```console
-$ helm repo add my-repo REPO
+$ helm repo add my-repo https://charts.bitnami.com/bitnami
 $ helm install my-release my-repo/postgresql-ha
 ```
-
-Remember to replace the `REPO` placeholder by the repository from where you would like to deploy this Helm chart.
 
 ## Introduction
 

--- a/bitnami/postgresql-ha/templates/_helpers.tpl
+++ b/bitnami/postgresql-ha/templates/_helpers.tpl
@@ -539,7 +539,7 @@ postgresql-ha: LDAP
     Invalid LDAP configuration. When enabling LDAP support, the parameters "ldap.uri",
     "ldap.basedn", "ldap.binddn", and "ldap.bindpw" are mandatory. Please provide them:
 
-    $ helm install {{ .Release.Name }} bitnami/postgresql-ha \
+    $ helm install {{ .Release.Name }} my-repo/postgresql-ha \
       --set ldap.enabled=true \
       --set ldap.uri="ldap://my_ldap_server" \
       --set ldap.basedn="dc=example\,dc=org" \
@@ -564,7 +564,7 @@ postgresql-ha: LDAP & pg_hba.conf
 postgresql-ha: Upgrade repmgr extension
     There must be only one replica when upgrading repmgr extension:
 
-    $ helm upgrade {{ .Release.Name }} bitnami/postgresql-ha \
+    $ helm upgrade {{ .Release.Name }} my-repo/postgresql-ha \
       --set postgresql.replicaCount=1 \
       --set postgresql.upgradeRepmgrExtension=true
 {{- end -}}


### PR DESCRIPTION
### Description of the change

There are no mentions of `bitnami/` when it's related to the Helm repo in the README. They are replaced by a generic `my-repo`

### Benefits

Readme instructions can be followed regardless of the repository used to deploy the Helm charts