### PR TITLE
Increase retry-count from 3 (default) to 6 in VIB action

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -160,6 +160,7 @@ jobs:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-publish.json
           config: charts/.vib/
           verification-mode: ${{ steps.get-asset-vib-config.outputs.verification_mode }}
+          retry-count: 6
         env:
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}
           VIB_ENV_ALTERNATIVE_TARGET_PLATFORM: ${{ secrets.VIB_ENV_ALTERNATIVE_TARGET_PLATFORM }}

--- a/.github/workflows/ci-pipeline-extra-thanos.yml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yml
@@ -32,5 +32,6 @@ jobs:
       - uses: vmware-labs/vmware-image-builder-action@main
         with:
           pipeline: thanos/bucketweb/vib-verify.json
+          retry-count: 6
         env:
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -115,6 +115,7 @@ jobs:
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-verify.json
           verification-mode: ${{ steps.get-asset-vib-config.outputs.verification_mode }}
+          retry-count: 6
         env:
           # Target-Platform used by default
           VIB_ENV_TARGET_PLATFORM: ${{ secrets.VIB_ENV_TARGET_PLATFORM }}


### PR DESCRIPTION
This is a temporary workaround in order to solve an internal networking issue that is producing some actions to fail due to
```
  Substituting variable VIB_ENV_TARGET_PLATFORM in parse/vib-publish.json
  Warning: Environment variable VIB_ENV_ALTERNATIVE_TARGET_PLATFORM is set but is not used within pipeline parse/vib-publish.json
  Substituting variable VIB_ENV_S3_URL in parse/vib-publish.json
  Substituting variable VIB_ENV_S3_USERNAME in parse/vib-publish.json
  Substituting variable VIB_ENV_S3_PASSWORD in parse/vib-publish.json
  The pipeline has been validated successfully.
  Request to /v1/pipelines failed. Retry: 0. Waiting 5000
  Request to /v1/pipelines failed. Retry: 1. Waiting 10000
  Request to /v1/pipelines failed. Retry: 2. Waiting 15000
  Error: Could not execute operation. Retried 3 times.
```