### PR TITLE
[bitnami/keycloak] Fix truststore and keystore passwords env vars in statefulset

### DIFF
--- a/bitnami/keycloak/templates/statefulset.yaml
+++ b/bitnami/keycloak/templates/statefulset.yaml
@@ -118,14 +118,14 @@ spec:
                   name: {{ include "keycloak.databaseSecretName" . }}
                   key: {{ include "keycloak.databaseSecretKey" . }}
             {{- if and .Values.tls.enabled (or .Values.tls.keystorePassword .Values.tls.passwordsSecret) }}
-            - name: KEYCLOAK_TLS_KEY_STORE_PASSWORD
+            - name: KEYCLOAK_HTTPS_KEY_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "keycloak.tlsPasswordsSecretName" . }}
                   key: "tls-keystore-password"
             {{- end }}
             {{- if and .Values.tls.enabled (or .Values.tls.truststorePassword .Values.tls.passwordsSecret) }}
-            - name: KEYCLOAK_TLS_TRUST_STORE_PASSWORD
+            - name: KEYCLOAK_HTTPS_TRUST_STORE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "keycloak.tlsPasswordsSecretName" . }}


### PR DESCRIPTION
Updated env vars according to Docker image documentation.

Signed-off-by: NicolasEspiau-urbasolar <117731290+NicolasEspiau-urbasolar@users.noreply.github.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Use the proper name of env vars for truststore and keystore passwords.

### Benefits

<!-- What benefits will be realized by the code change? -->

It's a fix, the server wouldn't start otherwise.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #13434

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

Followed documentation [here](https://hub.docker.com/r/bitnami/keycloak).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
