### PR TITLE
[bitnami/redis-cluster] add support to disable persistence and add custom config

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
   - http://redis.io/
-version: 8.2.7
+version: 8.3.0

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -145,6 +145,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `service.externalTrafficPolicy`                         | Service external traffic policy                                                                                                                     | `Cluster`               |
 | `service.sessionAffinity`                               | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                                                | `None`                  |
 | `service.sessionAffinityConfig`                         | Additional settings for the sessionAffinity                                                                                                         | `{}`                    |
+| `persistence.enabled`                                   | Enable persistence on Redis&reg;                                                                                                                    | `true`                  |
 | `persistence.path`                                      | Path to mount the volume at, to use other images Redis&reg; images.                                                                                 | `/bitnami/redis/data`   |
 | `persistence.subPath`                                   | The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services                                             | `""`                    |
 | `persistence.storageClass`                              | Storage class of backing PVC                                                                                                                        | `""`                    |
@@ -192,6 +193,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `redis.sidecars`                               | Extra sidecar containers to add to the deployment                                                          | `[]`            |
 | `redis.podLabels`                              | Additional labels for Redis&reg; pod                                                                       | `{}`            |
 | `redis.priorityClassName`                      | Redis&reg; Master pod priorityClassName                                                                    | `""`            |
+| `redis.defaultConfigOverride`                  | Optional default Redis&reg; configuration for the nodes                                                    | `""`            |
 | `redis.configmap`                              | Additional Redis&reg; configuration for the nodes                                                          | `""`            |
 | `redis.extraEnvVars`                           | An array to add extra environment variables                                                                | `[]`            |
 | `redis.extraEnvVarsCM`                         | ConfigMap with extra environment variables                                                                 | `""`            |

--- a/bitnami/redis-cluster/templates/configmap.yaml
+++ b/bitnami/redis-cluster/templates/configmap.yaml
@@ -11,6 +11,10 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 data:
+{{- if .Values.redis.defaultConfigOverride }}
+  redis-default.conf: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.redis.defaultConfigOverride "context" $) | nindent 4 }}
+{{- else }}
   redis-default.conf: |-
     # Redis configuration file example.
     #
@@ -2290,6 +2294,7 @@ data:
     # to suppress
     #
     # ignore-warnings ARM64-COW-BUG
+{{- end }}
 {{- if .Values.redis.configmap }}
 {{- include "common.tplvalues.render" (dict "value" .Values.redis.configmap "context" $) | nindent 4 }}
 {{- end }}

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -422,6 +422,11 @@ spec:
             secretName: {{ include "redis-cluster.tlsSecretName" . }}
             defaultMode: 256
         {{- end }}
+        {{- if not .Values.persistence.enabled }}
+        - name: redis-data
+          emptyDir: {}
+        {{- end }}
+  {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: redis-data
@@ -449,4 +454,5 @@ spec:
           {{- toYaml .Values.persistence.matchExpressions | nindent 12 }}
         {{- end -}}
         {{- end }}
+  {{- end }}
 {{- end }}

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -288,6 +288,11 @@ service:
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
+  ## @param persistence.enabled Enable persistence on Redis&reg;
+  ## If enabled, nodes are using Persistent Volume Claims
+  ## If disabled, an emptyDir volume is used
+  ##
+  enabled: true
   ## @param persistence.path Path to mount the volume at, to use other images Redis&reg; images.
   ##
   path: /bitnami/redis/data
@@ -461,6 +466,11 @@ redis:
   ## @param redis.priorityClassName Redis&reg; Master pod priorityClassName
   ##
   priorityClassName: ""
+  ## @param redis.defaultConfigOverride Optional default Redis&reg; configuration for the nodes
+  ## If not set, the default Redis configuration from the chart is used
+  ## ref: https://redis.io/topics/config
+  ##
+  defaultConfigOverride: ""
   ## @param redis.configmap Additional Redis&reg; configuration for the nodes
   ## ref: https://redis.io/topics/config
   ##


### PR DESCRIPTION

### Description of the change

* Adds support to disable persistence (uses emptyDir instead of a PVC). This is required if one wants to use Redis with in-memory data only. It makes sense to disable AOF and RDB persistence in the config in that case.
```
    # Disable AOF and RDB persistence as we keep everything in memory only, see https://redis.io/topics/persistence
    appendonly no
    # Disable RDB persistence, AOF persistence already disabled above.
    save ""
```

* Adds support to supply a custom Redis configuration, e.g. to support an older version of Redis. With the current setup the config is hard-coded and not backwards compatible, so the current chart version can't be used with an older version or Redis.

### Benefits

Adds additional features already covered, e.g. in the bitnami/redis chart. Does not change the default behavior and the changes are fully backwards compatible.

### Possible drawbacks

Additional complexity

### Applicable issues

  - fixes #4484
  - fixes #13409

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
