### PR TITLE
[bitnami/node] Deprecate NodeJS Helm chart

### DIFF
--- a/bitnami/node/Chart.lock
+++ b/bitnami/node/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: mongodb
   repository: https://charts.bitnami.com/bitnami
-  version: 13.1.7
+  version: 13.3.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.0.3
-digest: sha256:0178e159d660a26a4b285e2f475479b66b9302c0c0c03f6cb4ac1df5a9026d27
-generated: "2022-10-12T16:09:56.972555213Z"
+  version: 2.0.4
+digest: sha256:47451efb47e016ea65853c0ce01fde721abb39213505aa424af18cdffb32c0ab
+generated: "2022-10-25T14:53:05.392393477Z"

--- a/bitnami/node/Chart.yaml
+++ b/bitnami/node/Chart.yaml
@@ -12,7 +12,9 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x.x
-description: Node.js is a runtime environment built on V8 JavaScript engine. Its event-driven, non-blocking I/O model enables the development of fast, scalable, and data-intensive server applications.
+# The Node.js chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED Node.js is a runtime environment built on V8 JavaScript engine. Its event-driven, non-blocking I/O model enables the development of fast, scalable, and data-intensive server applications.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/node
 icon: https://bitnami.com/assets/stacks/nodejs/img/nodejs-stack-220x234.png
@@ -21,11 +23,9 @@ keywords:
   - javascript
   - nodejs
   - git
-maintainers:
-  - name: Bitnami
-    url: https://github.com/bitnami/charts
+maintainers: []
 name: node
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/node
   - http://nodejs.org/
-version: 19.1.6
+version: 19.1.7

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -8,6 +8,10 @@ Node.js is a runtime environment built on V8 JavaScript engine. Its event-driven
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
 
+## This Helm chart is deprecated
+
+This Helm chart will not receive new versions nor updates.
+
 ## TL;DR
 
 ```console

--- a/bitnami/node/README.md
+++ b/bitnami/node/README.md
@@ -112,7 +112,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
 | `image.registry`                              | NodeJS image registry                                                                                                    | `docker.io`            |
 | `image.repository`                            | NodeJS image repository                                                                                                  | `bitnami/node`         |
-| `image.tag`                                   | NodeJS image tag (immutable tags are recommended)                                                                        | `16.18.0-debian-11-r0` |
+| `image.tag`                                   | NodeJS image tag (immutable tags are recommended)                                                                        | `16.18.0-debian-11-r4` |
 | `image.digest`                                | NodeJS image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                   | `""`                   |
 | `image.pullPolicy`                            | NodeJS image pull policy                                                                                                 | `IfNotPresent`         |
 | `image.pullSecrets`                           | Specify docker-registry secret names as an array                                                                         | `[]`                   |
@@ -186,7 +186,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------ | --------------------------------------------------------------------------------------------------- | -------------------------------------------- |
 | `git.image.registry`           | Git image registry                                                                                  | `docker.io`                                  |
 | `git.image.repository`         | Git image repository                                                                                | `bitnami/git`                                |
-| `git.image.tag`                | Git image tag (immutable tags are recommended)                                                      | `2.38.0-debian-11-r2`                        |
+| `git.image.tag`                | Git image tag (immutable tags are recommended)                                                      | `2.38.1-debian-11-r2`                        |
 | `git.image.digest`             | Git image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                         |
 | `git.image.pullPolicy`         | Git image pull policy                                                                               | `IfNotPresent`                               |
 | `git.image.pullSecrets`        | Specify docker-registry secret names as an array                                                    | `[]`                                         |

--- a/bitnami/node/templates/NOTES.txt
+++ b/bitnami/node/templates/NOTES.txt
@@ -1,3 +1,5 @@
+This Helm chart is deprecated
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}

--- a/bitnami/node/values.yaml
+++ b/bitnami/node/values.yaml
@@ -134,7 +134,7 @@ externaldb:
 image:
   registry: docker.io
   repository: bitnami/node
-  tag: 16.18.0-debian-11-r0
+  tag: 16.18.0-debian-11-r4
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -418,7 +418,7 @@ git:
   image:
     registry: docker.io
     repository: bitnami/git
-    tag: 2.38.0-debian-11-r2
+    tag: 2.38.1-debian-11-r2
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
### Description of the change
The Node.js helm chart will be deprecated

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)