### PR TITLE
Bump slackapi/slack-github-action version from v1.19.0 to v1.23.0

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -240,7 +240,7 @@ jobs:
     steps:
       - name: Notify in Slack channel
         if: ${{ needs.vib-publish.result != 'success' || needs.update-index.result != 'success' }}
-        uses: slackapi/slack-github-action@v1.19.0
+        uses: slackapi/slack-github-action@v1.23.0
         with:
           channel-id: ${{ secrets.CD_SLACK_CHANNEL_ID }}
           payload: |


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> **Notify unsuccessful CD run**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: slackapi/slack-github-action

Taking a look at the version used for `slackapi/slack-github-action`:
```console
$ ag 'slackapi/slack-github-action' .github
.github/workflows/cd-pipeline.yml
243:        uses: slackapi/slack-github-action@v1.19.0
```

According to the above warning, we should bump the `slackapi/slack-github-action` version to `v1.23.0` everywhere in order to use the latest NodeJS version. Taking a look at the [slackapi/slack-github-action releases](https://github.com/slackapi/slack-github-action/releases/tag/v1.23.0), the new NodeJS version is used from 1.23.0 on.