### PR TITLE
[bitnami/rabbitmq] Generic README instructions related to the repo

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq
   - https://www.rabbitmq.com
-version: 10.3.6
+version: 10.3.7

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -7,13 +7,15 @@ RabbitMQ is an open source general-purpose message broker that is designed for c
 [Overview of RabbitMQ](https://www.rabbitmq.com)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami
-$ helm install my-release bitnami/rabbitmq
+$ helm repo add my-repo REPO
+$ helm install my-release my-repo/rabbitmq
 ```
+
+Remember to replace the `REPO` placeholder by the repository from where you would like to deploy this Helm chart.
 
 ## Introduction
 
@@ -32,7 +34,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install my-release bitnami/rabbitmq
+$ helm install my-release my-repo/rabbitmq
 ```
 
 The command deploys RabbitMQ on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -357,7 +359,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```bash
 $ helm install my-release \
   --set auth.username=admin,auth.password=secretpassword,auth.erlangCookie=secretcookie \
-    bitnami/rabbitmq
+    my-repo/rabbitmq
 ```
 
 The above command sets the RabbitMQ admin username and password to `admin` and `secretpassword` respectively. Additionally the secure erlang cookie is set to `secretcookie`.
@@ -367,7 +369,7 @@ The above command sets the RabbitMQ admin username and password to `admin` and `
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install my-release -f values.yaml bitnami/rabbitmq
+$ helm install my-release -f values.yaml my-repo/rabbitmq
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -499,7 +501,7 @@ This happens if the pod management policy of the statefulset is not `Parallel` a
 
 ```console
 $ kubectl delete statefulset STATEFULSET_NAME --cascade=false
-$ helm upgrade RELEASE_NAME bitnami/rabbitmq \
+$ helm upgrade RELEASE_NAME my-repo/rabbitmq \
     --set podManagementPolicy=Parallel \
     --set replicaCount=NUMBER_OF_REPLICAS \
     --set auth.password=PASSWORD \
@@ -511,7 +513,7 @@ For a faster resyncronization of the nodes, you can temporarily disable the read
 If the steps above don't bring the cluster to a healthy state, it could be possible that none of the RabbitMQ nodes think they were the last node to be up during the shutdown. In those cases, you can force the boot of the nodes by specifying the `clustering.forceBoot=true` parameter (which will execute [`rabbitmqctl force_boot`](https://www.rabbitmq.com/rabbitmqctl.8.html#force_boot) in each pod):
 
 ```console
-$ helm upgrade RELEASE_NAME bitnami/rabbitmq \
+$ helm upgrade RELEASE_NAME my-repo/rabbitmq \
     --set podManagementPolicy=Parallel \
     --set clustering.forceBoot=true \
     --set replicaCount=NUMBER_OF_REPLICAS \
@@ -538,7 +540,7 @@ The chart mounts a [Persistent Volume](https://kubernetes.io/docs/concepts/stora
 1. Install the chart
 
 ```bash
-$ helm install my-release --set persistence.existingClaim=PVC_NAME bitnami/rabbitmq
+$ helm install my-release --set persistence.existingClaim=PVC_NAME my-repo/rabbitmq
 ```
 
 ### Adjust permissions of the persistence volume mountpoint
@@ -573,7 +575,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 It's necessary to set the `auth.password` and `auth.erlangCookie` parameters when upgrading for readiness/liveness probes to work properly. When you install this chart for the first time, some notes will be displayed providing the credentials you must use under the 'Credentials' section. Please note down the password and the cookie, and run the command below to upgrade your chart:
 
 ```bash
-$ helm upgrade my-release bitnami/rabbitmq --set auth.password=[PASSWORD] --set auth.erlangCookie=[RABBITMQ_ERLANG_COOKIE]
+$ helm upgrade my-release my-repo/rabbitmq --set auth.password=[PASSWORD] --set auth.erlangCookie=[RABBITMQ_ERLANG_COOKIE]
 ```
 
 | Note: you need to substitute the placeholders [PASSWORD] and [RABBITMQ_ERLANG_COOKIE] with the values obtained in the installation notes.

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -11,11 +11,9 @@ Trademarks: This software listing is packaged by Bitnami. The respective tradema
 ## TL;DR
 
 ```bash
-$ helm repo add my-repo REPO
+$ helm repo add my-repo https://charts.bitnami.com/bitnami
 $ helm install my-release my-repo/rabbitmq
 ```
-
-Remember to replace the `REPO` placeholder by the repository from where you would like to deploy this Helm chart.
 
 ## Introduction
 

--- a/bitnami/rabbitmq/README.md
+++ b/bitnami/rabbitmq/README.md
@@ -32,6 +32,7 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment
 To install the chart with the release name `my-release`:
 
 ```bash
+$ helm repo add my-repo https://charts.bitnami.com/bitnami
 $ helm install my-release my-repo/rabbitmq
 ```
 

--- a/bitnami/rabbitmq/templates/_helpers.tpl
+++ b/bitnami/rabbitmq/templates/_helpers.tpl
@@ -152,7 +152,7 @@ Validate values of rabbitmq - LDAP support
 rabbitmq: LDAP
     Invalid LDAP configuration. When enabling LDAP support, the parameters "ldap.servers" or "ldap.uri" are mandatory
     to configure the connection and "ldap.userDnPattern" or "ldap.basedn" are necessary to lookup the users. Please provide them:
-    $ helm install {{ .Release.Name }} bitnami/rabbitmq \
+    $ helm install {{ .Release.Name }} my-repo/rabbitmq \
       --set ldap.enabled=true \
       --set ldap.servers[0]=my-ldap-server" \
       --set ldap.port="389" \
@@ -174,7 +174,7 @@ rabbitmq: memoryHighWatermark
     You enabled configuring memory high watermark using a relative limit. However,
     no memory limits were defined at POD level. Define your POD limits as shown below:
 
-    $ helm install {{ .Release.Name }} bitnami/rabbitmq \
+    $ helm install {{ .Release.Name }} my-repo/rabbitmq \
       --set memoryHighWatermark.enabled=true \
       --set memoryHighWatermark.type="relative" \
       --set memoryHighWatermark.value="0.4" \
@@ -182,7 +182,7 @@ rabbitmq: memoryHighWatermark
 
     Altenatively, user an absolute value for the memory memory high watermark :
 
-    $ helm install {{ .Release.Name }} bitnami/rabbitmq \
+    $ helm install {{ .Release.Name }} my-repo/rabbitmq \
       --set memoryHighWatermark.enabled=true \
       --set memoryHighWatermark.type="absolute" \
       --set memoryHighWatermark.value="512MB"


### PR DESCRIPTION
### Description of the change

There are no mentions of `bitnami/` when it's related to the Helm repo in the README. They are replaced by a generic `my-repo`

### Benefits

Readme instructions can be followed regardless of the repository used to deploy the Helm charts