### PR TITLE
[bitnami/template] Fix autoscaling reference in template chart deployment

### DIFF
--- a/template/CHART_NAME/templates/deployment.yaml
+++ b/template/CHART_NAME/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.enabled }}
   replicas: {{ .Values.%%MAIN_OBJECT_BLOCK%%.replicaCount }}
   {{- end }}
   {{- if .Values.%%MAIN_OBJECT_BLOCK%%.updateStrategy }}


### PR DESCRIPTION
In values.yaml, autoscaling is nested under %%MAIN_OBJECT_BLOCK%%.

Signed-off-by: Brad Solomon <81818815+brsolomon-deloitte@users.noreply.github.com>