### PR TITLE
[bitnami/spark]  Fixed the mount path of shared-certs volume

### DIFF
--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -22,4 +22,4 @@ name: spark
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/spark
   - https://spark.apache.org/
-version: 6.3.9
+version: 6.3.10

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -178,7 +178,7 @@ spec:
           volumeMounts:
             {{- if .Values.master.existingConfigmap }}
             - name: config
-              mountPath: /opt/bitnami/spark/conf/
+              mountPath: /bitnami/spark/conf/
             {{- end }}
             {{- if .Values.security.ssl.enabled }}
             - name: shared-certs

--- a/bitnami/spark/templates/statefulset-master.yaml
+++ b/bitnami/spark/templates/statefulset-master.yaml
@@ -178,11 +178,11 @@ spec:
           volumeMounts:
             {{- if .Values.master.existingConfigmap }}
             - name: config
-              mountPath: /bitnami/spark/conf/
+              mountPath: /opt/bitnami/spark/conf/
             {{- end }}
             {{- if .Values.security.ssl.enabled }}
             - name: shared-certs
-              mountPath: /bitnami/spark/conf/certs
+              mountPath: /opt/bitnami/spark/conf/certs
               readOnly: true
             {{- end }}
             {{- if .Values.master.extraVolumeMounts }}

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -182,7 +182,7 @@ spec:
           volumeMounts:
             {{- if .Values.worker.existingConfigmap }}
             - name: config
-              mountPath: '/opt/bitnami/spark/conf/'
+              mountPath: '/bitnami/spark/conf/'
             {{- end }}
             {{- if .Values.security.ssl.enabled }}
             - name: shared-certs

--- a/bitnami/spark/templates/statefulset-worker.yaml
+++ b/bitnami/spark/templates/statefulset-worker.yaml
@@ -142,7 +142,7 @@ spec:
           - name: certs
             mountPath: /certs
           - name: shared-certs
-            mountPath: /bitnami/spark/conf/certs
+            mountPath: /opt/bitnami/spark/conf/certs
         {{- end }}
       {{- end }}
       containers:
@@ -182,11 +182,11 @@ spec:
           volumeMounts:
             {{- if .Values.worker.existingConfigmap }}
             - name: config
-              mountPath: '/bitnami/spark/conf/'
+              mountPath: '/opt/bitnami/spark/conf/'
             {{- end }}
             {{- if .Values.security.ssl.enabled }}
             - name: shared-certs
-              mountPath: '/bitnami/spark/conf/certs'
+              mountPath: '/opt/bitnami/spark/conf/certs'
               readOnly: true
             - name: certs
               mountPath: /certs


### PR DESCRIPTION
### Description of the change
Changed the mount path of shared-certs volume in Apache Spark chart.

### Benefits

Successful deployment when SSL is enabled for Apache Spark. This change allows Spark to find the certificates in default location where it search them.

### Applicable issues

https://github.com/bitnami/charts/issues/13290 issue.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
