### PR TITLE
[bitnami/parse] Force chart publishing

### DIFF
--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/parse
   - https://github.com/bitnami/containers/tree/main/bitnami/parse-dashboard
   - https://parse.com/
-version: 19.1.6
+version: 19.1.7


### PR DESCRIPTION
### Description of the change

A typo in the CD pipeline prevented the chart from publishing in the index. After fixing the issue in https://github.com/bitnami/charts/pull/12976, this PR manually forces a new version of the chart to be created, uploaded, and listed in the index.

### Benefits

The index is updated with a new asset version, which includes all the changes in the GitHub repo.

### Possible drawbacks

None

### Applicable issues

NA

### Additional information

Related to https://github.com/bitnami/charts/pull/12976

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)
