### PR TITLE
Bump actions/github-script version to v6

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -128,7 +128,7 @@ jobs:
       - id: show-error
         name: 'Show error'
         if: ${{ steps.get-chart.outputs.result == 'fail' }}
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
               core.setFailed('${{ steps.get-chart.outputs.error }}')

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -75,7 +75,7 @@ jobs:
       - id: show-error
         name: Show error
         if: ${{ steps.get-chart.outputs.result == 'fail' }}
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             core.setFailed('${{ steps.get-chart.outputs.error }}')


### PR DESCRIPTION
We are receiving the following warning in relation to some of the GH actions we are running as part of our release and support workflows:

>*Get modified charts*
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/github-script

Taking a look at the version used for `actions/github-script`, currently there is a mix of `v3` and `v6`:
```console
$ ag 'uses: actions/github-script' */.github
charts/.github/workflows/ci-pipeline.yml
78:        uses: actions/github-script@v3

charts/.github/workflows/cd-pipeline.yml
131:        uses: actions/github-script@v3

charts/.github/workflows/assign-asset-label.yml
35:        uses: actions/github-script@v6

containers/.github/workflows/ci-pipeline.yml
123:        uses: actions/github-script@v6

containers/.github/workflows/assign-asset-label.yml
35:        uses: actions/github-script@v6

containers/.github/workflows/moving-cards.yml
77:        uses: actions/github-script@v6
```

According to the above warning, we should bump the `actions/github-script` version to `v6` everywhere in order to use the latest NodeJS version. Taking a look at the [`actions/github-script` releases](https://github.com/actions/github-script/releases/tag/v6.0.0), the new NodeJS version is used from 6.0.0 on.