### PR TITLE
[bitnami/opencart] Use templated values for opencart secret name

### DIFF
--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -29,4 +29,4 @@ name: opencart
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/opencart
   - https://opencart.com/
-version: 13.0.2
+version: 13.0.3

--- a/bitnami/opencart/templates/deployment.yaml
+++ b/bitnami/opencart/templates/deployment.yaml
@@ -189,7 +189,7 @@ spec:
             - name: OPENCART_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "common.names.fullname" . }}
+                  name: {{ include "opencart.secretName" . }}
                   key: opencart-password
             - name: OPENCART_EMAIL
               value: {{ .Values.opencartEmail | quote }}
@@ -209,7 +209,7 @@ spec:
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "common.names.fullname" . }}
+                  name: {{ include "opencart.secretName" . }}
                   key: smtp-password
             {{- end }}
             {{- if .Values.smtpProtocol }}


### PR DESCRIPTION
Allows using an existing secret for opencart password and SMTP password. 

Signed-off-by: Ricardo Herrera <rickhl@outlook.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Fixes a bug where using an `existingSecret` for opencart password and/or SMTP password does not result in the secret being used.

### Benefits

Allow `existingSecrets` to be used for opencart password and SMTP password.

### Possible drawbacks

None.

### Applicable issues

None

### Additional information

No

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
