### PR TITLE
[bitnami/postgresql] Update maintainers

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -22,10 +22,8 @@ keywords:
 maintainers:
   - name: Bitnami
     url: https://github.com/bitnami/charts
-  - email: cedric@desaintmartin.fr
-    name: desaintmartin
 name: postgresql
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
-version: 11.9.6
+version: 11.9.7


### PR DESCRIPTION
### Description of the change

In this PR the maintainers' metadata is updated to show the team in charge of the maintenance, updates, and support of this Helm chart.

We always appreciate the initial contribution of @desaintmartin when migrating this Helm chart from Helm stable

### Benefits

On websites like [ArtifactHUB](https://artifacthub.io/packages/helm/bitnami/postgresql), the current maintainers are showed