### PR TITLE
[bitnami/elasticsearch] Fix failed metrics pod in elasticsearch when deploy ES

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 19.4.6
+version: 19.5.0

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -535,6 +535,7 @@ $ helm delete --purge my-release
 | `metrics.image.digest`                          | Metrics exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag               | `""`                             |
 | `metrics.image.pullPolicy`                      | Metrics exporter image pull policy                                                                                             | `IfNotPresent`                   |
 | `metrics.image.pullSecrets`                     | Metrics exporter image pull secrets                                                                                            | `[]`                             |
+| `metrics.annotations`                           | Annotations for metrics                                                                                                        | `{}`                             |
 | `metrics.extraArgs`                             | Extra arguments to add to the default exporter command                                                                         | `[]`                             |
 | `metrics.hostAliases`                           | Add deployment host aliases                                                                                                    | `[]`                             |
 | `metrics.schedulerName`                         | Name of the k8s scheduler (other than default)                                                                                 | `""`                             |

--- a/bitnami/elasticsearch/templates/metrics/deployment.yaml
+++ b/bitnami/elasticsearch/templates/metrics/deployment.yaml
@@ -11,9 +11,13 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if .Values.commonAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
+  annotations:
+    {{- if .Values.metrics.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.metrics.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
   selector:

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -1768,6 +1768,12 @@ metrics:
     ##   - myRegistryKeySecretName
     ##
     pullSecrets: []
+  ## @param metrics.annotations [object] Annotations for metrics
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  annotations:
+    helm.sh/hook: "post-install,post-upgrade"
+    helm.sh/hook-weight: "5"
   ## @param metrics.extraArgs Extra arguments to add to the default exporter command
   ## ref: https://github.com/justwatchcom/elasticsearch_exporter
   ## e.g


### PR DESCRIPTION
Signed-off-by: Anton Patsev <patsev.anton@gmail.com>

### Description of the change

Fix failed metrics pod in elasticsearch when deploying elasticsearch

### Benefits

Fixed bug https://github.com/bitnami/charts/issues/12957

### Possible drawbacks
Limitations: run metrics after running core pods elasticsearch

### Applicable issues

  - fixes #12957
  - continues https://github.com/bitnami/charts/pull/12959

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)