### PR TITLE
[bitnami/redis] Update maintainers

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -19,9 +19,7 @@ keywords:
 maintainers:
   - name: Bitnami
     url: https://github.com/bitnami/charts
-  - email: cedric@desaintmartin.fr
-    name: desaintmartin
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 17.3.1
+version: 17.3.2


### PR DESCRIPTION
### Description of the change

In this PR the maintainers' metadata is updated to show the team in charge of the maintenance, updates, and support of this Helm chart.

We always appreciate the initial contribution of @desaintmartin when migrating this Helm chart from Helm stable

### Benefits

On websites like [ArtifactHUB](https://artifacthub.io/packages/helm/bitnami/redis), the current maintainers are showed