### PR TITLE
[bitnami/charts] Compact output for assignee list

### DIFF
--- a/.github/workflows/moving-cards.yml
+++ b/.github/workflows/moving-cards.yml
@@ -23,7 +23,7 @@ jobs:
         id: get-issue-step
         run: |
           issue_info=$(curl -s --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -X GET -G "${{ github.event.project_card.content_url }}" )
-          assignees="$(echo $issue_info | jq -r '.assignees')"
+          assignees="$(echo $issue_info | jq -cr '.assignees')"
           author="$(echo $issue_info | jq -r '.user.login')"
           pull_request="$(echo $issue_info | jq -r '.pull_request')"
           draft="$(echo $issue_info | jq -r '.draft' | sed -r "s|null|false|g")"


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use compact output in jq to retrieve the assignee list in order to avoid multiline output.

### Benefits

In #13158 the set-output command was change to use the output file. [Multiline outputs](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings) has to be adapted

### Possible drawbacks

None

### Applicable issues

Errors in actions like: https://github.com/bitnami/charts/actions/runs/3338362010/jobs/5525932191

### Additional information

Follow up #13158 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
