### PR TITLE
[bitnami/kafka] fix memory opts for jmx-exporter

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kafka
   - https://kafka.apache.org/
-version: 19.1.2
+version: 19.1.3

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -472,9 +472,7 @@ spec:
           command:
             - java
           args:
-            - -XX:+UnlockExperimentalVMOptions
-            - -XX:+UseCGroupMemoryLimitForHeap
-            - -XX:MaxRAMFraction=1
+            - -XX:MaxRAMPercentage=100
             - -XshowSettings:vm
             - -jar
             - jmx_prometheus_httpserver.jar


### PR DESCRIPTION
Signed-off-by: Cyril Jouve <jv.cyril@gmail.com>

### Description of the change

see #13428
- drop removed options in java11
- replace deprecated options by "new" ones

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #13428
  - fixes #13071 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

tested with:
``` yaml
metrics:
  jmx:
    enabled: true
    resources:
      limits: 1Gi
``` 
=>
```
VM settings:
Max. Heap Size (Estimated): 989.88M
Using VM: OpenJDK 64-Bit Server VM
``` 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
