### PR TITLE
[bitnami/mysql]: Add support for RuntimeClass

### DIFF
--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -25,4 +25,4 @@ name: mysql
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mysql
   - https://mysql.com
-version: 9.4.3
+version: 9.4.4

--- a/bitnami/mysql/README.md
+++ b/bitnami/mysql/README.md
@@ -126,6 +126,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `primary.nodeSelector`                          | Node labels for MySQL primary pods assignment                                                                   | `{}`                |
 | `primary.tolerations`                           | Tolerations for MySQL primary pods assignment                                                                   | `[]`                |
 | `primary.priorityClassName`                     | MySQL primary pods' priorityClassName                                                                           | `""`                |
+| `primary.runtimeClassName`                      | MySQL primary pods' runtimeClassName                                                                            | `""`                |
 | `primary.schedulerName`                         | Name of the k8s scheduler (other than default)                                                                  | `""`                |
 | `primary.terminationGracePeriodSeconds`         | In seconds, time the given to the MySQL primary pod needs to terminate gracefully                               | `""`                |
 | `primary.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                  | `[]`                |
@@ -215,6 +216,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secondary.nodeSelector`                          | Node labels for MySQL secondary pods assignment                                                                     | `{}`                |
 | `secondary.tolerations`                           | Tolerations for MySQL secondary pods assignment                                                                     | `[]`                |
 | `secondary.priorityClassName`                     | MySQL secondary pods' priorityClassName                                                                             | `""`                |
+| `secondary.runtimeClassName`                      | MySQL secondary pods' runtimeClassName                                                                              | `""`                |
 | `secondary.schedulerName`                         | Name of the k8s scheduler (other than default)                                                                      | `""`                |
 | `secondary.terminationGracePeriodSeconds`         | In seconds, time the given to the MySQL secondary pod needs to terminate gracefully                                 | `""`                |
 | `secondary.topologySpreadConstraints`             | Topology Spread Constraints for pod assignment                                                                      | `[]`                |

--- a/bitnami/mysql/templates/primary/statefulset.yaml
+++ b/bitnami/mysql/templates/primary/statefulset.yaml
@@ -58,6 +58,9 @@ spec:
       {{- if .Values.primary.priorityClassName }}
       priorityClassName: {{ .Values.primary.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.primary.runtimeClassName }}
+      runtimeClassName: {{ .Values.primary.runtimeClassName | quote }}
+      {{- end }}
       {{- if .Values.primary.schedulerName }}
       schedulerName: {{ .Values.primary.schedulerName | quote }}
       {{- end }}

--- a/bitnami/mysql/templates/secondary/statefulset.yaml
+++ b/bitnami/mysql/templates/secondary/statefulset.yaml
@@ -59,6 +59,9 @@ spec:
       {{- if .Values.secondary.priorityClassName }}
       priorityClassName: {{ .Values.secondary.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.secondary.runtimeClassName }}
+      runtimeClassName: {{ .Values.secondary.runtimeClassName | quote }}
+      {{- end }}
       {{- if .Values.secondary.schedulerName }}
       schedulerName: {{ .Values.secondary.schedulerName | quote }}
       {{- end }}

--- a/bitnami/mysql/values.yaml
+++ b/bitnami/mysql/values.yaml
@@ -260,6 +260,9 @@ primary:
   ## @param primary.priorityClassName MySQL primary pods' priorityClassName
   ##
   priorityClassName: ""
+  ## @param primary.runtimeClassName MySQL primary pods' runtimeClassName
+  ##
+  runtimeClassName: ""
   ## @param primary.schedulerName Name of the k8s scheduler (other than default)
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##
@@ -631,6 +634,9 @@ secondary:
   ## @param secondary.priorityClassName MySQL secondary pods' priorityClassName
   ##
   priorityClassName: ""
+  ## @param secondary.runtimeClassName MySQL secondary pods' runtimeClassName
+  ##
+  runtimeClassName: ""
   ## @param secondary.schedulerName Name of the k8s scheduler (other than default)
   ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
   ##


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Adding support for RuntimeClass into MySQL helm chart

### Benefits

It allows the MySQL workload to run on FireCracker, CloudHypervisor, Sysbox, gVisor...etc

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
