### PR TITLE
Bump actions/checkout version from v2 to v3

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -96,7 +96,7 @@ jobs:
       chart: ${{ steps.get-chart.outputs.chart }}
       result: ${{ steps.get-chart.outputs.result }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: charts
           fetch-depth: 2 # to be able to obtain files changed in the latest commit
@@ -138,7 +138,7 @@ jobs:
     if: ${{ needs.get-chart.outputs.result == 'ok' }}
     name: VIB Publish
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Repository
         with:
           path: charts
@@ -176,7 +176,7 @@ jobs:
         with:
           path: ~/artifacts
       # If we perform a checkout of the master branch, we will find conflicts with the submodules
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: 'index'
           path: index

--- a/.github/workflows/ci-pipeline-extra-thanos.yml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify BucketWeb on Tanzu Kubernetes Grid
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -93,7 +93,7 @@ jobs:
       )
     name: VIB Verify
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout Repository
         with:
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout bitnami-labs/readme-generator-for-helm
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'bitnami-labs/readme-generator-for-helm'
           ref: '1af12881436b1f58f0643d733fd5196b4a11caa8'
@@ -35,7 +35,7 @@ jobs:
         run: cd readme-generator-for-helm && npm install
 
       - name: Checkout bitnami/charts
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout

Taking a look at the version used for `actions/checkout`, currently, there is a mix of `v2` and `v3`:
```console
$ ag 'actions/checkout' .github
.github/workflows/cd-pipeline.yml
99:      - uses: actions/checkout@v2
141:      - uses: actions/checkout@v2
179:      - uses: actions/checkout@v2

.github/workflows/ci-pipeline.yml
96:      - uses: actions/checkout@v2

.github/workflows/triage.yml
19:        uses: actions/checkout@v3

.github/workflows/sync-teams.yml
14:        uses: actions/checkout@v3

.github/workflows/comments.yml
15:        uses: actions/checkout@v3

.github/workflows/ci-pipeline-extra-thanos.yml
28:      - uses: actions/checkout@v2

.github/workflows/srp-report.yml
23:      - uses: actions/checkout@v3

.github/workflows/moving-cards.yml
46:        uses: actions/checkout@v3
130:        uses: actions/checkout@v3

.github/workflows/generate-chart-readme.yml
17:        uses: actions/checkout@v2
38:        uses: actions/checkout@v2
```

According to the above warning, we should bump the `actions/checkout` version to `v3` everywhere in order to use the latest NodeJS version. Taking a look at the [_actions/checkout_ releases|https://github.com/actions/checkout/releases/tag/v3.0.0], the new node version is used from 3.0.0 on.