### PR TITLE
[bitnami/redis-cluster] Fix port number enviroment variables name

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
   - http://redis.io/
-version: 8.2.6
+version: 8.2.7

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -172,7 +172,7 @@ spec:
             - name: REDIS_TLS_ENABLED
               value: {{ ternary "yes" "no" .Values.tls.enabled | quote }}
             {{- if .Values.tls.enabled }}
-            - name: REDIS_TLS_PORT
+            - name: REDIS_TLS_PORT_NUMBER
               value: {{ .Values.redis.containerPorts.redis | quote }}
             - name:  REDIS_TLS_AUTH_CLIENTS
               value: {{ ternary "yes" "no" .Values.tls.authClients | quote }}
@@ -187,7 +187,7 @@ spec:
               value: {{ template "redis-cluster.tlsDHParams" . }}
             {{- end }}
             {{- else }}
-            - name: REDIS_PORT
+            - name: REDIS_PORT_NUMBER
               value: {{ .Values.redis.containerPorts.redis | quote }}
             {{- end }}
             {{- if .Values.redis.extraEnvVars }}

--- a/bitnami/redis-cluster/templates/scripts-configmap.yaml
+++ b/bitnami/redis-cluster/templates/scripts-configmap.yaml
@@ -28,13 +28,13 @@ data:
       redis-cli \
         -h localhost \
 {{- if .Values.tls.enabled }}
-        -p $REDIS_TLS_PORT \
+        -p $REDIS_TLS_PORT_NUMBER \
         --tls \
         --cert {{ template "redis-cluster.tlsCert" . }} \
         --key {{ template "redis-cluster.tlsCertKey" . }} \
         --cacert {{ template "redis-cluster.tlsCACert" . }} \
 {{- else }}
-        -p $REDIS_PORT \
+        -p $REDIS_PORT_NUMBER \
 {{- end }}
         ping
     )
@@ -53,13 +53,13 @@ data:
         redis-cli \
           -h localhost \
   {{- if .Values.tls.enabled }}
-          -p $REDIS_TLS_PORT \
+          -p $REDIS_TLS_PORT_NUMBER \
           --tls \
           --cert {{ template "redis-cluster.tlsCert" . }} \
           --key {{ template "redis-cluster.tlsCertKey" . }} \
           --cacert {{ template "redis-cluster.tlsCACert" . }} \
   {{- else }}
-          -p $REDIS_PORT \
+          -p $REDIS_PORT_NUMBER \
   {{- end }}
           CLUSTER INFO | grep cluster_state | tr -d '[:space:]'
       )
@@ -90,13 +90,13 @@ data:
       redis-cli \
         -h localhost \
 {{- if .Values.tls.enabled }}
-        -p $REDIS_TLS_PORT \
+        -p $REDIS_TLS_PORT_NUMBER \
         --tls \
         --cert {{ template "redis-cluster.tlsCert" . }} \
         --key {{ template "redis-cluster.tlsCertKey" . }} \
         --cacert {{ template "redis-cluster.tlsCACert" . }} \
 {{- else }}
-        -p $REDIS_PORT \
+        -p $REDIS_PORT_NUMBER \
 {{- end }}
         ping
     )

--- a/bitnami/redis-cluster/templates/update-cluster.yaml
+++ b/bitnami/redis-cluster/templates/update-cluster.yaml
@@ -95,9 +95,9 @@ spec:
               newNodeCounter=0
               for nodeIP in $(echo "{{ .Values.cluster.update.newExternalIPs }}" | cut -d [ -f2 | cut -d ] -f 1 ); do
                 {{- if .Values.tls.enabled }}
-                while [[ $(redis-cli -h "$nodeIP" -p "$REDIS_TLS_PORT" --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} ping) != 'PONG' ]]; do
+                while [[ $(redis-cli -h "$nodeIP" -p "$REDIS_TLS_PORT_NUMBER" --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} ping) != 'PONG' ]]; do
                 {{- else }}
-                while [[ $(redis-cli -h "$nodeIP" -p "$REDIS_PORT" ping) != 'PONG' ]]; do
+                while [[ $(redis-cli -h "$nodeIP" -p "$REDIS_PORT_NUMBER" ping) != 'PONG' ]]; do
                 {{- end }}
                   echo "Node $nodeIP not ready, waiting for all the nodes to be ready..."
                   sleep 5
@@ -107,9 +107,9 @@ spec:
                   slave+=("--cluster-slave")
                 fi
                 {{- if .Values.tls.enabled }}
-                while ! redis-cli --cluster --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} add-node "${nodeIP}:${REDIS_TLS_PORT}" "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_TLS_PORT}" ${slave[@]}; do
+                while ! redis-cli --cluster --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} add-node "${nodeIP}:${REDIS_TLS_PORT_NUMBER}" "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_TLS_PORT_NUMBER}" ${slave[@]}; do
                 {{- else }}
-                while ! redis-cli --cluster add-node "${nodeIP}:${REDIS_PORT}" "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_PORT}" ${slave[@]}; do
+                while ! redis-cli --cluster add-node "${nodeIP}:${REDIS_PORT_NUMBER}" "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_PORT_NUMBER}" ${slave[@]}; do
                 {{- end }}
                   echo "Add-node ${newNodeIndex} ${newNodeIP} failed, retrying"
                   sleep 5
@@ -118,16 +118,16 @@ spec:
               done
 
               {{- if .Values.tls.enabled }}
-              while ! redis-cli --cluster rebalance --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_TLS_PORT}" --cluster-use-empty-masters; do
+              while ! redis-cli --cluster rebalance --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_TLS_PORT_NUMBER}" --cluster-use-empty-masters; do
               {{- else }}
-              while ! redis-cli --cluster rebalance "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_PORT}" --cluster-use-empty-masters; do
+              while ! redis-cli --cluster rebalance "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_PORT_NUMBER}" --cluster-use-empty-masters; do
               {{- end }}
                 echo "Rebalance failed, retrying"
                 sleep 5
                 {{- if .Values.tls.enabled }}
-                redis-cli --cluster fix --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_TLS_PORT}"
+                redis-cli --cluster fix --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_TLS_PORT_NUMBER}"
                 {{- else }}
-                redis-cli --cluster fix "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_PORT}"
+                redis-cli --cluster fix "{{ index .Values.cluster.externalAccess.service.loadBalancerIP 0 }}:${REDIS_PORT_NUMBER}"
                 {{- end }}
               done
 
@@ -140,9 +140,9 @@ spec:
                 newNodeIndex="$(($node - 1))"
                 newNodeIP=$(wait_for_dns_lookup "{{ template "common.names.fullname" . }}-${newNodeIndex}.{{ template "common.names.fullname" . }}-headless" 120 5)
                 {{- if .Values.tls.enabled }}
-                while [[ $(redis-cli -h "$newNodeIP" -p "$REDIS_TLS_PORT" --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} ping) != 'PONG' ]]; do
+                while [[ $(redis-cli -h "$newNodeIP" -p "$REDIS_TLS_PORT_NUMBER" --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} ping) != 'PONG' ]]; do
                 {{- else }}
-                while [[ $(redis-cli -h "$newNodeIP" -p "$REDIS_PORT" ping) != 'PONG' ]]; do
+                while [[ $(redis-cli -h "$newNodeIP" -p "$REDIS_PORT_NUMBER" ping) != 'PONG' ]]; do
                 {{- end }}
                   echo "Node $newNodeIP not ready, waiting for all the nodes to be ready..."
                   newNodeIP=$(wait_for_dns_lookup "{{ template "common.names.fullname" . }}-${newNodeIndex}.{{ template "common.names.fullname" . }}-headless" 120 5)
@@ -155,9 +155,9 @@ spec:
                   slave+=("--cluster-slave")
                 fi
                 {{- if .Values.tls.enabled }}
-                while ! redis-cli --cluster add-node --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} "${newNodeIP}:${REDIS_TLS_PORT}" "${firstNodeIP}:${REDIS_TLS_PORT}" ${slave[@]}; do
+                while ! redis-cli --cluster add-node --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} "${newNodeIP}:${REDIS_TLS_PORT_NUMBER}" "${firstNodeIP}:${REDIS_TLS_PORT_NUMBER}" ${slave[@]}; do
                 {{- else }}
-                while ! redis-cli --cluster add-node "${newNodeIP}:${REDIS_PORT}" "${firstNodeIP}:${REDIS_PORT}" ${slave[@]}; do
+                while ! redis-cli --cluster add-node "${newNodeIP}:${REDIS_PORT_NUMBER}" "${firstNodeIP}:${REDIS_PORT_NUMBER}" ${slave[@]}; do
                 {{- end }}
                   echo "Add-node ${newNodeIndex} ${newNodeIP} failed, retrying"
                   sleep 5
@@ -167,17 +167,17 @@ spec:
               done
 
               {{- if .Values.tls.enabled }}
-              while ! redis-cli --cluster rebalance --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} "${firstNodeIP}:${REDIS_TLS_PORT}" --cluster-use-empty-masters; do
+              while ! redis-cli --cluster rebalance --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} "${firstNodeIP}:${REDIS_TLS_PORT_NUMBER}" --cluster-use-empty-masters; do
               {{- else }}
-              while ! redis-cli --cluster rebalance "${firstNodeIP}:${REDIS_PORT}" --cluster-use-empty-masters; do
+              while ! redis-cli --cluster rebalance "${firstNodeIP}:${REDIS_PORT_NUMBER}" --cluster-use-empty-masters; do
               {{- end }}
                 echo "Rebalance failed, retrying"
                 sleep 5
                 firstNodeIP=$(wait_for_dns_lookup "{{ template "common.names.fullname" . }}-0.{{ template "common.names.fullname" . }}-headless" 120 5)
                 {{- if .Values.tls.enabled }}
-                redis-cli --cluster fix --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} "${firstNodeIP}:${REDIS_TLS_PORT}"
+                redis-cli --cluster fix --tls --cert ${REDIS_TLS_CERT_FILE} --key ${REDIS_TLS_KEY_FILE} --cacert ${REDIS_TLS_CA_FILE} "${firstNodeIP}:${REDIS_TLS_PORT_NUMBER}"
                 {{- else }}
-                redis-cli --cluster fix "${firstNodeIP}:${REDIS_PORT}"
+                redis-cli --cluster fix "${firstNodeIP}:${REDIS_PORT_NUMBER}"
                 {{- end }}
               done
 
@@ -194,9 +194,9 @@ spec:
               value: {{ template "redis-cluster.tlsCertKey" . }}
             - name:  REDIS_TLS_CA_FILE
               value: {{ template "redis-cluster.tlsCACert" . }}
-            - name: REDIS_TLS_PORT
+            - name: REDIS_TLS_PORT_NUMBER
             {{- else }}
-            - name: REDIS_PORT
+            - name: REDIS_PORT_NUMBER
             {{- end }}
               value: {{ .Values.cluster.externalAccess.service.port | quote }}
             {{- else }}
@@ -207,9 +207,9 @@ spec:
               value: {{ template "redis-cluster.tlsCertKey" . }}
             - name:  REDIS_TLS_CA_FILE
               value: {{ template "redis-cluster.tlsCACert" . }}
-            - name: REDIS_TLS_PORT
+            - name: REDIS_TLS_PORT_NUMBER
             {{- else }}
-            - name: REDIS_PORT
+            - name: REDIS_PORT_NUMBER
             {{- end }}
               value: {{ .Values.redis.containerPorts.redis | quote }}
             {{- end }}


### PR DESCRIPTION
Signed-off-by: Rafael Rios Saavedra <rrios@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

The name of the environment variables in the container are:
- [REDIS_PORT_NUMBER](https://github.com/bitnami/containers/blob/512680642767755f31c5552b8048a49be14ab9f7/bitnami/redis/7.0/debian-11/rootfs/opt/bitnami/scripts/redis-env.sh#L32)
- [REDIS_TLS_PORT_NUMBER](https://github.com/bitnami/containers/blob/512680642767755f31c5552b8048a49be14ab9f7/bitnami/redis/7.0/debian-11/rootfs/opt/bitnami/scripts/redis-env.sh#L45)

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #13270

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
