### PR TITLE
[bitnami/thanos] update PrometheusRule names to be unique

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 11.6.2
+version: 11.6.3

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 11.6.1
+version: 11.6.2

--- a/bitnami/thanos/templates/alert-rule/absent_rules.yml
+++ b/bitnami/thanos/templates/alert-rule/absent_rules.yml
@@ -5,7 +5,7 @@ Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/ale
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname" . }}-component-absent
   namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/thanos/templates/alert-rule/compaction.yml
+++ b/bitnami/thanos/templates/alert-rule/compaction.yml
@@ -5,7 +5,7 @@ Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/ale
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname" . }}-compact
   namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/thanos/templates/alert-rule/query.yml
+++ b/bitnami/thanos/templates/alert-rule/query.yml
@@ -5,7 +5,7 @@ Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/ale
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname" . }}-query
   namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/thanos/templates/alert-rule/receive.yml
+++ b/bitnami/thanos/templates/alert-rule/receive.yml
@@ -5,7 +5,7 @@ Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/ale
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname" . }}-receive
   namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/thanos/templates/alert-rule/replicate.yml
+++ b/bitnami/thanos/templates/alert-rule/replicate.yml
@@ -5,7 +5,7 @@ Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/ale
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname" . }}-replicate
   namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/thanos/templates/alert-rule/ruler.yml
+++ b/bitnami/thanos/templates/alert-rule/ruler.yml
@@ -5,7 +5,7 @@ Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/ale
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}-rule
+  name: {{ template "common.names.fullname" . }}-ruler
   namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/thanos/templates/alert-rule/ruler.yml
+++ b/bitnami/thanos/templates/alert-rule/ruler.yml
@@ -5,7 +5,7 @@ Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/ale
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname" . }}-rule
   namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/thanos/templates/alert-rule/sidecar.yml
+++ b/bitnami/thanos/templates/alert-rule/sidecar.yml
@@ -5,7 +5,7 @@ Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/ale
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname" . }}-sidecar
   namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}
@@ -60,4 +60,3 @@ spec:
         {{- end }}
     {{- end }}
 {{- end }}
-

--- a/bitnami/thanos/templates/alert-rule/store_gateway.yml
+++ b/bitnami/thanos/templates/alert-rule/store_gateway.yml
@@ -5,7 +5,7 @@ Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/ale
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}
+  name: {{ template "common.names.fullname" . }}-store
   namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}

--- a/bitnami/thanos/templates/alert-rule/store_gateway.yml
+++ b/bitnami/thanos/templates/alert-rule/store_gateway.yml
@@ -5,7 +5,7 @@ Generated from https://github.com/thanos-io/thanos/blob/main/examples/alerts/ale
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "common.names.fullname" . }}-store
+  name: {{ template "common.names.fullname" . }}-store-gateway
   namespace: {{ default .Release.Namespace .Values.metrics.prometheusRule.namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}


### PR DESCRIPTION
### Description of the change

When setting `prometheusRule.enabled: true` in chart verstion 11.6.1 those CRDs resources fail with: 

> Helm upgrade failed: error while running post render on files: may not add resource with an already registered id

Issue is that it wants to create all of `PrometheusRule` resources with the same name in the same namespace.

### Benefits

This will add suffix referring to components that rules are for which will set different names to all those resources.

### Possible drawbacks

Maybe some better logic instead of hardcoding these. Though it should be ok since its related to this specific chart and should not clash with other resources of the same kind.

### Applicable issues

None that I know off.

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
