### PR TITLE
[bitnami/thanos] Modified logic for serviceAccount name in Thanos

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 11.5.6
+version: 11.5.7

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -337,7 +337,11 @@ Usage:
 {{- end -}}
 {{- if not (include "thanos.serviceAccount.useExisting" (dict "component" .component "context" .context)) -}}
     {{- if $component.serviceAccount.create -}}
-        {{ default (printf "%s-%s" (include "common.names.fullname" .context) .component) $component.serviceAccount.name }}
+        {{- if eq .context.Values.serviceAccount.name "" -}}
+            {{ default (printf "%s-%s" (include "common.names.fullname" .context) .component) $component.serviceAccount.name }}
+        {{- else -}}
+            {{ default (printf "%s-%s" (.context.Values.serviceAccount.name) .component) $component.serviceAccount.name }}
+        {{- end -}}
     {{- else if .context.Values.serviceAccount.create -}}
         {{ default (include "common.names.fullname" .context) .context.Values.serviceAccount.name  }}
     {{- else -}}

--- a/bitnami/thanos/templates/serviceaccount.yaml
+++ b/bitnami/thanos/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "common.names.fullname" . }}
+  name: {{ include "thanos.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway


### PR DESCRIPTION
### Description of the change

The template/serviceaccount file sets its name value using the _helpers.tlp file just like the other assets and not the common fullname value.

### Benefits

The format is the same as the other assets and the value is really being set with the value indicated

### Additional information

In addition, the logic of assigning the value of the serviceAccount.name variable in the _helpers.tlp file has been modified so that, when the value of serviceAccount.name in the values.yaml is set, it uses that value instead of the default value. .

- Fixes https://github.com/bitnami/charts/issues/12954

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
