### PR TITLE
[bitnami/charts] Use Environment Files instead of set-output

### DIFF
--- a/.github/workflows/assign-asset-label.yml
+++ b/.github/workflows/assign-asset-label.yml
@@ -23,13 +23,13 @@ jobs:
           assets=($(echo "$files_changed" | xargs dirname | sed -nr "s|bitnami/([^/]*).*|\1|p" | sort | uniq || true))
 
           if [[ "${#assets[@]}" -ne "1" ]]; then
-            echo "::set-output name=result::skip"
-            echo "::set-output name=message::Label cannot be set, cannot infer a single label from: ${assets[@]}"
-            echo "::set-output name=name::NONE"
+            echo "result=skip" >> $GITHUB_OUTPUT
+            echo "message=Label cannot be set, cannot infer a single label from: ${assets[@]}" >> $GITHUB_OUTPUT
+            echo "name=NONE" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=result::ok"
-            echo "::set-output name=message::Adding label '${assets}'"
-            echo "::set-output name=name::${assets}"
+            echo "result=ok" >> $GITHUB_OUTPUT
+            echo "message=Adding label '${assets}'" >> $GITHUB_OUTPUT
+            echo "name=${assets}" >> $GITHUB_OUTPUT
           fi
       - name: Show messages
         uses: actions/github-script@v6

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -113,7 +113,8 @@ jobs:
 
           if [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then
             # Changes done in charts but version not bumped -> ERROR
-            echo "error=Detected changes in charts without version bump in Chart.yaml.\nCharts changed: ${num_charts_changed}\n${charts_dirs_changed}\nVersion bumps detected: ${num_version_bumps}" >> $GITHUB_OUTPUT
+            charts_changed_str="$(echo ${charts_dirs_changed[@]})"
+            echo "error=Detected changes in charts without version bump in Chart.yaml. Charts changed: ${num_charts_changed} ${charts_changed_str}. Version bumps detected: ${num_version_bumps}" >> $GITHUB_OUTPUT
             echo "result=fail" >> $GITHUB_OUTPUT
           elif [[ "$num_charts_changed" -eq "1" ]]; then
             # Changes done in only one chart -> OK
@@ -122,7 +123,8 @@ jobs:
             echo "result=ok" >> $GITHUB_OUTPUT
           else
             # Changes done in more than chart -> FAIL
-            echo "error=Changes detected in more than one chart directory:\n${charts_dirs_changed}\nThe publish process will be stopped. Please create different commits for each chart." >> $GITHUB_OUTPUT
+            charts_changed_str="$(echo ${charts_dirs_changed[@]})"
+            echo "error=Changes detected in more than one chart directory: ${charts_changed_str}. The publish process will be stopped. Please create different commits for each chart." >> $GITHUB_OUTPUT
             echo "result=fail" >> $GITHUB_OUTPUT
           fi
       - id: show-error

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -113,17 +113,17 @@ jobs:
 
           if [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then
             # Changes done in charts but version not bumped -> ERROR
-            echo "::set-output name=error::Detected changes in charts without version bump in Chart.yaml.\nCharts changed: ${num_charts_changed}\n${charts_dirs_changed}\nVersion bumps detected: ${num_version_bumps}"
-            echo "::set-output name=result::fail"
+            echo "error=Detected changes in charts without version bump in Chart.yaml.\nCharts changed: ${num_charts_changed}\n${charts_dirs_changed}\nVersion bumps detected: ${num_version_bumps}" >> $GITHUB_OUTPUT
+            echo "result=fail" >> $GITHUB_OUTPUT
           elif [[ "$num_charts_changed" -eq "1" ]]; then
             # Changes done in only one chart -> OK
             chart_name=$(echo "$charts_dirs_changed" | sed "s|bitnami/||g")
-            echo "::set-output name=chart::${chart_name}"
-            echo "::set-output name=result::ok"
+            echo "chart=${chart_name}" >> $GITHUB_OUTPUT
+            echo "result=ok" >> $GITHUB_OUTPUT
           else
             # Changes done in more than chart -> FAIL
-            echo -e "::set-output name=error::Changes detected in more than one chart directory:\n${charts_dirs_changed}\nThe publish process will be stopped. Please create different commits for each chart."
-            echo "::set-output name=result::fail"
+            echo "error=Changes detected in more than one chart directory:\n${charts_dirs_changed}\nThe publish process will be stopped. Please create different commits for each chart." >> $GITHUB_OUTPUT
+            echo "result=fail" >> $GITHUB_OUTPUT
           fi
       - id: show-error
         name: 'Show error'
@@ -153,7 +153,7 @@ jobs:
           if [[ -f $config_file ]]; then
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
-          echo "::set-output name=verification_mode::${verification_mode}"
+          echo "verification_mode=${verification_mode}" >> $GITHUB_OUTPUT
       - uses: vmware-labs/vmware-image-builder-action@main
         name: Verify and publish ${{ needs.get-chart.outputs.chart }}
         with:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -48,7 +48,8 @@ jobs:
             echo "result=skip" >> $GITHUB_OUTPUT
           elif [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then
             # Changes done in charts but version not bumped -> ERROR
-            echo "error=Detected changes in charts without version bump in Chart.yaml.\nCharts changed: ${num_charts_changed}\n${charts_dirs_changed}\nVersion bumps detected: ${num_version_bumps}" >> $GITHUB_OUTPUT
+            charts_changed_str="$(echo ${charts_dirs_changed[@]})"
+            echo "error=Detected changes in charts without version bump in Chart.yaml. Charts changed: ${num_charts_changed} ${charts_changed_str}. Version bumps detected: ${num_version_bumps}" >> $GITHUB_OUTPUT
             echo "result=fail" >> $GITHUB_OUTPUT
           elif [[ "$num_charts_changed" -eq "1" ]]; then
             # Changes done in only one chart -> OK
@@ -67,18 +68,24 @@ jobs:
             echo "result=skip" >> $GITHUB_OUTPUT
           else
             # Changes done in more than chart -> SKIP
-            echo "error=Changes detected in more than one chart directory:\n${charts_dirs_changed}\nIt is strongly advised to change only one chart in a PR. The rest of the tests will be skipped." >> $GITHUB_OUTPUT
+            charts_changed_str="$(echo ${charts_dirs_changed[@]})"
+            echo "error=Changes detected in more than one chart directory: ${charts_changed_str}. It is strongly advised to change only one chart in a PR. The rest of the tests will be skipped." >> $GITHUB_OUTPUT
             echo "result=skip" >> $GITHUB_OUTPUT
           fi
       # Using actions/github-scripts because using exit 1 in the script above would not provide any output
       # Source: https://github.community/t/no-output-on-process-completed-with-exit-code-1/123821/3
       - id: show-error
         name: Show error
-        if: ${{ steps.get-chart.outputs.result == 'fail' }}
+        if: ${{ steps.get-chart.outputs.result != 'ok' }}
         uses: actions/github-script@v6
         with:
           script: |
-            core.setFailed('${{ steps.get-chart.outputs.error }}')
+            let message='${{ steps.get-chart.outputs.error }}';
+            if ('${{ steps.get-chart.outputs.result }}' === 'fail' ) {
+              core.setFailed(message);
+            } else {
+              core.warning(message);
+            }
   vib-verify:
     runs-on: ubuntu-latest
     needs: get-chart

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -45,30 +45,30 @@ jobs:
 
           if [[ "$non_readme_files" -le "0" ]]; then
             # The only changes are .md files -> SKIP
-            echo "::set-output name=result::skip"
+            echo "result=skip" >> $GITHUB_OUTPUT
           elif [[ "$num_charts_changed" -ne "$num_version_bumps" ]]; then
             # Changes done in charts but version not bumped -> ERROR
-            echo "::set-output name=error::Detected changes in charts without version bump in Chart.yaml.\nCharts changed: ${num_charts_changed}\n${charts_dirs_changed}\nVersion bumps detected: ${num_version_bumps}"
-            echo "::set-output name=result::fail"
+            echo "error=Detected changes in charts without version bump in Chart.yaml.\nCharts changed: ${num_charts_changed}\n${charts_dirs_changed}\nVersion bumps detected: ${num_version_bumps}" >> $GITHUB_OUTPUT
+            echo "result=fail" >> $GITHUB_OUTPUT
           elif [[ "$num_charts_changed" -eq "1" ]]; then
             # Changes done in only one chart -> OK
             chart_name=$(echo "$charts_dirs_changed" | sed "s|bitnami/||g")
-            echo "::set-output name=chart::${chart_name}"
+            echo "chart=${chart_name}" >> $GITHUB_OUTPUT
             if [[ "$chart_name" == "common" ]]; then
                 # Changes done in bitnami/common -> SKIP
-                echo "::set-output name=result::skip"
+                echo "result=skip" >> $GITHUB_OUTPUT
             else
                 # Changes done in a chart different from common -> OK
-                echo "::set-output name=result::ok"
+                echo "result=ok" >> $GITHUB_OUTPUT
             fi
           elif [[ "$num_charts_changed" -le "0" ]]; then
             # Changes done in the bitnami/ folder but not inside a chart subfolder -> SKIP
-            echo "::set-output name=error::No changes detected in charts. The rest of the tests will be skipped."
-            echo "::set-output name=result::skip"
+            echo "error=No changes detected in charts. The rest of the tests will be skipped." >> $GITHUB_OUTPUT
+            echo "result=skip" >> $GITHUB_OUTPUT
           else
             # Changes done in more than chart -> SKIP
-            echo "::set-output name=error::Changes detected in more than one chart directory:\n${charts_dirs_changed}\nIt is strongly advised to change only one chart in a PR. The rest of the tests will be skipped."
-            echo "::set-output name=result::skip"
+            echo "error=Changes detected in more than one chart directory:\n${charts_dirs_changed}\nIt is strongly advised to change only one chart in a PR. The rest of the tests will be skipped." >> $GITHUB_OUTPUT
+            echo "result=skip" >> $GITHUB_OUTPUT
           fi
       # Using actions/github-scripts because using exit 1 in the script above would not provide any output
       # Source: https://github.community/t/no-output-on-process-completed-with-exit-code-1/123821/3
@@ -109,7 +109,7 @@ jobs:
           if [[ -f $config_file ]]; then
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
-          echo "::set-output name=verification_mode::${verification_mode}"
+          echo "verification_mode=${verification_mode}" >> $GITHUB_OUTPUT
       - uses: vmware-labs/vmware-image-builder-action@main
         name: Verify ${{ needs.get-chart.outputs.chart }}
         with:

--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -32,11 +32,11 @@ jobs:
           if [[ "${pull_request}" == "null" ]]; then
             type="issue"
           fi
-          echo "::set-output name=assignees::${assignees}"
-          echo "::set-output name=author::${author}"
-          echo "::set-output name=type::${type}"
-          echo "::set-output name=draft::${draft}"
-          echo "::set-output name=number::${number}"
+          echo "assignees=${assignees}" >> $GITHUB_OUTPUT
+          echo "author=${author}" >> $GITHUB_OUTPUT
+          echo "type=${type}" >> $GITHUB_OUTPUT
+          echo "draft=${draft}" >> $GITHUB_OUTPUT
+          echo "number=${number}" >> $GITHUB_OUTPUT
   label-card:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/srp-report.yml
+++ b/.github/workflows/srp-report.yml
@@ -34,7 +34,7 @@ jobs:
             --name "bac-charts" --path . --saveto ./source-provenance.json \
             --comp-uid "${SRP_UID}" --build-number "${GITHUB_RUN_ID}" \
             --version "1.0" --all-ephemeral true --build-type release
-          echo "::set-output name=uid::${SRP_UID}"
+          echo "uid=${SRP_UID}" >> $GITHUB_OUTPUT
       - name: Archive SRP report
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           author="${{ github.event.issue != null && github.event.issue.user.login || github.event.pull_request.user.login }}"
           number="${{ github.event_name != 'issues' && github.event.number || github.event.issue.number }}"
-          echo "::set-output name=author::${author}"
-          echo "::set-output name=number::${number}"
+          echo "author=${author}" >> $GITHUB_OUTPUT
+          echo "number=${number}" >> $GITHUB_OUTPUT
       - name: Send to the board
         uses: peter-evans/create-or-update-project-card@v2
         with:


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The `set-output` command is deprecated and will be disabled soon. Here we upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Benefits

Code is up to date and warnings disappear from action runs.

### Possible drawbacks

None identified

### Additional information

Execution examples:
* https://github.com/fmulero/charts/actions/runs/3330002252
* https://github.com/fmulero/charts/actions/runs/3330893295

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
