### PR TITLE
[bitnami/redis] Fix typo in publish pipeline definition

### DIFF
--- a/.vib/redis/vib-publish.json
+++ b/.vib/redis/vib-publish.json
@@ -55,9 +55,9 @@
             },
             "remote": {
               "workload": "sts-redis-master"
-            }
-          },
-          "vars_file": "vars.yaml"
+            },
+            "vars_file": "vars.yaml"
+          }
         }
       ]
     },


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes typo introduced in https://github.com/bitnami/charts/pull/12797 related to goss's vars file that is currently making the related Redis' publish pipeline fail. See: https://github.com/bitnami/charts/commit/7f3f7f7cd84b510f08ddddac1e395e36b2903812

### Benefits

Fixes Redis' publish workflow.

### Possible drawbacks

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
