### PR TITLE
[bitnami/common] fix common topology key affinity function

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: Infrastructure
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.2.0
+appVersion: 2.2.1
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/main/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -20,4 +20,4 @@ sources:
   - https://github.com/bitnami/charts
   - https://www.bitnami.com/
 type: library
-version: 2.2.0
+version: 2.2.1

--- a/bitnami/common/templates/_affinities.tpl
+++ b/bitnami/common/templates/_affinities.tpl
@@ -70,7 +70,7 @@ preferredDuringSchedulingIgnoredDuringExecution:
           {{- range $key, $value := $extraMatchLabels }}
           {{ $key }}: {{ $value | quote }}
           {{- end }}
-      topologyKey: {{- include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) | indent 1 }}
+      topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
     weight: 1
 {{- end -}}
 
@@ -90,7 +90,7 @@ requiredDuringSchedulingIgnoredDuringExecution:
         {{- range $key, $value := $extraMatchLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-    topologyKey: {{- include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) | indent 1 }}
+    topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
 {{- end -}}
 
 {{/*

--- a/bitnami/common/templates/_affinities.tpl
+++ b/bitnami/common/templates/_affinities.tpl
@@ -47,11 +47,10 @@ Return a nodeAffinity definition
 
 {{/*
 Return a topologyKey definition
-{{ include "common.affinities.topologyKey" (dict "topologyKey" "BAR") -}}
+{{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) -}}
 */}}
 {{- define "common.affinities.topologyKey" -}}
-{{- $topologyKey := default "kubernetes.io/hostname" .topologyKey -}}
-{{- $topologyKey | indent 1 -}}
+{{ .topologyKey | default "kubernetes.io/hostname" -}}
 {{- end -}}
 
 {{/*
@@ -71,7 +70,7 @@ preferredDuringSchedulingIgnoredDuringExecution:
           {{- range $key, $value := $extraMatchLabels }}
           {{ $key }}: {{ $value | quote }}
           {{- end }}
-      topologyKey:{{ include "common.affinities.topologyKey" .topologyKey }}
+      topologyKey: {{- include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) | indent 1 }}
     weight: 1
 {{- end -}}
 
@@ -91,7 +90,7 @@ requiredDuringSchedulingIgnoredDuringExecution:
         {{- range $key, $value := $extraMatchLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
-    topologyKey:{{ include "common.affinities.topologyKey" .topologyKey }}
+    topologyKey: {{- include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) | indent 1 }}
 {{- end -}}
 
 {{/*

--- a/bitnami/common/templates/_affinities.tpl
+++ b/bitnami/common/templates/_affinities.tpl
@@ -47,7 +47,7 @@ Return a nodeAffinity definition
 
 {{/*
 Return a topologyKey definition
-{{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) -}}
+{{ include "common.affinities.topologyKey" (dict "topologyKey" "BAR") -}}
 */}}
 {{- define "common.affinities.topologyKey" -}}
 {{ .topologyKey | default "kubernetes.io/hostname" -}}


### PR DESCRIPTION
Signed-off-by: Kazimieras <kazimieras@omnisend.com>

### Description of the change

Fix topology key assignment. Could not assign from app chart as string, required nested dict.
Simplified `default` assignment

### Benefits

Fix

### Possible drawbacks

None as this functions is not adopted in other charts

### Applicable issues

In app chart it was desired to have this topology config:
```
topologyKey: topology.kubernetes.io/zone
```
but current implementation worked only with:
```
topologyKey: 
  topologyKey: topology.kubernetes.io/zone
```
### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
