### PR TITLE
Bump xom9ikk/dotenv version to v2

### DIFF
--- a/.github/workflows/comments.yml
+++ b/.github/workflows/comments.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Repo checkout
         uses: actions/checkout@v3
       - name: Load .env file
-        uses: xom9ikk/dotenv@v1.0.2
+        uses: xom9ikk/dotenv@v2
         with:
           path: .github/workflows/
       - name: Move into From Build Maintenance

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Load .env file
-        uses: xom9ikk/dotenv@v1.0.2
+        uses: xom9ikk/dotenv@v2
         with:
           path: .github/workflows/
       # Now handling the needed labeling
@@ -118,7 +118,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Load .env file
-        uses: xom9ikk/dotenv@v1.0.2
+        uses: xom9ikk/dotenv@v2
         with:
           path: .github/workflows/
       - name: Assign to a person to work on it

--- a/.github/workflows/sync-teams.yml
+++ b/.github/workflows/sync-teams.yml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.BITNAMI_BOT_TOKEN }}
           fetch-depth: 1
       - name: Load .env file
-        uses: xom9ikk/dotenv@v1.0.2
+        uses: xom9ikk/dotenv@v2
         with:
           path: .github/workflows/
       - name: Updating members of the Bitnami team

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Load .env file
-        uses: xom9ikk/dotenv@v1.0.2
+        uses: xom9ikk/dotenv@v2
         with:
           path: .github/workflows/
       - name: Get author


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

> **label-card**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: xom9ikk/dotenv, andymckay/labeler

Taking a look at the version used for `xom9ikk/dotenv`:
```console
$ ag 'xom9ikk/dotenv' charts/.github vms/.github containers/.github
charts/.github/workflows/triage.yml
23:        uses: xom9ikk/dotenv@v1.0.2

charts/.github/workflows/sync-teams.yml
19:        uses: xom9ikk/dotenv@v1.0.2

charts/.github/workflows/comments.yml
17:        uses: xom9ikk/dotenv@v1.0.2

charts/.github/workflows/moving-cards.yml
50:        uses: xom9ikk/dotenv@v1.0.2
134:        uses: xom9ikk/dotenv@v1.0.2

vms/.github/workflows/move-closed-issues.yml
29:        uses: xom9ikk/dotenv@v1.0.2

vms/.github/workflows/triage.yml
32:        uses: xom9ikk/dotenv@v1.0.2

vms/.github/workflows/sync-teams.yml
19:        uses: xom9ikk/dotenv@v1.0.2

vms/.github/workflows/comments.yml
25:        uses: xom9ikk/dotenv@v1.0.2

vms/.github/workflows/moving-cards.yml
27:        uses: xom9ikk/dotenv@v1.0.2
64:        uses: xom9ikk/dotenv@v1.0.2

containers/.github/workflows/triage.yml
23:        uses: xom9ikk/dotenv@v1.0.2

containers/.github/workflows/comments.yml
17:        uses: xom9ikk/dotenv@v1.0.2

containers/.github/workflows/moving-cards.yml
53:        uses: xom9ikk/dotenv@v1.0.2
137:        uses: xom9ikk/dotenv@v1.0.2

containers/.github/workflows/sync-teams.yml
19:        uses: xom9ikk/dotenv@v1.0.2
```

According to the above warning, we should bump the `xom9ikk/dotenv` version to, at least, `v2` everywhere in order to use the latest NodeJS version. Taking a look at the [`xom9ikk/dotenv` releases](https://github.com/xom9ikk/dotenv/releases/tag/v2), the new NodeJS version is used from `v2` on.