### PR TITLE
[bitnami/contour] Update maintainers

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -17,8 +17,6 @@ keywords:
   - envoy
   - contour
 maintainers:
-  - name: cellebyte
-    url: https://github.com/Cellebyte
   - name: Bitnami
     url: https://github.com/bitnami/charts
 name: contour
@@ -27,4 +25,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/containers/tree/main/bitnami/contour
   - https://projectcontour.io
-version: 9.1.4
+version: 9.1.5


### PR DESCRIPTION
### Description of the change

In this PR the maintainers' metadata is updated to show the team in charge of the maintenance, updates, and support of this Helm chart.

We always appreciate the initial contribution of @Cellebyte at https://github.com/bitnami/charts/pull/2069

### Benefits

On websites like [ArtifactHUB](https://artifacthub.io/packages/helm/bitnami/contour), the current maintainers are showed