### PR TITLE
[bitnami/solr] Add "app.kubernetes.io/component: solr" to matchLabels

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/solr
   - https://lucene.apache.org/solr/
-version: 6.3.0
+version: 6.3.1

--- a/bitnami/solr/templates/pdb.yaml
+++ b/bitnami/solr/templates/pdb.yaml
@@ -20,4 +20,5 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: solr
 {{- end }}


### PR DESCRIPTION
### Description of the change
In #13463 I added a PDB for `solr`. Turns out, the provided `common.labels.matchLabels` are not sufficient: The `solr-exporter` uses the same set. They are only distinguishable by the label `app.kubernetes.io/component`. Values are `solr` or `exporter` of which we need to match `solr`.

This PR adds the label directly in template pdb.yaml. I'm not sure if this is the right way, so feel free to criticize.

### Benefits

PDB can distinguish between `solr` and `solr-exporter`.

### Possible drawbacks
There are no known drawbacks.

### Applicable issues
n/a

### Additional information
n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
