### PR TITLE
[bitnami/*] Add logic to avoid Cypress failure on unhandled exceptions

### DIFF
--- a/.vib/keycloak/cypress/cypress/fixtures/users.json
+++ b/.vib/keycloak/cypress/cypress/fixtures/users.json
@@ -6,5 +6,10 @@
     "email": "thea@mail.com",
     "password": "someComplicatedPass12345!",
     "role": "User"
+  },
+  "importedUser": {
+    "lastName": "Ranvenclaw",
+    "username": "theo",
+    "email": "theo@mail.com"
   }
 }

--- a/.vib/keycloak/cypress/cypress/integration/keycloak_spec.js
+++ b/.vib/keycloak/cypress/cypress/integration/keycloak_spec.js
@@ -20,20 +20,19 @@ it('import and check user information', () => {
   cy.get('[data-testid="action-dropdown"]').click();
   cy.get('[data-testid="openPartialImportModal"]').click();
   const importFile = 'cypress/fixtures/import-data.json';
-  const randomUsername = `test-realm-user-${random}`;
-  const randomEmail = `test-realm-user-${random}@example.com`;
-  const randomLastname = `user-${random}`;
-  cy.readFile(importFile).then((obj) => {
-    obj.users[0].username = randomUsername;
-    obj.users[0].email = randomEmail;
-    obj.users[0].lastName = randomLastname;
-    const jsonText = JSON.stringify(obj);
-    cy.get('.view-line').type(jsonText, { parseSpecialCharSequences: false, delay: 1 });
+  cy.fixture('users').then((user) => {
+    cy.readFile(importFile).then((obj) => {
+      obj.users[0].username = `${user.importedUser.username}.${random}`;
+      obj.users[0].email = `${random}.${user.importedUser.email}`;
+      obj.users[0].lastName = `${user.importedUser.lastName}-${random}`;
+      const jsonText = JSON.stringify(obj);
+      cy.get('.view-line').type(jsonText, { parseSpecialCharSequences: false, delay: 1 });
+    });
+    cy.get('[data-testid="users-checkbox"]').click();
+    cy.get('[data-testid="import-button"]').click();
+    cy.contains('record added');
+    cy.get('[data-testid="close-button"]').click();
+    cy.get('[href*="/users"]').click();
+    cy.contains(`${user.importedUser.username}.${random}`);
   });
-  cy.get('[data-testid="users-checkbox"]').click();
-  cy.get('[data-testid="import-button"]').click();
-  cy.contains('One record added');
-  cy.get('[data-testid="close-button"]').click();
-  cy.get('[href*="/users"]').click();
-  cy.contains(randomEmail);
 });

--- a/.vib/keycloak/cypress/cypress/support/commands.js
+++ b/.vib/keycloak/cypress/cypress/support/commands.js
@@ -20,5 +20,17 @@ Cypress.Commands.add(
     cy.get('#username').type(username);
     cy.get('#password').type(password);
     cy.get('[type="submit"]').click();
+    cy.contains('Loading').should('not.exist');
   }
 );
+
+Cypress.on('uncaught:exception', (err, runnable, promise) => {
+  // when the exception originated from an unhandled promise
+  // rejection, the promise is provided as a third argument
+  // you can turn off failing the test in this case
+  if (promise) {
+    return false
+  }
+  // we still want to ensure there are no other unexpected
+  // errors, so we let them fail the test
+})

--- a/.vib/odoo/cypress/cypress/support/commands.js
+++ b/.vib/odoo/cypress/cypress/support/commands.js
@@ -21,3 +21,14 @@ Cypress.Commands.add(
     cy.contains('button', 'Log in').click();
   }
 );
+
+Cypress.on('uncaught:exception', (err, runnable, promise) => {
+  // when the exception originated from an unhandled promise
+  // rejection, the promise is provided as a third argument
+  // you can turn off failing the test in this case
+  if (promise) {
+    return false
+  }
+  // we still want to ensure there are no other unexpected
+  // errors, so we let them fail the test
+})

--- a/.vib/rabbitmq-cluster-operator/cypress/cypress/support/commands.js
+++ b/.vib/rabbitmq-cluster-operator/cypress/cypress/support/commands.js
@@ -21,3 +21,13 @@ Cypress.Commands.add(
     cy.contains('Login').click();
   }
 );
+
+Cypress.on('uncaught:exception', (err, runnable) => {
+  // we expect a 3rd party library error with message 'list not defined'
+  // and don't want to fail the test so we return false
+  if (err.message.includes('Cannot read properties of undefined')) {
+    return false;
+  }
+  // we still want to ensure there are no other unexpected
+  // errors, so we let them fail the test
+});

--- a/.vib/rabbitmq/cypress/cypress/support/commands.js
+++ b/.vib/rabbitmq/cypress/cypress/support/commands.js
@@ -21,3 +21,13 @@ Cypress.Commands.add(
     cy.contains('Login').click();
   }
 );
+
+Cypress.on('uncaught:exception', (err, runnable) => {
+  // we expect a 3rd party library error with message 'list not defined'
+  // and don't want to fail the test so we return false
+  if (err.message.includes('Cannot read properties of undefined')) {
+    return false;
+  }
+  // we still want to ensure there are no other unexpected
+  // errors, so we let them fail the test
+});


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Both Keycloak and Odoo are affected by the following error:

```
FAILURES: [The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.    > Error  When Cypress detects uncaught errors originating from your application it will automatically fail the current test.  This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.  https://on.cypress.io/uncaught-exception-from-application]
```

In the case of rabbitmq, the error is similar to the one above:

```
FAILURES: [The following error originated from your application code, not from Cypress.    > Cannot read properties of undefined (reading 'options')  When Cypress detects uncaught errors originating from your application it will automatically fail the current test.  This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.  https://on.cypress.io/uncaught-exception-from-application]
```

For this second case, the logic added here was mistakenly removed at https://github.com/bitnami/charts/pull/12733

This PR also includes:
- Added logic for rabbitmq-cluster-operator as the tests are identical to rabbitmq
- Modified a Keycloak test to conform to the followed best practices.
- Use of additional login logic to avoid potentials 401 errors in keycloak.

### Benefits

Cypress won't fail because of an unhandled app exception. 

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

Keycloak changes tested in fork https://github.com/FraPazGal/charts/pull/122

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
