### PR TITLE
[bitnami/common] Add new function 'common.secrets.lookup'

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - https://www.bitnami.com/
 type: library
-version: 2.0.4
+version: 2.1.0

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -123,6 +123,32 @@ The order in which this function returns a secret password:
 {{- end -}}
 
 {{/*
+Reuses the value from an existing secret, otherwise sets its value to a default value.
+
+Usage:
+{{ include "common.secrets.lookup" (dict "secret" "secret-name" "key" "keyName" "defaultValue" .Values.myValue "context" $) }}
+
+Params:
+  - secret - String - Required - Name of the 'Secret' resource where the password is stored.
+  - key - String - Required - Name of the key in the secret.
+  - defaultValue - String - Required - The path to the validating value in the values.yaml, e.g: "mysql.password". Will pick first parameter with a defined value.
+  - context - Context - Required - Parent context.
+
+*/}}
+{{- define "common.secrets.lookup" -}}
+
+{{- $value := "" -}}
+{{- $defaultValue := required "\n'common.secrets.lookup': Argument 'defaultValue' missing or empty" .defaultValue -}}
+{{- $secretData := (lookup "v1" "Secret" $.context.Release.Namespace .secret).data -}}
+{{- if and $secretData (hasKey $secretData .key) -}}
+  {{- $value = index $secretData .key | quote -}}
+{{- else -}}
+  {{- $value = $defaultValue | toString | b64enc | quote -}}
+{{- end -}}
+{{- printf "%s" $value -}}
+{{- end -}}
+
+{{/*
 Returns whether a previous generated secret already exists
 
 Usage:

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -136,7 +136,6 @@ Params:
 
 */}}
 {{- define "common.secrets.lookup" -}}
-
 {{- $value := "" -}}
 {{- $defaultValue := required "\n'common.secrets.lookup': Argument 'defaultValue' missing or empty" .defaultValue -}}
 {{- $secretData := (lookup "v1" "Secret" $.context.Release.Namespace .secret).data -}}

--- a/bitnami/common/templates/_secrets.tpl
+++ b/bitnami/common/templates/_secrets.tpl
@@ -141,9 +141,9 @@ Params:
 {{- $defaultValue := required "\n'common.secrets.lookup': Argument 'defaultValue' missing or empty" .defaultValue -}}
 {{- $secretData := (lookup "v1" "Secret" $.context.Release.Namespace .secret).data -}}
 {{- if and $secretData (hasKey $secretData .key) -}}
-  {{- $value = index $secretData .key | quote -}}
+  {{- $value = index $secretData .key -}}
 {{- else -}}
-  {{- $value = $defaultValue | toString | b64enc | quote -}}
+  {{- $value = $defaultValue | toString | b64enc -}}
 {{- end -}}
 {{- printf "%s" $value -}}
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

### Description of the change

This PR adds a new common function, that depends on the Helm `lookup` function.

This function searches for a key in an existing secret, otherwise sets a default value.

### Benefits

This function can be used to prevent regenerating secrets when upgrading, for example, for autogenerated certs.

Currently, we do not have a method to lookup for a value in an existing secret, and it could be used, for example, in cases like this:
```diff
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $crt.Cert | b64enc | quote }}
-  tls.key: {{ $crt.Key | b64enc | quote }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $crt.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $crt.Key "context" $) }}
```

### Possible drawbacks

This function is similar to "common.secrets.passwords.manage", but much more simple. 
If configured with some specific parameters, its functionality could overlap and we could end up with both methods used for the same purpose in some cases.

### Applicable issues

  Would help fixing #11847

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
