### PR TITLE
[bitnami/grafana-loki]  fixed hardcoded table manager configpath

### DIFF
--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -44,4 +44,4 @@ name: grafana-loki
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/grafana-loki
   - https://github.com/grafana/loki/
-version: 2.4.3
+version: 2.4.4

--- a/bitnami/grafana-loki/templates/table-manager/deployment.yaml
+++ b/bitnami/grafana-loki/templates/table-manager/deployment.yaml
@@ -91,7 +91,7 @@ spec:
           {{- else }}
           args:
             - -target=table-manager
-            - -config.file=/bitnami/grafana-loki/conf/loki.yaml
+            - -config.file={{ .Values.loki.dataDir }}/conf/loki.yaml
           {{- end }}
           {{- if .Values.tableManager.extraEnvVars }}
           env: {{- include "common.tplvalues.render" (dict "value" .Values.tableManager.extraEnvVars "context" $) | nindent 12 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

fixes a hardcoded path for the config in grafana-loki table-manager component

### Benefits

Changes to `.Values.loki.dataDir` will be used in table-manager as well

### Possible drawbacks

none

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - mentioned in #12833

### Additional information

i was not able to test this, as i never deployed helm charts directly from the forked bitnami chart repo


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
