### PR TITLE
[bitnami/rabbitmq-cluster-operator] RabbitMQ messaging topology operator allow edit secrets in clusterrole (bitnami#13497)

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -26,4 +26,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 3.1.2
+version: 3.1.3

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/clusterrole.yaml
@@ -29,6 +29,8 @@ rules:
       - create
       - get
       - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - ""


### PR DESCRIPTION
[bitnami/rabbitmq-cluster-operator] RabbitMQ messaging topology operator allow edit secrets in clusterrole (bitnami#13497)

### Description of the change

Since [messaging-topology-operator/user_controller.go](https://github.com/rabbitmq/messaging-topology-operator/blob/main/controllers/user_controller.go#L57) introduce autogenerated user password when it's empty in predefined secret, the operator has to be able to update this secret.

### Benefits

Successful User reconciliation with updated secret.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
