### PR TITLE
[bitnami/postgresql-ha] Align postgresql and postgresql-ha secrets

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -29,4 +29,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
-version: 10.0.5
+version: 10.0.6

--- a/bitnami/postgresql-ha/templates/NOTES.txt
+++ b/bitnami/postgresql-ha/templates/NOTES.txt
@@ -38,7 +38,7 @@ Pgpool acts as a load balancer for PostgreSQL and forward read/write connections
 
 To get the password for {{ (include "postgresql-ha.postgresqlUsername" .) | quote }} run:
 
-    export POSTGRES_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "postgresql-ha.postgresqlSecretName" . }} -o jsonpath="{.data.postgresql-password}" | base64 -d)
+    export POSTGRES_PASSWORD=$(kubectl get secret --namespace {{ .Release.Namespace }} {{ include "postgresql-ha.postgresqlSecretName" . }} -o jsonpath="{.data.password}" | base64 -d)
 
 To get the password for {{ (include "postgresql-ha.postgresqlRepmgrUsername" .) | quote }} run:
 
@@ -86,7 +86,7 @@ To connect to your database from outside the cluster execute the following comma
 {{- $requiredPasswords := list -}}
 {{- if not (include "postgresql-ha.postgresql.existingSecretProvided" . ) }}
 {{- $secretName := include "postgresql-ha.postgresqlSecretName" . -}}
-{{- $requiredPostgresqlPassword := dict "valueKey" "postgresql.password" "secret" $secretName "field" "postgresql-password" "context" $ -}}
+{{- $requiredPostgresqlPassword := dict "valueKey" "postgresql.password" "secret" $secretName "field" "password" "context" $ -}}
 {{- $requiredPasswords = append $requiredPasswords $requiredPostgresqlPassword -}}
 {{- $requiredRepmgrPassword := dict "valueKey" "postgresql.repmgrPassword" "secret" $secretName "field" "repmgr-password" "context" $ -}}
 {{- $requiredPasswords = append $requiredPasswords $requiredRepmgrPassword -}}

--- a/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/deployment.yaml
@@ -199,7 +199,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql-ha.postgresqlSecretName" . }}
-                  key: postgresql-password
+                  key: password
             {{- end }}
             - name: PGPOOL_ADMIN_USERNAME
               value: {{ (include "postgresql-ha.pgpoolAdminUsername" .) | quote }}

--- a/bitnami/postgresql-ha/templates/postgresql/secrets.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/secrets.yaml
@@ -15,8 +15,8 @@ metadata:
 type: Opaque
 data:
   {{- if and (include "postgresql-ha.postgresqlPostgresPassword" .) (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) }}
-  postgresql-postgres-password: {{ include "postgresql-ha.postgresqlPostgresPassword" . | b64enc | quote }}
+  postgres-password: {{ include "postgresql-ha.postgresqlPostgresPassword" . | b64enc | quote }}
   {{- end }}
-  postgresql-password: {{ (include "postgresql-ha.postgresqlPassword" .) | b64enc | quote }}
+  password: {{ (include "postgresql-ha.postgresqlPassword" .) | b64enc | quote }}
   repmgr-password: {{ (include "postgresql-ha.postgresqlRepmgrPassword" .) | b64enc | quote }}
 {{- end -}}

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -185,13 +185,13 @@ spec:
               value: {{ (include "postgresql-ha.postgresqlUsername" .) | quote }}
             {{- if .Values.postgresql.usePasswordFile }}
             - name: POSTGRES_PASSWORD_FILE
-              value: "/opt/bitnami/postgresql/secrets/postgresql-password"
+              value: "/opt/bitnami/postgresql/secrets/password"
             {{- else }}
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql-ha.postgresqlSecretName" . }}
-                  key: postgresql-password
+                  key: password
             {{- end }}
             {{- if not (empty (include "postgresql-ha.postgresqlDatabase" .)) }}
             - name: POSTGRES_DB
@@ -413,7 +413,7 @@ spec:
               mountPath: /docker-entrypoint-initdb.d/secret
             {{- end }}
             {{- if .Values.postgresql.usePasswordFile }}
-            - name: postgresql-password
+            - name: password
               mountPath: /opt/bitnami/postgresql/secrets/
             {{- end }}
             {{- if .Values.postgresql.tls.enabled }}
@@ -442,13 +442,13 @@ spec:
               value: {{ printf "127.0.0.1:%d/%s?sslmode=disable" (.Values.postgresql.containerPorts.postgresql | int64) (include "postgresql-ha.postgresqlDatabase" .) | quote }}
             {{- if .Values.postgresql.usePasswordFile }}
             - name: DATA_SOURCE_PASS_FILE
-              value: "/opt/bitnami/postgresql/secrets/postgresql-password"
+              value: "/opt/bitnami/postgresql/secrets/password"
             {{- else }}
             - name: DATA_SOURCE_PASS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql-ha.postgresqlSecretName" . }}
-                  key: postgresql-password
+                  key: password
             {{- end }}
             - name: DATA_SOURCE_USER
               value: {{ (include "postgresql-ha.postgresqlUsername" .) | quote }}
@@ -499,7 +499,7 @@ spec:
           {{- end }}
           volumeMounts:
             {{- if .Values.postgresql.usePasswordFile }}
-            - name: postgresql-password
+            - name: password
               mountPath: /opt/bitnami/postgresql/secrets/
             {{- end }}
             {{- if .Values.metrics.customMetrics }}
@@ -548,7 +548,7 @@ spec:
             secretName: {{ template "postgresql-ha.postgresqlInitdbScriptsSecret" . }}
         {{- end }}
         {{- if .Values.postgresql.usePasswordFile }}
-        - name: postgresql-password
+        - name: password
           secret:
             secretName: {{ include "postgresql-ha.postgresqlSecretName" . }}
         {{- end }}

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -172,13 +172,13 @@ spec:
             {{- if and (or (not (include "postgresql-ha.postgresqlCreateSecret" .)) (include "postgresql-ha.postgresqlPasswordProvided" .)) (not (eq (include "postgresql-ha.postgresqlUsername" .) "postgres")) }}
             {{- if .Values.postgresql.usePasswordFile }}
             - name: POSTGRES_POSTGRES_PASSWORD_FILE
-              value: "/opt/bitnami/postgresql/secrets/postgresql-postgres-password"
+              value: "/opt/bitnami/postgresql/secrets/postgres-password"
             {{- else }}
             - name: POSTGRES_POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ template "postgresql-ha.postgresqlSecretName" . }}
-                  key: postgresql-postgres-password
+                  key: postgres-password
             {{- end }}
             {{- end }}
             - name: POSTGRES_USER


### PR DESCRIPTION
### Description of the change

Align postgresql and postgresql-ha secrets

### Benefits

with this change, the postgresql and postgresql-ha Helm charts can be switch to each other without changing the application mount point

### Possible drawbacks

none

### Applicable issues

- Fixes https://github.com/bitnami/charts/issues/13660

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
