### PR TITLE
[bitnami/elasticsearch] fix wrong apiversion for statefulset

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 19.5.2
+version: 19.5.3

--- a/bitnami/elasticsearch/templates/coordinating/hpa.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/hpa.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   scaleTargetRef:
-    apiVersion: {{ template "common.capabilities.deployment.apiVersion" . }}
+    apiVersion: {{ template "common.capabilities.statefulset.apiVersion" . }}
     kind: StatefulSet
     name: {{ include "elasticsearch.coordinating.fullname" . }}
   minReplicas: {{ .Values.coordinating.autoscaling.minReplicas }}


### PR DESCRIPTION
[bitnami/elasticsearch] fix wrong apiversion for statefulset