### PR TITLE
[bitnami/thanos] Fix issue with serviceAccount.create

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 11.5.9
+version: 11.5.10

--- a/bitnami/thanos/templates/serviceaccount.yaml
+++ b/bitnami/thanos/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "thanos.serviceAccountName" . }}
+  name: {{ include "thanos.serviceAccountName" (dict "component" "" "context" $) }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

### Description of the change

Fixes an issue with the serviceaccount.yaml template introduced in #13312, where the helper 'thanos.serviceAccountName' is missing its arguments.

We could either use `component=""` or revert back to `common.names.fullname`.

The benefits of using `component=""` is that the ServiceAccount name can be created using the name `.Values.serviceAccount.name`.

### Applicable issues

  - fixes #13466

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
