### PR TITLE
[bitnami/argo-cd] Fix wrong value reference

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/containers/tree/main/bitnami/dex
   - https://github.com/dexidp/dex
-version: 4.2.3
+version: 4.2.4

--- a/bitnami/argo-cd/templates/repo-server/metrics-svc.yaml
+++ b/bitnami/argo-cd/templates/repo-server/metrics-svc.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.repoServer.metrics.service.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.repoServer.metrics.service.annotations "context" $) | nindent 4 }}
     {{- end }}
 spec:
   type: {{ .Values.repoServer.metrics.service.type }}


### PR DESCRIPTION
# Description of the change

There is a bug in the current version of the chart:

repo-server/metrics-svc.yaml  references a non existing value which leads to nil pointer exception. 

``` "argo-cd/templates/repo-server/metrics-svc.yaml" at <.Values.service.annotations>: nil pointer evaluating interface {}.annotations``` 

We fixed this by simple replacing the wrong reference with the correct value:

```Values.service.annotations``` -> ```Values.repo-server.metrics.service.annotations```



### Benefits

No errors anymore when enabling metrics 

### Possible drawbacks

No


<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
