### PR TITLE
[bitnami/postgresql-ha] Fix typo in CD health-check endpoint

### DIFF
--- a/.vib/postgresql-ha/vib-publish.json
+++ b/.vib/postgresql-ha/vib-publish.json
@@ -34,7 +34,7 @@
         {
           "action_id": "health-check",
           "params": {
-            "endpoint": "lb-postgresql-ha-psql-ha-pgpool-postgresql"
+            "endpoint": "lb-postgresql-ha-pgpool-postgresql"
           }
         },
         {


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The publish pipeline for `bitnami/postgresql-ha` is failing because the endpoint used in the health-check action was not updated in https://github.com/bitnami/charts/pull/12713.

### Benefits

The publish pipeline succeeds hereon.

### Possible drawbacks

None

### Additional information

Failed publish action: https://github.com/bitnami/charts/actions/runs/3295703998/jobs/5434524413

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
