### PR TITLE
[bitnami/*] Allow VIB action configuration per asset

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -142,11 +142,24 @@ jobs:
         name: Checkout Repository
         with:
           path: charts
+      - id: get-asset-vib-config
+        name: Get asset-specific configuration for VIB action
+        run: |
+          config_file="charts/.vib/${{ needs.get-chart.outputs.chart }}/vib-action.config"
+
+          # Supported configuration customizations and default values
+          verification_mode="PARALLEL"
+
+          if [[ -f $config_file ]]; then
+            verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
+          fi
+          echo "::set-output name=verification_mode::${verification_mode}"
       - uses: vmware-labs/vmware-image-builder-action@main
         name: Verify and publish ${{ needs.get-chart.outputs.chart }}
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-publish.json
           config: charts/.vib/
+          verification-mode: ${{ steps.get-asset-vib-config.outputs.verification_mode }}
         env:
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
           VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -98,10 +98,23 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - id: get-asset-vib-config
+        name: Get asset-specific configuration for VIB action
+        run: |
+          config_file=".vib/${{ needs.get-chart.outputs.chart }}/vib-action.config"
+
+          # Supported configuration customizations and default values
+          verification_mode="PARALLEL"
+
+          if [[ -f $config_file ]]; then
+            verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
+          fi
+          echo "::set-output name=verification_mode::${verification_mode}"
       - uses: vmware-labs/vmware-image-builder-action@main
         name: Verify ${{ needs.get-chart.outputs.chart }}
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-verify.json
+          verification-mode: ${{ steps.get-asset-vib-config.outputs.verification_mode }}
         env:
           # Target-Platform used by default
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}


### PR DESCRIPTION
### Description of the change

As described in the [documentation](https://github.com/vmware-labs/vmware-image-builder-action#action-input-parameters), the VMware Image Builder action accepts several parameters as inputs to customize its execution. These parameters are not meant to be defined at pipeline-level though, as they are inputs of the action.

This PR introduces logic to allow to define, per asset, this configuration by creating a file under `.vib/ASSET/vib-action.config`. It also adds initial support to recognize the `verification-mode` one.

### Benefits

Assets can define specific configurations to launch the VIB action, such as the `verification-mode`.

### Possible drawbacks

None, backward compatibility is maintained.

### Applicable issues

NA.

### Additional information

Tested in [joancafom-serial](https://github.com/joancafom/charts/actions/runs/3242108696/jobs/5314926901) and [joancafom-parallel](https://github.com/joancafom/charts/actions/runs/3242279443/jobs/5315320370)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
