### PR TITLE
[bitnami/ejbca] Fix EJBCA Cypress Test

### DIFF
--- a/.vib/ejbca/cypress/cypress/integration/ejbca_spec.js
+++ b/.vib/ejbca/cypress/cypress/integration/ejbca_spec.js
@@ -23,13 +23,12 @@ it('allows to enrol and verify certificate', () => {
           doc.addEventListener('click', () => {
             setTimeout(function () {
               doc.location.reload();
-            }, 2000);
+            }, 5000);
           });
 
           cy.contains('input', 'Enroll').click();
         });
     }
-    cy.readFile(certFile).should('exist');
   });
 
   cy.visit('/ejbca/retrieve/list_certs.jsp');


### PR DESCRIPTION
Signed-off-by: Michiel <michield@vmware.com>

### Description of the change

Currently the EJBCA Cypress test is unstable. The p12 is not always downloaded due to a bug in [Cypress](https://github.com/cypress-io/cypress/issues/14857). A workaround for this bug is to avoid checking for the file, and continue with the test after a few seconds. As the test later checks if the certificate exists, we can safely assume it has been possible to create a certificate.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

