### PR TITLE
[bitnami/kube-state-metrics] Add tests and publishing using VIB

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -39,6 +39,7 @@ on: # rebuild any PRs and main branch changes
       - 'bitnami/kibana/**'
       - 'bitnami/kong/**'
       - 'bitnami/kube-prometheus/**'
+      - 'bitnami/kube-state-metrics/**'
       - 'bitnami/kubernetes-event-exporter/**'
       - 'bitnami/logstash/**'
       - 'bitnami/magento/**'

--- a/.vib/kube-state-metrics/goss/goss.yaml
+++ b/.vib/kube-state-metrics/goss/goss.yaml
@@ -1,0 +1,19 @@
+http:
+  http://kube-state-metrics:{{ .Vars.service.ports.http }}/metrics:
+    status: 200
+    body:
+    - /kube_deployment_status_replicas_ready.*kube-state-metrics.*{{ .Vars.replicaCount }}/
+    - "!kube_secret_"
+file:
+  /var/run/secrets/kubernetes.io/serviceaccount:
+    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
+    filetype: directory
+    mode: "3777"
+    owner: root
+command:
+  check-user-info:
+    exec: id
+    exit-status: 0
+    stdout:
+    - uid={{ .Vars.containerSecurityContext.runAsUser }}
+    - /groups=.*{{ .Vars.podSecurityContext.fsGroup }}/

--- a/.vib/kube-state-metrics/goss/vars.yaml
+++ b/.vib/kube-state-metrics/goss/vars.yaml
@@ -1,0 +1,10 @@
+serviceAccount:
+  automountServiceAccountToken: true
+podSecurityContext:
+  fsGroup: 1002
+containerSecurityContext:
+  runAsUser: 1002
+service:
+  ports:
+    http: 80
+replicaCount: 2

--- a/.vib/kube-state-metrics/vib-publish.json
+++ b/.vib/kube-state-metrics/vib-publish.json
@@ -16,6 +16,42 @@
         }
       ]
     },
+    "verify": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/kube-state-metrics"
+        },
+        "runtime_parameters": "cmJhYzoKICBjcmVhdGU6IHRydWUKc2VydmljZUFjY291bnQ6CiAgY3JlYXRlOiB0cnVlCiAgYXV0b21vdW50U2VydmljZUFjY291bnRUb2tlbjogdHJ1ZQprdWJlUmVzb3VyY2VzOgogIHJlcGxpY2FzZXRzOiB0cnVlCiAgc2VjcmV0czogZmFsc2UKcG9kU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBmc0dyb3VwOiAxMDAyCmNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICBlbmFibGVkOiB0cnVlCiAgcnVuQXNVc2VyOiAxMDAyCnNlcnZpY2U6CiAgdHlwZTogTG9hZEJhbGFuY2VyCiAgcG9ydHM6CiAgICBodHRwOiA4MApyZXBsaWNhQ291bnQ6IDI=",
+        "target_platform": {
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
+          "size": {
+            "name": "S4"
+          }
+        }
+      },
+      "actions": [
+        {
+          "action_id": "health-check",
+          "params": {
+            "endpoint": "lb-kube-state-metrics-http",
+            "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/kube-state-metrics/goss"
+            },
+            "vars_file": "vars.yaml",
+            "remote": {
+              "workload": "deploy-kube-state-metrics"
+            }
+          }
+        }
+      ]
+    },
     "publish": {
       "actions": [
         {

--- a/.vib/kube-state-metrics/vib-verify.json
+++ b/.vib/kube-state-metrics/vib-verify.json
@@ -15,6 +15,42 @@
           "action_id": "helm-lint"
         }
       ]
+    },
+    "verify": {
+      "context": {
+        "resources": {
+          "url": "{SHA_ARCHIVE}",
+          "path": "/bitnami/kube-state-metrics"
+        },
+        "runtime_parameters": "cmJhYzoKICBjcmVhdGU6IHRydWUKc2VydmljZUFjY291bnQ6CiAgY3JlYXRlOiB0cnVlCiAgYXV0b21vdW50U2VydmljZUFjY291bnRUb2tlbjogdHJ1ZQprdWJlUmVzb3VyY2VzOgogIHJlcGxpY2FzZXRzOiB0cnVlCiAgc2VjcmV0czogZmFsc2UKcG9kU2VjdXJpdHlDb250ZXh0OgogIGVuYWJsZWQ6IHRydWUKICBmc0dyb3VwOiAxMDAyCmNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICBlbmFibGVkOiB0cnVlCiAgcnVuQXNVc2VyOiAxMDAyCnNlcnZpY2U6CiAgdHlwZTogTG9hZEJhbGFuY2VyCiAgcG9ydHM6CiAgICBodHRwOiA4MApyZXBsaWNhQ291bnQ6IDI=",
+        "target_platform": {
+          "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
+          "size": {
+            "name": "S4"
+          }
+        }
+      },
+      "actions": [
+        {
+          "action_id": "health-check",
+          "params": {
+            "endpoint": "lb-kube-state-metrics-http",
+            "app_protocol": "HTTP"
+          }
+        },
+        {
+          "action_id": "goss",
+          "params": {
+            "resources": {
+              "path": "/.vib/kube-state-metrics/goss"
+            },
+            "vars_file": "vars.yaml",
+            "remote": {
+              "workload": "deploy-kube-state-metrics"
+            }
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
### Description of the change

The main objective of this PR is to publish our Bitnami Kube State Metrics Helm Chart using VMware Image Builder. In order to do that, several changes are included:

- Adding the asset to the publishing workflow
- Increasing the existing test coverage of the asset by adding Goss tests.

### Benefits

- Ensuring higher quality of the Helm charts.
- Increased pool of assets completely handled by VMware Image Builder.

### Possible drawbacks

Automated tests could show to be potentially flaky. 

### Applicable issues

NA

### Additional information

Tested in https://github.com/joancafom/charts/pull/96

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)

