### PR TITLE
[bitnami/grafana-operator] Update maintainers

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -16,12 +16,10 @@ keywords:
   - operator
   - monitoring
 maintainers:
-  - name: cellebyte
-    url: cellebyte@gmail.com
   - name: Bitnami
     url: https://github.com/bitnami/charts
 name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/containers/tree/main/bitnami/grafana-operator
-version: 2.7.5
+version: 2.7.6


### PR DESCRIPTION
### Description of the change

In this PR the maintainers' metadata is updated to show the team in charge of the maintenance, updates, and support of this Helm chart.

We always appreciate the initial contribution of @Cellebyte at https://github.com/bitnami/charts/pull/3287

### Benefits

On websites like [ArtifactHUB](https://artifacthub.io/packages/helm/bitnami/grafana-operator), the current maintainers are showed