### PR TITLE
[bitnami/sealed-secrets] fix: Align sealed-secrets security context to the pod security standards

### DIFF
--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -23,4 +23,4 @@ name: sealed-secrets
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/sealed-secrets
   - https://github.com/bitnami-labs/sealed-secrets
-version: 1.1.7
+version: 1.1.8

--- a/bitnami/sealed-secrets/README.md
+++ b/bitnami/sealed-secrets/README.md
@@ -77,72 +77,76 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Sealed Secrets Parameters
 
-| Name                                              | Description                                                                                                              | Value                    |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
-| `image.registry`                                  | Sealed Secrets image registry                                                                                            | `docker.io`              |
-| `image.repository`                                | Sealed Secrets image repository                                                                                          | `bitnami/sealed-secrets` |
-| `image.tag`                                       | Sealed Secrets image tag (immutable tags are recommended)                                                                | `0.19.1-scratch-r0`      |
-| `image.digest`                                    | Sealed Secrets image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag           | `""`                     |
-| `image.pullPolicy`                                | Sealed Secrets image pull policy                                                                                         | `IfNotPresent`           |
-| `image.pullSecrets`                               | Sealed Secrets image pull secrets                                                                                        | `[]`                     |
-| `image.debug`                                     | Enable Sealed Secrets image debug mode                                                                                   | `false`                  |
-| `command`                                         | Override default container command (useful when using custom images)                                                     | `[]`                     |
-| `commandArgs`                                     | Additional args (doesn't override the default ones)                                                                      | `[]`                     |
-| `args`                                            | Override default container args (useful when using custom images)                                                        | `[]`                     |
-| `containerPorts.http`                             | Controller HTTP container port to open                                                                                   | `8080`                   |
-| `resources.limits`                                | The resources limits for the Sealed Secret containers                                                                    | `{}`                     |
-| `resources.requests`                              | The requested resources for the Sealed Secret containers                                                                 | `{}`                     |
-| `livenessProbe.enabled`                           | Enable livenessProbe on Sealed Secret containers                                                                         | `true`                   |
-| `livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                                  | `5`                      |
-| `livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                                         | `10`                     |
-| `livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                                                        | `1`                      |
-| `livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                                                      | `3`                      |
-| `livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                                                      | `1`                      |
-| `readinessProbe.enabled`                          | Enable readinessProbe on Sealed Secret containers                                                                        | `true`                   |
-| `readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                                                 | `5`                      |
-| `readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                                                        | `10`                     |
-| `readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                                                       | `1`                      |
-| `readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                                                     | `3`                      |
-| `readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                                                     | `1`                      |
-| `startupProbe.enabled`                            | Enable startupProbe on Sealed Secret containers                                                                          | `false`                  |
-| `startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                                                   | `10`                     |
-| `startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                                                          | `10`                     |
-| `startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                                                         | `1`                      |
-| `startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                                                       | `15`                     |
-| `startupProbe.successThreshold`                   | Success threshold for startupProbe                                                                                       | `1`                      |
-| `customLivenessProbe`                             | Custom livenessProbe that overrides the default one                                                                      | `{}`                     |
-| `customReadinessProbe`                            | Custom readinessProbe that overrides the default one                                                                     | `{}`                     |
-| `customStartupProbe`                              | Custom startupProbe that overrides the default one                                                                       | `{}`                     |
-| `podSecurityContext.enabled`                      | Enabled Sealed Secret pods' Security Context                                                                             | `true`                   |
-| `podSecurityContext.fsGroup`                      | Set Sealed Secret pod's Security Context fsGroup                                                                         | `1001`                   |
-| `containerSecurityContext.enabled`                | Enabled Sealed Secret containers' Security Context                                                                       | `true`                   |
-| `containerSecurityContext.readOnlyRootFilesystem` | Whether the Sealed Secret container has a read-only root filesystem                                                      | `true`                   |
-| `containerSecurityContext.runAsNonRoot`           | Indicates that the Sealed Secret container must run as a non-root user                                                   | `true`                   |
-| `containerSecurityContext.runAsUser`              | Set Sealed Secret containers' Security Context runAsUser                                                                 | `1001`                   |
-| `hostAliases`                                     | Sealed Secret pods host aliases                                                                                          | `[]`                     |
-| `podLabels`                                       | Extra labels for Sealed Secret pods                                                                                      | `{}`                     |
-| `podAnnotations`                                  | Annotations for Sealed Secret pods                                                                                       | `{}`                     |
-| `podAffinityPreset`                               | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                     |
-| `podAntiAffinityPreset`                           | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                   |
-| `nodeAffinityPreset.type`                         | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                     |
-| `nodeAffinityPreset.key`                          | Node label key to match. Ignored if `affinity` is set                                                                    | `""`                     |
-| `nodeAffinityPreset.values`                       | Node label values to match. Ignored if `affinity` is set                                                                 | `[]`                     |
-| `affinity`                                        | Affinity for Sealed Secret pods assignment                                                                               | `{}`                     |
-| `nodeSelector`                                    | Node labels for Sealed Secret pods assignment                                                                            | `{}`                     |
-| `tolerations`                                     | Tolerations for Sealed Secret pods assignment                                                                            | `[]`                     |
-| `updateStrategy.type`                             | Sealed Secret statefulset strategy type                                                                                  | `RollingUpdate`          |
-| `priorityClassName`                               | Sealed Secret pods' priorityClassName                                                                                    | `""`                     |
-| `topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                     |
-| `schedulerName`                                   | Name of the k8s scheduler (other than default) for Sealed Secret pods                                                    | `""`                     |
-| `terminationGracePeriodSeconds`                   | Seconds Redmine pod needs to terminate gracefully                                                                        | `""`                     |
-| `lifecycleHooks`                                  | for the Sealed Secret container(s) to automate configuration before or after startup                                     | `{}`                     |
-| `extraEnvVars`                                    | Array with extra environment variables to add to Sealed Secret nodes                                                     | `[]`                     |
-| `extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars for Sealed Secret nodes                                             | `""`                     |
-| `extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars for Sealed Secret nodes                                                | `""`                     |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the Sealed Secret pod(s)                                         | `[]`                     |
-| `extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the Sealed Secret container(s)                              | `[]`                     |
-| `sidecars`                                        | Add additional sidecar containers to the Sealed Secret pod(s)                                                            | `{}`                     |
-| `initContainers`                                  | Add additional init containers to the Sealed Secret pod(s)                                                               | `{}`                     |
+| Name                                                | Description                                                                                                              | Value                    |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------ |
+| `image.registry`                                    | Sealed Secrets image registry                                                                                            | `docker.io`              |
+| `image.repository`                                  | Sealed Secrets image repository                                                                                          | `bitnami/sealed-secrets` |
+| `image.tag`                                         | Sealed Secrets image tag (immutable tags are recommended)                                                                | `0.19.1-scratch-r0`      |
+| `image.digest`                                      | Sealed Secrets image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag           | `""`                     |
+| `image.pullPolicy`                                  | Sealed Secrets image pull policy                                                                                         | `IfNotPresent`           |
+| `image.pullSecrets`                                 | Sealed Secrets image pull secrets                                                                                        | `[]`                     |
+| `image.debug`                                       | Enable Sealed Secrets image debug mode                                                                                   | `false`                  |
+| `command`                                           | Override default container command (useful when using custom images)                                                     | `[]`                     |
+| `commandArgs`                                       | Additional args (doesn't override the default ones)                                                                      | `[]`                     |
+| `args`                                              | Override default container args (useful when using custom images)                                                        | `[]`                     |
+| `containerPorts.http`                               | Controller HTTP container port to open                                                                                   | `8080`                   |
+| `resources.limits`                                  | The resources limits for the Sealed Secret containers                                                                    | `{}`                     |
+| `resources.requests`                                | The requested resources for the Sealed Secret containers                                                                 | `{}`                     |
+| `livenessProbe.enabled`                             | Enable livenessProbe on Sealed Secret containers                                                                         | `true`                   |
+| `livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                                  | `5`                      |
+| `livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                                         | `10`                     |
+| `livenessProbe.timeoutSeconds`                      | Timeout seconds for livenessProbe                                                                                        | `1`                      |
+| `livenessProbe.failureThreshold`                    | Failure threshold for livenessProbe                                                                                      | `3`                      |
+| `livenessProbe.successThreshold`                    | Success threshold for livenessProbe                                                                                      | `1`                      |
+| `readinessProbe.enabled`                            | Enable readinessProbe on Sealed Secret containers                                                                        | `true`                   |
+| `readinessProbe.initialDelaySeconds`                | Initial delay seconds for readinessProbe                                                                                 | `5`                      |
+| `readinessProbe.periodSeconds`                      | Period seconds for readinessProbe                                                                                        | `10`                     |
+| `readinessProbe.timeoutSeconds`                     | Timeout seconds for readinessProbe                                                                                       | `1`                      |
+| `readinessProbe.failureThreshold`                   | Failure threshold for readinessProbe                                                                                     | `3`                      |
+| `readinessProbe.successThreshold`                   | Success threshold for readinessProbe                                                                                     | `1`                      |
+| `startupProbe.enabled`                              | Enable startupProbe on Sealed Secret containers                                                                          | `false`                  |
+| `startupProbe.initialDelaySeconds`                  | Initial delay seconds for startupProbe                                                                                   | `10`                     |
+| `startupProbe.periodSeconds`                        | Period seconds for startupProbe                                                                                          | `10`                     |
+| `startupProbe.timeoutSeconds`                       | Timeout seconds for startupProbe                                                                                         | `1`                      |
+| `startupProbe.failureThreshold`                     | Failure threshold for startupProbe                                                                                       | `15`                     |
+| `startupProbe.successThreshold`                     | Success threshold for startupProbe                                                                                       | `1`                      |
+| `customLivenessProbe`                               | Custom livenessProbe that overrides the default one                                                                      | `{}`                     |
+| `customReadinessProbe`                              | Custom readinessProbe that overrides the default one                                                                     | `{}`                     |
+| `customStartupProbe`                                | Custom startupProbe that overrides the default one                                                                       | `{}`                     |
+| `podSecurityContext.enabled`                        | Enabled Sealed Secret pods' Security Context                                                                             | `true`                   |
+| `podSecurityContext.fsGroup`                        | Set Sealed Secret pod's Security Context fsGroup                                                                         | `1001`                   |
+| `podSecurityContext.seccompProfile.type`            | Set Sealed Secret pod's Security Context seccompProfile type                                                             | `RuntimeDefault`         |
+| `containerSecurityContext.enabled`                  | Enabled Sealed Secret containers' Security Context                                                                       | `true`                   |
+| `containerSecurityContext.allowPrivilegeEscalation` | Whether the Sealed Secret container can escalate privileges                                                              | `false`                  |
+| `containerSecurityContext.capabilities.drop`        | Which privileges to drop in the Sealed Secret container                                                                  | `["ALL"]`                |
+| `containerSecurityContext.readOnlyRootFilesystem`   | Whether the Sealed Secret container has a read-only root filesystem                                                      | `true`                   |
+| `containerSecurityContext.runAsNonRoot`             | Indicates that the Sealed Secret container must run as a non-root user                                                   | `true`                   |
+| `containerSecurityContext.runAsUser`                | Set Sealed Secret containers' Security Context runAsUser                                                                 | `1001`                   |
+| `containerSecurityContext.seccompProfile.type`      | Set Sealed Secret container's Security Context seccompProfile type                                                       | `RuntimeDefault`         |
+| `hostAliases`                                       | Sealed Secret pods host aliases                                                                                          | `[]`                     |
+| `podLabels`                                         | Extra labels for Sealed Secret pods                                                                                      | `{}`                     |
+| `podAnnotations`                                    | Annotations for Sealed Secret pods                                                                                       | `{}`                     |
+| `podAffinityPreset`                                 | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                      | `""`                     |
+| `podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                 | `soft`                   |
+| `nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                | `""`                     |
+| `nodeAffinityPreset.key`                            | Node label key to match. Ignored if `affinity` is set                                                                    | `""`                     |
+| `nodeAffinityPreset.values`                         | Node label values to match. Ignored if `affinity` is set                                                                 | `[]`                     |
+| `affinity`                                          | Affinity for Sealed Secret pods assignment                                                                               | `{}`                     |
+| `nodeSelector`                                      | Node labels for Sealed Secret pods assignment                                                                            | `{}`                     |
+| `tolerations`                                       | Tolerations for Sealed Secret pods assignment                                                                            | `[]`                     |
+| `updateStrategy.type`                               | Sealed Secret statefulset strategy type                                                                                  | `RollingUpdate`          |
+| `priorityClassName`                                 | Sealed Secret pods' priorityClassName                                                                                    | `""`                     |
+| `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                     |
+| `schedulerName`                                     | Name of the k8s scheduler (other than default) for Sealed Secret pods                                                    | `""`                     |
+| `terminationGracePeriodSeconds`                     | Seconds Redmine pod needs to terminate gracefully                                                                        | `""`                     |
+| `lifecycleHooks`                                    | for the Sealed Secret container(s) to automate configuration before or after startup                                     | `{}`                     |
+| `extraEnvVars`                                      | Array with extra environment variables to add to Sealed Secret nodes                                                     | `[]`                     |
+| `extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Sealed Secret nodes                                             | `""`                     |
+| `extraEnvVarsSecret`                                | Name of existing Secret containing extra env vars for Sealed Secret nodes                                                | `""`                     |
+| `extraVolumes`                                      | Optionally specify extra list of additional volumes for the Sealed Secret pod(s)                                         | `[]`                     |
+| `extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the Sealed Secret container(s)                              | `[]`                     |
+| `sidecars`                                          | Add additional sidecar containers to the Sealed Secret pod(s)                                                            | `{}`                     |
+| `initContainers`                                    | Add additional init containers to the Sealed Secret pod(s)                                                               | `{}`                     |
 
 
 ### Traffic Exposure Parameters

--- a/bitnami/sealed-secrets/values.yaml
+++ b/bitnami/sealed-secrets/values.yaml
@@ -157,22 +157,34 @@ customStartupProbe: {}
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Sealed Secret pods' Security Context
 ## @param podSecurityContext.fsGroup Set Sealed Secret pod's Security Context fsGroup
+## @param podSecurityContext.seccompProfile.type Set Sealed Secret pod's Security Context seccompProfile type
 ##
 podSecurityContext:
   enabled: true
   fsGroup: 1001
+  seccompProfile:
+    type: RuntimeDefault
 ## Configure Container Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param containerSecurityContext.enabled Enabled Sealed Secret containers' Security Context
+## @param containerSecurityContext.allowPrivilegeEscalation Whether the Sealed Secret container can escalate privileges
+## @param containerSecurityContext.capabilities.drop Which privileges to drop in the Sealed Secret container
 ## @param containerSecurityContext.readOnlyRootFilesystem Whether the Sealed Secret container has a read-only root filesystem
 ## @param containerSecurityContext.runAsNonRoot Indicates that the Sealed Secret container must run as a non-root user
 ## @param containerSecurityContext.runAsUser Set Sealed Secret containers' Security Context runAsUser
+## @param containerSecurityContext.seccompProfile.type Set Sealed Secret container's Security Context seccompProfile type
 ##
 containerSecurityContext:
   enabled: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
   readOnlyRootFilesystem: true
   runAsNonRoot: true
   runAsUser: 1001
+  seccompProfile:
+    type: RuntimeDefault
 ## @param hostAliases [array] Sealed Secret pods host aliases
 ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
 ##


### PR DESCRIPTION

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

This aligns the sealed-secrets pod with the [pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)

### Benefits

<!-- What benefits will be realized by the code change? -->

Sealed secrets will pass the restricted baseline validation

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

We're running with these settings, and nothing appears to be broken

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
