### PR TITLE
[bitnami/sealed-secrets] Fixes the Sealed Secrets chart readme links

### DIFF
--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -23,4 +23,4 @@ name: sealed-secrets
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/sealed-secrets
   - https://github.com/bitnami-labs/sealed-secrets
-version: 1.1.8
+version: 1.1.9

--- a/bitnami/sealed-secrets/README.md
+++ b/bitnami/sealed-secrets/README.md
@@ -138,7 +138,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `priorityClassName`                                 | Sealed Secret pods' priorityClassName                                                                                    | `""`                     |
 | `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`                     |
 | `schedulerName`                                     | Name of the k8s scheduler (other than default) for Sealed Secret pods                                                    | `""`                     |
-| `terminationGracePeriodSeconds`                     | Seconds Redmine pod needs to terminate gracefully                                                                        | `""`                     |
+| `terminationGracePeriodSeconds`                     | Seconds the pod needs to terminate gracefully                                                                            | `""`                     |
 | `lifecycleHooks`                                    | for the Sealed Secret container(s) to automate configuration before or after startup                                     | `{}`                     |
 | `extraEnvVars`                                      | Array with extra environment variables to add to Sealed Secret nodes                                                     | `[]`                     |
 | `extraEnvVarsCM`                                    | Name of existing ConfigMap containing extra env vars for Sealed Secret nodes                                             | `""`                     |
@@ -247,7 +247,7 @@ kubeseal --fetch-cert \
 > pub-cert.pem
 ```
 
-Refer to Sealed Secrets documentation for more infomation about [kubeseal usage](https://github.com/bitnami-labs/sealed-secrets#usage).
+Refer to Sealed Secrets documentation for more information about [kubeseal usage](https://github.com/bitnami-labs/sealed-secrets#usage).
 
 ### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
 
@@ -259,15 +259,15 @@ Bitnami will release a new chart updating its containers if a new version of the
 
 This chart provides support for Ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress-controller](https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller) or [contour](https://github.com/bitnami/charts/tree/main/bitnami/contour) you can utilize the ingress controller to serve your application.
 
-To enable Ingress integration, set `ingress.enabled` to `true`. The `ingress.hostname` property can be used to set the host name. The `ingress.tls` parameter can be used to add the TLS configuration for this host. It is also possible to have more than one host, with a separate TLS configuration for each host. [Learn more about configuring and using Ingress](https://docs.bitnami.com/kubernetes/apps/sealed-secrets/configuration/configure-use-ingress/).
+To enable Ingress integration, set `ingress.enabled` to `true`. The `ingress.hostname` property can be used to set the host name. The `ingress.tls` parameter can be used to add the TLS configuration for this host. It is also possible to have more than one host, with a separate TLS configuration for each host. [Learn more about configuring and using Ingress](https://docs.bitnami.com/kubernetes/infrastructure/sealed-secrets/configuration/configure-ingress/).
 
 ### TLS secrets
 
-The chart also facilitates the creation of TLS secrets for use with the Ingress controller, with different options for certificate management. [Learn more about TLS secrets](https://docs.bitnami.com/kubernetes/apps/sealed-secrets/administration/enable-tls/).
+The chart also facilitates the creation of TLS secrets for use with the Ingress controller, with different options for certificate management. [Learn more about TLS secrets](https://docs.bitnami.com/kubernetes/infrastructure/sealed-secrets/administration/enable-tls-ingress/).
 
 ### Sidecars
 
-If additional containers are needed in the same pod as Sealed Secrets (such as additional metrics or logging exporters), they can be defined using the `sidecars` parameter. If these sidecars export extra ports, extra port definitions can be added using the `service.extraPorts` parameter. [Learn more about configuring and using sidecar containers](https://docs.bitnami.com/kubernetes/apps/sealed-secrets/administration/configure-use-sidecars/).
+If additional containers are needed in the same pod as Sealed Secrets (such as additional metrics or logging exporters), they can be defined using the `sidecars` parameter. If these sidecars export extra ports, extra port definitions can be added using the `service.extraPorts` parameter. [Learn more about configuring and using sidecar containers](https://docs.bitnami.com/kubernetes/infrastructure/sealed-secrets/configuration/configure-sidecar-init-containers/).
 
 ### Pod affinity
 

--- a/bitnami/sealed-secrets/values.yaml
+++ b/bitnami/sealed-secrets/values.yaml
@@ -254,7 +254,7 @@ topologySpreadConstraints: []
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
 schedulerName: ""
-## @param terminationGracePeriodSeconds Seconds Redmine pod needs to terminate gracefully
+## @param terminationGracePeriodSeconds Seconds the pod needs to terminate gracefully
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
 ##
 terminationGracePeriodSeconds: ""


### PR DESCRIPTION
Signed-off-by: Alfredo Garcia <algarcia@vmware.com>

### Description of the change

Fixes the Sealed Secrets chart readme links

### Benefits

Links to the Bitnami Sealed Secrets documentation are not correct in the `README` file; this PR modifies the links to the appropriate URL. 
 
### Possible drawbacks

None. 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
