### PR TITLE
[bitnami/thanos] Remove subPath from servicediscovery.yml

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 11.5.5
+version: 11.5.6

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -110,7 +110,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- if or (include "thanos.query.createSDConfigmap" .) .Values.query.existingSDConfigmap }}
-            - --store.sd-files=/conf/servicediscovery.yml
+            - --store.sd-files=/conf/sd/servicediscovery.yml
             {{- end }}
             {{- if and .Values.query.dnsDiscovery.enabled .Values.query.dnsDiscovery.sidecarsService .Values.query.dnsDiscovery.sidecarsNamespace }}
             - --endpoint=dnssrv+_grpc._tcp.{{- include "common.tplvalues.render" ( dict "value" .Values.query.dnsDiscovery.sidecarsService "context" $) -}}.{{- include "common.tplvalues.render"  ( dict "value" .Values.query.dnsDiscovery.sidecarsNamespace "context" $) -}}.svc.{{ .Values.clusterDomain }}
@@ -236,8 +236,7 @@ spec:
             {{- end }}
             {{- if or (include "thanos.query.createSDConfigmap" .) .Values.query.existingSDConfigmap }}
             - name: sd-config
-              mountPath: /conf/servicediscovery.yml
-              subPath: servicediscovery.yml
+              mountPath: /conf/sd
             {{- end }}
             {{- if .Values.query.grpc.server.tls.enabled }}
             - name: grpc-server-tls


### PR DESCRIPTION
Signed-off-by: Boris Kreitchman <bkreitch@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->
A container using a ConfigMap as a subPath volume mount does not receive ConfigMap updates, so currently Query doesn't see the changes to servicediscovery.yml. This PR removes subPath and mounts volume on a directory to allow ConfigMap updates and automatic reloads.
### Benefits

<!-- What benefits will be realized by the code change? -->
Allows automatic reloads of Query servicediscovery.yml
### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
