### PR TITLE
[bitnami/nats] Add support for JetStream

### DIFF
--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -24,4 +24,4 @@ name: nats
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/nats
   - https://nats.io/
-version: 7.4.12
+version: 7.5.0

--- a/bitnami/nats/README.md
+++ b/bitnami/nats/README.md
@@ -92,11 +92,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `auth.timeout`           | Client authentication timeout (seconds)                                                               | `1`                  |
 | `auth.usersCredentials`  | Client authentication users credentials collection                                                    | `[]`                 |
 | `auth.noAuthUser`        | Client authentication username from auth.usersCredentials map to be used when no credentials provided | `""`                 |
+| `cluster.name`           | Cluster name                                                                                          | `nats`               |
 | `cluster.connectRetries` | Configure number of connect retries for implicit routes, otherwise leave blank                        | `""`                 |
 | `cluster.auth.enabled`   | Switch to enable/disable cluster authentication                                                       | `true`               |
 | `cluster.auth.user`      | Cluster authentication user                                                                           | `nats_cluster`       |
 | `cluster.auth.password`  | Cluster authentication password                                                                       | `""`                 |
-| `cluster.auth.token`     | Cluster authentication token                                                                          | `""`                 |
+| `jetstream.enabled`      | Switch to enable/disable JetStream                                                                    | `false`              |
+| `jetstream.maxMemory`    | Max memory usage for JetStream                                                                        | `1G`                 |
 | `debug.enabled`          | Switch to enable/disable debug on logging                                                             | `false`              |
 | `debug.trace`            | Switch to enable/disable trace debug level on logging                                                 | `false`              |
 | `debug.logtime`          | Switch to enable/disable logtime on logging                                                           | `false`              |
@@ -239,6 +241,18 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                                               | `[]`                    |
 | `metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                                             | `[]`                    |
 | `metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                    | `{}`                    |
+
+
+### Persistence parameters
+
+| Name                       | Description                                                         | Value               |
+| -------------------------- | ------------------------------------------------------------------- | ------------------- |
+| `persistence.enabled`      | Enable NATS data persistence using PVC(s)                           | `false`             |
+| `persistence.storageClass` | PVC Storage Class for NATS data volume                              | `""`                |
+| `persistence.accessModes`  | PVC Access modes                                                    | `["ReadWriteOnce"]` |
+| `persistence.size`         | PVC Storage Request for NATS data volume                            | `8Gi`               |
+| `persistence.annotations`  | Annotations for the PVC                                             | `{}`                |
+| `persistence.selector`     | Selector to match an existing Persistent Volume for NATS's data PVC | `{}`                |
 
 
 ### Other parameters

--- a/bitnami/nats/templates/_helpers.tpl
+++ b/bitnami/nats/templates/_helpers.tpl
@@ -55,6 +55,7 @@ Compile all warnings into a single message, and call fail.
 {{- define "nats.validateValues" -}}
 {{- $messages := list -}}
 {{- $messages := append $messages (include "nats.validateValues.resourceType" .) -}}
+{{- $messages := append $messages (include "nats.validateValues.jetstream" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -69,5 +70,14 @@ Compile all warnings into a single message, and call fail.
 nats: resourceType
     Invalid resourceType selected. Valid values are "deployment" and
     "statefulset". Please set a valid mode (--set resourceType="xxxx")
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of NATS - enabling JetStream requires persistence & statefulsets */}}
+{{- define "nats.validateValues.jetstream" -}}
+{{- if and .Values.jetstream.enabled (or (ne .Values.resourceType "statefulset") (not .Values.persistence.enabled)) -}}
+nats: jetstream
+    Invalid configuration selected. Enabling jetstream requires enabling persistence
+    and using a "statefulset" (--set persistence.enabled=true,resourceType="statefulset")
 {{- end -}}
 {{- end -}}

--- a/bitnami/nats/templates/statefulset.yaml
+++ b/bitnami/nats/templates/statefulset.yaml
@@ -88,6 +88,10 @@ spec:
               value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
             - name: NATS_FILENAME
               value: {{ .Values.natsFilename | quote }}
+            - name: NATS_SERVER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
@@ -144,6 +148,10 @@ spec:
             - name: config
               mountPath: /bitnami/nats/conf/{{ .Values.natsFilename }}.conf
               subPath: {{ .Values.natsFilename }}.conf
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: /data
+            {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -189,4 +197,31 @@ spec:
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        annotations:
+          {{- if .Values.persistence.annotations }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+          {{- end }}
+          {{- if .Values.commonAnnotations }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.commonAnnotations "context" $) | nindent 10 }}
+          {{- end }}
+        {{- if .Values.commonLabels }}
+        labels: {{- include "common.tplvalues.render" (dict "value" .Values.commonLabels "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+        {{- range .Values.persistence.accessModes }}
+          - {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size | quote }}
+        {{- if .Values.persistence.selector }}
+        selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 10 }}
+        {{- end }}
+        {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 8 }}
+  {{- end }}
 {{- end }}

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -82,7 +82,7 @@ image:
   ##
   debug: false
 ## Client Authentication
-## ref: https://github.com/nats-io/gnatsd#authentication
+## ref: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro
 ## @param auth.enabled Switch to enable/disable client authentication
 ## @param auth.user Client authentication user
 ## @param auth.password Client authentication password
@@ -104,23 +104,32 @@ auth:
   usersCredentials: []
   noAuthUser: ""
 ## Cluster Configuration
+## ref: https://docs.nats.io/running-a-nats-service/configuration/clustering/cluster_config
 ##
 cluster:
+  ## @param cluster.name Cluster name
+  name: nats
   ## @param cluster.connectRetries Configure number of connect retries for implicit routes, otherwise leave blank
   ##
   connectRetries: ""
   ## Cluster Authentication
-  ## ref: https://github.com/nats-io/gnatsd#authentication
+  ## ref: https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro
   ## @param cluster.auth.enabled Switch to enable/disable cluster authentication
   ## @param cluster.auth.user Cluster authentication user
   ## @param cluster.auth.password Cluster authentication password
-  ## @param cluster.auth.token Cluster authentication token
   ##
   auth:
     enabled: true
     user: nats_cluster
     password: ""
-    token: ""
+## JetStream Configuration
+## ref: https://docs.nats.io/running-a-nats-service/configuration/resource_management
+## @param jetstream.enabled Switch to enable/disable JetStream
+## @param jetstream.maxMemory Max memory usage for JetStream
+##
+jetstream:
+  enabled: false
+  maxMemory: 1G
 ## Logging parameters
 ## ref: https://github.com/nats-io/gnatsd#command-line-arguments
 ## @param debug.enabled Switch to enable/disable debug on logging
@@ -165,6 +174,7 @@ natsFilename: nats-server
 configuration: |-
   {{- $authPwd := default (include "nats.randomPassword" .) .Values.auth.password -}}
   {{- $clusterAuthPwd := default (include "nats.randomPassword" .) .Values.cluster.auth.password -}}
+  server_name: $NATS_SERVER_NAME
   listen: 0.0.0.0:{{ .Values.containerPorts.client }}
   http: 0.0.0.0:{{ .Values.containerPorts.monitoring }}
 
@@ -213,16 +223,13 @@ configuration: |-
 
   # Clustering definition
   cluster {
+    name: {{ .Values.cluster.name | quote }}
     listen: 0.0.0.0:{{ .Values.containerPorts.cluster }}
     {{- if .Values.cluster.auth.enabled }}
     # Authorization for cluster connections
     authorization {
-      {{- if .Values.cluster.auth.user }}
       user: {{ .Values.cluster.auth.user | quote }}
       password: {{ $clusterAuthPwd | quote }}
-      {{- else if .Values.cluster.auth.token }}
-      token: {{ .Values.cluster.auth.token | quote }}
-      {{- end }}
       timeout:  1
     }
     {{- end }}
@@ -231,11 +238,7 @@ configuration: |-
     # in their routes definitions from above
     routes = [
       {{- if .Values.cluster.auth.enabled }}
-      {{- if .Values.cluster.auth.user }}
       nats://{{ .Values.cluster.auth.user }}:{{ $clusterAuthPwd }}@{{ include "common.names.fullname" . }}:{{ .Values.service.ports.cluster }}
-      {{- else if .Values.cluster.auth.token }}
-      nats://{{ .Values.cluster.auth.token }}@{{ template "common.names.fullname" . }}:{{ .Values.service.ports.cluster }}
-      {{- end }}
       {{- else }}
       nats://{{ template "common.names.fullname" . }}:{{ .Values.service.ports.cluster }}
       {{- end }}
@@ -245,6 +248,17 @@ configuration: |-
     connect_retries: {{ .Values.cluster.connectRetries }}
     {{- end }}
   }
+
+  {{- if .Values.jetstream.enabled }}
+  # JetStream configuration
+  jetstream: enabled
+  jetstream {
+    store_dir: /data/jetstream
+    max_memory_store: {{ .Values.jetstream.maxMemory }}
+    max_file_store: {{ .Values.persistence.size }}
+  }
+  {{- end }}
+
 ## @param existingSecret The name of an existing Secret with your custom configuration for NATS
 ## NOTE: When it's set the configuration parameter is ignored
 ##
@@ -755,6 +769,41 @@ metrics:
     ## ref: https://github.com/bitnami/charts/tree/main/bitnami/prometheus-operator#prometheus-configuration
     ##
     selector: {}
+
+## @section Persistence parameters
+
+## Enable persistence using Persistent Volume Claims
+## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  ## @param persistence.enabled Enable NATS data persistence using PVC(s)
+  ##
+  enabled: false
+  ## @param persistence.storageClass PVC Storage Class for NATS data volume
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner
+  ##
+  storageClass: ""
+  ## @param persistence.accessModes PVC Access modes
+  ##
+  accessModes:
+    - ReadWriteOnce
+  ## @param persistence.size PVC Storage Request for NATS data volume
+  ##
+  size: 8Gi
+  ## @param persistence.annotations Annotations for the PVC
+  ##
+  annotations: {}
+  ## @param persistence.selector Selector to match an existing Persistent Volume for NATS's data PVC
+  ## If set, the PVC can't have a PV dynamically provisioned for it
+  ## E.g.
+  ## selector:
+  ##   matchLabels:
+  ##     app: my-app
+  ##
+  selector: {}
 
 ## @section Other parameters
 

--- a/bitnami/nats/values.yaml
+++ b/bitnami/nats/values.yaml
@@ -174,7 +174,9 @@ natsFilename: nats-server
 configuration: |-
   {{- $authPwd := default (include "nats.randomPassword" .) .Values.auth.password -}}
   {{- $clusterAuthPwd := default (include "nats.randomPassword" .) .Values.cluster.auth.password -}}
+  {{- if eq .Values.resourceType "statefulset" }}
   server_name: $NATS_SERVER_NAME
+  {{- end }}
   listen: 0.0.0.0:{{ .Values.containerPorts.client }}
   http: 0.0.0.0:{{ .Values.containerPorts.monitoring }}
 


### PR DESCRIPTION
### Description of the change

This PR adds support for [NATS JetStream](https://docs.nats.io/nats-concepts/jetstream)

### Benefits

Users can deploy a NATS cluster with JetStream enabled.

### Possible drawbacks

None

### Applicable issues

N/A

### Additional information

N/A

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
