### PR TITLE
[bitnami/kafka] Adding publishNotReadyAddresses to kafka services headless and external.

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kafka
   - https://kafka.apache.org/
-version: 19.1.3
+version: 19.1.4

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -232,52 +232,54 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Traffic Exposure parameters
 
-| Name                                              | Description                                                                                                | Value                 |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------- |
-| `service.type`                                    | Kubernetes Service type                                                                                    | `ClusterIP`           |
-| `service.ports.client`                            | Kafka svc port for client connections                                                                      | `9092`                |
-| `service.ports.internal`                          | Kafka svc port for inter-broker connections                                                                | `9093`                |
-| `service.ports.external`                          | Kafka svc port for external connections                                                                    | `9094`                |
-| `service.nodePorts.client`                        | Node port for the Kafka client connections                                                                 | `""`                  |
-| `service.nodePorts.external`                      | Node port for the Kafka external connections                                                               | `""`                  |
-| `service.sessionAffinity`                         | Control where client requests go, to the same pod or round-robin                                           | `None`                |
-| `service.sessionAffinityConfig`                   | Additional settings for the sessionAffinity                                                                | `{}`                  |
-| `service.clusterIP`                               | Kafka service Cluster IP                                                                                   | `""`                  |
-| `service.loadBalancerIP`                          | Kafka service Load Balancer IP                                                                             | `""`                  |
-| `service.loadBalancerSourceRanges`                | Kafka service Load Balancer sources                                                                        | `[]`                  |
-| `service.externalTrafficPolicy`                   | Kafka service external traffic policy                                                                      | `Cluster`             |
-| `service.annotations`                             | Additional custom annotations for Kafka service                                                            | `{}`                  |
-| `service.headless.annotations`                    | Annotations for the headless service.                                                                      | `{}`                  |
-| `service.headless.labels`                         | Labels for the headless service.                                                                           | `{}`                  |
-| `service.extraPorts`                              | Extra ports to expose in the Kafka service (normally used with the `sidecar` value)                        | `[]`                  |
-| `externalAccess.enabled`                          | Enable Kubernetes external cluster access to Kafka brokers                                                 | `false`               |
-| `externalAccess.autoDiscovery.enabled`            | Enable using an init container to auto-detect external IPs/ports by querying the K8s API                   | `false`               |
-| `externalAccess.autoDiscovery.image.registry`     | Init container auto-discovery image registry                                                               | `docker.io`           |
-| `externalAccess.autoDiscovery.image.repository`   | Init container auto-discovery image repository                                                             | `bitnami/kubectl`     |
-| `externalAccess.autoDiscovery.image.tag`          | Init container auto-discovery image tag (immutable tags are recommended)                                   | `1.25.3-debian-11-r8` |
-| `externalAccess.autoDiscovery.image.digest`       | Petete image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag     | `""`                  |
-| `externalAccess.autoDiscovery.image.pullPolicy`   | Init container auto-discovery image pull policy                                                            | `IfNotPresent`        |
-| `externalAccess.autoDiscovery.image.pullSecrets`  | Init container auto-discovery image pull secrets                                                           | `[]`                  |
-| `externalAccess.autoDiscovery.resources.limits`   | The resources limits for the auto-discovery init container                                                 | `{}`                  |
-| `externalAccess.autoDiscovery.resources.requests` | The requested resources for the auto-discovery init container                                              | `{}`                  |
-| `externalAccess.service.type`                     | Kubernetes Service type for external access. It can be NodePort, LoadBalancer or ClusterIP                 | `LoadBalancer`        |
-| `externalAccess.service.ports.external`           | Kafka port used for external access when service type is LoadBalancer                                      | `9094`                |
-| `externalAccess.service.loadBalancerIPs`          | Array of load balancer IPs for each Kafka broker. Length must be the same as replicaCount                  | `[]`                  |
-| `externalAccess.service.loadBalancerNames`        | Array of load balancer Names for each Kafka broker. Length must be the same as replicaCount                | `[]`                  |
-| `externalAccess.service.loadBalancerAnnotations`  | Array of load balancer annotations for each Kafka broker. Length must be the same as replicaCount          | `[]`                  |
-| `externalAccess.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                                  | `[]`                  |
-| `externalAccess.service.nodePorts`                | Array of node ports used for each Kafka broker. Length must be the same as replicaCount                    | `[]`                  |
-| `externalAccess.service.useHostIPs`               | Use service host IPs to configure Kafka external listener when service type is NodePort                    | `false`               |
-| `externalAccess.service.usePodIPs`                | using the MY_POD_IP address for external access.                                                           | `false`               |
-| `externalAccess.service.domain`                   | Domain or external ip used to configure Kafka external listener when service type is NodePort or ClusterIP | `""`                  |
-| `externalAccess.service.labels`                   | Service labels for external access                                                                         | `{}`                  |
-| `externalAccess.service.annotations`              | Service annotations for external access                                                                    | `{}`                  |
-| `externalAccess.service.extraPorts`               | Extra ports to expose in the Kafka external service                                                        | `[]`                  |
-| `networkPolicy.enabled`                           | Specifies whether a NetworkPolicy should be created                                                        | `false`               |
-| `networkPolicy.allowExternal`                     | Don't require client label for connections                                                                 | `true`                |
-| `networkPolicy.explicitNamespacesSelector`        | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed             | `{}`                  |
-| `networkPolicy.externalAccess.from`               | customize the from section for External Access on tcp-external port                                        | `[]`                  |
-| `networkPolicy.egressRules.customRules`           | Custom network policy rule                                                                                 | `{}`                  |
+| Name                                              | Description                                                                                                              | Value                 |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------- |
+| `service.type`                                    | Kubernetes Service type                                                                                                  | `ClusterIP`           |
+| `service.ports.client`                            | Kafka svc port for client connections                                                                                    | `9092`                |
+| `service.ports.internal`                          | Kafka svc port for inter-broker connections                                                                              | `9093`                |
+| `service.ports.external`                          | Kafka svc port for external connections                                                                                  | `9094`                |
+| `service.nodePorts.client`                        | Node port for the Kafka client connections                                                                               | `""`                  |
+| `service.nodePorts.external`                      | Node port for the Kafka external connections                                                                             | `""`                  |
+| `service.sessionAffinity`                         | Control where client requests go, to the same pod or round-robin                                                         | `None`                |
+| `service.sessionAffinityConfig`                   | Additional settings for the sessionAffinity                                                                              | `{}`                  |
+| `service.clusterIP`                               | Kafka service Cluster IP                                                                                                 | `""`                  |
+| `service.loadBalancerIP`                          | Kafka service Load Balancer IP                                                                                           | `""`                  |
+| `service.loadBalancerSourceRanges`                | Kafka service Load Balancer sources                                                                                      | `[]`                  |
+| `service.externalTrafficPolicy`                   | Kafka service external traffic policy                                                                                    | `Cluster`             |
+| `service.annotations`                             | Additional custom annotations for Kafka service                                                                          | `{}`                  |
+| `service.headless.publishNotReadyAddresses`       | Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready | `false`               |
+| `service.headless.annotations`                    | Annotations for the headless service.                                                                                    | `{}`                  |
+| `service.headless.labels`                         | Labels for the headless service.                                                                                         | `{}`                  |
+| `service.extraPorts`                              | Extra ports to expose in the Kafka service (normally used with the `sidecar` value)                                      | `[]`                  |
+| `externalAccess.enabled`                          | Enable Kubernetes external cluster access to Kafka brokers                                                               | `false`               |
+| `externalAccess.autoDiscovery.enabled`            | Enable using an init container to auto-detect external IPs/ports by querying the K8s API                                 | `false`               |
+| `externalAccess.autoDiscovery.image.registry`     | Init container auto-discovery image registry                                                                             | `docker.io`           |
+| `externalAccess.autoDiscovery.image.repository`   | Init container auto-discovery image repository                                                                           | `bitnami/kubectl`     |
+| `externalAccess.autoDiscovery.image.tag`          | Init container auto-discovery image tag (immutable tags are recommended)                                                 | `1.25.3-debian-11-r8` |
+| `externalAccess.autoDiscovery.image.digest`       | Petete image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                   | `""`                  |
+| `externalAccess.autoDiscovery.image.pullPolicy`   | Init container auto-discovery image pull policy                                                                          | `IfNotPresent`        |
+| `externalAccess.autoDiscovery.image.pullSecrets`  | Init container auto-discovery image pull secrets                                                                         | `[]`                  |
+| `externalAccess.autoDiscovery.resources.limits`   | The resources limits for the auto-discovery init container                                                               | `{}`                  |
+| `externalAccess.autoDiscovery.resources.requests` | The requested resources for the auto-discovery init container                                                            | `{}`                  |
+| `externalAccess.service.type`                     | Kubernetes Service type for external access. It can be NodePort, LoadBalancer or ClusterIP                               | `LoadBalancer`        |
+| `externalAccess.service.ports.external`           | Kafka port used for external access when service type is LoadBalancer                                                    | `9094`                |
+| `externalAccess.service.loadBalancerIPs`          | Array of load balancer IPs for each Kafka broker. Length must be the same as replicaCount                                | `[]`                  |
+| `externalAccess.service.loadBalancerNames`        | Array of load balancer Names for each Kafka broker. Length must be the same as replicaCount                              | `[]`                  |
+| `externalAccess.service.loadBalancerAnnotations`  | Array of load balancer annotations for each Kafka broker. Length must be the same as replicaCount                        | `[]`                  |
+| `externalAccess.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                                                | `[]`                  |
+| `externalAccess.service.nodePorts`                | Array of node ports used for each Kafka broker. Length must be the same as replicaCount                                  | `[]`                  |
+| `externalAccess.service.useHostIPs`               | Use service host IPs to configure Kafka external listener when service type is NodePort                                  | `false`               |
+| `externalAccess.service.usePodIPs`                | using the MY_POD_IP address for external access.                                                                         | `false`               |
+| `externalAccess.service.domain`                   | Domain or external ip used to configure Kafka external listener when service type is NodePort or ClusterIP               | `""`                  |
+| `externalAccess.service.publishNotReadyAddresses` | Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready | `false`               |
+| `externalAccess.service.labels`                   | Service labels for external access                                                                                       | `{}`                  |
+| `externalAccess.service.annotations`              | Service annotations for external access                                                                                  | `{}`                  |
+| `externalAccess.service.extraPorts`               | Extra ports to expose in the Kafka external service                                                                      | `[]`                  |
+| `networkPolicy.enabled`                           | Specifies whether a NetworkPolicy should be created                                                                      | `false`               |
+| `networkPolicy.allowExternal`                     | Don't require client label for connections                                                                               | `true`                |
+| `networkPolicy.explicitNamespacesSelector`        | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                           | `{}`                  |
+| `networkPolicy.externalAccess.from`               | customize the from section for External Access on tcp-external port                                                      | `[]`                  |
+| `networkPolicy.egressRules.customRules`           | Custom network policy rule                                                                                               | `{}`                  |
 
 
 ### Persistence parameters

--- a/bitnami/kafka/templates/svc-external-access.yaml
+++ b/bitnami/kafka/templates/svc-external-access.yaml
@@ -42,6 +42,7 @@ spec:
   loadBalancerSourceRanges: {{- toYaml $root.Values.externalAccess.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   {{- end }}
+  publishNotReadyAddresses: {{ $root.Values.externalAccess.service.publishNotReadyAddresses }}
   ports:
     - name: tcp-kafka
       port: {{ $root.Values.externalAccess.service.ports.external }}

--- a/bitnami/kafka/templates/svc-headless.yaml
+++ b/bitnami/kafka/templates/svc-headless.yaml
@@ -23,6 +23,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: {{ .Values.service.headless.publishNotReadyAddresses }}
   ports:
     - name: tcp-client
       port: {{ .Values.service.ports.client }}

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -840,7 +840,7 @@ externalAccess:
     ##
     domain: ""
     ## @param externalAccess.service.publishNotReadyAddresses Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready
-    ## ref: https://manifests.io/k8s-1.21/service.spec
+    ## ref: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/
     publishNotReadyAddresses: false
     ## @param externalAccess.service.labels Service labels for external access
     ##

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -723,7 +723,7 @@ service:
   ##
   headless:
     ## @param service.headless.publishNotReadyAddresses Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready
-    ## ref: https://manifests.io/k8s-1.21/service.spec
+    ## ref: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/
     publishNotReadyAddresses: false
     ## @param service.headless.annotations Annotations for the headless service.
     ##

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -722,6 +722,9 @@ service:
   ## Headless service properties
   ##
   headless:
+    ## @param service.headless.publishNotReadyAddresses Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready
+    ## ref: https://manifests.io/k8s-1.21/service.spec
+    publishNotReadyAddresses: false
     ## @param service.headless.annotations Annotations for the headless service.
     ##
     annotations: {}
@@ -836,6 +839,9 @@ externalAccess:
     ## ClusterIP: Must be specified, ingress IP or domain where tcp for external ports is configured
     ##
     domain: ""
+    ## @param externalAccess.service.publishNotReadyAddresses Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready
+    ## ref: https://manifests.io/k8s-1.21/service.spec
+    publishNotReadyAddresses: false
     ## @param externalAccess.service.labels Service labels for external access
     ##
     labels: {}


### PR DESCRIPTION
Signed-off-by: David Ballano <dfernandez@demonware.net>

### Description of the change

lets you chose if you want to keep the endpoints under headless and external service services when pods are not ready yet.
this is closer to what kafka behaviour should be.
### Benefits

Once you have enabled the setting you could modify the readiness prod or prestop/prestart hooks in order to slow down rolling restart for example.

### Possible drawbacks

there is no drawbacks, this is how bitnamis zookeeper chart works by default..

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes https://github.com/bitnami/charts/issues/13129

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
