### PR TITLE
Use 0.4.11 as pinned version for vib action

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -167,7 +167,7 @@ jobs:
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
           echo "verification_mode=${verification_mode}" >> $GITHUB_OUTPUT
-      - uses: vmware-labs/vmware-image-builder-action@0.4.10
+      - uses: vmware-labs/vmware-image-builder-action@0.4.11
         name: Verify and publish ${{ needs.get-chart.outputs.chart }}
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-publish.json

--- a/.github/workflows/ci-pipeline-extra-thanos.yml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - uses: vmware-labs/vmware-image-builder-action@0.4.10
+      - uses: vmware-labs/vmware-image-builder-action@0.4.11
         with:
           pipeline: thanos/bucketweb/vib-verify.json
         env:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -117,7 +117,7 @@ jobs:
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
           echo "verification_mode=${verification_mode}" >> $GITHUB_OUTPUT
-      - uses: vmware-labs/vmware-image-builder-action@0.4.10
+      - uses: vmware-labs/vmware-image-builder-action@0.4.11
         name: Verify ${{ needs.get-chart.outputs.chart }}
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-verify.json


### PR DESCRIPTION
This version should include changes from the following PR:
* https://github.com/vmware-labs/vmware-image-builder-action/pull/104

**Changelog**:
* Timeouts are now 120s
* There is a new info log line that will print on slow requests (>60s)
* Removed the stack from the trace on retries and almost reverted to the simpler format that we had before plus a couple of additional pieces of info.