### PR TITLE
[bitnami/kafka] Add nodeSelector to Kafka provisioning

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kafka
   - https://kafka.apache.org/
-version: 19.0.0
+version: 19.0.1

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -427,6 +427,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `provisioning.numPartitions`                         | Default number of partitions for topics when unspecified                                                                      | `1`                   |
 | `provisioning.replicationFactor`                     | Default replication factor for topics when unspecified                                                                        | `1`                   |
 | `provisioning.topics`                                | Kafka topics to provision                                                                                                     | `[]`                  |
+| `provisioning.nodeSelector`                          | Node labels for pod assignment                                                                                                | `{}`                  |
 | `provisioning.tolerations`                           | Tolerations for pod assignment                                                                                                | `[]`                  |
 | `provisioning.extraProvisioningCommands`             | Extra commands to run to provision cluster resources                                                                          | `[]`                  |
 | `provisioning.parallel`                              | Number of provisioning commands to run at the same time                                                                       | `1`                   |

--- a/bitnami/kafka/templates/kafka-provisioning.yaml
+++ b/bitnami/kafka/templates/kafka-provisioning.yaml
@@ -38,6 +38,9 @@ spec:
       {{- end }}
       restartPolicy: OnFailure
       terminationGracePeriodSeconds: 0
+      {{- if .Values.provisioning.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.provisioning.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
       {{- if .Values.provisioning.tolerations }}
       tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.provisioning.tolerations "context" .) | nindent 8 }}
       {{- end }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1483,6 +1483,10 @@ provisioning:
   ##     flush.messages: 1
   ##
   topics: []
+  ## @param provisioning.nodeSelector Node labels for pod assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
   ## @param provisioning.tolerations Tolerations for pod assignment
   ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Added `nodeSelector` to the provisioning job. This matches the `statefulset` and `kafka-metrics-deployments` YAML.

### Benefits

The chart user can control on which nodes the batch pods are scheduled. For example at the moment on a mixed Linux/Windows cluster the provisioning job can end up on Windows nodes incorrectly.

### Possible drawbacks

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

The provisioning batch does not include support for `podAffinity`, `podAntiAffinity` or `nodeAffinity`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
