### PR TITLE
[bitnami/grafana-operator] Fix wrong argument name for parameter `zapLevel`

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -22,4 +22,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/containers/tree/main/bitnami/grafana-operator
-version: 2.7.8
+version: 2.7.9

--- a/bitnami/grafana-operator/templates/deployment.yaml
+++ b/bitnami/grafana-operator/templates/deployment.yaml
@@ -107,7 +107,7 @@ spec:
             - --zap-encoder={{ .Values.operator.zapEncoder }}
             {{- end }}
             {{- if .Values.operator.zapLevel }}
-            - --zap-level=True
+            - --zap-log-level={{ .Values.operator.zapLevel }}
             {{- end }}
             {{- if .Values.operator.zapSample }}
             - --zap-sample={{ .Values.operator.zapSample }}


### PR DESCRIPTION
The proper argument name is `--zap-log-level` (see https://github.com/grafana-operator/grafana-operator/blob/955daa6abb9b6efe85d921a783eeffd51853fae4/documentation/deploy_grafana.md?plain=1#L87)

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
