### PR TITLE
[bitnami/rabbitmq-cluster-operator] update the rabbitmq operator CRDs

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -26,4 +26,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 3.1.1
+version: 3.1.2

--- a/bitnami/rabbitmq-cluster-operator/crds/crd-rabbitmq-cluster.yaml
+++ b/bitnami/rabbitmq-cluster-operator/crds/crd-rabbitmq-cluster.yaml
@@ -3,678 +3,4197 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
-  name: rabbitmqclusters.rabbitmq.com
+    controller-gen.kubebuilder.io/version: v0.9.2
   labels:
     app.kubernetes.io/component: rabbitmq-operator
+    app.kubernetes.io/name: rabbitmq-cluster-operator
     app.kubernetes.io/part-of: rabbitmq
+  name: rabbitmqclusters.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: RabbitmqCluster
     listKind: RabbitmqClusterList
     plural: rabbitmqclusters
     shortNames:
-      - rmq
+    - rmq
     singular: rabbitmqcluster
   scope: Namespaced
   versions:
-    - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type == 'AllReplicasReady')].status
-          name: AllReplicasReady
-          type: string
-        - jsonPath: .status.conditions[?(@.type == 'ReconcileSuccess')].status
-          name: ReconcileSuccess
-          type: string
-        - jsonPath: .metadata.creationTimestamp
-          name: Age
-          type: date
-      name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: RabbitmqCluster is the Schema for the RabbitmqCluster API. Each instance of this object corresponds to a single RabbitMQ cluster.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec is the desired state of the RabbitmqCluster Custom Resource.
-              properties:
-                affinity:
-                  description: Affinity scheduling rules to be applied on created Pods.
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for the pod.
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                            properties:
-                              preference:
-                                description: A node selector term, associated with the corresponding weight.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
-                                    items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements by node's fields.
-                                    items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
-                          properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms. The terms are ORed.
-                              items:
-                                description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements by node's labels.
-                                    items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements by node's fields.
-                                    items:
-                                      description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                            - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources, in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources, in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaceSelector:
-                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources, in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaceSelector:
-                                description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                image:
-                  description: Image is the name of the RabbitMQ docker image to use for RabbitMQ nodes in the RabbitmqCluster. Must be provided together with ImagePullSecrets in order to use an image in a private registry.
-                  type: string
-                imagePullSecrets:
-                  description: List of Secret resource containing access credentials to the registry for the RabbitMQ image. Required if the docker registry is private.
-                  items:
-                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type == 'AllReplicasReady')].status
+      name: AllReplicasReady
+      type: string
+    - jsonPath: .status.conditions[?(@.type == 'ReconcileSuccess')].status
+      name: ReconcileSuccess
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RabbitmqCluster is the Schema for the RabbitmqCluster API. Each
+          instance of this object corresponds to a single RabbitMQ cluster.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec is the desired state of the RabbitmqCluster Custom Resource.
+            properties:
+              affinity:
+                description: Affinity scheduling rules to be applied on created Pods.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
                     properties:
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                        type: string
-                    type: object
-                  type: array
-                override:
-                  properties:
-                    service:
-                      properties:
-                        metadata:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node matches
+                          the corresponding matchExpressions; the node(s) with the
+                          highest sum are the most preferred.
+                        items:
+                          description: An empty preferred scheduling term matches
+                            all objects with implicit weight 0 (i.e. it's a no-op).
+                            A null preferred scheduling term matches no objects (i.e.
+                            is also a no-op).
                           properties:
-                            annotations:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            labels:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                        spec:
-                          properties:
-                            allocateLoadBalancerNodePorts:
-                              type: boolean
-                            clusterIP:
-                              type: string
-                            clusterIPs:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            externalIPs:
-                              items:
-                                type: string
-                              type: array
-                            externalName:
-                              type: string
-                            externalTrafficPolicy:
-                              type: string
-                            healthCheckNodePort:
-                              format: int32
-                              type: integer
-                            internalTrafficPolicy:
-                              type: string
-                            ipFamilies:
-                              items:
-                                type: string
-                              type: array
-                              x-kubernetes-list-type: atomic
-                            ipFamilyPolicy:
-                              type: string
-                            loadBalancerClass:
-                              type: string
-                            loadBalancerIP:
-                              type: string
-                            loadBalancerSourceRanges:
-                              items:
-                                type: string
-                              type: array
-                            ports:
-                              items:
-                                properties:
-                                  appProtocol:
-                                    type: string
-                                  name:
-                                    type: string
-                                  nodePort:
-                                    format: int32
-                                    type: integer
-                                  port:
-                                    format: int32
-                                    type: integer
-                                  protocol:
-                                    default: TCP
-                                    type: string
-                                  targetPort:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - port
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                                - port
-                                - protocol
-                              x-kubernetes-list-type: map
-                            publishNotReadyAddresses:
-                              type: boolean
-                            selector:
-                              additionalProperties:
-                                type: string
-                              type: object
-                              x-kubernetes-map-type: atomic
-                            sessionAffinity:
-                              type: string
-                            sessionAffinityConfig:
-                              properties:
-                                clientIP:
-                                  properties:
-                                    timeoutSeconds:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                              type: object
-                            type:
-                              type: string
-                          type: object
-                      type: object
-                    statefulSet:
-                      properties:
-                        metadata:
-                          properties:
-                            annotations:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            labels:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          type: object
-                        spec:
-                          properties:
-                            podManagementPolicy:
-                              type: string
-                            replicas:
-                              format: int32
-                              type: integer
-                            selector:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
                               properties:
                                 matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
                                   items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
                                     properties:
                                       key:
+                                        description: The label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
                                         type: string
                                       values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
                                     required:
-                                      - key
-                                      - operator
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to an update), the system may or may not try to
+                          eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: A null or empty node selector term matches
+                                no objects. The requirements of them are ANDed. The
+                                TopologySelectorTerm type implements a subset of the
+                                NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: A node selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: Represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists, DoesNotExist. Gt, and
+                                          Lt.
+                                        type: string
+                                      values:
+                                        description: An array of string values. If
+                                          the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator
+                                          is Exists or DoesNotExist, the values array
+                                          must be empty. If the operator is Gt or
+                                          Lt, the values array must have a single
+                                          element, which will be interpreted as an
+                                          integer. This array is replaced during a
+                                          strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the affinity expressions specified by
+                          this field, but it may choose a node that violates one or
+                          more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this
+                          field are not met at scheduling time, the pod will not be
+                          scheduled onto the node. If the affinity requirements specified
+                          by this field cease to be met at some point during pod execution
+                          (e.g. due to a pod label update), the system may or may
+                          not try to eventually evict the pod from its node. When
+                          there are multiple elements, the lists of nodes corresponding
+                          to each podAffinityTerm are intersected, i.e. all terms
+                          must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
                                     type: object
                                   type: array
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
                                   type: object
                               type: object
-                            serviceName:
-                              type: string
-                            template:
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
                               properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to
+                          nodes that satisfy the anti-affinity expressions specified
+                          by this field, but it may choose a node that violates one
+                          or more of the expressions. The node that is most preferred
+                          is the one with the greatest sum of weights, i.e. for each
+                          node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions,
+                          etc.), compute a sum by iterating through the elements of
+                          this field and adding "weight" to the sum if the node has
+                          pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces
+                                    that the term applies to. The term is applied
+                                    to the union of the namespaces selected by this
+                                    field and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list
+                                    means "this pod's namespace". An empty selector
+                                    ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement
+                                          is a selector that contains values, a key,
+                                          and an operator that relates the key and
+                                          values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and
+                                              DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty.
+                                              If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This
+                                              array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is
+                                        "In", and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: namespaces specifies a static list
+                                    of namespace names that the term applies to. The
+                                    term is applied to the union of the namespaces
+                                    listed in this field and the ones selected by
+                                    namespaceSelector. null or empty namespaces list
+                                    and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey
+                                    matches that of any node on which any of the selected
+                                    pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding
+                                podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by
+                          this field are not met at scheduling time, the pod will
+                          not be scheduled onto the node. If the anti-affinity requirements
+                          specified by this field cease to be met at some point during
+                          pod execution (e.g. due to a pod label update), the system
+                          may or may not try to eventually evict the pod from its
+                          node. When there are multiple elements, the lists of nodes
+                          corresponding to each podAffinityTerm are intersected, i.e.
+                          all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching
+                            the labelSelector relative to the given namespace(s))
+                            that this pod should be co-located (affinity) or not co-located
+                            (anti-affinity) with, where co-located is defined as running
+                            on a node whose value of the label with key <topologyKey>
+                            matches that of any node on which a pod of the set of
+                            pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources,
+                                in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaceSelector:
+                              description: A label query over the set of namespaces
+                                that the term applies to. The term is applied to the
+                                union of the namespaces selected by this field and
+                                the ones listed in the namespaces field. null selector
+                                and null or empty namespaces list means "this pod's
+                                namespace". An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: namespaces specifies a static list of namespace
+                                names that the term applies to. The term is applied
+                                to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector. null or
+                                empty namespaces list and null namespaceSelector means
+                                "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity)
+                                or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where
+                                co-located is defined as running on a node whose value
+                                of the label with key topologyKey matches that of
+                                any node on which any of the selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              image:
+                description: Image is the name of the RabbitMQ docker image to use
+                  for RabbitMQ nodes in the RabbitmqCluster. Must be provided together
+                  with ImagePullSecrets in order to use an image in a private registry.
+                type: string
+              imagePullSecrets:
+                description: List of Secret resource containing access credentials
+                  to the registry for the RabbitMQ image. Required if the docker registry
+                  is private.
+                items:
+                  description: LocalObjectReference contains enough information to
+                    let you locate the referenced object inside the same namespace.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              override:
+                properties:
+                  service:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      spec:
+                        properties:
+                          allocateLoadBalancerNodePorts:
+                            type: boolean
+                          clusterIP:
+                            type: string
+                          clusterIPs:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          externalIPs:
+                            items:
+                              type: string
+                            type: array
+                          externalName:
+                            type: string
+                          externalTrafficPolicy:
+                            type: string
+                          healthCheckNodePort:
+                            format: int32
+                            type: integer
+                          internalTrafficPolicy:
+                            type: string
+                          ipFamilies:
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          ipFamilyPolicy:
+                            type: string
+                          loadBalancerClass:
+                            type: string
+                          loadBalancerIP:
+                            type: string
+                          loadBalancerSourceRanges:
+                            items:
+                              type: string
+                            type: array
+                          ports:
+                            items:
+                              properties:
+                                appProtocol:
+                                  type: string
+                                name:
+                                  type: string
+                                nodePort:
+                                  format: int32
+                                  type: integer
+                                port:
+                                  format: int32
+                                  type: integer
+                                protocol:
+                                  default: TCP
+                                  type: string
+                                targetPort:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - port
+                            - protocol
+                            x-kubernetes-list-type: map
+                          publishNotReadyAddresses:
+                            type: boolean
+                          selector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          sessionAffinity:
+                            type: string
+                          sessionAffinityConfig:
+                            properties:
+                              clientIP:
+                                properties:
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                    type: object
+                  statefulSet:
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
+                      spec:
+                        properties:
+                          podManagementPolicy:
+                            type: string
+                          replicas:
+                            format: int32
+                            type: integer
+                          selector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          serviceName:
+                            type: string
+                          template:
+                            properties:
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                              spec:
+                                properties:
+                                  activeDeadlineSeconds:
+                                    format: int64
+                                    type: integer
+                                  affinity:
+                                    properties:
+                                      nodeAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                preference:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - preference
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            properties:
+                                              nodeSelectorTerms:
+                                                items:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchFields:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                type: array
+                                            required:
+                                            - nodeSelectorTerms
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      podAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                podAffinityTerm:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaceSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                      podAntiAffinity:
+                                        properties:
+                                          preferredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                podAffinityTerm:
+                                                  properties:
+                                                    labelSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaceSelector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    namespaces:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    topologyKey:
+                                                      type: string
+                                                  required:
+                                                  - topologyKey
+                                                  type: object
+                                                weight:
+                                                  format: int32
+                                                  type: integer
+                                              required:
+                                              - podAffinityTerm
+                                              - weight
+                                              type: object
+                                            type: array
+                                          requiredDuringSchedulingIgnoredDuringExecution:
+                                            items:
+                                              properties:
+                                                labelSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaceSelector:
+                                                  properties:
+                                                    matchExpressions:
+                                                      items:
+                                                        properties:
+                                                          key:
+                                                            type: string
+                                                          operator:
+                                                            type: string
+                                                          values:
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                topologyKey:
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            type: array
+                                        type: object
+                                    type: object
+                                  automountServiceAccountToken:
+                                    type: boolean
+                                  containers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                          type: array
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  dnsConfig:
+                                    properties:
+                                      nameservers:
+                                        items:
+                                          type: string
+                                        type: array
+                                      options:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          type: object
+                                        type: array
+                                      searches:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  dnsPolicy:
+                                    type: string
+                                  enableServiceLinks:
+                                    type: boolean
+                                  ephemeralContainers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                          type: array
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        targetContainerName:
+                                          type: string
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  hostAliases:
+                                    items:
+                                      properties:
+                                        hostnames:
+                                          items:
+                                            type: string
+                                          type: array
+                                        ip:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  hostIPC:
+                                    type: boolean
+                                  hostNetwork:
+                                    type: boolean
+                                  hostPID:
+                                    type: boolean
+                                  hostUsers:
+                                    type: boolean
+                                  hostname:
+                                    type: string
+                                  imagePullSecrets:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                  initContainers:
+                                    items:
+                                      properties:
+                                        args:
+                                          items:
+                                            type: string
+                                          type: array
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                        env:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                              valueFrom:
+                                                properties:
+                                                  configMapKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  secretKeyRef:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    required:
+                                                    - key
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: object
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                        envFrom:
+                                          items:
+                                            properties:
+                                              configMapRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              prefix:
+                                                type: string
+                                              secretRef:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  optional:
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                          type: array
+                                        image:
+                                          type: string
+                                        imagePullPolicy:
+                                          type: string
+                                        lifecycle:
+                                          properties:
+                                            postStart:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                            preStop:
+                                              properties:
+                                                exec:
+                                                  properties:
+                                                    command:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  type: object
+                                                httpGet:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    httpHeaders:
+                                                      items:
+                                                        properties:
+                                                          name:
+                                                            type: string
+                                                          value:
+                                                            type: string
+                                                        required:
+                                                        - name
+                                                        - value
+                                                        type: object
+                                                      type: array
+                                                    path:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                    scheme:
+                                                      type: string
+                                                  required:
+                                                  - port
+                                                  type: object
+                                                tcpSocket:
+                                                  properties:
+                                                    host:
+                                                      type: string
+                                                    port:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      x-kubernetes-int-or-string: true
+                                                  required:
+                                                  - port
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        livenessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        name:
+                                          type: string
+                                        ports:
+                                          items:
+                                            properties:
+                                              containerPort:
+                                                format: int32
+                                                type: integer
+                                              hostIP:
+                                                type: string
+                                              hostPort:
+                                                format: int32
+                                                type: integer
+                                              name:
+                                                type: string
+                                              protocol:
+                                                default: TCP
+                                                type: string
+                                            required:
+                                            - containerPort
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                          x-kubernetes-list-type: map
+                                        readinessProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        resources:
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              type: object
+                                          type: object
+                                        securityContext:
+                                          properties:
+                                            allowPrivilegeEscalation:
+                                              type: boolean
+                                            capabilities:
+                                              properties:
+                                                add:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                drop:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            privileged:
+                                              type: boolean
+                                            procMount:
+                                              type: string
+                                            readOnlyRootFilesystem:
+                                              type: boolean
+                                            runAsGroup:
+                                              format: int64
+                                              type: integer
+                                            runAsNonRoot:
+                                              type: boolean
+                                            runAsUser:
+                                              format: int64
+                                              type: integer
+                                            seLinuxOptions:
+                                              properties:
+                                                level:
+                                                  type: string
+                                                role:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                                user:
+                                                  type: string
+                                              type: object
+                                            seccompProfile:
+                                              properties:
+                                                localhostProfile:
+                                                  type: string
+                                                type:
+                                                  type: string
+                                              required:
+                                              - type
+                                              type: object
+                                            windowsOptions:
+                                              properties:
+                                                gmsaCredentialSpec:
+                                                  type: string
+                                                gmsaCredentialSpecName:
+                                                  type: string
+                                                hostProcess:
+                                                  type: boolean
+                                                runAsUserName:
+                                                  type: string
+                                              type: object
+                                          type: object
+                                        startupProbe:
+                                          properties:
+                                            exec:
+                                              properties:
+                                                command:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              type: object
+                                            failureThreshold:
+                                              format: int32
+                                              type: integer
+                                            grpc:
+                                              properties:
+                                                port:
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            httpGet:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                httpHeaders:
+                                                  items:
+                                                    properties:
+                                                      name:
+                                                        type: string
+                                                      value:
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                path:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            initialDelaySeconds:
+                                              format: int32
+                                              type: integer
+                                            periodSeconds:
+                                              format: int32
+                                              type: integer
+                                            successThreshold:
+                                              format: int32
+                                              type: integer
+                                            tcpSocket:
+                                              properties:
+                                                host:
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                            terminationGracePeriodSeconds:
+                                              format: int64
+                                              type: integer
+                                            timeoutSeconds:
+                                              format: int32
+                                              type: integer
+                                          type: object
+                                        stdin:
+                                          type: boolean
+                                        stdinOnce:
+                                          type: boolean
+                                        terminationMessagePath:
+                                          type: string
+                                        terminationMessagePolicy:
+                                          type: string
+                                        tty:
+                                          type: boolean
+                                        volumeDevices:
+                                          items:
+                                            properties:
+                                              devicePath:
+                                                type: string
+                                              name:
+                                                type: string
+                                            required:
+                                            - devicePath
+                                            - name
+                                            type: object
+                                          type: array
+                                        volumeMounts:
+                                          items:
+                                            properties:
+                                              mountPath:
+                                                type: string
+                                              mountPropagation:
+                                                type: string
+                                              name:
+                                                type: string
+                                              readOnly:
+                                                type: boolean
+                                              subPath:
+                                                type: string
+                                              subPathExpr:
+                                                type: string
+                                            required:
+                                            - mountPath
+                                            - name
+                                            type: object
+                                          type: array
+                                        workingDir:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                  nodeName:
+                                    type: string
+                                  nodeSelector:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  os:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  overhead:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  preemptionPolicy:
+                                    type: string
+                                  priority:
+                                    format: int32
+                                    type: integer
+                                  priorityClassName:
+                                    type: string
+                                  readinessGates:
+                                    items:
+                                      properties:
+                                        conditionType:
+                                          type: string
+                                      required:
+                                      - conditionType
+                                      type: object
+                                    type: array
+                                  restartPolicy:
+                                    type: string
+                                  runtimeClassName:
+                                    type: string
+                                  schedulerName:
+                                    type: string
+                                  securityContext:
+                                    properties:
+                                      fsGroup:
+                                        format: int64
+                                        type: integer
+                                      fsGroupChangePolicy:
+                                        type: string
+                                      runAsGroup:
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        type: boolean
+                                      runAsUser:
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        properties:
+                                          level:
+                                            type: string
+                                          role:
+                                            type: string
+                                          type:
+                                            type: string
+                                          user:
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        properties:
+                                          localhostProfile:
+                                            type: string
+                                          type:
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      supplementalGroups:
+                                        items:
+                                          format: int64
+                                          type: integer
+                                        type: array
+                                      sysctls:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      windowsOptions:
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            type: string
+                                          hostProcess:
+                                            type: boolean
+                                          runAsUserName:
+                                            type: string
+                                        type: object
+                                    type: object
+                                  serviceAccount:
+                                    type: string
+                                  serviceAccountName:
+                                    type: string
+                                  setHostnameAsFQDN:
+                                    type: boolean
+                                  shareProcessNamespace:
+                                    type: boolean
+                                  subdomain:
+                                    type: string
+                                  terminationGracePeriodSeconds:
+                                    format: int64
+                                    type: integer
+                                  tolerations:
+                                    items:
+                                      properties:
+                                        effect:
+                                          type: string
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        tolerationSeconds:
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  topologySpreadConstraints:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        maxSkew:
+                                          format: int32
+                                          type: integer
+                                        minDomains:
+                                          format: int32
+                                          type: integer
+                                        nodeAffinityPolicy:
+                                          type: string
+                                        nodeTaintsPolicy:
+                                          type: string
+                                        topologyKey:
+                                          type: string
+                                        whenUnsatisfiable:
+                                          type: string
+                                      required:
+                                      - maxSkew
+                                      - topologyKey
+                                      - whenUnsatisfiable
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - topologyKey
+                                    - whenUnsatisfiable
+                                    x-kubernetes-list-type: map
+                                  volumes:
+                                    items:
+                                      properties:
+                                        awsElasticBlockStore:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            partition:
+                                              format: int32
+                                              type: integer
+                                            readOnly:
+                                              type: boolean
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        azureDisk:
+                                          properties:
+                                            cachingMode:
+                                              type: string
+                                            diskName:
+                                              type: string
+                                            diskURI:
+                                              type: string
+                                            fsType:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - diskName
+                                          - diskURI
+                                          type: object
+                                        azureFile:
+                                          properties:
+                                            readOnly:
+                                              type: boolean
+                                            secretName:
+                                              type: string
+                                            shareName:
+                                              type: string
+                                          required:
+                                          - secretName
+                                          - shareName
+                                          type: object
+                                        cephfs:
+                                          properties:
+                                            monitors:
+                                              items:
+                                                type: string
+                                              type: array
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretFile:
+                                              type: string
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            user:
+                                              type: string
+                                          required:
+                                          - monitors
+                                          type: object
+                                        cinder:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        configMap:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        csi:
+                                          properties:
+                                            driver:
+                                              type: string
+                                            fsType:
+                                              type: string
+                                            nodePublishSecretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            readOnly:
+                                              type: boolean
+                                            volumeAttributes:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          required:
+                                          - driver
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        emptyDir:
+                                          properties:
+                                            medium:
+                                              type: string
+                                            sizeLimit:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                        ephemeral:
+                                          properties:
+                                            volumeClaimTemplate:
+                                              properties:
+                                                metadata:
+                                                  type: object
+                                                spec:
+                                                  properties:
+                                                    accessModes:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                    dataSource:
+                                                      properties:
+                                                        apiGroup:
+                                                          type: string
+                                                        kind:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - kind
+                                                      - name
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    dataSourceRef:
+                                                      properties:
+                                                        apiGroup:
+                                                          type: string
+                                                        kind:
+                                                          type: string
+                                                        name:
+                                                          type: string
+                                                      required:
+                                                      - kind
+                                                      - name
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    resources:
+                                                      properties:
+                                                        limits:
+                                                          additionalProperties:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          type: object
+                                                        requests:
+                                                          additionalProperties:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          type: object
+                                                      type: object
+                                                    selector:
+                                                      properties:
+                                                        matchExpressions:
+                                                          items:
+                                                            properties:
+                                                              key:
+                                                                type: string
+                                                              operator:
+                                                                type: string
+                                                              values:
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                            - key
+                                                            - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    storageClassName:
+                                                      type: string
+                                                    volumeMode:
+                                                      type: string
+                                                    volumeName:
+                                                      type: string
+                                                  type: object
+                                              required:
+                                              - spec
+                                              type: object
+                                          type: object
+                                        fc:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            lun:
+                                              format: int32
+                                              type: integer
+                                            readOnly:
+                                              type: boolean
+                                            targetWWNs:
+                                              items:
+                                                type: string
+                                              type: array
+                                            wwids:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        flexVolume:
+                                          properties:
+                                            driver:
+                                              type: string
+                                            fsType:
+                                              type: string
+                                            options:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          required:
+                                          - driver
+                                          type: object
+                                        flocker:
+                                          properties:
+                                            datasetName:
+                                              type: string
+                                            datasetUUID:
+                                              type: string
+                                          type: object
+                                        gcePersistentDisk:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            partition:
+                                              format: int32
+                                              type: integer
+                                            pdName:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - pdName
+                                          type: object
+                                        gitRepo:
+                                          properties:
+                                            directory:
+                                              type: string
+                                            repository:
+                                              type: string
+                                            revision:
+                                              type: string
+                                          required:
+                                          - repository
+                                          type: object
+                                        glusterfs:
+                                          properties:
+                                            endpoints:
+                                              type: string
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - endpoints
+                                          - path
+                                          type: object
+                                        hostPath:
+                                          properties:
+                                            path:
+                                              type: string
+                                            type:
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                        iscsi:
+                                          properties:
+                                            chapAuthDiscovery:
+                                              type: boolean
+                                            chapAuthSession:
+                                              type: boolean
+                                            fsType:
+                                              type: string
+                                            initiatorName:
+                                              type: string
+                                            iqn:
+                                              type: string
+                                            iscsiInterface:
+                                              type: string
+                                            lun:
+                                              format: int32
+                                              type: integer
+                                            portals:
+                                              items:
+                                                type: string
+                                              type: array
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            targetPortal:
+                                              type: string
+                                          required:
+                                          - iqn
+                                          - lun
+                                          - targetPortal
+                                          type: object
+                                        name:
+                                          type: string
+                                        nfs:
+                                          properties:
+                                            path:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            server:
+                                              type: string
+                                          required:
+                                          - path
+                                          - server
+                                          type: object
+                                        persistentVolumeClaim:
+                                          properties:
+                                            claimName:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                          required:
+                                          - claimName
+                                          type: object
+                                        photonPersistentDisk:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            pdID:
+                                              type: string
+                                          required:
+                                          - pdID
+                                          type: object
+                                        portworxVolume:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            volumeID:
+                                              type: string
+                                          required:
+                                          - volumeID
+                                          type: object
+                                        projected:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            sources:
+                                              items:
+                                                properties:
+                                                  configMap:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  downwardAPI:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            fieldRef:
+                                                              properties:
+                                                                apiVersion:
+                                                                  type: string
+                                                                fieldPath:
+                                                                  type: string
+                                                              required:
+                                                              - fieldPath
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                            resourceFieldRef:
+                                                              properties:
+                                                                containerName:
+                                                                  type: string
+                                                                divisor:
+                                                                  anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                  x-kubernetes-int-or-string: true
+                                                                resource:
+                                                                  type: string
+                                                              required:
+                                                              - resource
+                                                              type: object
+                                                              x-kubernetes-map-type: atomic
+                                                          required:
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                  secret:
+                                                    properties:
+                                                      items:
+                                                        items:
+                                                          properties:
+                                                            key:
+                                                              type: string
+                                                            mode:
+                                                              format: int32
+                                                              type: integer
+                                                            path:
+                                                              type: string
+                                                          required:
+                                                          - key
+                                                          - path
+                                                          type: object
+                                                        type: array
+                                                      name:
+                                                        type: string
+                                                      optional:
+                                                        type: boolean
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  serviceAccountToken:
+                                                    properties:
+                                                      audience:
+                                                        type: string
+                                                      expirationSeconds:
+                                                        format: int64
+                                                        type: integer
+                                                      path:
+                                                        type: string
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                type: object
+                                              type: array
+                                          type: object
+                                        quobyte:
+                                          properties:
+                                            group:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            registry:
+                                              type: string
+                                            tenant:
+                                              type: string
+                                            user:
+                                              type: string
+                                            volume:
+                                              type: string
+                                          required:
+                                          - registry
+                                          - volume
+                                          type: object
+                                        rbd:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            image:
+                                              type: string
+                                            keyring:
+                                              type: string
+                                            monitors:
+                                              items:
+                                                type: string
+                                              type: array
+                                            pool:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            user:
+                                              type: string
+                                          required:
+                                          - image
+                                          - monitors
+                                          type: object
+                                        scaleIO:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            gateway:
+                                              type: string
+                                            protectionDomain:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            sslEnabled:
+                                              type: boolean
+                                            storageMode:
+                                              type: string
+                                            storagePool:
+                                              type: string
+                                            system:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          required:
+                                          - gateway
+                                          - secretRef
+                                          - system
+                                          type: object
+                                        secret:
+                                          properties:
+                                            defaultMode:
+                                              format: int32
+                                              type: integer
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            optional:
+                                              type: boolean
+                                            secretName:
+                                              type: string
+                                          type: object
+                                        storageos:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            readOnly:
+                                              type: boolean
+                                            secretRef:
+                                              properties:
+                                                name:
+                                                  type: string
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            volumeName:
+                                              type: string
+                                            volumeNamespace:
+                                              type: string
+                                          type: object
+                                        vsphereVolume:
+                                          properties:
+                                            fsType:
+                                              type: string
+                                            storagePolicyID:
+                                              type: string
+                                            storagePolicyName:
+                                              type: string
+                                            volumePath:
+                                              type: string
+                                          required:
+                                          - volumePath
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                required:
+                                - containers
+                                type: object
+                            type: object
+                          updateStrategy:
+                            properties:
+                              rollingUpdate:
+                                properties:
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              type:
+                                type: string
+                            type: object
+                          volumeClaimTemplates:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                kind:
+                                  type: string
                                 metadata:
                                   properties:
                                     annotations:
@@ -692,3424 +4211,457 @@ spec:
                                   type: object
                                 spec:
                                   properties:
-                                    activeDeadlineSeconds:
-                                      format: int64
-                                      type: integer
-                                    affinity:
-                                      properties:
-                                        nodeAffinity:
-                                          properties:
-                                            preferredDuringSchedulingIgnoredDuringExecution:
-                                              items:
-                                                properties:
-                                                  preference:
-                                                    properties:
-                                                      matchExpressions:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchFields:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                    type: object
-                                                  weight:
-                                                    format: int32
-                                                    type: integer
-                                                required:
-                                                  - preference
-                                                  - weight
-                                                type: object
-                                              type: array
-                                            requiredDuringSchedulingIgnoredDuringExecution:
-                                              properties:
-                                                nodeSelectorTerms:
-                                                  items:
-                                                    properties:
-                                                      matchExpressions:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchFields:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                    type: object
-                                                  type: array
-                                              required:
-                                                - nodeSelectorTerms
-                                              type: object
-                                          type: object
-                                        podAffinity:
-                                          properties:
-                                            preferredDuringSchedulingIgnoredDuringExecution:
-                                              items:
-                                                properties:
-                                                  podAffinityTerm:
-                                                    properties:
-                                                      labelSelector:
-                                                        properties:
-                                                          matchExpressions:
-                                                            items:
-                                                              properties:
-                                                                key:
-                                                                  type: string
-                                                                operator:
-                                                                  type: string
-                                                                values:
-                                                                  items:
-                                                                    type: string
-                                                                  type: array
-                                                              required:
-                                                                - key
-                                                                - operator
-                                                              type: object
-                                                            type: array
-                                                          matchLabels:
-                                                            additionalProperties:
-                                                              type: string
-                                                            type: object
-                                                        type: object
-                                                      namespaceSelector:
-                                                        properties:
-                                                          matchExpressions:
-                                                            items:
-                                                              properties:
-                                                                key:
-                                                                  type: string
-                                                                operator:
-                                                                  type: string
-                                                                values:
-                                                                  items:
-                                                                    type: string
-                                                                  type: array
-                                                              required:
-                                                                - key
-                                                                - operator
-                                                              type: object
-                                                            type: array
-                                                          matchLabels:
-                                                            additionalProperties:
-                                                              type: string
-                                                            type: object
-                                                        type: object
-                                                      namespaces:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                      topologyKey:
-                                                        type: string
-                                                    required:
-                                                      - topologyKey
-                                                    type: object
-                                                  weight:
-                                                    format: int32
-                                                    type: integer
-                                                required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                type: object
-                                              type: array
-                                            requiredDuringSchedulingIgnoredDuringExecution:
-                                              items:
-                                                properties:
-                                                  labelSelector:
-                                                    properties:
-                                                      matchExpressions:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchLabels:
-                                                        additionalProperties:
-                                                          type: string
-                                                        type: object
-                                                    type: object
-                                                  namespaceSelector:
-                                                    properties:
-                                                      matchExpressions:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchLabels:
-                                                        additionalProperties:
-                                                          type: string
-                                                        type: object
-                                                    type: object
-                                                  namespaces:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                  topologyKey:
-                                                    type: string
-                                                required:
-                                                  - topologyKey
-                                                type: object
-                                              type: array
-                                          type: object
-                                        podAntiAffinity:
-                                          properties:
-                                            preferredDuringSchedulingIgnoredDuringExecution:
-                                              items:
-                                                properties:
-                                                  podAffinityTerm:
-                                                    properties:
-                                                      labelSelector:
-                                                        properties:
-                                                          matchExpressions:
-                                                            items:
-                                                              properties:
-                                                                key:
-                                                                  type: string
-                                                                operator:
-                                                                  type: string
-                                                                values:
-                                                                  items:
-                                                                    type: string
-                                                                  type: array
-                                                              required:
-                                                                - key
-                                                                - operator
-                                                              type: object
-                                                            type: array
-                                                          matchLabels:
-                                                            additionalProperties:
-                                                              type: string
-                                                            type: object
-                                                        type: object
-                                                      namespaceSelector:
-                                                        properties:
-                                                          matchExpressions:
-                                                            items:
-                                                              properties:
-                                                                key:
-                                                                  type: string
-                                                                operator:
-                                                                  type: string
-                                                                values:
-                                                                  items:
-                                                                    type: string
-                                                                  type: array
-                                                              required:
-                                                                - key
-                                                                - operator
-                                                              type: object
-                                                            type: array
-                                                          matchLabels:
-                                                            additionalProperties:
-                                                              type: string
-                                                            type: object
-                                                        type: object
-                                                      namespaces:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                      topologyKey:
-                                                        type: string
-                                                    required:
-                                                      - topologyKey
-                                                    type: object
-                                                  weight:
-                                                    format: int32
-                                                    type: integer
-                                                required:
-                                                  - podAffinityTerm
-                                                  - weight
-                                                type: object
-                                              type: array
-                                            requiredDuringSchedulingIgnoredDuringExecution:
-                                              items:
-                                                properties:
-                                                  labelSelector:
-                                                    properties:
-                                                      matchExpressions:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchLabels:
-                                                        additionalProperties:
-                                                          type: string
-                                                        type: object
-                                                    type: object
-                                                  namespaceSelector:
-                                                    properties:
-                                                      matchExpressions:
-                                                        items:
-                                                          properties:
-                                                            key:
-                                                              type: string
-                                                            operator:
-                                                              type: string
-                                                            values:
-                                                              items:
-                                                                type: string
-                                                              type: array
-                                                          required:
-                                                            - key
-                                                            - operator
-                                                          type: object
-                                                        type: array
-                                                      matchLabels:
-                                                        additionalProperties:
-                                                          type: string
-                                                        type: object
-                                                    type: object
-                                                  namespaces:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                  topologyKey:
-                                                    type: string
-                                                required:
-                                                  - topologyKey
-                                                type: object
-                                              type: array
-                                          type: object
-                                      type: object
-                                    automountServiceAccountToken:
-                                      type: boolean
-                                    containers:
+                                    accessModes:
                                       items:
-                                        properties:
-                                          args:
-                                            items:
-                                              type: string
-                                            type: array
-                                          command:
-                                            items:
-                                              type: string
-                                            type: array
-                                          env:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                                valueFrom:
-                                                  properties:
-                                                    configMapKeyRef:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        name:
-                                                          type: string
-                                                        optional:
-                                                          type: boolean
-                                                      required:
-                                                        - key
-                                                      type: object
-                                                    fieldRef:
-                                                      properties:
-                                                        apiVersion:
-                                                          type: string
-                                                        fieldPath:
-                                                          type: string
-                                                      required:
-                                                        - fieldPath
-                                                      type: object
-                                                    resourceFieldRef:
-                                                      properties:
-                                                        containerName:
-                                                          type: string
-                                                        divisor:
-                                                          anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                          x-kubernetes-int-or-string: true
-                                                        resource:
-                                                          type: string
-                                                      required:
-                                                        - resource
-                                                      type: object
-                                                    secretKeyRef:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        name:
-                                                          type: string
-                                                        optional:
-                                                          type: boolean
-                                                      required:
-                                                        - key
-                                                      type: object
-                                                  type: object
-                                              required:
-                                                - name
-                                              type: object
-                                            type: array
-                                          envFrom:
-                                            items:
-                                              properties:
-                                                configMapRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  type: object
-                                                prefix:
-                                                  type: string
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  type: object
-                                              type: object
-                                            type: array
-                                          image:
-                                            type: string
-                                          imagePullPolicy:
-                                            type: string
-                                          lifecycle:
-                                            properties:
-                                              postStart:
-                                                properties:
-                                                  exec:
-                                                    properties:
-                                                      command:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    type: object
-                                                  httpGet:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      httpHeaders:
-                                                        items:
-                                                          properties:
-                                                            name:
-                                                              type: string
-                                                            value:
-                                                              type: string
-                                                          required:
-                                                            - name
-                                                            - value
-                                                          type: object
-                                                        type: array
-                                                      path:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                      scheme:
-                                                        type: string
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                  tcpSocket:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                type: object
-                                              preStop:
-                                                properties:
-                                                  exec:
-                                                    properties:
-                                                      command:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    type: object
-                                                  httpGet:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      httpHeaders:
-                                                        items:
-                                                          properties:
-                                                            name:
-                                                              type: string
-                                                            value:
-                                                              type: string
-                                                          required:
-                                                            - name
-                                                            - value
-                                                          type: object
-                                                        type: array
-                                                      path:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                      scheme:
-                                                        type: string
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                  tcpSocket:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                type: object
-                                            type: object
-                                          livenessProbe:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              failureThreshold:
-                                                format: int32
-                                                type: integer
-                                              grpc:
-                                                properties:
-                                                  port:
-                                                    format: int32
-                                                    type: integer
-                                                  service:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              initialDelaySeconds:
-                                                format: int32
-                                                type: integer
-                                              periodSeconds:
-                                                format: int32
-                                                type: integer
-                                              successThreshold:
-                                                format: int32
-                                                type: integer
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                              terminationGracePeriodSeconds:
-                                                format: int64
-                                                type: integer
-                                              timeoutSeconds:
-                                                format: int32
-                                                type: integer
-                                            type: object
-                                          name:
-                                            type: string
-                                          ports:
-                                            items:
-                                              properties:
-                                                containerPort:
-                                                  format: int32
-                                                  type: integer
-                                                hostIP:
-                                                  type: string
-                                                hostPort:
-                                                  format: int32
-                                                  type: integer
-                                                name:
-                                                  type: string
-                                                protocol:
-                                                  default: TCP
-                                                  type: string
-                                              required:
-                                                - containerPort
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-map-keys:
-                                              - containerPort
-                                              - protocol
-                                            x-kubernetes-list-type: map
-                                          readinessProbe:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              failureThreshold:
-                                                format: int32
-                                                type: integer
-                                              grpc:
-                                                properties:
-                                                  port:
-                                                    format: int32
-                                                    type: integer
-                                                  service:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              initialDelaySeconds:
-                                                format: int32
-                                                type: integer
-                                              periodSeconds:
-                                                format: int32
-                                                type: integer
-                                              successThreshold:
-                                                format: int32
-                                                type: integer
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                              terminationGracePeriodSeconds:
-                                                format: int64
-                                                type: integer
-                                              timeoutSeconds:
-                                                format: int32
-                                                type: integer
-                                            type: object
-                                          resources:
-                                            properties:
-                                              limits:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                              requests:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                            type: object
-                                          securityContext:
-                                            properties:
-                                              allowPrivilegeEscalation:
-                                                type: boolean
-                                              capabilities:
-                                                properties:
-                                                  add:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                  drop:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              privileged:
-                                                type: boolean
-                                              procMount:
-                                                type: string
-                                              readOnlyRootFilesystem:
-                                                type: boolean
-                                              runAsGroup:
-                                                format: int64
-                                                type: integer
-                                              runAsNonRoot:
-                                                type: boolean
-                                              runAsUser:
-                                                format: int64
-                                                type: integer
-                                              seLinuxOptions:
-                                                properties:
-                                                  level:
-                                                    type: string
-                                                  role:
-                                                    type: string
-                                                  type:
-                                                    type: string
-                                                  user:
-                                                    type: string
-                                                type: object
-                                              seccompProfile:
-                                                properties:
-                                                  localhostProfile:
-                                                    type: string
-                                                  type:
-                                                    type: string
-                                                required:
-                                                  - type
-                                                type: object
-                                              windowsOptions:
-                                                properties:
-                                                  gmsaCredentialSpec:
-                                                    type: string
-                                                  gmsaCredentialSpecName:
-                                                    type: string
-                                                  hostProcess:
-                                                    type: boolean
-                                                  runAsUserName:
-                                                    type: string
-                                                type: object
-                                            type: object
-                                          startupProbe:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              failureThreshold:
-                                                format: int32
-                                                type: integer
-                                              grpc:
-                                                properties:
-                                                  port:
-                                                    format: int32
-                                                    type: integer
-                                                  service:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              initialDelaySeconds:
-                                                format: int32
-                                                type: integer
-                                              periodSeconds:
-                                                format: int32
-                                                type: integer
-                                              successThreshold:
-                                                format: int32
-                                                type: integer
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                              terminationGracePeriodSeconds:
-                                                format: int64
-                                                type: integer
-                                              timeoutSeconds:
-                                                format: int32
-                                                type: integer
-                                            type: object
-                                          stdin:
-                                            type: boolean
-                                          stdinOnce:
-                                            type: boolean
-                                          terminationMessagePath:
-                                            type: string
-                                          terminationMessagePolicy:
-                                            type: string
-                                          tty:
-                                            type: boolean
-                                          volumeDevices:
-                                            items:
-                                              properties:
-                                                devicePath:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                              required:
-                                                - devicePath
-                                                - name
-                                              type: object
-                                            type: array
-                                          volumeMounts:
-                                            items:
-                                              properties:
-                                                mountPath:
-                                                  type: string
-                                                mountPropagation:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                subPath:
-                                                  type: string
-                                                subPathExpr:
-                                                  type: string
-                                              required:
-                                                - mountPath
-                                                - name
-                                              type: object
-                                            type: array
-                                          workingDir:
-                                            type: string
-                                        required:
-                                          - name
-                                        type: object
-                                      type: array
-                                    dnsConfig:
-                                      properties:
-                                        nameservers:
-                                          items:
-                                            type: string
-                                          type: array
-                                        options:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            type: object
-                                          type: array
-                                        searches:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    dnsPolicy:
-                                      type: string
-                                    enableServiceLinks:
-                                      type: boolean
-                                    ephemeralContainers:
-                                      items:
-                                        properties:
-                                          args:
-                                            items:
-                                              type: string
-                                            type: array
-                                          command:
-                                            items:
-                                              type: string
-                                            type: array
-                                          env:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                                valueFrom:
-                                                  properties:
-                                                    configMapKeyRef:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        name:
-                                                          type: string
-                                                        optional:
-                                                          type: boolean
-                                                      required:
-                                                        - key
-                                                      type: object
-                                                    fieldRef:
-                                                      properties:
-                                                        apiVersion:
-                                                          type: string
-                                                        fieldPath:
-                                                          type: string
-                                                      required:
-                                                        - fieldPath
-                                                      type: object
-                                                    resourceFieldRef:
-                                                      properties:
-                                                        containerName:
-                                                          type: string
-                                                        divisor:
-                                                          anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                          x-kubernetes-int-or-string: true
-                                                        resource:
-                                                          type: string
-                                                      required:
-                                                        - resource
-                                                      type: object
-                                                    secretKeyRef:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        name:
-                                                          type: string
-                                                        optional:
-                                                          type: boolean
-                                                      required:
-                                                        - key
-                                                      type: object
-                                                  type: object
-                                              required:
-                                                - name
-                                              type: object
-                                            type: array
-                                          envFrom:
-                                            items:
-                                              properties:
-                                                configMapRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  type: object
-                                                prefix:
-                                                  type: string
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  type: object
-                                              type: object
-                                            type: array
-                                          image:
-                                            type: string
-                                          imagePullPolicy:
-                                            type: string
-                                          lifecycle:
-                                            properties:
-                                              postStart:
-                                                properties:
-                                                  exec:
-                                                    properties:
-                                                      command:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    type: object
-                                                  httpGet:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      httpHeaders:
-                                                        items:
-                                                          properties:
-                                                            name:
-                                                              type: string
-                                                            value:
-                                                              type: string
-                                                          required:
-                                                            - name
-                                                            - value
-                                                          type: object
-                                                        type: array
-                                                      path:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                      scheme:
-                                                        type: string
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                  tcpSocket:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                type: object
-                                              preStop:
-                                                properties:
-                                                  exec:
-                                                    properties:
-                                                      command:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    type: object
-                                                  httpGet:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      httpHeaders:
-                                                        items:
-                                                          properties:
-                                                            name:
-                                                              type: string
-                                                            value:
-                                                              type: string
-                                                          required:
-                                                            - name
-                                                            - value
-                                                          type: object
-                                                        type: array
-                                                      path:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                      scheme:
-                                                        type: string
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                  tcpSocket:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                type: object
-                                            type: object
-                                          livenessProbe:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              failureThreshold:
-                                                format: int32
-                                                type: integer
-                                              grpc:
-                                                properties:
-                                                  port:
-                                                    format: int32
-                                                    type: integer
-                                                  service:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              initialDelaySeconds:
-                                                format: int32
-                                                type: integer
-                                              periodSeconds:
-                                                format: int32
-                                                type: integer
-                                              successThreshold:
-                                                format: int32
-                                                type: integer
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                              terminationGracePeriodSeconds:
-                                                format: int64
-                                                type: integer
-                                              timeoutSeconds:
-                                                format: int32
-                                                type: integer
-                                            type: object
-                                          name:
-                                            type: string
-                                          ports:
-                                            items:
-                                              properties:
-                                                containerPort:
-                                                  format: int32
-                                                  type: integer
-                                                hostIP:
-                                                  type: string
-                                                hostPort:
-                                                  format: int32
-                                                  type: integer
-                                                name:
-                                                  type: string
-                                                protocol:
-                                                  default: TCP
-                                                  type: string
-                                              required:
-                                                - containerPort
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-map-keys:
-                                              - containerPort
-                                              - protocol
-                                            x-kubernetes-list-type: map
-                                          readinessProbe:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              failureThreshold:
-                                                format: int32
-                                                type: integer
-                                              grpc:
-                                                properties:
-                                                  port:
-                                                    format: int32
-                                                    type: integer
-                                                  service:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              initialDelaySeconds:
-                                                format: int32
-                                                type: integer
-                                              periodSeconds:
-                                                format: int32
-                                                type: integer
-                                              successThreshold:
-                                                format: int32
-                                                type: integer
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                              terminationGracePeriodSeconds:
-                                                format: int64
-                                                type: integer
-                                              timeoutSeconds:
-                                                format: int32
-                                                type: integer
-                                            type: object
-                                          resources:
-                                            properties:
-                                              limits:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                              requests:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                            type: object
-                                          securityContext:
-                                            properties:
-                                              allowPrivilegeEscalation:
-                                                type: boolean
-                                              capabilities:
-                                                properties:
-                                                  add:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                  drop:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              privileged:
-                                                type: boolean
-                                              procMount:
-                                                type: string
-                                              readOnlyRootFilesystem:
-                                                type: boolean
-                                              runAsGroup:
-                                                format: int64
-                                                type: integer
-                                              runAsNonRoot:
-                                                type: boolean
-                                              runAsUser:
-                                                format: int64
-                                                type: integer
-                                              seLinuxOptions:
-                                                properties:
-                                                  level:
-                                                    type: string
-                                                  role:
-                                                    type: string
-                                                  type:
-                                                    type: string
-                                                  user:
-                                                    type: string
-                                                type: object
-                                              seccompProfile:
-                                                properties:
-                                                  localhostProfile:
-                                                    type: string
-                                                  type:
-                                                    type: string
-                                                required:
-                                                  - type
-                                                type: object
-                                              windowsOptions:
-                                                properties:
-                                                  gmsaCredentialSpec:
-                                                    type: string
-                                                  gmsaCredentialSpecName:
-                                                    type: string
-                                                  hostProcess:
-                                                    type: boolean
-                                                  runAsUserName:
-                                                    type: string
-                                                type: object
-                                            type: object
-                                          startupProbe:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              failureThreshold:
-                                                format: int32
-                                                type: integer
-                                              grpc:
-                                                properties:
-                                                  port:
-                                                    format: int32
-                                                    type: integer
-                                                  service:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              initialDelaySeconds:
-                                                format: int32
-                                                type: integer
-                                              periodSeconds:
-                                                format: int32
-                                                type: integer
-                                              successThreshold:
-                                                format: int32
-                                                type: integer
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                              terminationGracePeriodSeconds:
-                                                format: int64
-                                                type: integer
-                                              timeoutSeconds:
-                                                format: int32
-                                                type: integer
-                                            type: object
-                                          stdin:
-                                            type: boolean
-                                          stdinOnce:
-                                            type: boolean
-                                          targetContainerName:
-                                            type: string
-                                          terminationMessagePath:
-                                            type: string
-                                          terminationMessagePolicy:
-                                            type: string
-                                          tty:
-                                            type: boolean
-                                          volumeDevices:
-                                            items:
-                                              properties:
-                                                devicePath:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                              required:
-                                                - devicePath
-                                                - name
-                                              type: object
-                                            type: array
-                                          volumeMounts:
-                                            items:
-                                              properties:
-                                                mountPath:
-                                                  type: string
-                                                mountPropagation:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                subPath:
-                                                  type: string
-                                                subPathExpr:
-                                                  type: string
-                                              required:
-                                                - mountPath
-                                                - name
-                                              type: object
-                                            type: array
-                                          workingDir:
-                                            type: string
-                                        required:
-                                          - name
-                                        type: object
-                                      type: array
-                                    hostAliases:
-                                      items:
-                                        properties:
-                                          hostnames:
-                                            items:
-                                              type: string
-                                            type: array
-                                          ip:
-                                            type: string
-                                        type: object
-                                      type: array
-                                    hostIPC:
-                                      type: boolean
-                                    hostNetwork:
-                                      type: boolean
-                                    hostPID:
-                                      type: boolean
-                                    hostname:
-                                      type: string
-                                    imagePullSecrets:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                        type: object
-                                      type: array
-                                    initContainers:
-                                      items:
-                                        properties:
-                                          args:
-                                            items:
-                                              type: string
-                                            type: array
-                                          command:
-                                            items:
-                                              type: string
-                                            type: array
-                                          env:
-                                            items:
-                                              properties:
-                                                name:
-                                                  type: string
-                                                value:
-                                                  type: string
-                                                valueFrom:
-                                                  properties:
-                                                    configMapKeyRef:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        name:
-                                                          type: string
-                                                        optional:
-                                                          type: boolean
-                                                      required:
-                                                        - key
-                                                      type: object
-                                                    fieldRef:
-                                                      properties:
-                                                        apiVersion:
-                                                          type: string
-                                                        fieldPath:
-                                                          type: string
-                                                      required:
-                                                        - fieldPath
-                                                      type: object
-                                                    resourceFieldRef:
-                                                      properties:
-                                                        containerName:
-                                                          type: string
-                                                        divisor:
-                                                          anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                          x-kubernetes-int-or-string: true
-                                                        resource:
-                                                          type: string
-                                                      required:
-                                                        - resource
-                                                      type: object
-                                                    secretKeyRef:
-                                                      properties:
-                                                        key:
-                                                          type: string
-                                                        name:
-                                                          type: string
-                                                        optional:
-                                                          type: boolean
-                                                      required:
-                                                        - key
-                                                      type: object
-                                                  type: object
-                                              required:
-                                                - name
-                                              type: object
-                                            type: array
-                                          envFrom:
-                                            items:
-                                              properties:
-                                                configMapRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  type: object
-                                                prefix:
-                                                  type: string
-                                                secretRef:
-                                                  properties:
-                                                    name:
-                                                      type: string
-                                                    optional:
-                                                      type: boolean
-                                                  type: object
-                                              type: object
-                                            type: array
-                                          image:
-                                            type: string
-                                          imagePullPolicy:
-                                            type: string
-                                          lifecycle:
-                                            properties:
-                                              postStart:
-                                                properties:
-                                                  exec:
-                                                    properties:
-                                                      command:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    type: object
-                                                  httpGet:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      httpHeaders:
-                                                        items:
-                                                          properties:
-                                                            name:
-                                                              type: string
-                                                            value:
-                                                              type: string
-                                                          required:
-                                                            - name
-                                                            - value
-                                                          type: object
-                                                        type: array
-                                                      path:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                      scheme:
-                                                        type: string
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                  tcpSocket:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                type: object
-                                              preStop:
-                                                properties:
-                                                  exec:
-                                                    properties:
-                                                      command:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                    type: object
-                                                  httpGet:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      httpHeaders:
-                                                        items:
-                                                          properties:
-                                                            name:
-                                                              type: string
-                                                            value:
-                                                              type: string
-                                                          required:
-                                                            - name
-                                                            - value
-                                                          type: object
-                                                        type: array
-                                                      path:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                      scheme:
-                                                        type: string
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                  tcpSocket:
-                                                    properties:
-                                                      host:
-                                                        type: string
-                                                      port:
-                                                        anyOf:
-                                                          - type: integer
-                                                          - type: string
-                                                        x-kubernetes-int-or-string: true
-                                                    required:
-                                                      - port
-                                                    type: object
-                                                type: object
-                                            type: object
-                                          livenessProbe:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              failureThreshold:
-                                                format: int32
-                                                type: integer
-                                              grpc:
-                                                properties:
-                                                  port:
-                                                    format: int32
-                                                    type: integer
-                                                  service:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              initialDelaySeconds:
-                                                format: int32
-                                                type: integer
-                                              periodSeconds:
-                                                format: int32
-                                                type: integer
-                                              successThreshold:
-                                                format: int32
-                                                type: integer
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                              terminationGracePeriodSeconds:
-                                                format: int64
-                                                type: integer
-                                              timeoutSeconds:
-                                                format: int32
-                                                type: integer
-                                            type: object
-                                          name:
-                                            type: string
-                                          ports:
-                                            items:
-                                              properties:
-                                                containerPort:
-                                                  format: int32
-                                                  type: integer
-                                                hostIP:
-                                                  type: string
-                                                hostPort:
-                                                  format: int32
-                                                  type: integer
-                                                name:
-                                                  type: string
-                                                protocol:
-                                                  default: TCP
-                                                  type: string
-                                              required:
-                                                - containerPort
-                                              type: object
-                                            type: array
-                                            x-kubernetes-list-map-keys:
-                                              - containerPort
-                                              - protocol
-                                            x-kubernetes-list-type: map
-                                          readinessProbe:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              failureThreshold:
-                                                format: int32
-                                                type: integer
-                                              grpc:
-                                                properties:
-                                                  port:
-                                                    format: int32
-                                                    type: integer
-                                                  service:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              initialDelaySeconds:
-                                                format: int32
-                                                type: integer
-                                              periodSeconds:
-                                                format: int32
-                                                type: integer
-                                              successThreshold:
-                                                format: int32
-                                                type: integer
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                              terminationGracePeriodSeconds:
-                                                format: int64
-                                                type: integer
-                                              timeoutSeconds:
-                                                format: int32
-                                                type: integer
-                                            type: object
-                                          resources:
-                                            properties:
-                                              limits:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                              requests:
-                                                additionalProperties:
-                                                  anyOf:
-                                                    - type: integer
-                                                    - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                type: object
-                                            type: object
-                                          securityContext:
-                                            properties:
-                                              allowPrivilegeEscalation:
-                                                type: boolean
-                                              capabilities:
-                                                properties:
-                                                  add:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                  drop:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              privileged:
-                                                type: boolean
-                                              procMount:
-                                                type: string
-                                              readOnlyRootFilesystem:
-                                                type: boolean
-                                              runAsGroup:
-                                                format: int64
-                                                type: integer
-                                              runAsNonRoot:
-                                                type: boolean
-                                              runAsUser:
-                                                format: int64
-                                                type: integer
-                                              seLinuxOptions:
-                                                properties:
-                                                  level:
-                                                    type: string
-                                                  role:
-                                                    type: string
-                                                  type:
-                                                    type: string
-                                                  user:
-                                                    type: string
-                                                type: object
-                                              seccompProfile:
-                                                properties:
-                                                  localhostProfile:
-                                                    type: string
-                                                  type:
-                                                    type: string
-                                                required:
-                                                  - type
-                                                type: object
-                                              windowsOptions:
-                                                properties:
-                                                  gmsaCredentialSpec:
-                                                    type: string
-                                                  gmsaCredentialSpecName:
-                                                    type: string
-                                                  hostProcess:
-                                                    type: boolean
-                                                  runAsUserName:
-                                                    type: string
-                                                type: object
-                                            type: object
-                                          startupProbe:
-                                            properties:
-                                              exec:
-                                                properties:
-                                                  command:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                type: object
-                                              failureThreshold:
-                                                format: int32
-                                                type: integer
-                                              grpc:
-                                                properties:
-                                                  port:
-                                                    format: int32
-                                                    type: integer
-                                                  service:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              httpGet:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  httpHeaders:
-                                                    items:
-                                                      properties:
-                                                        name:
-                                                          type: string
-                                                        value:
-                                                          type: string
-                                                      required:
-                                                        - name
-                                                        - value
-                                                      type: object
-                                                    type: array
-                                                  path:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                  scheme:
-                                                    type: string
-                                                required:
-                                                  - port
-                                                type: object
-                                              initialDelaySeconds:
-                                                format: int32
-                                                type: integer
-                                              periodSeconds:
-                                                format: int32
-                                                type: integer
-                                              successThreshold:
-                                                format: int32
-                                                type: integer
-                                              tcpSocket:
-                                                properties:
-                                                  host:
-                                                    type: string
-                                                  port:
-                                                    anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                    x-kubernetes-int-or-string: true
-                                                required:
-                                                  - port
-                                                type: object
-                                              terminationGracePeriodSeconds:
-                                                format: int64
-                                                type: integer
-                                              timeoutSeconds:
-                                                format: int32
-                                                type: integer
-                                            type: object
-                                          stdin:
-                                            type: boolean
-                                          stdinOnce:
-                                            type: boolean
-                                          terminationMessagePath:
-                                            type: string
-                                          terminationMessagePolicy:
-                                            type: string
-                                          tty:
-                                            type: boolean
-                                          volumeDevices:
-                                            items:
-                                              properties:
-                                                devicePath:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                              required:
-                                                - devicePath
-                                                - name
-                                              type: object
-                                            type: array
-                                          volumeMounts:
-                                            items:
-                                              properties:
-                                                mountPath:
-                                                  type: string
-                                                mountPropagation:
-                                                  type: string
-                                                name:
-                                                  type: string
-                                                readOnly:
-                                                  type: boolean
-                                                subPath:
-                                                  type: string
-                                                subPathExpr:
-                                                  type: string
-                                              required:
-                                                - mountPath
-                                                - name
-                                              type: object
-                                            type: array
-                                          workingDir:
-                                            type: string
-                                        required:
-                                          - name
-                                        type: object
-                                      type: array
-                                    nodeName:
-                                      type: string
-                                    nodeSelector:
-                                      additionalProperties:
                                         type: string
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    os:
+                                      type: array
+                                    dataSource:
                                       properties:
+                                        apiGroup:
+                                          type: string
+                                        kind:
+                                          type: string
                                         name:
                                           type: string
                                       required:
-                                        - name
+                                      - kind
+                                      - name
                                       type: object
-                                    overhead:
-                                      additionalProperties:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                    preemptionPolicy:
-                                      type: string
-                                    priority:
-                                      format: int32
-                                      type: integer
-                                    priorityClassName:
-                                      type: string
-                                    readinessGates:
-                                      items:
-                                        properties:
-                                          conditionType:
-                                            type: string
-                                        required:
-                                          - conditionType
-                                        type: object
-                                      type: array
-                                    restartPolicy:
-                                      type: string
-                                    runtimeClassName:
-                                      type: string
-                                    schedulerName:
-                                      type: string
-                                    securityContext:
+                                      x-kubernetes-map-type: atomic
+                                    dataSourceRef:
                                       properties:
-                                        fsGroup:
-                                          format: int64
-                                          type: integer
-                                        fsGroupChangePolicy:
+                                        apiGroup:
                                           type: string
-                                        runAsGroup:
-                                          format: int64
-                                          type: integer
-                                        runAsNonRoot:
-                                          type: boolean
-                                        runAsUser:
-                                          format: int64
-                                          type: integer
-                                        seLinuxOptions:
-                                          properties:
-                                            level:
-                                              type: string
-                                            role:
-                                              type: string
-                                            type:
-                                              type: string
-                                            user:
-                                              type: string
+                                        kind:
+                                          type: string
+                                        name:
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resources:
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
                                           type: object
-                                        seccompProfile:
-                                          properties:
-                                            localhostProfile:
-                                              type: string
-                                            type:
-                                              type: string
-                                          required:
-                                            - type
-                                          type: object
-                                        supplementalGroups:
-                                          items:
-                                            format: int64
-                                            type: integer
-                                          type: array
-                                        sysctls:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                              - name
-                                              - value
-                                            type: object
-                                          type: array
-                                        windowsOptions:
-                                          properties:
-                                            gmsaCredentialSpec:
-                                              type: string
-                                            gmsaCredentialSpecName:
-                                              type: string
-                                            hostProcess:
-                                              type: boolean
-                                            runAsUserName:
-                                              type: string
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
                                           type: object
                                       type: object
-                                    serviceAccount:
+                                    selector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    storageClassName:
                                       type: string
-                                    serviceAccountName:
+                                    volumeMode:
                                       type: string
-                                    setHostnameAsFQDN:
-                                      type: boolean
-                                    shareProcessNamespace:
-                                      type: boolean
-                                    subdomain:
+                                    volumeName:
                                       type: string
-                                    terminationGracePeriodSeconds:
-                                      format: int64
-                                      type: integer
-                                    tolerations:
-                                      items:
-                                        properties:
-                                          effect:
-                                            type: string
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          tolerationSeconds:
-                                            format: int64
-                                            type: integer
-                                          value:
-                                            type: string
-                                        type: object
-                                      type: array
-                                    topologySpreadConstraints:
-                                      items:
-                                        properties:
-                                          labelSelector:
-                                            properties:
-                                              matchExpressions:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    operator:
-                                                      type: string
-                                                    values:
-                                                      items:
-                                                        type: string
-                                                      type: array
-                                                  required:
-                                                    - key
-                                                    - operator
-                                                  type: object
-                                                type: array
-                                              matchLabels:
-                                                additionalProperties:
-                                                  type: string
-                                                type: object
-                                            type: object
-                                          maxSkew:
-                                            format: int32
-                                            type: integer
-                                          topologyKey:
-                                            type: string
-                                          whenUnsatisfiable:
-                                            type: string
-                                        required:
-                                          - maxSkew
-                                          - topologyKey
-                                          - whenUnsatisfiable
-                                        type: object
-                                      type: array
-                                      x-kubernetes-list-map-keys:
-                                        - topologyKey
-                                        - whenUnsatisfiable
-                                      x-kubernetes-list-type: map
-                                    volumes:
-                                      items:
-                                        properties:
-                                          awsElasticBlockStore:
-                                            properties:
-                                              fsType:
-                                                type: string
-                                              partition:
-                                                format: int32
-                                                type: integer
-                                              readOnly:
-                                                type: boolean
-                                              volumeID:
-                                                type: string
-                                            required:
-                                              - volumeID
-                                            type: object
-                                          azureDisk:
-                                            properties:
-                                              cachingMode:
-                                                type: string
-                                              diskName:
-                                                type: string
-                                              diskURI:
-                                                type: string
-                                              fsType:
-                                                type: string
-                                              kind:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                            required:
-                                              - diskName
-                                              - diskURI
-                                            type: object
-                                          azureFile:
-                                            properties:
-                                              readOnly:
-                                                type: boolean
-                                              secretName:
-                                                type: string
-                                              shareName:
-                                                type: string
-                                            required:
-                                              - secretName
-                                              - shareName
-                                            type: object
-                                          cephfs:
-                                            properties:
-                                              monitors:
-                                                items:
-                                                  type: string
-                                                type: array
-                                              path:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              secretFile:
-                                                type: string
-                                              secretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                type: object
-                                              user:
-                                                type: string
-                                            required:
-                                              - monitors
-                                            type: object
-                                          cinder:
-                                            properties:
-                                              fsType:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              secretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                type: object
-                                              volumeID:
-                                                type: string
-                                            required:
-                                              - volumeID
-                                            type: object
-                                          configMap:
-                                            properties:
-                                              defaultMode:
-                                                format: int32
-                                                type: integer
-                                              items:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    mode:
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      type: string
-                                                  required:
-                                                    - key
-                                                    - path
-                                                  type: object
-                                                type: array
-                                              name:
-                                                type: string
-                                              optional:
-                                                type: boolean
-                                            type: object
-                                          csi:
-                                            properties:
-                                              driver:
-                                                type: string
-                                              fsType:
-                                                type: string
-                                              nodePublishSecretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                type: object
-                                              readOnly:
-                                                type: boolean
-                                              volumeAttributes:
-                                                additionalProperties:
-                                                  type: string
-                                                type: object
-                                            required:
-                                              - driver
-                                            type: object
-                                          downwardAPI:
-                                            properties:
-                                              defaultMode:
-                                                format: int32
-                                                type: integer
-                                              items:
-                                                items:
-                                                  properties:
-                                                    fieldRef:
-                                                      properties:
-                                                        apiVersion:
-                                                          type: string
-                                                        fieldPath:
-                                                          type: string
-                                                      required:
-                                                        - fieldPath
-                                                      type: object
-                                                    mode:
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      type: string
-                                                    resourceFieldRef:
-                                                      properties:
-                                                        containerName:
-                                                          type: string
-                                                        divisor:
-                                                          anyOf:
-                                                            - type: integer
-                                                            - type: string
-                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                          x-kubernetes-int-or-string: true
-                                                        resource:
-                                                          type: string
-                                                      required:
-                                                        - resource
-                                                      type: object
-                                                  required:
-                                                    - path
-                                                  type: object
-                                                type: array
-                                            type: object
-                                          emptyDir:
-                                            properties:
-                                              medium:
-                                                type: string
-                                              sizeLimit:
-                                                anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                            type: object
-                                          ephemeral:
-                                            properties:
-                                              volumeClaimTemplate:
-                                                properties:
-                                                  metadata:
-                                                    type: object
-                                                  spec:
-                                                    properties:
-                                                      accessModes:
-                                                        items:
-                                                          type: string
-                                                        type: array
-                                                      dataSource:
-                                                        properties:
-                                                          apiGroup:
-                                                            type: string
-                                                          kind:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                        required:
-                                                          - kind
-                                                          - name
-                                                        type: object
-                                                      dataSourceRef:
-                                                        properties:
-                                                          apiGroup:
-                                                            type: string
-                                                          kind:
-                                                            type: string
-                                                          name:
-                                                            type: string
-                                                        required:
-                                                          - kind
-                                                          - name
-                                                        type: object
-                                                      resources:
-                                                        properties:
-                                                          limits:
-                                                            additionalProperties:
-                                                              anyOf:
-                                                                - type: integer
-                                                                - type: string
-                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                              x-kubernetes-int-or-string: true
-                                                            type: object
-                                                          requests:
-                                                            additionalProperties:
-                                                              anyOf:
-                                                                - type: integer
-                                                                - type: string
-                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                              x-kubernetes-int-or-string: true
-                                                            type: object
-                                                        type: object
-                                                      selector:
-                                                        properties:
-                                                          matchExpressions:
-                                                            items:
-                                                              properties:
-                                                                key:
-                                                                  type: string
-                                                                operator:
-                                                                  type: string
-                                                                values:
-                                                                  items:
-                                                                    type: string
-                                                                  type: array
-                                                              required:
-                                                                - key
-                                                                - operator
-                                                              type: object
-                                                            type: array
-                                                          matchLabels:
-                                                            additionalProperties:
-                                                              type: string
-                                                            type: object
-                                                        type: object
-                                                      storageClassName:
-                                                        type: string
-                                                      volumeMode:
-                                                        type: string
-                                                      volumeName:
-                                                        type: string
-                                                    type: object
-                                                required:
-                                                  - spec
-                                                type: object
-                                            type: object
-                                          fc:
-                                            properties:
-                                              fsType:
-                                                type: string
-                                              lun:
-                                                format: int32
-                                                type: integer
-                                              readOnly:
-                                                type: boolean
-                                              targetWWNs:
-                                                items:
-                                                  type: string
-                                                type: array
-                                              wwids:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            type: object
-                                          flexVolume:
-                                            properties:
-                                              driver:
-                                                type: string
-                                              fsType:
-                                                type: string
-                                              options:
-                                                additionalProperties:
-                                                  type: string
-                                                type: object
-                                              readOnly:
-                                                type: boolean
-                                              secretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                type: object
-                                            required:
-                                              - driver
-                                            type: object
-                                          flocker:
-                                            properties:
-                                              datasetName:
-                                                type: string
-                                              datasetUUID:
-                                                type: string
-                                            type: object
-                                          gcePersistentDisk:
-                                            properties:
-                                              fsType:
-                                                type: string
-                                              partition:
-                                                format: int32
-                                                type: integer
-                                              pdName:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                            required:
-                                              - pdName
-                                            type: object
-                                          gitRepo:
-                                            properties:
-                                              directory:
-                                                type: string
-                                              repository:
-                                                type: string
-                                              revision:
-                                                type: string
-                                            required:
-                                              - repository
-                                            type: object
-                                          glusterfs:
-                                            properties:
-                                              endpoints:
-                                                type: string
-                                              path:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                            required:
-                                              - endpoints
-                                              - path
-                                            type: object
-                                          hostPath:
-                                            properties:
-                                              path:
-                                                type: string
-                                              type:
-                                                type: string
-                                            required:
-                                              - path
-                                            type: object
-                                          iscsi:
-                                            properties:
-                                              chapAuthDiscovery:
-                                                type: boolean
-                                              chapAuthSession:
-                                                type: boolean
-                                              fsType:
-                                                type: string
-                                              initiatorName:
-                                                type: string
-                                              iqn:
-                                                type: string
-                                              iscsiInterface:
-                                                type: string
-                                              lun:
-                                                format: int32
-                                                type: integer
-                                              portals:
-                                                items:
-                                                  type: string
-                                                type: array
-                                              readOnly:
-                                                type: boolean
-                                              secretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                type: object
-                                              targetPortal:
-                                                type: string
-                                            required:
-                                              - iqn
-                                              - lun
-                                              - targetPortal
-                                            type: object
-                                          name:
-                                            type: string
-                                          nfs:
-                                            properties:
-                                              path:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              server:
-                                                type: string
-                                            required:
-                                              - path
-                                              - server
-                                            type: object
-                                          persistentVolumeClaim:
-                                            properties:
-                                              claimName:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                            required:
-                                              - claimName
-                                            type: object
-                                          photonPersistentDisk:
-                                            properties:
-                                              fsType:
-                                                type: string
-                                              pdID:
-                                                type: string
-                                            required:
-                                              - pdID
-                                            type: object
-                                          portworxVolume:
-                                            properties:
-                                              fsType:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              volumeID:
-                                                type: string
-                                            required:
-                                              - volumeID
-                                            type: object
-                                          projected:
-                                            properties:
-                                              defaultMode:
-                                                format: int32
-                                                type: integer
-                                              sources:
-                                                items:
-                                                  properties:
-                                                    configMap:
-                                                      properties:
-                                                        items:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              mode:
-                                                                format: int32
-                                                                type: integer
-                                                              path:
-                                                                type: string
-                                                            required:
-                                                              - key
-                                                              - path
-                                                            type: object
-                                                          type: array
-                                                        name:
-                                                          type: string
-                                                        optional:
-                                                          type: boolean
-                                                      type: object
-                                                    downwardAPI:
-                                                      properties:
-                                                        items:
-                                                          items:
-                                                            properties:
-                                                              fieldRef:
-                                                                properties:
-                                                                  apiVersion:
-                                                                    type: string
-                                                                  fieldPath:
-                                                                    type: string
-                                                                required:
-                                                                  - fieldPath
-                                                                type: object
-                                                              mode:
-                                                                format: int32
-                                                                type: integer
-                                                              path:
-                                                                type: string
-                                                              resourceFieldRef:
-                                                                properties:
-                                                                  containerName:
-                                                                    type: string
-                                                                  divisor:
-                                                                    anyOf:
-                                                                      - type: integer
-                                                                      - type: string
-                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                                    x-kubernetes-int-or-string: true
-                                                                  resource:
-                                                                    type: string
-                                                                required:
-                                                                  - resource
-                                                                type: object
-                                                            required:
-                                                              - path
-                                                            type: object
-                                                          type: array
-                                                      type: object
-                                                    secret:
-                                                      properties:
-                                                        items:
-                                                          items:
-                                                            properties:
-                                                              key:
-                                                                type: string
-                                                              mode:
-                                                                format: int32
-                                                                type: integer
-                                                              path:
-                                                                type: string
-                                                            required:
-                                                              - key
-                                                              - path
-                                                            type: object
-                                                          type: array
-                                                        name:
-                                                          type: string
-                                                        optional:
-                                                          type: boolean
-                                                      type: object
-                                                    serviceAccountToken:
-                                                      properties:
-                                                        audience:
-                                                          type: string
-                                                        expirationSeconds:
-                                                          format: int64
-                                                          type: integer
-                                                        path:
-                                                          type: string
-                                                      required:
-                                                        - path
-                                                      type: object
-                                                  type: object
-                                                type: array
-                                            type: object
-                                          quobyte:
-                                            properties:
-                                              group:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              registry:
-                                                type: string
-                                              tenant:
-                                                type: string
-                                              user:
-                                                type: string
-                                              volume:
-                                                type: string
-                                            required:
-                                              - registry
-                                              - volume
-                                            type: object
-                                          rbd:
-                                            properties:
-                                              fsType:
-                                                type: string
-                                              image:
-                                                type: string
-                                              keyring:
-                                                type: string
-                                              monitors:
-                                                items:
-                                                  type: string
-                                                type: array
-                                              pool:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              secretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                type: object
-                                              user:
-                                                type: string
-                                            required:
-                                              - image
-                                              - monitors
-                                            type: object
-                                          scaleIO:
-                                            properties:
-                                              fsType:
-                                                type: string
-                                              gateway:
-                                                type: string
-                                              protectionDomain:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              secretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                type: object
-                                              sslEnabled:
-                                                type: boolean
-                                              storageMode:
-                                                type: string
-                                              storagePool:
-                                                type: string
-                                              system:
-                                                type: string
-                                              volumeName:
-                                                type: string
-                                            required:
-                                              - gateway
-                                              - secretRef
-                                              - system
-                                            type: object
-                                          secret:
-                                            properties:
-                                              defaultMode:
-                                                format: int32
-                                                type: integer
-                                              items:
-                                                items:
-                                                  properties:
-                                                    key:
-                                                      type: string
-                                                    mode:
-                                                      format: int32
-                                                      type: integer
-                                                    path:
-                                                      type: string
-                                                  required:
-                                                    - key
-                                                    - path
-                                                  type: object
-                                                type: array
-                                              optional:
-                                                type: boolean
-                                              secretName:
-                                                type: string
-                                            type: object
-                                          storageos:
-                                            properties:
-                                              fsType:
-                                                type: string
-                                              readOnly:
-                                                type: boolean
-                                              secretRef:
-                                                properties:
-                                                  name:
-                                                    type: string
-                                                type: object
-                                              volumeName:
-                                                type: string
-                                              volumeNamespace:
-                                                type: string
-                                            type: object
-                                          vsphereVolume:
-                                            properties:
-                                              fsType:
-                                                type: string
-                                              storagePolicyID:
-                                                type: string
-                                              storagePolicyName:
-                                                type: string
-                                              volumePath:
-                                                type: string
-                                            required:
-                                              - volumePath
-                                            type: object
-                                        required:
-                                          - name
-                                        type: object
-                                      type: array
-                                  required:
-                                    - containers
                                   type: object
                               type: object
-                            updateStrategy:
-                              properties:
-                                rollingUpdate:
-                                  properties:
-                                    partition:
-                                      format: int32
-                                      type: integer
-                                  type: object
-                                type:
-                                  type: string
-                              type: object
-                            volumeClaimTemplates:
-                              items:
-                                properties:
-                                  apiVersion:
-                                    type: string
-                                  kind:
-                                    type: string
-                                  metadata:
-                                    properties:
-                                      annotations:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      labels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                      name:
-                                        type: string
-                                      namespace:
-                                        type: string
-                                    type: object
-                                  spec:
-                                    properties:
-                                      accessModes:
-                                        items:
-                                          type: string
-                                        type: array
-                                      dataSource:
-                                        properties:
-                                          apiGroup:
-                                            type: string
-                                          kind:
-                                            type: string
-                                          name:
-                                            type: string
-                                        required:
-                                          - kind
-                                          - name
-                                        type: object
-                                      dataSourceRef:
-                                        properties:
-                                          apiGroup:
-                                            type: string
-                                          kind:
-                                            type: string
-                                          name:
-                                            type: string
-                                        required:
-                                          - kind
-                                          - name
-                                        type: object
-                                      resources:
-                                        properties:
-                                          limits:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                          requests:
-                                            additionalProperties:
-                                              anyOf:
-                                                - type: integer
-                                                - type: string
-                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                              x-kubernetes-int-or-string: true
-                                            type: object
-                                        type: object
-                                      selector:
-                                        properties:
-                                          matchExpressions:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                operator:
-                                                  type: string
-                                                values:
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            type: object
-                                        type: object
-                                      storageClassName:
-                                        type: string
-                                      volumeMode:
-                                        type: string
-                                      volumeName:
-                                        type: string
-                                    type: object
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                  type: object
-                persistence:
-                  default:
-                    storage: 10Gi
-                  description: The desired persistent storage configuration for each Pod in the cluster.
-                  properties:
-                    storage:
+                            type: array
+                        type: object
+                    type: object
+                type: object
+              persistence:
+                default:
+                  storage: 10Gi
+                description: The desired persistent storage configuration for each
+                  Pod in the cluster.
+                properties:
+                  storage:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 10Gi
+                    description: The requested size of the persistent volume attached
+                      to each Pod in the RabbitmqCluster. The format of this field
+                      matches that defined by kubernetes/apimachinery. See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity
+                      for more info on the format of this field.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  storageClassName:
+                    description: The name of the StorageClass to claim a PersistentVolume
+                      from.
+                    type: string
+                type: object
+              rabbitmq:
+                description: Configuration options for RabbitMQ Pods created in the
+                  cluster.
+                properties:
+                  additionalConfig:
+                    description: Modify to add to the rabbitmq.conf file in addition
+                      to default configurations set by the operator. Modifying this
+                      property on an existing RabbitmqCluster will trigger a StatefulSet
+                      rolling restart and will cause rabbitmq downtime. For more information
+                      on this config, see https://www.rabbitmq.com/configure.html#config-file
+                    maxLength: 2000
+                    type: string
+                  additionalPlugins:
+                    description: 'List of plugins to enable in addition to essential
+                      plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.'
+                    items:
+                      description: A Plugin to enable on the RabbitmqCluster.
+                      maxLength: 100
+                      pattern: ^\w+$
+                      type: string
+                    maxItems: 100
+                    type: array
+                  advancedConfig:
+                    description: Specify any rabbitmq advanced.config configurations
+                      to apply to the cluster. For more information on advanced config,
+                      see https://www.rabbitmq.com/configure.html#advanced-config-file
+                    maxLength: 100000
+                    type: string
+                  envConfig:
+                    description: Modify to add to the rabbitmq-env.conf file. Modifying
+                      this property on an existing RabbitmqCluster will trigger a
+                      StatefulSet rolling restart and will cause rabbitmq downtime.
+                      For more information on env config, see https://www.rabbitmq.com/man/rabbitmq-env.conf.5.html
+                    maxLength: 100000
+                    type: string
+                type: object
+              replicas:
+                default: 1
+                description: Replicas is the number of nodes in the RabbitMQ cluster.
+                  Each node is deployed as a Replica in a StatefulSet. Only 1, 3,
+                  5 replicas clusters are tested. This value should be an odd number
+                  to ensure the resultant cluster can establish exactly one quorum
+                  of nodes in the event of a fragmenting network partition.
+                format: int32
+                minimum: 0
+                type: integer
+              resources:
+                default:
+                  limits:
+                    cpu: 2000m
+                    memory: 2Gi
+                  requests:
+                    cpu: 1000m
+                    memory: 2Gi
+                description: The desired compute resource requirements of Pods in
+                  the cluster.
+                properties:
+                  limits:
+                    additionalProperties:
                       anyOf:
-                        - type: integer
-                        - type: string
-                      default: 10Gi
-                      description: The requested size of the persistent volume attached to each Pod in the RabbitmqCluster. The format of this field matches that defined by kubernetes/apimachinery. See https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity for more info on the format of this field.
+                      - type: integer
+                      - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    storageClassName:
-                      description: The name of the StorageClass to claim a PersistentVolume from.
-                      type: string
-                  type: object
-                rabbitmq:
-                  description: Configuration options for RabbitMQ Pods created in the cluster.
-                  properties:
-                    additionalConfig:
-                      description: Modify to add to the rabbitmq.conf file in addition to default configurations set by the operator. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime. For more information on this config, see https://www.rabbitmq.com/configure.html#config-file
-                      maxLength: 2000
-                      type: string
-                    additionalPlugins:
-                      description: 'List of plugins to enable in addition to essential plugins: rabbitmq_management, rabbitmq_prometheus, and rabbitmq_peer_discovery_k8s.'
-                      items:
-                        description: A Plugin to enable on the RabbitmqCluster.
-                        maxLength: 100
-                        pattern: ^\w+$
-                        type: string
-                      maxItems: 100
-                      type: array
-                    advancedConfig:
-                      description: Specify any rabbitmq advanced.config configurations to apply to the cluster. For more information on advanced config, see https://www.rabbitmq.com/configure.html#advanced-config-file
-                      maxLength: 100000
-                      type: string
-                    envConfig:
-                      description: Modify to add to the rabbitmq-env.conf file. Modifying this property on an existing RabbitmqCluster will trigger a StatefulSet rolling restart and will cause rabbitmq downtime. For more information on env config, see https://www.rabbitmq.com/man/rabbitmq-env.conf.5.html
-                      maxLength: 100000
-                      type: string
-                  type: object
-                replicas:
-                  default: 1
-                  description: Replicas is the number of nodes in the RabbitMQ cluster. Each node is deployed as a Replica in a StatefulSet. Only 1, 3, 5 replicas clusters are tested. This value should be an odd number to ensure the resultant cluster can establish exactly one quorum of nodes in the event of a fragmenting network partition.
-                  format: int32
-                  minimum: 0
-                  type: integer
-                resources:
-                  default:
-                    limits:
-                      cpu: 2000m
-                      memory: 2Gi
-                    requests:
-                      cpu: 1000m
-                      memory: 2Gi
-                  description: The desired compute resource requirements of Pods in the cluster.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                      type: object
-                  type: object
-                secretBackend:
-                  description: Secret backend configuration for the RabbitmqCluster. Enables to fetch default user credentials and certificates from K8s external secret stores.
-                  properties:
-                    vault:
-                      description: VaultSpec will add Vault annotations (see https://www.vaultproject.io/docs/platform/k8s/injector/annotations) to RabbitMQ Pods. It requires a Vault Agent Sidecar Injector (https://www.vaultproject.io/docs/platform/k8s/injector) to be installed in the K8s cluster. The injector is a K8s Mutation Webhook Controller that alters RabbitMQ Pod specifications (based on the added Vault annotations) to include Vault Agent containers that render Vault secrets to the volume.
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: Vault annotations that override the Vault annotations set by the cluster-operator. For a list of valid Vault annotations, see https://www.vaultproject.io/docs/platform/k8s/injector/annotations
-                          type: object
-                        defaultUserPath:
-                          description: Path in Vault to access a KV (Key-Value) secret with the fields username and password for the default user. For example "secret/data/rabbitmq/config".
-                          type: string
-                        defaultUserUpdaterImage:
-                          description: Sidecar container that updates the default user's password in RabbitMQ when it changes in Vault. Additionally, it updates /var/lib/rabbitmq/.rabbitmqadmin.conf (used by rabbitmqadmin CLI). Set to empty string to disable the sidecar container.
-                          type: string
-                        role:
-                          description: Role in Vault. If vault.defaultUserPath is set, this role must have capability to read the pre-created default user credential in Vault. If vault.tls is set, this role must have capability to create and update certificates in the Vault PKI engine for the domains "<namespace>" and "<namespace>.svc".
-                          type: string
-                        tls:
-                          properties:
-                            altNames:
-                              description: 'Specifies the requested Subject Alternative Names (SANs), in a comma-delimited list. These will be appended to the SANs added by the cluster-operator. The cluster-operator will add SANs: "<RabbitmqCluster name>-server-<index>.<RabbitmqCluster name>-nodes.<namespace>" for each pod, e.g. "myrabbit-server-0.myrabbit-nodes.default".'
-                              type: string
-                            commonName:
-                              description: Specifies the requested certificate Common Name (CN). Defaults to <serviceName>.<namespace>.svc if not provided.
-                              type: string
-                            ipSans:
-                              description: Specifies the requested IP Subject Alternative Names, in a comma-delimited list.
-                              type: string
-                            pkiIssuerPath:
-                              description: Path in Vault PKI engine. For example "pki/issue/hashicorp-com". required
-                              type: string
-                          type: object
-                      type: object
-                  type: object
-                service:
-                  default:
-                    type: ClusterIP
-                  description: The desired state of the Kubernetes Service to create for the cluster.
-                  properties:
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations to add to the Service.
-                      type: object
-                    type:
-                      default: ClusterIP
-                      description: 'Type of Service to create for the cluster. Must be one of: ClusterIP, LoadBalancer, NodePort. For more info see https://pkg.go.dev/k8s.io/api/core/v1#ServiceType'
-                      enum:
-                        - ClusterIP
-                        - LoadBalancer
-                        - NodePort
-                      type: string
-                  type: object
-                skipPostDeploySteps:
-                  description: If unset, or set to false, the cluster will run `rabbitmq-queues rebalance all` whenever the cluster is updated. Set to true to prevent the operator rebalancing queue leaders after a cluster update. Has no effect if the cluster only consists of one node. For more information, see https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
-                  type: boolean
-                terminationGracePeriodSeconds:
-                  default: 604800
-                  description: 'TerminationGracePeriodSeconds is the timeout that each rabbitmqcluster pod will have to terminate gracefully. It defaults to 604800 seconds ( a week long) to ensure that the container preStop lifecycle hook can finish running. For more information, see: https://github.com/rabbitmq/cluster-operator/blob/main/docs/design/20200520-graceful-pod-termination.md'
-                  format: int64
-                  minimum: 0
-                  type: integer
-                tls:
-                  description: TLS-related configuration for the RabbitMQ cluster.
-                  properties:
-                    caSecretName:
-                      description: Name of a Secret in the same Namespace as the RabbitmqCluster, containing the Certificate Authority's public certificate for TLS. The Secret must store this as ca.crt. This Secret can be created by running `kubectl create secret generic ca-secret --from-file=ca.crt=path/to/ca.cert` Used for mTLS, and TLS for rabbitmq_web_stomp and rabbitmq_web_mqtt.
-                      type: string
-                    disableNonTLSListeners:
-                      description: 'When set to true, the RabbitmqCluster disables non-TLS listeners for RabbitMQ, management plugin and for any enabled plugins in the following list: stomp, mqtt, web_stomp, web_mqtt. Only TLS-enabled clients will be able to connect.'
-                      type: boolean
-                    secretName:
-                      description: Name of a Secret in the same Namespace as the RabbitmqCluster, containing the server's private key & public certificate for TLS. The Secret must store these as tls.key and tls.crt, respectively. This Secret can be created by running `kubectl create secret tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key`
-                      type: string
-                  type: object
-                tolerations:
-                  description: Tolerations is the list of Toleration resources attached to each Pod in the RabbitmqCluster.
-                  items:
-                    description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
-                        type: string
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                     type: object
-                  type: array
-              type: object
-            status:
-              description: Status presents the observed state of RabbitmqCluster
-              properties:
-                binding:
-                  description: 'Binding exposes a secret containing the binding information for this RabbitmqCluster. It implements the service binding Provisioned Service duck type. See: https://github.com/servicebinding/spec#provisioned-service'
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              secretBackend:
+                description: Secret backend configuration for the RabbitmqCluster.
+                  Enables to fetch default user credentials and certificates from
+                  K8s external secret stores.
+                properties:
+                  vault:
+                    description: VaultSpec will add Vault annotations (see https://www.vaultproject.io/docs/platform/k8s/injector/annotations)
+                      to RabbitMQ Pods. It requires a Vault Agent Sidecar Injector
+                      (https://www.vaultproject.io/docs/platform/k8s/injector) to
+                      be installed in the K8s cluster. The injector is a K8s Mutation
+                      Webhook Controller that alters RabbitMQ Pod specifications (based
+                      on the added Vault annotations) to include Vault Agent containers
+                      that render Vault secrets to the volume.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Vault annotations that override the Vault annotations
+                          set by the cluster-operator. For a list of valid Vault annotations,
+                          see https://www.vaultproject.io/docs/platform/k8s/injector/annotations
+                        type: object
+                      defaultUserPath:
+                        description: Path in Vault to access a KV (Key-Value) secret
+                          with the fields username and password for the default user.
+                          For example "secret/data/rabbitmq/config".
+                        type: string
+                      defaultUserUpdaterImage:
+                        description: Sidecar container that updates the default user's
+                          password in RabbitMQ when it changes in Vault. Additionally,
+                          it updates /var/lib/rabbitmq/.rabbitmqadmin.conf (used by
+                          rabbitmqadmin CLI). Set to empty string to disable the sidecar
+                          container.
+                        type: string
+                      role:
+                        description: Role in Vault. If vault.defaultUserPath is set,
+                          this role must have capability to read the pre-created default
+                          user credential in Vault. If vault.tls is set, this role
+                          must have capability to create and update certificates in
+                          the Vault PKI engine for the domains "<namespace>" and "<namespace>.svc".
+                        type: string
+                      tls:
+                        properties:
+                          altNames:
+                            description: 'Specifies the requested Subject Alternative
+                              Names (SANs), in a comma-delimited list. These will
+                              be appended to the SANs added by the cluster-operator.
+                              The cluster-operator will add SANs: "<RabbitmqCluster
+                              name>-server-<index>.<RabbitmqCluster name>-nodes.<namespace>"
+                              for each pod, e.g. "myrabbit-server-0.myrabbit-nodes.default".'
+                            type: string
+                          commonName:
+                            description: Specifies the requested certificate Common
+                              Name (CN). Defaults to <serviceName>.<namespace>.svc
+                              if not provided.
+                            type: string
+                          ipSans:
+                            description: Specifies the requested IP Subject Alternative
+                              Names, in a comma-delimited list.
+                            type: string
+                          pkiIssuerPath:
+                            description: Path in Vault PKI engine. For example "pki/issue/hashicorp-com".
+                              required
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              service:
+                default:
+                  type: ClusterIP
+                description: The desired state of the Kubernetes Service to create
+                  for the cluster.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations to add to the Service.
+                    type: object
+                  type:
+                    default: ClusterIP
+                    description: 'Type of Service to create for the cluster. Must
+                      be one of: ClusterIP, LoadBalancer, NodePort. For more info
+                      see https://pkg.go.dev/k8s.io/api/core/v1#ServiceType'
+                    enum:
+                    - ClusterIP
+                    - LoadBalancer
+                    - NodePort
+                    type: string
+                type: object
+              skipPostDeploySteps:
+                description: If unset, or set to false, the cluster will run `rabbitmq-queues
+                  rebalance all` whenever the cluster is updated. Set to true to prevent
+                  the operator rebalancing queue leaders after a cluster update. Has
+                  no effect if the cluster only consists of one node. For more information,
+                  see https://www.rabbitmq.com/rabbitmq-queues.8.html#rebalance
+                type: boolean
+              terminationGracePeriodSeconds:
+                default: 604800
+                description: 'TerminationGracePeriodSeconds is the timeout that each
+                  rabbitmqcluster pod will have to terminate gracefully. It defaults
+                  to 604800 seconds ( a week long) to ensure that the container preStop
+                  lifecycle hook can finish running. For more information, see: https://github.com/rabbitmq/cluster-operator/blob/main/docs/design/20200520-graceful-pod-termination.md'
+                format: int64
+                minimum: 0
+                type: integer
+              tls:
+                description: TLS-related configuration for the RabbitMQ cluster.
+                properties:
+                  caSecretName:
+                    description: Name of a Secret in the same Namespace as the RabbitmqCluster,
+                      containing the Certificate Authority's public certificate for
+                      TLS. The Secret must store this as ca.crt. This Secret can be
+                      created by running `kubectl create secret generic ca-secret
+                      --from-file=ca.crt=path/to/ca.cert` Used for mTLS, and TLS for
+                      rabbitmq_web_stomp and rabbitmq_web_mqtt.
+                    type: string
+                  disableNonTLSListeners:
+                    description: 'When set to true, the RabbitmqCluster disables non-TLS
+                      listeners for RabbitMQ, management plugin and for any enabled
+                      plugins in the following list: stomp, mqtt, web_stomp, web_mqtt.
+                      Only TLS-enabled clients will be able to connect.'
+                    type: boolean
+                  secretName:
+                    description: Name of a Secret in the same Namespace as the RabbitmqCluster,
+                      containing the server's private key & public certificate for
+                      TLS. The Secret must store these as tls.key and tls.crt, respectively.
+                      This Secret can be created by running `kubectl create secret
+                      tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key`
+                    type: string
+                type: object
+              tolerations:
+                description: Tolerations is the list of Toleration resources attached
+                  to each Pod in the RabbitmqCluster.
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
                   properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
                       type: string
                   type: object
-                conditions:
-                  description: Set of Conditions describing the current state of the RabbitmqCluster
-                  items:
+                type: array
+            type: object
+          status:
+            description: Status presents the observed state of RabbitmqCluster
+            properties:
+              binding:
+                description: 'Binding exposes a secret containing the binding information
+                  for this RabbitmqCluster. It implements the service binding Provisioned
+                  Service duck type. See: https://github.com/servicebinding/spec#provisioned-service'
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: Set of Conditions describing the current state of the
+                  RabbitmqCluster
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition type changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of RabbitmqCluster status
+                        addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              defaultUser:
+                description: Identifying information on internal resources
+                properties:
+                  secretReference:
+                    description: Reference to the Kubernetes Secret containing the
+                      credentials of the default user.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition type changed.
-                        format: date-time
+                      keys:
+                        additionalProperties:
+                          type: string
+                        description: Key-value pairs in the Secret corresponding to
+                          `username`, `password`, `host`, and `port`
+                        type: object
+                      name:
+                        description: Name of the Secret containing the default user
+                          credentials
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of RabbitmqCluster status addressed by the condition.
+                      namespace:
+                        description: Namespace of the Secret containing the default
+                          user credentials
                         type: string
                     required:
-                      - status
-                      - type
+                    - keys
+                    - name
+                    - namespace
                     type: object
-                  type: array
-                defaultUser:
-                  description: Identifying information on internal resources
-                  properties:
-                    secretReference:
-                      description: Reference to the Kubernetes Secret containing the credentials of the default user.
-                      properties:
-                        keys:
-                          additionalProperties:
-                            type: string
-                          description: Key-value pairs in the Secret corresponding to `username`, `password`, `host`, and `port`
-                          type: object
-                        name:
-                          description: Name of the Secret containing the default user credentials
-                          type: string
-                        namespace:
-                          description: Namespace of the Secret containing the default user credentials
-                          type: string
-                      required:
-                        - keys
-                        - name
-                        - namespace
-                      type: object
-                    serviceReference:
-                      description: Reference to the Kubernetes Service serving the cluster.
-                      properties:
-                        name:
-                          description: Name of the Service serving the cluster
-                          type: string
-                        namespace:
-                          description: Namespace of the Service serving the cluster
-                          type: string
-                      required:
-                        - name
-                        - namespace
-                      type: object
-                  type: object
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation observed for this RabbitmqCluster. It corresponds to the RabbitmqCluster's generation, which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-              required:
-                - conditions
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                  serviceReference:
+                    description: Reference to the Kubernetes Service serving the cluster.
+                    properties:
+                      name:
+                        description: Name of the Service serving the cluster
+                        type: string
+                      namespace:
+                        description: Namespace of the Service serving the cluster
+                        type: string
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                type: object
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this RabbitmqCluster. It corresponds to the RabbitmqCluster's
+                  generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bitnami/rabbitmq-cluster-operator/crds/crds-messaging-topology-operator.yaml
+++ b/bitnami/rabbitmq-cluster-operator/crds/crds-messaging-topology-operator.yaml
@@ -3,865 +3,837 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: bindings.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: Binding
     listKind: BindingList
     plural: bindings
     singular: binding
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Binding is the Schema for the bindings API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: BindingSpec defines the desired state of Binding
-              properties:
-                arguments:
-                  description: Cannot be updated
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                destination:
-                  description: Cannot be updated
-                  type: string
-                destinationType:
-                  description: Cannot be updated
-                  enum:
-                    - exchange
-                    - queue
-                  type: string
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that the binding will
-                    be created in. Required property.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                routingKey:
-                  description: Cannot be updated
-                  type: string
-                source:
-                  description: Cannot be updated
-                  type: string
-                vhost:
-                  default: /
-                  description: Default to vhost '/'; cannot be updated
-                  type: string
-              required:
-                - rabbitmqClusterReference
-              type: object
-            status:
-              description: BindingStatus defines the observed state of Binding
-              properties:
-                conditions:
-                  items:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Binding is the Schema for the bindings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BindingSpec defines the desired state of Binding
+            properties:
+              arguments:
+                description: Cannot be updated
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              destination:
+                description: Cannot be updated
+                type: string
+              destinationType:
+                description: Cannot be updated
+                enum:
+                - exchange
+                - queue
+                type: string
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that the binding will
+                  be created in. Required property.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this Binding. It corresponds to the Binding's generation,
-                    which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              routingKey:
+                description: Cannot be updated
+                type: string
+              source:
+                description: Cannot be updated
+                type: string
+              vhost:
+                default: /
+                description: Default to vhost '/'; cannot be updated
+                type: string
+            required:
+            - rabbitmqClusterReference
+            type: object
+          status:
+            description: BindingStatus defines the observed state of Binding
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Binding. It corresponds to the Binding's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: exchanges.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: Exchange
     listKind: ExchangeList
     plural: exchanges
     singular: exchange
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Exchange is the Schema for the exchanges API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: ExchangeSpec defines the desired state of Exchange
-              properties:
-                arguments:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                autoDelete:
-                  description: Cannot be updated
-                  type: boolean
-                durable:
-                  description: Cannot be updated
-                  type: boolean
-                name:
-                  description: Required property; cannot be updated
-                  type: string
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that the exchange will
-                    be created in. Required property.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                type:
-                  default: direct
-                  description: Cannot be updated
-                  type: string
-                vhost:
-                  default: /
-                  description: Default to vhost '/'; cannot be updated
-                  type: string
-              required:
-                - name
-                - rabbitmqClusterReference
-              type: object
-            status:
-              description: ExchangeStatus defines the observed state of Exchange
-              properties:
-                conditions:
-                  items:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Exchange is the Schema for the exchanges API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ExchangeSpec defines the desired state of Exchange
+            properties:
+              arguments:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              autoDelete:
+                description: Cannot be updated
+                type: boolean
+              durable:
+                description: Cannot be updated
+                type: boolean
+              name:
+                description: Required property; cannot be updated
+                type: string
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that the exchange will
+                  be created in. Required property.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this Exchange. It corresponds to the Exchange's generation,
-                    which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              type:
+                default: direct
+                description: Cannot be updated
+                type: string
+              vhost:
+                default: /
+                description: Default to vhost '/'; cannot be updated
+                type: string
+            required:
+            - name
+            - rabbitmqClusterReference
+            type: object
+          status:
+            description: ExchangeStatus defines the observed state of Exchange
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Exchange. It corresponds to the Exchange's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: federations.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: Federation
     listKind: FederationList
     plural: federations
     singular: federation
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Federation is the Schema for the federations API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: 'FederationSpec defines the desired state of Federation For
-                how to configure federation upstreams, see: https://www.rabbitmq.com/federation-reference.html.'
-              properties:
-                ackMode:
-                  enum:
-                    - on-confirm
-                    - on-publish
-                    - no-ack
-                  type: string
-                exchange:
-                  type: string
-                expires:
-                  type: integer
-                maxHops:
-                  type: integer
-                messageTTL:
-                  type: integer
-                name:
-                  description: Required property; cannot be updated
-                  type: string
-                prefetch-count:
-                  type: integer
-                queue:
-                  type: string
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that this federation
-                    upstream will be created in. Required property.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                reconnectDelay:
-                  type: integer
-                trustUserId:
-                  type: boolean
-                uriSecret:
-                  description: Secret contains the AMQP URI(s) for the upstream. The
-                    Secret must contain the key `uri` or operator will error. `uri`
-                    should be one or multiple uris separated by ','. Required property.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                vhost:
-                  default: /
-                  description: Default to vhost '/'; cannot be updated
-                  type: string
-              required:
-                - name
-                - rabbitmqClusterReference
-                - uriSecret
-              type: object
-            status:
-              description: FederationStatus defines the observed state of Federation
-              properties:
-                conditions:
-                  items:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Federation is the Schema for the federations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'FederationSpec defines the desired state of Federation For
+              how to configure federation upstreams, see: https://www.rabbitmq.com/federation-reference.html.'
+            properties:
+              ackMode:
+                enum:
+                - on-confirm
+                - on-publish
+                - no-ack
+                type: string
+              exchange:
+                type: string
+              expires:
+                type: integer
+              maxHops:
+                type: integer
+              messageTTL:
+                type: integer
+              name:
+                description: Required property; cannot be updated
+                type: string
+              prefetch-count:
+                type: integer
+              queue:
+                type: string
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that this federation
+                  upstream will be created in. Required property.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this Federation. It corresponds to the Federation's
-                    generation, which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              reconnectDelay:
+                type: integer
+              trustUserId:
+                type: boolean
+              uriSecret:
+                description: Secret contains the AMQP URI(s) for the upstream. The
+                  Secret must contain the key `uri` or operator will error. `uri`
+                  should be one or multiple uris separated by ','. Required property.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              vhost:
+                default: /
+                description: Default to vhost '/'; cannot be updated
+                type: string
+            required:
+            - name
+            - rabbitmqClusterReference
+            - uriSecret
+            type: object
+          status:
+            description: FederationStatus defines the observed state of Federation
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Federation. It corresponds to the Federation's
+                  generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: permissions.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: Permission
     listKind: PermissionList
     plural: permissions
     singular: permission
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Permission is the Schema for the permissions API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: PermissionSpec defines the desired state of Permission
-              properties:
-                permissions:
-                  description: 'Permissions to grant to the user in the specific vhost;
-                    required property. See RabbitMQ doc for more information: https://www.rabbitmq.com/access-control.html#user-management'
-                  properties:
-                    configure:
-                      type: string
-                    read:
-                      type: string
-                    write:
-                      type: string
-                  type: object
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that both the provided
-                    user and vhost are. Required property.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                user:
-                  description: Name of an existing user; must provide user or userReference,
-                    else create/update will fail; cannot be updated
-                  type: string
-                userReference:
-                  description: Reference to an existing user.rabbitmq.com object; must
-                    provide user or userReference, else create/update will fail; cannot
-                    be updated
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                vhost:
-                  description: Name of an existing vhost; required property; cannot
-                    be updated
-                  type: string
-              required:
-                - permissions
-                - rabbitmqClusterReference
-                - vhost
-              type: object
-            status:
-              description: PermissionStatus defines the observed state of Permission
-              properties:
-                conditions:
-                  items:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Permission is the Schema for the permissions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PermissionSpec defines the desired state of Permission
+            properties:
+              permissions:
+                description: 'Permissions to grant to the user in the specific vhost;
+                  required property. See RabbitMQ doc for more information: https://www.rabbitmq.com/access-control.html#user-management'
+                properties:
+                  configure:
+                    type: string
+                  read:
+                    type: string
+                  write:
+                    type: string
+                type: object
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that both the provided
+                  user and vhost are. Required property.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this Permission. It corresponds to the Permission's
-                    generation, which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              user:
+                description: Name of an existing user; must provide user or userReference,
+                  else create/update will fail; cannot be updated
+                type: string
+              userReference:
+                description: Reference to an existing user.rabbitmq.com object; must
+                  provide user or userReference, else create/update will fail; cannot
+                  be updated
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              vhost:
+                description: Name of an existing vhost; required property; cannot
+                  be updated
+                type: string
+            required:
+            - permissions
+            - rabbitmqClusterReference
+            - vhost
+            type: object
+          status:
+            description: PermissionStatus defines the observed state of Permission
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Permission. It corresponds to the Permission's
+                  generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: policies.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: Policy
     listKind: PolicyList
     plural: policies
     singular: policy
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Policy is the Schema for the policies API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: PolicySpec defines the desired state of Policy https://www.rabbitmq.com/parameters.html#policies
-              properties:
-                applyTo:
-                  default: all
-                  description: 'What this policy applies to: ''queues'', ''exchanges'',
-                    or ''all''. Default to ''all''.'
-                  enum:
-                    - queues
-                    - exchanges
-                    - all
-                  type: string
-                definition:
-                  description: Policy definition. Required property.
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                name:
-                  description: Required property; cannot be updated
-                  type: string
-                pattern:
-                  description: Regular expression pattern used to match queues and exchanges,
-                    e.g. "^amq.". Required property.
-                  type: string
-                priority:
-                  default: 0
-                  description: Default to '0'. In the event that more than one policy
-                    can match a given exchange or queue, the policy with the greatest
-                    priority applies.
-                  type: integer
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that the exchange will
-                    be created in. Required property.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                vhost:
-                  default: /
-                  description: Default to vhost '/'; cannot be updated
-                  type: string
-              required:
-                - definition
-                - name
-                - pattern
-                - rabbitmqClusterReference
-              type: object
-            status:
-              description: PolicyStatus defines the observed state of Policy
-              properties:
-                conditions:
-                  items:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Policy is the Schema for the policies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicySpec defines the desired state of Policy https://www.rabbitmq.com/parameters.html#policies
+            properties:
+              applyTo:
+                default: all
+                description: 'What this policy applies to: ''queues'', ''exchanges'',
+                  or ''all''. Default to ''all''.'
+                enum:
+                - queues
+                - exchanges
+                - all
+                type: string
+              definition:
+                description: Policy definition. Required property.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              name:
+                description: Required property; cannot be updated
+                type: string
+              pattern:
+                description: Regular expression pattern used to match queues and exchanges,
+                  e.g. "^amq.". Required property.
+                type: string
+              priority:
+                default: 0
+                description: Default to '0'. In the event that more than one policy
+                  can match a given exchange or queue, the policy with the greatest
+                  priority applies.
+                type: integer
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that the exchange will
+                  be created in. Required property.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this Policy. It corresponds to the Policy's generation,
-                    which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              vhost:
+                default: /
+                description: Default to vhost '/'; cannot be updated
+                type: string
+            required:
+            - definition
+            - name
+            - pattern
+            - rabbitmqClusterReference
+            type: object
+          status:
+            description: PolicyStatus defines the observed state of Policy
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Policy. It corresponds to the Policy's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: queues.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: Queue
     listKind: QueueList
     plural: queues
     singular: queue
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Queue is the Schema for the queues API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: QueueSpec defines the desired state of Queue
-              properties:
-                arguments:
-                  description: 'Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit:
-                    10000. Configuring queues through arguments is not recommended because
-                    they cannot be updated once set; we recommend configuring queues
-                    through policies instead.'
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                autoDelete:
-                  description: when set to true, queues that have had at least one consumer
-                    before are deleted after the last consumer unsubscribes.
-                  type: boolean
-                durable:
-                  description: When set to false queues does not survive server restart.
-                  type: boolean
-                name:
-                  description: Name of the queue; required property.
-                  type: string
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that the queue will
-                    be created in. Required property.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                type:
-                  type: string
-                vhost:
-                  default: /
-                  description: Default to vhost '/'
-                  type: string
-              required:
-                - name
-                - rabbitmqClusterReference
-              type: object
-            status:
-              description: QueueStatus defines the observed state of Queue
-              properties:
-                conditions:
-                  items:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Queue is the Schema for the queues API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: QueueSpec defines the desired state of Queue
+            properties:
+              arguments:
+                description: 'Queue arguments in the format of KEY: VALUE. e.g. x-delivery-limit:
+                  10000. Configuring queues through arguments is not recommended because
+                  they cannot be updated once set; we recommend configuring queues
+                  through policies instead.'
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              autoDelete:
+                description: when set to true, queues that have had at least one consumer
+                  before are deleted after the last consumer unsubscribes.
+                type: boolean
+              durable:
+                description: When set to false queues does not survive server restart.
+                type: boolean
+              name:
+                description: Name of the queue; required property.
+                type: string
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that the queue will
+                  be created in. Required property.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this Queue. It corresponds to the Queue's generation,
-                    which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              type:
+                type: string
+              vhost:
+                default: /
+                description: Default to vhost '/'
+                type: string
+            required:
+            - name
+            - rabbitmqClusterReference
+            type: object
+          status:
+            description: QueueStatus defines the observed state of Queue
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Queue. It corresponds to the Queue's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: schemareplications.rabbitmq.com
 spec:
@@ -873,721 +845,858 @@ spec:
     singular: schemareplication
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: 'SchemaReplication is the Schema for the schemareplications API
-            This feature requires Tanzu RabbitMQ with schema replication plugin. For
-            more information, see: https://tanzu.vmware.com/rabbitmq and https://www.rabbitmq.com/definitions-standby.html.'
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: SchemaReplicationSpec defines the desired state of SchemaReplication
-              properties:
-                endpoints:
-                  description: endpoints should be one or multiple endpoints separated
-                    by ','. Must provide either spec.endpoints or endpoints in spec.upstreamSecret.
-                    When endpoints are provided in both spec.endpoints and spec.upstreamSecret,
-                    spec.endpoints takes precedence.
-                  type: string
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that schema replication
-                    would be set for. Must be an existing cluster.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                upstreamSecret:
-                  description: Defines a Secret which contains credentials to be used
-                    for schema replication. The Secret must contain the keys `username`
-                    and `password` in its Data field, or operator will error.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-              required:
-                - rabbitmqClusterReference
-              type: object
-            status:
-              description: SchemaReplicationStatus defines the observed state of SchemaReplication
-              properties:
-                conditions:
-                  items:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: 'SchemaReplication is the Schema for the schemareplications API
+          This feature requires Tanzu RabbitMQ with schema replication plugin. For
+          more information, see: https://tanzu.vmware.com/rabbitmq and https://www.rabbitmq.com/definitions-standby.html.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SchemaReplicationSpec defines the desired state of SchemaReplication
+            properties:
+              endpoints:
+                description: endpoints should be one or multiple endpoints separated
+                  by ','. Must provide either spec.endpoints or endpoints in spec.upstreamSecret.
+                  When endpoints are provided in both spec.endpoints and spec.upstreamSecret,
+                  spec.endpoints takes precedence.
+                type: string
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that schema replication
+                  would be set for. Must be an existing cluster.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this Queue. It corresponds to the Queue's generation,
-                    which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              secretBackend:
+                description: Set to fetch user credentials from K8s external secret
+                  stores to be used for schema replication.
+                properties:
+                  vault:
+                    properties:
+                      secretPath:
+                        description: Path in Vault to access a KV (Key-Value) secret
+                          with the fields username and password to be used for replication.
+                          For example "secret/data/rabbitmq/config". Optional; if
+                          not provided, username and password will come from upstreamSecret
+                          instead. Have to set either secretBackend.vault.secretPath
+                          or upstreamSecret, but not both.
+                        type: string
+                    type: object
+                type: object
+              upstreamSecret:
+                description: Defines a Secret which contains credentials to be used
+                  for schema replication. The Secret must contain the keys `username`
+                  and `password` in its Data field, or operator will error. Have to
+                  set either secretBackend.vault.secretPath or spec.upstreamSecret,
+                  but not both.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - rabbitmqClusterReference
+            type: object
+          status:
+            description: SchemaReplicationStatus defines the observed state of SchemaReplication
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Queue. It corresponds to the Queue's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: shovels.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: Shovel
     listKind: ShovelList
     plural: shovels
     singular: shovel
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Shovel is the Schema for the shovels API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: 'ShovelSpec defines the desired state of Shovel For how to
-                configure Shovel, see: https://www.rabbitmq.com/shovel.html.'
-              properties:
-                ackMode:
-                  enum:
-                    - on-confirm
-                    - on-publish
-                    - no-ack
-                  type: string
-                addForwardHeaders:
-                  type: boolean
-                deleteAfter:
-                  type: string
-                destAddForwardHeaders:
-                  type: boolean
-                destAddTimestampHeader:
-                  type: boolean
-                destAddress:
-                  type: string
-                destApplicationProperties:
-                  type: string
-                destExchange:
-                  type: string
-                destExchangeKey:
-                  type: string
-                destProperties:
-                  type: string
-                destProtocol:
-                  type: string
-                destPublishProperties:
-                  type: string
-                destQueue:
-                  type: string
-                name:
-                  description: Required property; cannot be updated
-                  type: string
-                prefetchCount:
-                  type: integer
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that this Shovel will
-                    be created in. Required property.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                reconnectDelay:
-                  type: integer
-                srcAddress:
-                  type: string
-                srcDeleteAfter:
-                  type: string
-                srcExchange:
-                  type: string
-                srcExchangeKey:
-                  type: string
-                srcPrefetchCount:
-                  type: integer
-                srcProtocol:
-                  type: string
-                srcQueue:
-                  type: string
-                uriSecret:
-                  description: Secret contains the AMQP URI(s) to configure Shovel destination
-                    and source. The Secret must contain the key `destUri` and `srcUri`
-                    or operator will error. Both fields should be one or multiple uris
-                    separated by ','. Required property.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                vhost:
-                  default: /
-                  description: Default to vhost '/'; cannot be updated
-                  type: string
-              required:
-                - name
-                - rabbitmqClusterReference
-                - uriSecret
-              type: object
-            status:
-              description: ShovelStatus defines the observed state of Shovel
-              properties:
-                conditions:
-                  items:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Shovel is the Schema for the shovels API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'ShovelSpec defines the desired state of Shovel For how to
+              configure Shovel, see: https://www.rabbitmq.com/shovel.html.'
+            properties:
+              ackMode:
+                enum:
+                - on-confirm
+                - on-publish
+                - no-ack
+                type: string
+              addForwardHeaders:
+                type: boolean
+              deleteAfter:
+                type: string
+              destAddForwardHeaders:
+                type: boolean
+              destAddTimestampHeader:
+                type: boolean
+              destAddress:
+                type: string
+              destApplicationProperties:
+                type: string
+              destExchange:
+                type: string
+              destExchangeKey:
+                type: string
+              destProperties:
+                type: string
+              destProtocol:
+                type: string
+              destPublishProperties:
+                type: string
+              destQueue:
+                type: string
+              name:
+                description: Required property; cannot be updated
+                type: string
+              prefetchCount:
+                type: integer
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that this Shovel will
+                  be created in. Required property.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this Shovel. It corresponds to the Shovel's generation,
-                    which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              reconnectDelay:
+                type: integer
+              srcAddress:
+                type: string
+              srcDeleteAfter:
+                type: string
+              srcExchange:
+                type: string
+              srcExchangeKey:
+                type: string
+              srcPrefetchCount:
+                type: integer
+              srcProtocol:
+                type: string
+              srcQueue:
+                type: string
+              uriSecret:
+                description: Secret contains the AMQP URI(s) to configure Shovel destination
+                  and source. The Secret must contain the key `destUri` and `srcUri`
+                  or operator will error. Both fields should be one or multiple uris
+                  separated by ','. Required property.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              vhost:
+                default: /
+                description: Default to vhost '/'; cannot be updated
+                type: string
+            required:
+            - name
+            - rabbitmqClusterReference
+            - uriSecret
+            type: object
+          status:
+            description: ShovelStatus defines the observed state of Shovel
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Shovel. It corresponds to the Shovel's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: superstreams.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: SuperStream
     listKind: SuperStreamList
     plural: superstreams
     singular: superstream
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: SuperStream is the Schema for the queues API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: SuperStreamSpec defines the desired state of SuperStream
-              properties:
-                name:
-                  description: Name of the queue; required property.
-                  type: string
-                partitions:
-                  default: 3
-                  description: Number of partitions to create within this super stream.
-                    Defaults to '3'.
-                  type: integer
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that the SuperStream
-                    will be created in. Required property.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                routingKeys:
-                  description: Routing keys to use for each of the partitions in the
-                    SuperStream If unset, the routing keys for the partitions will be
-                    set to the index of the partitions
-                  items:
-                    type: string
-                  type: array
-                vhost:
-                  default: /
-                  description: Default to vhost '/'; cannot be updated
-                  type: string
-              required:
-                - name
-                - rabbitmqClusterReference
-              type: object
-            status:
-              description: SuperStreamStatus defines the observed state of SuperStream
-              properties:
-                conditions:
-                  items:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SuperStream is the Schema for the queues API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SuperStreamSpec defines the desired state of SuperStream
+            properties:
+              name:
+                description: Name of the queue; required property.
+                type: string
+              partitions:
+                default: 3
+                description: Number of partitions to create within this super stream.
+                  Defaults to '3'.
+                type: integer
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that the SuperStream
+                  will be created in. Required property.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this SuperStream. It corresponds to the SuperStream's
-                    generation, which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-                partitions:
-                  description: Partitions are a list of the stream queue names which
-                    form the partitions of this SuperStream.
-                  items:
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
                     type: string
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              routingKeys:
+                description: Routing keys to use for each of the partitions in the
+                  SuperStream If unset, the routing keys for the partitions will be
+                  set to the index of the partitions
+                items:
+                  type: string
+                type: array
+              vhost:
+                default: /
+                description: Default to vhost '/'; cannot be updated
+                type: string
+            required:
+            - name
+            - rabbitmqClusterReference
+            type: object
+          status:
+            description: SuperStreamStatus defines the observed state of SuperStream
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this SuperStream. It corresponds to the SuperStream's
+                  generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              partitions:
+                description: Partitions are a list of the stream queue names which
+                  form the partitions of this SuperStream.
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  name: topicpermissions.rabbitmq.com
+spec:
+  group: rabbitmq.com
+  names:
+    kind: TopicPermission
+    listKind: TopicPermissionList
+    plural: topicpermissions
+    singular: topicpermission
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TopicPermission is the Schema for the topicpermissions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TopicPermissionSpec defines the desired state of TopicPermission
+            properties:
+              permissions:
+                description: Permissions to grant to the user to a topic exchange;
+                  required property.
+                properties:
+                  exchange:
+                    description: Name of a topic exchange; required property; cannot
+                      be updated.
+                    type: string
+                  read:
+                    type: string
+                  write:
+                    type: string
+                type: object
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that both the provided
+                  user and vhost are. Required property.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              user:
+                description: Name of an existing user; must provide user or userReference,
+                  else create/update will fail; cannot be updated.
+                type: string
+              userReference:
+                description: Reference to an existing user.rabbitmq.com object; must
+                  provide user or userReference, else create/update will fail; cannot
+                  be updated.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              vhost:
+                description: Name of an existing vhost; required property; cannot
+                  be updated.
+                type: string
+            required:
+            - permissions
+            - rabbitmqClusterReference
+            - vhost
+            type: object
+          status:
+            description: TopicPermissionStatus defines the observed state of TopicPermission
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this TopicPermission. It corresponds to the TopicPermission's
+                  generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: users.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: User
     listKind: UserList
     plural: users
     singular: user
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: User is the Schema for the users API.
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec configures the desired state of the User object.
-              properties:
-                importCredentialsSecret:
-                  description: Defines a Secret used to pre-define the username and
-                    password set for this User. User objects created with this field
-                    set will not have randomly-generated credentials, and will instead
-                    import the username/password values from this Secret. The Secret
-                    must contain the keys `username` and `password` in its Data field,
-                    or the import will fail. Note that this import only occurs at creation
-                    time, and is ignored once a password has been set on a User.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that the user will be
-                    created for. This cluster must exist for the User object to be created.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                tags:
-                  description: List of permissions tags to associate with the user.
-                    This determines the level of access to the RabbitMQ management UI
-                    granted to the user. Omitting this field will lead to a user than
-                    can still connect to the cluster through messaging protocols, but
-                    cannot perform any management actions. For more information, see
-                    https://www.rabbitmq.com/management.html#permissions.
-                  items:
-                    description: UserTag defines the level of access to the management
-                      UI allocated to the user. For more information, see https://www.rabbitmq.com/management.html#permissions.
-                    enum:
-                      - management
-                      - policymaker
-                      - monitoring
-                      - administrator
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: User is the Schema for the users API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec configures the desired state of the User object.
+            properties:
+              importCredentialsSecret:
+                description: Defines a Secret used to pre-define the username and
+                  password set for this User. User objects created with this field
+                  set will not have randomly-generated credentials, and will instead
+                  import the username/password values from this Secret. The Secret
+                  must contain the keys `username` and `password` in its Data field,
+                  or the import will fail. Note that this import only occurs at creation
+                  time, and is ignored once a password has been set on a User.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
                     type: string
-                  type: array
-              required:
-                - rabbitmqClusterReference
-              type: object
-            status:
-              description: Status exposes the observed state of the User object.
-              properties:
-                conditions:
-                  items:
+                type: object
+                x-kubernetes-map-type: atomic
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that the user will be
+                  created for. This cluster must exist for the User object to be created.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                credentials:
-                  description: Provides a reference to a Secret object containing the
-                    user credentials.
-                  properties:
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                  type: object
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this User. It corresponds to the User's generation,
-                    which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-                username:
-                  description: Provide rabbitmq Username
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              tags:
+                description: List of permissions tags to associate with the user.
+                  This determines the level of access to the RabbitMQ management UI
+                  granted to the user. Omitting this field will lead to a user than
+                  can still connect to the cluster through messaging protocols, but
+                  cannot perform any management actions. For more information, see
+                  https://www.rabbitmq.com/management.html#permissions.
+                items:
+                  description: UserTag defines the level of access to the management
+                    UI allocated to the user. For more information, see https://www.rabbitmq.com/management.html#permissions.
+                  enum:
+                  - management
+                  - policymaker
+                  - monitoring
+                  - administrator
                   type: string
-              required:
-                - username
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                type: array
+            required:
+            - rabbitmqClusterReference
+            type: object
+          status:
+            description: Status exposes the observed state of the User object.
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              credentials:
+                description: Provides a reference to a Secret object containing the
+                  user credentials.
+                properties:
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this User. It corresponds to the User's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              username:
+                description: Provide rabbitmq Username
+                type: string
+            required:
+            - username
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: vhosts.rabbitmq.com
 spec:
   group: rabbitmq.com
   names:
     categories:
-      - all
-      - rabbitmq
+    - all
+    - rabbitmq
     kind: Vhost
     listKind: VhostList
     plural: vhosts
     singular: vhost
   scope: Namespaced
   versions:
-    - name: v1beta1
-      schema:
-        openAPIV3Schema:
-          description: Vhost is the Schema for the vhosts API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: VhostSpec defines the desired state of Vhost
-              properties:
-                name:
-                  description: Name of the vhost; see https://www.rabbitmq.com/vhosts.html.
-                  type: string
-                rabbitmqClusterReference:
-                  description: Reference to the RabbitmqCluster that the vhost will
-                    be created in. Required property.
-                  properties:
-                    connectionSecret:
-                      description: Secret contains the http management uri for the RabbitMQ
-                        cluster. The Secret must contain the key `uri`, `username` and
-                        `password` or operator will error. Have to set either name or
-                        connectionSecret, but not both.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    name:
-                      description: The name of the RabbitMQ cluster to reference. Have
-                        to set either name or connectionSecret, but not both.
-                      type: string
-                    namespace:
-                      description: The namespace of the RabbitMQ cluster to reference.
-                        Defaults to the namespace of the requested resource if omitted.
-                      type: string
-                  type: object
-                tags:
-                  items:
-                    type: string
-                  type: array
-                tracing:
-                  type: boolean
-              required:
-                - name
-                - rabbitmqClusterReference
-              type: object
-            status:
-              description: VhostStatus defines the observed state of Vhost
-              properties:
-                conditions:
-                  items:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Vhost is the Schema for the vhosts API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VhostSpec defines the desired state of Vhost
+            properties:
+              name:
+                description: Name of the vhost; see https://www.rabbitmq.com/vhosts.html.
+                type: string
+              rabbitmqClusterReference:
+                description: Reference to the RabbitmqCluster that the vhost will
+                  be created in. Required property.
+                properties:
+                  connectionSecret:
+                    description: Secret contains the http management uri for the RabbitMQ
+                      cluster. The Secret must contain the key `uri`, `username` and
+                      `password` or operator will error. Have to set either name or
+                      connectionSecret, but not both.
                     properties:
-                      lastTransitionTime:
-                        description: The last time this Condition status changed.
-                        format: date-time
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
-                      message:
-                        description: Full text reason for current status of the condition.
-                        type: string
-                      reason:
-                        description: One word, camel-case reason for current status
-                          of the condition.
-                        type: string
-                      status:
-                        description: True, False, or Unknown
-                        type: string
-                      type:
-                        description: Type indicates the scope of the custom resource
-                          status addressed by the condition.
-                        type: string
-                    required:
-                      - status
-                      - type
                     type: object
-                  type: array
-                observedGeneration:
-                  description: observedGeneration is the most recent successful generation
-                    observed for this Vhost. It corresponds to the Vhost's generation,
-                    which is updated on mutation by the API Server.
-                  format: int64
-                  type: integer
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+                    x-kubernetes-map-type: atomic
+                  name:
+                    description: The name of the RabbitMQ cluster to reference. Have
+                      to set either name or connectionSecret, but not both.
+                    type: string
+                  namespace:
+                    description: The namespace of the RabbitMQ cluster to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              tags:
+                items:
+                  type: string
+                type: array
+              tracing:
+                type: boolean
+            required:
+            - name
+            - rabbitmqClusterReference
+            type: object
+          status:
+            description: VhostStatus defines the observed state of Vhost
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: The last time this Condition status changed.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Full text reason for current status of the condition.
+                      type: string
+                    reason:
+                      description: One word, camel-case reason for current status
+                        of the condition.
+                      type: string
+                    status:
+                      description: True, False, or Unknown
+                      type: string
+                    type:
+                      description: Type indicates the scope of the custom resource
+                        status addressed by the condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recent successful generation
+                  observed for this Vhost. It corresponds to the Vhost's generation,
+                  which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
@@ -272,4 +272,24 @@ rules:
       - get
       - patch
       - update
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - topicpermissions
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rabbitmq.com
+    resources:
+      - topicpermissions/status
+    verbs:
+      - get
+      - patch
+      - update
 {{- end }}


### PR DESCRIPTION
Signed-off-by: David van der Spek <vanderspek.david@gmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
This PR updates the CRDs for the RabbitMQ Cluster Operator and RabbitMQ Messaging Topology Operator.

### Benefits

The CRDs have changed since they were last synced so they should be updated.

### Possible drawbacks

The CRDs for the RabbitMQ Messaging Topology Operator were generated for `v1.9.0`. The current image is for `v1.8.0`, so a new image for the correct version should be built.
If the RabbitMQ Messaging Topology Operator is updated to `v1.9.0`, the RBAC needs to be updated for a new CRD type. This RBAC update is included in this PR.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
