### PR TITLE
[bitnami/redis] Fix redis master.api.svc.cluster.local missing

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 17.3.6
+version: 17.3.7

--- a/bitnami/redis/templates/tls-secret.yaml
+++ b/bitnami/redis/templates/tls-secret.yaml
@@ -7,8 +7,8 @@
 {{- $fullname := include "common.names.fullname" . }}
 {{- $serviceName := include "common.names.fullname" . }}
 {{- $headlessServiceName := printf "%s-headless" (include "common.names.fullname" .) }}
-{{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) "127.0.0.1" "localhost" $fullname }}
-{{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
+{{- $masterServiceName := printf "%s-master" (include "common.names.fullname" .) }}
+{{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $masterServiceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $masterServiceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) "127.0.0.1" "localhost" $fullname }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/redis/templates/tls-secret.yaml
+++ b/bitnami/redis/templates/tls-secret.yaml
@@ -9,6 +9,7 @@
 {{- $headlessServiceName := printf "%s-headless" (include "common.names.fullname" .) }}
 {{- $masterServiceName := printf "%s-master" (include "common.names.fullname" .) }}
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $masterServiceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $masterServiceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) "127.0.0.1" "localhost" $fullname }}
+{{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Signed-off-by: Celia Garcia Marquez <gcelia@vmware.com>

### Description of the change

Fix redis-master-api-svc-local missing in auto generated cert altnames.

### Applicable issues

  - fixes #12172 

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
