### PR TITLE
[bitnami/jasperreports] Add tests and publishing using VIB

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -32,6 +32,7 @@ on: # rebuild any PRs and main branch changes
       - 'bitnami/haproxy-intel/**'
       - 'bitnami/harbor/**'
       - 'bitnami/influxdb/**'
+      - 'bitnami/jasperreports/**'
       - 'bitnami/jenkins/**'
       - 'bitnami/joomla/**'
       - 'bitnami/kafka/**'

--- a/.vib/jasperreports/cypress/cypress.json
+++ b/.vib/jasperreports/cypress/cypress.json
@@ -1,0 +1,8 @@
+{
+  "baseUrl": "http://localhost/",
+  "env": {
+    "username": "jaspervibadmin",
+    "password": "ComplicatedPassword123!4"
+  },
+  "defaultCommandTimeout": 30000
+}

--- a/.vib/jasperreports/cypress/cypress/fixtures/WorkingReport.jrxml
+++ b/.vib/jasperreports/cypress/cypress/fixtures/WorkingReport.jrxml
@@ -1,0 +1,17 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!DOCTYPE jasperReport PUBLIC "-//JasperReports//DTD Report Design//EN" "http://jasperreports.sourceforge.net/dtds/jasperreport.dtd">
+
+<jasperReport name="report" topMargin="20" bottomMargin="20" whenNoDataType="NoDataSection">
+    <noData>
+        <band height="15">
+            <staticText>
+                <reportElement x="0" y="0" width="200" height="15"/>
+                <box>
+                    <bottomPen lineWidth="1.0" lineColor="#CCCCCC"/>
+                </box>
+                <textElement />
+                <text><![CDATA[Cherries From Barn with ID sg4y9]]></text>
+            </staticText>
+        </band>
+    </noData>
+</jasperReport>

--- a/.vib/jasperreports/cypress/cypress/fixtures/reports.json
+++ b/.vib/jasperreports/cypress/cypress/fixtures/reports.json
@@ -1,0 +1,7 @@
+{
+  "newReport": {
+    "name": "ShoppingList",
+    "file": "WorkingReport.jrxml",
+    "textToRandomize": "Cherries From Barn with ID "
+  }
+}

--- a/.vib/jasperreports/cypress/cypress/integration/jasperreports_spec.js
+++ b/.vib/jasperreports/cypress/cypress/integration/jasperreports_spec.js
@@ -1,0 +1,32 @@
+/// <reference types="cypress" />
+import { random } from '../support/utils';
+
+it('allows to upload and view a new Report', () => {
+  cy.login();
+  cy.visit('/jasperserver/flow.html?_flowId=reportUnitFlow&ParentFolderUri=/');
+
+  cy.fixture('reports').then((reports) => {
+    const reportFile = `cypress/fixtures/${reports.newReport.file}`;
+    cy.readFile(reportFile).then((data) => {
+      const regex = new RegExp(
+        `${reports.newReport.textToRandomize}[a-z0-9_]+`
+      );
+      const randomizedData = data.replace(
+        regex,
+        `${reports.newReport.textToRandomize}${random}`
+      );
+      cy.writeFile(reportFile, randomizedData);
+    });
+
+    cy.get('[name="reportUnit.label"]')
+      .click()
+      .type(`${reports.newReport.name}_${random}`);
+    cy.get('#fromLocal').click();
+    cy.get('[type="file"]').selectFile(reportFile, { force: true });
+    cy.contains('Submit').click();
+    cy.get('#resultsContainer').within(() => {
+      cy.contains(`${reports.newReport.name}_${random}`).click();
+    });
+    cy.contains(`${reports.newReport.textToRandomize}${random}`);
+  });
+});

--- a/.vib/jasperreports/cypress/cypress/support/commands.js
+++ b/.vib/jasperreports/cypress/cypress/support/commands.js
@@ -1,0 +1,36 @@
+const COMMAND_DELAY = 2000;
+
+for (const command of ['click']) {
+  Cypress.Commands.overwrite(command, (originalFn, ...args) => {
+    const origVal = originalFn(...args);
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(origVal);
+      }, COMMAND_DELAY);
+    });
+  });
+}
+
+Cypress.Commands.add(
+  'login',
+  (username = Cypress.env('username'), password = Cypress.env('password')) => {
+    cy.visit('/jasperserver/login.html');
+    cy.get('#j_username').click().type(username);
+    cy.get('#j_password_pseudo').click().type(password);
+    cy.get('#submitButton').click();
+
+    // The login process completes when the directory tree is fully loaded
+    cy.get('#folders').within(() => {
+      cy.contains('root');
+    });
+    cy.get('body').then(($body) => {
+      // Close the pop-up if appears
+      if ($body.find('#heartbeatOptin').is(':visible')) {
+        cy.get('#heartbeatOptin').within(() => {
+          cy.contains('button', 'OK').click();
+        });
+      }
+    });
+  }
+);

--- a/.vib/jasperreports/cypress/cypress/support/index.js
+++ b/.vib/jasperreports/cypress/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/.vib/jasperreports/cypress/cypress/support/utils.js
+++ b/.vib/jasperreports/cypress/cypress/support/utils.js
@@ -1,0 +1,3 @@
+/// <reference types="cypress" />
+
+export let random = (Math.random() + 1).toString(36).substring(7);

--- a/.vib/jasperreports/goss/goss.yaml
+++ b/.vib/jasperreports/goss/goss.yaml
@@ -1,0 +1,25 @@
+http:
+  http://localhost:{{ .Vars.containerPorts.http }}:
+    status: 200
+    allow-insecure: true
+command:
+  check-user-info:
+    exec: id
+    exit-status: 0
+    stdout:
+      - uid={{ .Vars.containerSecurityContext.runAsUser }}
+      - /groups=.*{{ .Vars.podSecurityContext.fsGroup }}/
+file:
+  /opt/bitnami/jasperreports/META-INF/context.xml:
+    exists: true
+    filetype: file
+    mode: '0644'
+    contains:
+      - /mysql.*{{ .Vars.mariadb.auth.database }}/
+      - /username.*{{ .Vars.mariadb.auth.username }}/
+      - /password.*{{ .Vars.mariadb.auth.password }}/
+  /bitnami/jasperreports:
+    exists: true
+    filetype: directory
+    mode: '2775'
+    owner: root

--- a/.vib/jasperreports/goss/vars.yaml
+++ b/.vib/jasperreports/goss/vars.yaml
@@ -1,0 +1,11 @@
+containerPorts:
+  http: 8080
+podSecurityContext:
+  fsGroup: 1002
+containerSecurityContext:
+  runAsUser: 1002
+mariadb:
+  auth:
+    database: bitnami_test_jasperreports
+    username: bn_test_jasperreports
+    password: bitnami_test_password

--- a/.vib/jasperreports/vib-publish.json
+++ b/.vib/jasperreports/vib-publish.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/jasperreports"
         },
-        "runtime_parameters": "Imphc3BlcnJlcG9ydHNQYXNzd29yZCI6ICJTMzlCS1dqU2toIg==",
+        "runtime_parameters": "amFzcGVycmVwb3J0c1VzZXJuYW1lOiBqYXNwZXJ2aWJhZG1pbgpqYXNwZXJyZXBvcnRzUGFzc3dvcmQ6ICJDb21wbGljYXRlZFBhc3N3b3JkMTIzITQiCmNvbnRhaW5lclBvcnRzOgogIGh0dHA6IDgwODAKcG9kU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBmc0dyb3VwOiAxMDAyCmNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICBlbmFibGVkOiB0cnVlCiAgcnVuQXNVc2VyOiAxMDAyCnBlcnNpc3RlbmNlOgogIGVuYWJsZWQ6IHRydWUKc2VydmljZToKICB0eXBlOiBMb2FkQmFsYW5jZXIKICBwb3J0czoKICAgIGh0dHA6IDgwCm1hcmlhZGI6CiAgZW5hYmxlZDogdHJ1ZQogIGF1dGg6CiAgICBkYXRhYmFzZTogYml0bmFtaV90ZXN0X2phc3BlcnJlcG9ydHMKICAgIHVzZXJuYW1lOiBibl90ZXN0X2phc3BlcnJlcG9ydHMKICAgIHBhc3N3b3JkOiBiaXRuYW1pX3Rlc3RfcGFzc3dvcmQ=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -36,6 +36,32 @@
           "params": {
             "endpoint": "lb-jasperreports-http",
             "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/jasperreports/goss"
+            },
+            "remote": {
+              "workload": "deploy-jasperreports"
+            },
+            "vars_file": "vars.yaml"
+          }
+        },
+        {
+          "action_id": "cypress",
+          "params": {
+            "resources": {
+              "path": "/.vib/jasperreports/cypress"
+            },
+            "endpoint": "lb-jasperreports-http",
+            "app_protocol": "HTTP",
+            "env": {
+              "username": "jaspervibadmin",
+              "password": "ComplicatedPassword123!4"
+            }
           }
         }
       ]

--- a/.vib/jasperreports/vib-verify.json
+++ b/.vib/jasperreports/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/jasperreports"
         },
-        "runtime_parameters": "Imphc3BlcnJlcG9ydHNQYXNzd29yZCI6ICJTMzlCS1dqU2toIg==",
+        "runtime_parameters": "amFzcGVycmVwb3J0c1VzZXJuYW1lOiBqYXNwZXJ2aWJhZG1pbgpqYXNwZXJyZXBvcnRzUGFzc3dvcmQ6ICJDb21wbGljYXRlZFBhc3N3b3JkMTIzITQiCmNvbnRhaW5lclBvcnRzOgogIGh0dHA6IDgwODAKcG9kU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBmc0dyb3VwOiAxMDAyCmNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICBlbmFibGVkOiB0cnVlCiAgcnVuQXNVc2VyOiAxMDAyCnBlcnNpc3RlbmNlOgogIGVuYWJsZWQ6IHRydWUKc2VydmljZToKICB0eXBlOiBMb2FkQmFsYW5jZXIKICBwb3J0czoKICAgIGh0dHA6IDgwCm1hcmlhZGI6CiAgZW5hYmxlZDogdHJ1ZQogIGF1dGg6CiAgICBkYXRhYmFzZTogYml0bmFtaV90ZXN0X2phc3BlcnJlcG9ydHMKICAgIHVzZXJuYW1lOiBibl90ZXN0X2phc3BlcnJlcG9ydHMKICAgIHBhc3N3b3JkOiBiaXRuYW1pX3Rlc3RfcGFzc3dvcmQ=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -36,6 +36,32 @@
           "params": {
             "endpoint": "lb-jasperreports-http",
             "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/jasperreports/goss"
+            },
+            "remote": {
+              "workload": "deploy-jasperreports"
+            },
+            "vars_file": "vars.yaml"
+          }
+        },
+        {
+          "action_id": "cypress",
+          "params": {
+            "resources": {
+              "path": "/.vib/jasperreports/cypress"
+            },
+            "endpoint": "lb-jasperreports-http",
+            "app_protocol": "HTTP",
+            "env": {
+              "username": "jaspervibadmin",
+              "password": "ComplicatedPassword123!4"
+            }
           }
         }
       ]


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami JasperReports Helm Chart using VMware Image Builder. In order to do that, several changes are included:

- Adding the asset to the publishing workflow
- Increasing the existing test coverage of the asset by adding Cypress tests.
- Increasing the existing test coverage of the asset by adding Goss tests.

### Benefits

- Ensuring higher quality of the Helm charts.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could show to be potentially flaky. 

### Applicable issues

NA

### Additional information

Tested in https://github.com/joancafom/charts/pull/95

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

