### PR TITLE
[bitnami/cert-manager] Rename Cert Manager to cert-manager

### DIFF
--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x.x
-description: Cert Manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
+description: cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
 engine: gotpl
 home: https://github.com/jetstack/cert-manager
 icon: https://bitnami.com/assets/stacks/cert-manager/img/cert-manager-stack-220x234.png
@@ -26,4 +26,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/cert-manager-webhook
   - https://github.com/bitnami/containers/tree/main/bitnami/cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.8.6
+version: 0.8.7

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -1,10 +1,10 @@
-<!--- app-name: Cert Manager -->
+<!--- app-name: cert-manager -->
 
-# Cert Manager packaged by Bitnami
+# cert-manager packaged by Bitnami
 
-Cert Manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
+cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
 
-[Overview of Cert Manager](https://github.com/jetstack/cert-manager)
+[Overview of cert-manager](https://github.com/jetstack/cert-manager)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
                            
@@ -71,11 +71,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | `commonLabels`             | Labels to add to all deployed objects                                                                                                             | `{}`          |
 | `commonAnnotations`        | Annotations to add to all deployed objects                                                                                                        | `{}`          |
 | `extraDeploy`              | Array of extra objects to deploy with the release                                                                                                 | `[]`          |
-| `logLevel`                 | Set up cert manager log level                                                                                                                     | `2`           |
+| `logLevel`                 | Set up cert-manager log level                                                                                                                     | `2`           |
 | `clusterResourceNamespace` | Namespace used to store DNS provider credentials etc. for ClusterIssuer resources. If empty, uses the namespace where the controller is deployed. | `""`          |
 | `leaderElection.namespace` | Namespace which leaderElection works.                                                                                                             | `kube-system` |
-| `installCRDs`              | Flag to install Cert Manager CRDs                                                                                                                 | `false`       |
-| `replicaCount`             | Number of Cert Manager replicas                                                                                                                   | `1`           |
+| `installCRDs`              | Flag to install cert-Manager CRDs                                                                                                                 | `false`       |
+| `replicaCount`             | Number of cert-manager replicas                                                                                                                   | `1`           |
 
 
 ### Controller deployment parameters
@@ -109,7 +109,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `controller.affinity` is set. Allowed values: `soft` or `hard`       | `""`                   |
 | `controller.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `controller.affinity` is set                                           | `""`                   |
 | `controller.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `controller.affinity` is set                                        | `[]`                   |
-| `controller.affinity`                                    | Affinity for Cert Manager Controller                                                                       | `{}`                   |
+| `controller.affinity`                                    | Affinity for cert-manager Controller                                                                       | `{}`                   |
 | `controller.nodeSelector`                                | Node labels for pod assignment                                                                             | `{}`                   |
 | `controller.containerPort`                               | Controller container port                                                                                  | `9402`                 |
 | `controller.command`                                     | Override Controller default command                                                                        | `[]`                   |
@@ -165,7 +165,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `webhook.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `webhook.affinity` is set. Allowed values: `soft` or `hard`       | `""`                           |
 | `webhook.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `webhook.affinity` is set                                           | `""`                           |
 | `webhook.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `webhook.affinity` is set                                        | `[]`                           |
-| `webhook.affinity`                                    | Affinity for Cert Manager Webhook                                                                       | `{}`                           |
+| `webhook.affinity`                                    | Affinity for cert-manager Webhook                                                                       | `{}`                           |
 | `webhook.nodeSelector`                                | Node labels for pod assignment                                                                          | `{}`                           |
 | `webhook.containerPort`                               | Webhook container port                                                                                  | `10250`                        |
 | `webhook.httpsPort`                                   | Webhook container port                                                                                  | `443`                          |
@@ -237,7 +237,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cainjector.nodeAffinityPreset.type`                     | Node affinity preset type. Ignored if `cainjector.affinity` is set. Allowed values: `soft` or `hard`       | `""`                  |
 | `cainjector.nodeAffinityPreset.key`                      | Node label key to match. Ignored if `cainjector.affinity` is set                                           | `""`                  |
 | `cainjector.nodeAffinityPreset.values`                   | Node label values to match. Ignored if `cainjector.affinity` is set                                        | `[]`                  |
-| `cainjector.affinity`                                    | Affinity for Cert Manager CAInjector                                                                       | `{}`                  |
+| `cainjector.affinity`                                    | Affinity for cert-manager CAInjector                                                                       | `{}`                  |
 | `cainjector.nodeSelector`                                | Node labels for pod assignment                                                                             | `{}`                  |
 | `cainjector.command`                                     | Override CAInjector default command                                                                        | `[]`                  |
 | `cainjector.args`                                        | Override CAInjector default args                                                                           | `[]`                  |
@@ -271,7 +271,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                       | Description                                                                       | Value      |
 | ------------------------------------------ | --------------------------------------------------------------------------------- | ---------- |
 | `metrics.enabled`                          | Start metrics                                                                     | `true`     |
-| `metrics.podAnnotations`                   | Annotations for Cert Manager exporter pods                                        | `{}`       |
+| `metrics.podAnnotations`                   | Annotations for cert-manager exporter pods                                        | `{}`       |
 | `metrics.serviceMonitor.path`              | The path which the ServiceMonitor will monitor                                    | `/metrics` |
 | `metrics.serviceMonitor.targetPort`        | The port in which the ServiceMonitor will monitor                                 | `9402`     |
 | `metrics.serviceMonitor.enabled`           | Create ServiceMonitor Resource for scraping metrics using PrometheusOperator      | `false`    |
@@ -331,7 +331,7 @@ Alternatively, you can use a ConfigMap or a Secret with the environment variable
 
 ### Sidecars and Init Containers
 
-If you have a need for additional containers to run within the same pod as the Cert Manager app (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
+If you have a need for additional containers to run within the same pod as the cert-manager app (e.g. an additional metrics or logging exporter), you can do so via the `sidecars` config parameter. Simply define your container according to the Kubernetes container spec.
 
 ```yaml
 sidecars:
@@ -373,7 +373,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ### To 0.5.0
 
-Exisiting CRDs have been syncronised with the official [Cert Manager repository](https://github.com/cert-manager/cert-manager/tree/master/deploy/crds). Using the templates present in the 1.8.0 tag.
+Exisiting CRDs have been syncronised with the official [cert-manager repository](https://github.com/cert-manager/cert-manager/tree/master/deploy/crds). Using the templates present in the 1.8.0 tag.
 
 ## License
 

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -74,7 +74,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `logLevel`                 | Set up cert-manager log level                                                                                                                     | `2`           |
 | `clusterResourceNamespace` | Namespace used to store DNS provider credentials etc. for ClusterIssuer resources. If empty, uses the namespace where the controller is deployed. | `""`          |
 | `leaderElection.namespace` | Namespace which leaderElection works.                                                                                                             | `kube-system` |
-| `installCRDs`              | Flag to install cert-Manager CRDs                                                                                                                 | `false`       |
+| `installCRDs`              | Flag to install cert-manager CRDs                                                                                                                 | `false`       |
 | `replicaCount`             | Number of cert-manager replicas                                                                                                                   | `1`           |
 
 
@@ -85,14 +85,14 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.replicaCount`                                | Number of Controller replicas                                                                              | `1`                    |
 | `controller.image.registry`                              | Controller image registry                                                                                  | `docker.io`            |
 | `controller.image.repository`                            | Controller image repository                                                                                | `bitnami/cert-manager` |
-| `controller.image.tag`                                   | Controller image tag (immutable tags are recommended)                                                      | `1.9.1-debian-11-r26`  |
+| `controller.image.tag`                                   | Controller image tag (immutable tags are recommended)                                                      | `1.10.0-debian-11-r0`  |
 | `controller.image.digest`                                | Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
 | `controller.image.pullPolicy`                            | Controller image pull policy                                                                               | `IfNotPresent`         |
 | `controller.image.pullSecrets`                           | Controller image pull secrets                                                                              | `[]`                   |
 | `controller.image.debug`                                 | Controller image debug mode                                                                                | `false`                |
 | `controller.acmesolver.image.registry`                   | Controller image registry                                                                                  | `docker.io`            |
 | `controller.acmesolver.image.repository`                 | Controller image repository                                                                                | `bitnami/acmesolver`   |
-| `controller.acmesolver.image.tag`                        | Controller image tag (immutable tags are recommended)                                                      | `1.9.1-debian-11-r28`  |
+| `controller.acmesolver.image.tag`                        | Controller image tag (immutable tags are recommended)                                                      | `1.10.0-debian-11-r0`  |
 | `controller.acmesolver.image.digest`                     | Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
 | `controller.acmesolver.image.pullPolicy`                 | Controller image pull policy                                                                               | `IfNotPresent`         |
 | `controller.acmesolver.image.pullSecrets`                | Controller image pull secrets                                                                              | `[]`                   |
@@ -148,7 +148,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `webhook.replicaCount`                                | Number of Webhook replicas                                                                              | `1`                            |
 | `webhook.image.registry`                              | Webhook image registry                                                                                  | `docker.io`                    |
 | `webhook.image.repository`                            | Webhook image repository                                                                                | `bitnami/cert-manager-webhook` |
-| `webhook.image.tag`                                   | Webhook image tag (immutable tags are recommended)                                                      | `1.9.1-debian-11-r24`          |
+| `webhook.image.tag`                                   | Webhook image tag (immutable tags are recommended)                                                      | `1.9.1-debian-11-r28`          |
 | `webhook.image.digest`                                | Webhook image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                           |
 | `webhook.image.pullPolicy`                            | Webhook image pull policy                                                                               | `IfNotPresent`                 |
 | `webhook.image.pullSecrets`                           | Webhook image pull secrets                                                                              | `[]`                           |
@@ -220,7 +220,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `cainjector.replicaCount`                                | Number of CAInjector replicas                                                                              | `1`                   |
 | `cainjector.image.registry`                              | CAInjector image registry                                                                                  | `docker.io`           |
 | `cainjector.image.repository`                            | CAInjector image repository                                                                                | `bitnami/cainjector`  |
-| `cainjector.image.tag`                                   | CAInjector image tag (immutable tags are recommended)                                                      | `1.9.1-debian-11-r26` |
+| `cainjector.image.tag`                                   | CAInjector image tag (immutable tags are recommended)                                                      | `1.10.0-debian-11-r0` |
 | `cainjector.image.digest`                                | CAInjector image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
 | `cainjector.image.pullPolicy`                            | CAInjector image pull policy                                                                               | `IfNotPresent`        |
 | `cainjector.image.pullSecrets`                           | CAInjector image pull secrets                                                                              | `[]`                  |

--- a/bitnami/cert-manager/templates/_helpers.tpl
+++ b/bitnami/cert-manager/templates/_helpers.tpl
@@ -150,12 +150,12 @@ Compile all warnings into a single message.
 {{- end -}}
 {{- end -}}
 
-{{/* Validate values of Cert Manager - CRD */}}
+{{/* Validate values of cert-manager - CRD */}}
 {{- define "certmanager.validateValues.setCRD" -}}
 {{- if not .Values.installCRDs -}}
 cert-manager: CRDs
-    You will use cert manager without installing CRDs.
-    If you want to include our CRD resources, please install the cert manager using the crd flags (--set .Values.installCRDs=true).
+    You will use cert-manager without installing CRDs.
+    If you want to include our CRD resources, please install the cert-manager using the crd flags (--set .Values.installCRDs=true).
 {{- end -}}
 {{- end -}}
 

--- a/bitnami/cert-manager/values.yaml
+++ b/bitnami/cert-manager/values.yaml
@@ -31,7 +31,7 @@ commonAnnotations: {}
 ## @param extraDeploy Array of extra objects to deploy with the release
 ##
 extraDeploy: []
-## @param logLevel Set up cert manager log level
+## @param logLevel Set up cert-manager log level
 ##
 logLevel: 2
 ## @param clusterResourceNamespace Namespace used to store DNS provider credentials etc. for ClusterIssuer resources. If empty, uses the namespace where the controller is deployed.
@@ -41,10 +41,10 @@ clusterResourceNamespace: ""
 ##
 leaderElection:
   namespace: "kube-system"
-## @param installCRDs Flag to install Cert Manager CRDs
+## @param installCRDs Flag to install cert-manager CRDs
 ##
 installCRDs: false
-## @param replicaCount Number of Cert Manager replicas
+## @param replicaCount Number of cert-manager replicas
 ##
 replicaCount: 1
 
@@ -56,7 +56,7 @@ controller:
   ## @param controller.replicaCount Number of Controller replicas
   ##
   replicaCount: 1
-  ## Bitnami Cert Manager image
+  ## Bitnami cert-manager image
   ## ref: https://hub.docker.com/r/bitnami/cert-manager/tags/
   ## @param controller.image.registry Controller image registry
   ## @param controller.image.repository Controller image repository
@@ -167,7 +167,7 @@ controller:
     ##   - e2e-az2
     ##
     values: []
-  ## @param controller.affinity Affinity for Cert Manager Controller
+  ## @param controller.affinity Affinity for cert-manager Controller
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## NOTE: `controller.podAffinityPreset`, `controller.podAntiAffinityPreset`, and `controller.nodeAffinityPreset` will be ignored when it's set
   ##
@@ -313,7 +313,7 @@ webhook:
   ## @param webhook.replicaCount Number of Webhook replicas
   ##
   replicaCount: 1
-  ## Bitnami Cert Manager Webhook image
+  ## Bitnami cert-manager Webhook image
   ## ref: https://hub.docker.com/r/bitnami/cert-manager-webhook/tags/
   ## @param webhook.image.registry Webhook image registry
   ## @param webhook.image.repository Webhook image repository
@@ -395,7 +395,7 @@ webhook:
     ##   - e2e-az2
     ##
     values: []
-  ## @param webhook.affinity Affinity for Cert Manager Webhook
+  ## @param webhook.affinity Affinity for cert-manager Webhook
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## NOTE: `webhook.podAffinityPreset`, `webhook.podAntiAffinityPreset`, and `webhook.nodeAffinityPreset` will be ignored when it's set
   ##
@@ -659,7 +659,7 @@ cainjector:
     ##   - e2e-az2
     ##
     values: []
-  ## @param cainjector.affinity Affinity for Cert Manager CAInjector
+  ## @param cainjector.affinity Affinity for cert-manager CAInjector
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   ## NOTE: `cainjector.podAffinityPreset`, `cainjector.podAntiAffinityPreset`, and `cainjector.nodeAffinityPreset` will be ignored when it's set
   ##
@@ -789,7 +789,7 @@ metrics:
   ## ref: https://github.com/coreos/prometheus-operator
   ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
   ##
-  ## @param metrics.podAnnotations [object] Annotations for Cert Manager exporter pods
+  ## @param metrics.podAnnotations [object] Annotations for cert-manager exporter pods
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   podAnnotations:


### PR DESCRIPTION
Following the upstream nomenclature, all the occurrences of _Cert Manager_ were replaced by _cert-manager_.

Related to https://github.com/bitnami/containers/pull/13324