### PR TITLE
[bitnami/solr]  Add subPath and subPathExpr

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/solr
   - https://lucene.apache.org/solr/
-version: 7.0.1
+version: 7.1.0

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -204,18 +204,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Persistence parameters
 
-| Name                        | Description                                                                                                                                                                                                                                                                                       | Value               |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `persistence.enabled`       | Use a PVC to persist data.                                                                                                                                                                                                                                                                        | `true`              |
-| `persistence.existingClaim` | A manually managed Persistent Volume and Claim                                                                                                                                                                                                                                                    | `""`                |
-| `persistence.storageClass`  | Storage class of backing PVC                                                                                                                                                                                                                                                                      | `""`                |
-| `persistence.accessModes`   | Persistent Volume Access Modes                                                                                                                                                                                                                                                                    | `["ReadWriteOnce"]` |
-| `persistence.size`          | Size of data volume                                                                                                                                                                                                                                                                               | `8Gi`               |
-| `persistence.annotations`   | Persistence annotations for Solr                                                                                                                                                                                                                                                                  | `{}`                |
-| `persistence.mountPath`     | Persistence mount path for Solr                                                                                                                                                                                                                                                                   | `/bitnami/solr`     |
-| `persistence.subPath`       | Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).                                                                                                                                                                                       | `""`                |
-| `persistence.subPathExpr`   | Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. | `""`              |
-| `persistence.selector`      | Selector to match an existing Persistent Volume for WordPress data PVC                                                                                                                                                                                                                            | `{}`                |
+| Name                        | Description                                                            | Value               |
+| --------------------------- | ---------------------------------------------------------------------- | ------------------- |
+| `persistence.enabled`       | Use a PVC to persist data.                                             | `true`              |
+| `persistence.existingClaim` | A manually managed Persistent Volume and Claim                         | `""`                |
+| `persistence.storageClass`  | Storage class of backing PVC                                           | `""`                |
+| `persistence.accessModes`   | Persistent Volume Access Modes                                         | `["ReadWriteOnce"]` |
+| `persistence.size`          | Size of data volume                                                    | `8Gi`               |
+| `persistence.annotations`   | Persistence annotations for Solr                                       | `{}`                |
+| `persistence.mountPath`     | Persistence mount path for Solr                                        | `/bitnami/solr`     |
+| `persistence.subPath`       | Path within the volume from which the container's                      | `""`                |
+| `persistence.subPathExpr`   | Expanded path within the volume from which                             | `""`                |
+| `persistence.selector`      | Selector to match an existing Persistent Volume for WordPress data PVC | `{}`                |
 
 
 ### Volume Permissions parameters

--- a/bitnami/solr/README.md
+++ b/bitnami/solr/README.md
@@ -204,16 +204,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Persistence parameters
 
-| Name                        | Description                                                            | Value               |
-| --------------------------- | ---------------------------------------------------------------------- | ------------------- |
-| `persistence.enabled`       | Use a PVC to persist data.                                             | `true`              |
-| `persistence.existingClaim` | A manually managed Persistent Volume and Claim                         | `""`                |
-| `persistence.storageClass`  | Storage class of backing PVC                                           | `""`                |
-| `persistence.accessModes`   | Persistent Volume Access Modes                                         | `["ReadWriteOnce"]` |
-| `persistence.size`          | Size of data volume                                                    | `8Gi`               |
-| `persistence.annotations`   | Persistence annotations for Solr                                       | `{}`                |
-| `persistence.mountPath`     | Persistence mount path for Solr                                        | `/bitnami/solr`     |
-| `persistence.selector`      | Selector to match an existing Persistent Volume for WordPress data PVC | `{}`                |
+| Name                        | Description                                                                                                                                                                                                                                                                                       | Value               |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `persistence.enabled`       | Use a PVC to persist data.                                                                                                                                                                                                                                                                        | `true`              |
+| `persistence.existingClaim` | A manually managed Persistent Volume and Claim                                                                                                                                                                                                                                                    | `""`                |
+| `persistence.storageClass`  | Storage class of backing PVC                                                                                                                                                                                                                                                                      | `""`                |
+| `persistence.accessModes`   | Persistent Volume Access Modes                                                                                                                                                                                                                                                                    | `["ReadWriteOnce"]` |
+| `persistence.size`          | Size of data volume                                                                                                                                                                                                                                                                               | `8Gi`               |
+| `persistence.annotations`   | Persistence annotations for Solr                                                                                                                                                                                                                                                                  | `{}`                |
+| `persistence.mountPath`     | Persistence mount path for Solr                                                                                                                                                                                                                                                                   | `/bitnami/solr`     |
+| `persistence.subPath`       | Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).                                                                                                                                                                                       | `""`                |
+| `persistence.subPathExpr`   | Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. | `""`              |
+| `persistence.selector`      | Selector to match an existing Persistent Volume for WordPress data PVC                                                                                                                                                                                                                            | `{}`                |
 
 
 ### Volume Permissions parameters

--- a/bitnami/solr/templates/statefulset.yaml
+++ b/bitnami/solr/templates/statefulset.yaml
@@ -341,6 +341,11 @@ spec:
               subPath: setup.sh
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
+            {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+            {{- else if .Values.persistence.subPathExpr }}
+              subPathExpr: {{ .Values.persistence.subPathExpr }}
+            {{- end }}
             {{- if .Values.tls.enabled }}
             - name: shared-certs
               mountPath: '/opt/bitnami/solr/certs'

--- a/bitnami/solr/values.yaml
+++ b/bitnami/solr/values.yaml
@@ -552,6 +552,17 @@ persistence:
   ## @param persistence.mountPath Persistence mount path for Solr
   ##
   mountPath: /bitnami/solr
+  ## @param persistence.subPath Path within the volume from which the container's
+  ## volume should be mounted. Defaults to "" (volume's root).
+  ##
+  subPath: ""
+  ## @param persistence.subPathExpr Expanded path within the volume from which
+  ## the container's volume should be mounted. Behaves similarly to SubPath but
+  ## environment variable references $(VAR_NAME) are expanded using the
+  ## container's environment. Defaults to "" (volume's root).
+  ## SubPathExpr and SubPath are mutually exclusive.
+  ##
+  subPathExpr: ""
   ## @param persistence.selector Selector to match an existing Persistent Volume for WordPress data PVC
   ## If set, the PVC can't have a PV dynamically provisioned for it
   ## E.g.


### PR DESCRIPTION

### Description of the change

Added subPath and subPathExpr properties to persistence parameters.
See also https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1

### Benefits

It's now possible to use these parameters during installation.

### Possible drawbacks

None I can think of.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)

Signed-off-by: mgmgwi <guido.wischrop@mgm-tp.com>