### PR TITLE
Bump hmarr/auto-approve-action version to v3.0.0

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -143,7 +143,7 @@ jobs:
       # Approved by the 'github-actions' user; a PR can't be approved by its author
       - name: PR approval
         if: ${{ needs.vib-verify.result == 'success' }}
-        uses: hmarr/auto-approve-action@v2.4.0
+        uses: hmarr/auto-approve-action@v3.0.0
         with:
           pull-request-number: ${{ github.event.number }}
       # If the CI did not succeed ('VIB Verify' failed or skipped),


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> **Reviewal for automated PRs**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: reitermarkus/automerge, hmarr/auto-approve-action

Taking a look at the version used for `hmarr/auto-approve-action`:
```console
$ ag 'hmarr/auto-approve-action' charts/.github vms/.github containers/.github
charts/.github/workflows/ci-pipeline.yml
146:        uses: hmarr/auto-approve-action@v2.4.0

containers/.github/workflows/ci-pipeline.yml
178:        uses: hmarr/auto-approve-action@v2.4.0
```

According to the above warning, we should bump the `hmarr/auto-approve-action` version to, at least, `v3.0.0` everywhere in order to use the latest NodeJS version. Taking a look at the [`hmarr/auto-approve-action` releases](https://github.com/hmarr/auto-approve-action/releases/tag/v3.0.0), the new NodeJS version is used from `v3.0.0` on.