### PR TITLE
[bitnami/fluentd] fix extraEnvVars typo in values.yaml

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/fluentd
   - https://www.fluentd.org/
-version: 5.5.7
+version: 5.5.8

--- a/bitnami/fluentd/values.yaml
+++ b/bitnami/fluentd/values.yaml
@@ -271,7 +271,7 @@ forwarder:
   ##
   extraArgs: ""
   ## @param forwarder.extraEnvVars Extra environment variables to pass to the container
-  ## extraEnv:
+  ## extraEnvVars:
   ##   - name: MY_ENV_VAR
   ##     value: my_value
   ##
@@ -773,7 +773,7 @@ aggregator:
   ##
   extraArgs: ""
   ## @param aggregator.extraEnvVars Extra environment variables to pass to the container
-  ## extraEnv:
+  ## extraEnvVars:
   ##   - name: MY_ENV_VAR
   ##     value: my_value
   ##


### PR DESCRIPTION
Signed-off-by: Petrus.Z <silencly07@gmail.com>

### Description of the change

Fix extraEnvVars typo in comments of the values.yaml file.

### Benefits

Make values.yaml more clear.

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
