### PR TITLE
[bitnami/tomcat] Removed enforcement of tomcatPassword variable on upgrades

### DIFF
--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -26,4 +26,4 @@ name: tomcat
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/tomcat
   - http://tomcat.apache.org
-version: 10.4.9
+version: 10.5.0

--- a/bitnami/tomcat/templates/NOTES.txt
+++ b/bitnami/tomcat/templates/NOTES.txt
@@ -48,10 +48,3 @@ APP VERSION: {{ .Chart.AppVersion }}
   echo Password: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "common.names.fullname" . }} -o jsonpath="{.data.tomcat-password}" | base64 -d)
 
 {{- include "tomcat.checkRollingTags" . }}
-{{- $passwordValidationErrors := list -}}
-{{- $secretName := include "common.names.fullname" . -}}
-{{- $requiredTomcatPassword := dict "valueKey" "tomcatPassword" "secret" $secretName "field" "tomcat-password" "context" $ -}}
-{{- $requiredTomcatPasswordError := include "common.validations.values.single.empty" $requiredTomcatPassword -}}
-{{- $passwordValidationErrors = append $passwordValidationErrors $requiredTomcatPasswordError -}}
-{{- include "common.errors.upgrade.passwords.empty" (dict "validationErrors" $passwordValidationErrors "context" $) -}}
-{{- include "tomcat.validateValues" . -}}

--- a/bitnami/tomcat/templates/secrets.yaml
+++ b/bitnami/tomcat/templates/secrets.yaml
@@ -12,8 +12,4 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if .Values.tomcatPassword }}
-  tomcat-password: {{ .Values.tomcatPassword | b64enc | quote }}
-  {{- else }}
-  tomcat-password: {{ randAlphaNum 10 | b64enc | quote }}
-  {{- end }}
+  tomcat-password: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "tomcat-password" "providedValues" (list "tomcatPassword") "length" 10 "strong" false "context" $) }}


### PR DESCRIPTION
Signed-off-by: Daniel Haß <danielhass@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

https://github.com/bitnami/charts/issues/12296 https://github.com/bitnami/charts/issues/13048

Removing the enforced check of the `tomcatPassword` value on subsequent upgrades and moving the secret generation from an in chart conditional to the commons `common.secrets.passwords.manage` function.

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

From my understanding this enforcement of the `tomcatPassword` being set on subsequent upgrades is not necessary as the password is stored properly inside a Kubernetes Secret that is evaluated automatically on every container startup.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #13048
  - fixes #12296

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
