### PR TITLE
add namespaces to clusterrole for grafana-operator

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -22,4 +22,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/containers/tree/main/bitnami/grafana-operator
-version: 2.7.8
+version: 2.7.9

--- a/bitnami/grafana-operator/templates/rbac.yaml
+++ b/bitnami/grafana-operator/templates/rbac.yaml
@@ -112,6 +112,7 @@ rules:
       - ""
     resources:
       - pods
+      - namespaces
     verbs:
       - get
       - list


### PR DESCRIPTION
Fixes `scanAllNamespaces: true`
```
failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:grafana:grafana-operator" cannot list resource "namespaces" in API group "" at the cluster scope
```