### PR TITLE
[bitnami/metallb] Fix service account name handling

### DIFF
--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -28,4 +28,4 @@ sources:
   - https://github.com/metallb/metallb
   - https://github.com/bitnami/containers/tree/main/bitnami/metallb
   - https://metallb.universe.tf
-version: 4.1.8
+version: 4.1.9

--- a/bitnami/metallb/templates/_helpers.tpl
+++ b/bitnami/metallb/templates/_helpers.tpl
@@ -1,17 +1,25 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Create the name of the controller service account to use
-*/}}
+ Create the name of the controller service account to use
+ */}}
 {{- define "metallb.controller.serviceAccountName" -}}
-{{ include "common.secrets.name" (dict "existingSecret" .Values.controller.serviceAccount.name "defaultNameSuffix" "controller" "context" $) }}
+{{- if .Values.controller.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.controller.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.controller.serviceAccount.name }}
+{{- end -}}
 {{- end -}}
 
 {{/*
-Create the name of the speaker service account to use
-*/}}
+ Create the name of the speaker service account to use
+ */}}
 {{- define "metallb.speaker.serviceAccountName" -}}
-{{ include "common.secrets.name" (dict "existingSecret" .Values.speaker.serviceAccount.name "defaultNameSuffix" "speaker" "context" $) }}
+{{- if .Values.speaker.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.speaker.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.speaker.serviceAccount.name }}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Signed-off-by: Rafael Rios Saavedra <rrios@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes the service account name when disabling it.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
