### PR TITLE
Serve minimal index.html file at the root of the Helm repository

### DIFF
--- a/.github/workflows/sync-chart-index.yaml
+++ b/.github/workflows/sync-chart-index.yaml
@@ -16,3 +16,5 @@ jobs:
     - name: Upload to S3
       run: |
         s3cmd put --region=${{ secrets.AWS_REGION }} --access_key=${{ secrets.AWS_ACCESS_KEY_ID }} --secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }} --follow-symlinks bitnami/index.yaml s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/
+        s3cmd put --region=${{ secrets.AWS_REGION }} --access_key=${{ secrets.AWS_ACCESS_KEY_ID }} --secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }} --follow-symlinks bitnami/index.html s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/
+        s3cmd put --region=${{ secrets.AWS_REGION }} --access_key=${{ secrets.AWS_ACCESS_KEY_ID }} --secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }} --follow-symlinks bitnami/index.html s3://${{ secrets.AWS_S3_BUCKET }}/

--- a/bitnami/index.html
+++ b/bitnami/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html;charset=UTF-8">
+    <title>Bitnami Helm Charts</title>
+  </head>
+  <body>
+
+  <h1 id="bitnami-library-kubernetes">The Bitnami Library for Kubernetes</h1>
+
+  Popular applications, provided by <a href="https://bitnami.com">Bitnami</a>, ready to launch on Kubernetes using <a href="https://github.com/helm/helm">Kubernetes Helm</a>.
+
+  <h2 id="tldr">TL;DR</h2>
+
+  <code>
+  $ helm repo add bitnami https://charts.bitnami.com/bitnami<br />
+  $ helm search repo bitnami<br />
+  $ helm install my-release bitnami/&lt;chart&gt;
+  </code>
+
+  <p>For more information, please refer to the <a href="https://github.com/bitnami/charts">Bitnami charts project on GitHub</a>.</p>
+
+  </body>
+</html>


### PR DESCRIPTION
### Description of the change

We should serve a simple `index.html` file from the root of the Helm repository instead of the whole `index.yaml` file.

### Benefits

This will serve two purposes:
- Help end users configure Bitnami's Helm repository.
- Reduce the traffic for non-helm requests (helm CLI always asks for `index.yaml` specifically).

### Possible drawbacks

None that I can think of, since all current features will be kept.

### Applicable issues

None.

### Additional information

N/A

### Checklist

- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
