### PR TITLE
[bitnami/parse] Fix typo in the health-check endpoint blocking publishing

### DIFF
--- a/.vib/parse/vib-publish.json
+++ b/.vib/parse/vib-publish.json
@@ -34,7 +34,7 @@
         {
           "action_id": "health-check",
           "params": {
-            "endpoint": "lb-parse-dasboard-http-dashboard"
+            "endpoint": "lb-parse-dashboard-http-dashboard"
           }
         },
         {


### PR DESCRIPTION
### Description of the change

There is a typo in the endpoint which is blocking releases due to the following error:
```
health-check( 07156f31-f051-4668-9d90-62523ca722bb ). Error:  The pipeline contains the following invalid fields: $.phases.verify.actions[0].params.port is required but it is missing (The field can be injected from the output attribute $.endpoints[?(@.name == 'lb-parse-dasboard-http-dashboard')].port of a previous 'deployment' action. Are {endpoint: lb-parse-dasboard-http-dashboard} valid values?). $.phases.verify.actions[0].params.host is required but it is missing (The field can be injected from the output attribute $.endpoints[?(@.name == 'lb-parse-dasboard-http-dashboard')].host of a previous 'deployment' action. Are {endpoint: lb-parse-dasboard-http-dashboard} valid values?)
```

See https://github.com/bitnami/charts/actions/runs/3263351921/jobs/5362040113

### Benefits

Releases are back to normal

### Checklist

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)