### PR TITLE
[bitnami/kong] Adds missing get/list/watch permissions for ingressclassparameterses

### DIFF
--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -36,4 +36,4 @@ name: kong
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kong
   - https://konghq.com/
-version: 7.0.3
+version: 7.0.4

--- a/bitnami/kong/templates/ingress-controller-rbac.yaml
+++ b/bitnami/kong/templates/ingress-controller-rbac.yaml
@@ -159,6 +159,14 @@ rules:
       - patch
       - update
   - apiGroups:
+    - configuration.konghq.com
+    resources:
+      - ingressclassparameterses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - configuration.konghq.com
     resources:
       - kongclusterplugins


### PR DESCRIPTION
**Description of the change**

This change adds missing persmissions on ingressclassparameterses.

Issue: https://github.com/bitnami/charts/issues/13005