### PR TITLE
[bitnami/contour] adds missing RBAC to watch Gateway API ReferenceGrants

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -25,4 +25,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/containers/tree/main/bitnami/contour
   - https://projectcontour.io
-version: 10.0.0
+version: 10.0.1

--- a/bitnami/contour/templates/contour/rbac.yaml
+++ b/bitnami/contour/templates/contour/rbac.yaml
@@ -86,6 +86,7 @@ rules:
       - tlsroutes
       - udproutes
       - referencepolicies
+      - referencegrants
     verbs:
       - get
       - list


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Adds missing RBAC that allows Contour to watch [Gateway API ReferenceGrants](https://gateway-api.sigs.k8s.io/api-types/referencegrant/).
This change follows what was done in upstream Contour for 1.23 release (1.23 is the app version for latest Contour Helm chart from this repo) https://github.com/projectcontour/contour/commit/c74c33a84f16c6a3818967c0c0232ec2e90061c0

### Benefits

<!-- What benefits will be realized by the code change? -->

Users will be able to use this Helm chart to install Contour v1.23 for use with Gateway API in ['static'](https://projectcontour.io/guides/gateway-api/#:~:text=Option%20%231%3A%20Statically%20provisioned) mode.


### Applicable issues

#11722 

### Additional information

To reproduce the bug:
```bash
// Apply Gateway API CRDs
kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v0.5.1/experimental-install.yaml
// install Contour in 'static' mode
cat << EOF > config.yaml
gateway:
  controllerName: projectcontour.io/projectcontour/contour
EOF
helm install contour bitnami/contour --set-file configInline=config.yaml --wait
```
Observe that installation crashes and Contour errors with `...failed to list *v1alpha2.ReferenceGrant...` errors.

To verify this fix, repeat the same steps with chart from this PR.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ x ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ x ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ x ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
