### PR TITLE
[bitnami/metallb] Update maintainers

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -21,8 +21,6 @@ keywords:
   - vrrp
   - vip
 maintainers:
-  - email: cellebyte@gmail.com
-    name: cellebyte
   - name: Bitnami
     url: https://github.com/bitnami/charts
 name: metallb
@@ -30,4 +28,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/containers/tree/main/bitnami/metallb
   - https://metallb.universe.tf
-version: 4.1.4
+version: 4.1.5


### PR DESCRIPTION
### Description of the change

In this PR the maintainers' metadata is updated to show the team in charge of the maintenance, updates, and support of this Helm chart.

We always appreciate the initial contribution of @Cellebyte at https://github.com/bitnami/charts/pull/2068

### Benefits

On websites like [ArtifactHUB](https://artifacthub.io/packages/helm/bitnami/metallb), the current maintainers are showed