### PR TITLE
[bitnami/thanos] Fix serviceAccount name logic for Thanos

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 11.5.7
+version: 11.5.8

--- a/bitnami/thanos/templates/_helpers.tpl
+++ b/bitnami/thanos/templates/_helpers.tpl
@@ -326,9 +326,9 @@ false
 
 {{/* Service account name
 Usage:
-{{ include "thanos.serviceAccount.name" (dict "component" "bucketweb" "context" $) }}
+{{ include "thanos.serviceAccountName" (dict "component" "bucketweb" "context" $) }}
 */}}
-{{- define "thanos.serviceAccount.name" -}}
+{{- define "thanos.serviceAccountName" -}}
 {{- $component := index .context.Values .component -}}
 {{- if eq .component "query-frontend" -}}
 {{- $component = index .context.Values "queryFrontend" -}}

--- a/bitnami/thanos/templates/bucketweb/deployment.yaml
+++ b/bitnami/thanos/templates/bucketweb/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         {{- end }}
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
-      serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "bucketweb" "context" $) }}
+      serviceAccount: {{ include "thanos.serviceAccountName" (dict "component" "bucketweb" "context" $) }}
       automountServiceAccountToken: {{ .Values.bucketweb.automountServiceAccountToken }}
       {{- if .Values.bucketweb.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.bucketweb.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/thanos/templates/bucketweb/serviceaccount.yaml
+++ b/bitnami/thanos/templates/bucketweb/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccount.name" (dict "component" "bucketweb" "context" $) }}
+  name: {{ include "thanos.serviceAccountName" (dict "component" "bucketweb" "context" $) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb

--- a/bitnami/thanos/templates/compactor/deployment.yaml
+++ b/bitnami/thanos/templates/compactor/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         {{- end }}
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
-      serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "compactor" "context" $) }}
+      serviceAccount: {{ include "thanos.serviceAccountName" (dict "component" "compactor" "context" $) }}
       automountServiceAccountToken: {{ .Values.compactor.automountServiceAccountToken }}
       {{- if .Values.compactor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.compactor.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/thanos/templates/compactor/serviceaccount.yaml
+++ b/bitnami/thanos/templates/compactor/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccount.name" (dict "component" "compactor" "context" $) }}
+  name: {{ include "thanos.serviceAccountName" (dict "component" "compactor" "context" $) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: compactor

--- a/bitnami/thanos/templates/query-frontend/deployment.yaml
+++ b/bitnami/thanos/templates/query-frontend/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
-      serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "query-frontend" "context" $) }}
+      serviceAccount: {{ include "thanos.serviceAccountName" (dict "component" "query-frontend" "context" $) }}
       automountServiceAccountToken: {{ .Values.queryFrontend.automountServiceAccountToken }}
       {{- if .Values.queryFrontend.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.queryFrontend.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query-frontend/psp-clusterrolebinding.yaml
@@ -19,6 +19,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: {{ include "thanos.serviceAccount.name" (dict "component" "query-frontend" "context" $) }}
+    name: {{ include "thanos.serviceAccountName" (dict "component" "query-frontend" "context" $) }}
     namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/thanos/templates/query-frontend/serviceaccount.yaml
+++ b/bitnami/thanos/templates/query-frontend/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccount.name" (dict "component" "query-frontend" "context" $) }}
+  name: {{ include "thanos.serviceAccountName" (dict "component" "query-frontend" "context" $) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend

--- a/bitnami/thanos/templates/query/deployment.yaml
+++ b/bitnami/thanos/templates/query/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       {{- end }}
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
-      serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "query" "context" $) }}
+      serviceAccount: {{ include "thanos.serviceAccountName" (dict "component" "query" "context" $) }}
       automountServiceAccountToken: {{ .Values.query.automountServiceAccountToken }}
       {{- if .Values.query.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.query.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
+++ b/bitnami/thanos/templates/query/psp-clusterrolebinding.yaml
@@ -20,6 +20,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: {{ include "thanos.serviceAccount.name" (dict "component" "query" "context" $) }}
+    name: {{ include "thanos.serviceAccountName" (dict "component" "query" "context" $) }}
     namespace: {{ .Release.Namespace | quote }}
 {{- end }}

--- a/bitnami/thanos/templates/query/serviceaccount.yaml
+++ b/bitnami/thanos/templates/query/serviceaccount.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccount.name" (dict "component" "query" "context" $) }}
+  name: {{ include "thanos.serviceAccountName" (dict "component" "query" "context" $) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query

--- a/bitnami/thanos/templates/receive-distributor/deployment.yaml
+++ b/bitnami/thanos/templates/receive-distributor/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         {{- end }}
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
-      serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "receive" "context" $) }}
+      serviceAccount: {{ include "thanos.serviceAccountName" (dict "component" "receive" "context" $) }}
       automountServiceAccountToken: {{ .Values.receiveDistributor.automountServiceAccountToken }}
       {{- if .Values.receiveDistributor.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.receiveDistributor.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/thanos/templates/receive-distributor/serviceaccount.yaml
+++ b/bitnami/thanos/templates/receive-distributor/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccount.name" (dict "component" "receive-distributor" "context" $) }}
+  name: {{ include "thanos.serviceAccountName" (dict "component" "receive-distributor" "context" $) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive-distributor

--- a/bitnami/thanos/templates/receive/serviceaccount.yaml
+++ b/bitnami/thanos/templates/receive/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccount.name" (dict "component" "receive" "context" $) }}
+  name: {{ include "thanos.serviceAccountName" (dict "component" "receive" "context" $) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive

--- a/bitnami/thanos/templates/receive/statefulset.yaml
+++ b/bitnami/thanos/templates/receive/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         {{- end }}
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
-      serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "receive" "context" $) }}
+      serviceAccount: {{ include "thanos.serviceAccountName" (dict "component" "receive" "context" $) }}
       automountServiceAccountToken: {{ .Values.receive.automountServiceAccountToken }}
       {{- if .Values.receive.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.receive.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/thanos/templates/ruler/serviceaccount.yaml
+++ b/bitnami/thanos/templates/ruler/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccount.name" (dict "component" "ruler" "context" $) }}
+  name: {{ include "thanos.serviceAccountName" (dict "component" "ruler" "context" $) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler

--- a/bitnami/thanos/templates/ruler/statefulset.yaml
+++ b/bitnami/thanos/templates/ruler/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
         {{- end }}
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
-      serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "ruler" "context" $) }}
+      serviceAccount: {{ include "thanos.serviceAccountName" (dict "component" "ruler" "context" $) }}
       automountServiceAccountToken: {{ .Values.ruler.automountServiceAccountToken }}
       {{- if .Values.ruler.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.ruler.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/thanos/templates/serviceaccount.yaml
+++ b/bitnami/thanos/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccount.name" . }}
+  name: {{ include "thanos.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway

--- a/bitnami/thanos/templates/serviceaccount.yaml
+++ b/bitnami/thanos/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccountName" . }}
+  name: {{ include "thanos.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway

--- a/bitnami/thanos/templates/storegateway/serviceaccount.yaml
+++ b/bitnami/thanos/templates/storegateway/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccount.name" (dict "component" "storegateway" "context" $) }}
+  name: {{ include "thanos.serviceAccountName" (dict "component" "storegateway" "context" $) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -59,7 +59,7 @@ spec:
         {{- end }}
     spec:
       {{- include "thanos.imagePullSecrets" $ | nindent 6 }}
-      serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "storegateway" "context" $) }}
+      serviceAccount: {{ include "thanos.serviceAccountName" (dict "component" "storegateway" "context" $) }}
       automountServiceAccountToken: {{ $.Values.storegateway.automountServiceAccountToken }}
       {{- if $.Values.storegateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.hostAliases "context" $) | nindent 8 }}

--- a/bitnami/thanos/templates/storegateway/statefulset.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         {{- end }}
     spec:
       {{- include "thanos.imagePullSecrets" . | nindent 6 }}
-      serviceAccount: {{ include "thanos.serviceAccount.name" (dict "component" "storegateway" "context" $) }}
+      serviceAccount: {{ include "thanos.serviceAccountName" (dict "component" "storegateway" "context" $) }}
       automountServiceAccountToken: {{ .Values.storegateway.automountServiceAccountToken }}
       {{- if .Values.storegateway.hostAliases }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.storegateway.hostAliases "context" $) | nindent 8 }}


### PR DESCRIPTION
### Description of the change

The template/serviceaccount file sets its name value using the _helpers.tlp file just like the other assets and not the common fullname value.

### Benefits

The format is the same as the other assets and the value is really being set with the value indicated.

### Additional information

- Fixes https://github.com/bitnami/charts/issues/13378

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
