### PR TITLE
[bitnami/keycloak] Add support for custom infinispan/jgroups cache stacks (e.g. istio)

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 12.0.1
+version: 12.1.0

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -130,6 +130,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replicaCount`                          | Number of Keycloak replicas to deploy                                                                                    | `1`             |
 | `containerPorts.http`                   | Keycloak HTTP container port                                                                                             | `8080`          |
 | `containerPorts.https`                  | Keycloak HTTPS container port                                                                                            | `8443`          |
+| `extraContainerPorts`                   | Optionally specify extra list of additional port-mappings for Keycloak container                                         | `[]`            |
 | `podSecurityContext.enabled`            | Enabled Keycloak pods' Security Context                                                                                  | `true`          |
 | `podSecurityContext.fsGroup`            | Set Keycloak pod's Security Context fsGroup                                                                              | `1001`          |
 | `containerSecurityContext.enabled`      | Enabled Keycloak containers' Security Context                                                                            | `true`          |
@@ -200,6 +201,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.externalTrafficPolicy`    | Enable client source IP preservation                                                                                             | `Cluster`                |
 | `service.annotations`              | Additional custom annotations for Keycloak service                                                                               | `{}`                     |
 | `service.extraPorts`               | Extra port to expose on Keycloak service                                                                                         | `[]`                     |
+| `service.extraHeadlessPorts`       | Extra ports to expose on Keycloak headless service                                                                               | `[]`                     |
 | `ingress.enabled`                  | Enable ingress record generation for Keycloak                                                                                    | `false`                  |
 | `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                     |
 | `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
@@ -330,9 +332,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Keycloak Cache parameters
 
-| Name            | Description                                                                | Value  |
-| --------------- | -------------------------------------------------------------------------- | ------ |
-| `cache.enabled` | Switch to enable or disable the keycloak distributed cache for kubernetes. | `true` |
+| Name              | Description                                                                | Value        |
+| ----------------- | -------------------------------------------------------------------------- | ------------ |
+| `cache.enabled`   | Switch to enable or disable the keycloak distributed cache for kubernetes. | `true`       |
+| `cache.stackName` | Set infinispan cache stack to use                                          | `kubernetes` |
+| `cache.stackFile` | Set infinispan cache stack filename to use                                 | `""`         |
 
 
 ### Keycloak Logging parameters

--- a/bitnami/keycloak/templates/configmap-env-vars.yaml
+++ b/bitnami/keycloak/templates/configmap-env-vars.yaml
@@ -41,7 +41,12 @@ data:
   {{- end }}
   {{- if .Values.cache.enabled }}
   KEYCLOAK_CACHE_TYPE: "ispn"
-  KEYCLOAK_CACHE_STACK: "kubernetes"
+  {{- if .Values.cache.stackName }}
+  KEYCLOAK_CACHE_STACK: {{ .Values.cache.stackName | quote }} 
+  {{- end }}
+  {{- if .Values.cache.stackFile }}
+  KEYCLOAK_CACHE_CONFIG_FILE: {{ .Values.cache.stackFile | quote }} 
+  {{- end }}
   JAVA_OPTS_APPEND: {{ printf "-Djgroups.dns.query=%s-headless.%s.svc.%s" (include "common.names.fullname" .) (include "common.names.namespace" .) .Values.clusterDomain | quote }}
   {{- else }}
   KEYCLOAK_CACHE_TYPE: "local"

--- a/bitnami/keycloak/templates/headless-service.yaml
+++ b/bitnami/keycloak/templates/headless-service.yaml
@@ -25,6 +25,9 @@ spec:
       protocol: TCP
       targetPort: https
     {{- end }}
+    {{- if .Values.service.extraHeadlessPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraHeadlessPorts "context" $) | nindent 4 }}
+    {{- end }}
   publishNotReadyAddresses: true
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak

--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -174,6 +174,9 @@ spec:
               containerPort: {{ .Values.containerPorts.https }}
               protocol: TCP
             {{- end }}
+            {{- if .Values.extraContainerPorts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraContainerPorts "context" $) | nindent 12 }}
+            {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -249,6 +249,10 @@ replicaCount: 1
 containerPorts:
   http: 8080
   https: 8443
+## @param extraContainerPorts Optionally specify extra list of additional port-mappings for Keycloak container
+##
+extraContainerPorts: []
+
 ## Keycloak pods' SecurityContext
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enabled Keycloak pods' Security Context
@@ -500,6 +504,9 @@ service:
   ## @param service.extraPorts Extra port to expose on Keycloak service
   ##
   extraPorts: []
+  ## @param service.extraHeadlessPorts Extra ports to expose on Keycloak headless service
+  ##
+  extraHeadlessPorts: []
 
 ## Keycloak ingress parameters
 ## ref: https://kubernetes.io/docs/user-guide/ingress/
@@ -993,9 +1000,13 @@ externalDatabase:
 ## ref: https://www.keycloak.org/server/caching
 ## @param cache.enabled Switch to enable or disable the keycloak distributed cache for kubernetes.
 ## NOTE: Set to false to use 'local' cache (only supported when replicaCount=1).
+## @param cache.stackName Set infinispan cache stack to use
+## @param cache.stackFile Set infinispan cache stack filename to use
 ##
 cache:
   enabled: true
+  stackName: kubernetes
+  stackFile: ""
 
 ## @section Keycloak Logging parameters
 


### PR DESCRIPTION
### Description of the change

Add the possibility to use cache stacks beside the default 'kubernetes' one as well as additional ports used by those stacks.

### Benefits

The change allows the chart to be used in environments where infinispan discovery and communication does not work according to the standard kubernetes stack. This is the case, for example, in the context of the istio service mesh or even when a remote infinispan cluster is configured as cache store. Then additional port mappings and adjustments to the stack are required.

See https://www.keycloak.org/server/caching for caching-options supported out-of-the-box by keycloak.

### Possible drawbacks

None, as only optional parameters are added.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
