### PR TITLE
Bump actions/cache version to v3

### DIFF
--- a/.github/workflows/generate-chart-readme.yml
+++ b/.github/workflows/generate-chart-readme.yml
@@ -21,7 +21,7 @@ jobs:
           path: readme-generator-for-helm
 
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> **update-readme-metadata**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/cache, actions/cache

Taking a look at the version used for `actions/cache`, currently, there is a mix of `v2` and `v3`:
```
$ ag 'actions/cache' charts/.github vms/.github containers/.github
charts/.github/workflows/generate-chart-readme.yml
24:        uses: actions/cache@v2
```

According to the above warning, we should bump the `actions/cache` version to `v3` everywhere in order to use the latest NodeJS version. Taking a look at the [`actions/cache` releases](https://github.com/actions/cache/releases/tag/v3.0.0), the new NodeJS version is used from 3.0.0 on.