### PR TITLE
[bitnami/keycloak] Add postgresql.auth.postgresPassword to default va…

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 12.1.5
+version: 12.1.6

--- a/bitnami/keycloak/values.yaml
+++ b/bitnami/keycloak/values.yaml
@@ -961,6 +961,7 @@ keycloakConfigCli:
 ## PostgreSQL chart configuration
 ## ref: https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
 ## @param postgresql.enabled Switch to enable or disable the PostgreSQL helm chart
+## @param postgresql.auth.postgresPassword Password for the "postgres" admin user. Ignored if `auth.existingSecret` with key `postgres-password` is provided
 ## @param postgresql.auth.username Name for a custom user to create
 ## @param postgresql.auth.password Password for the custom user to create
 ## @param postgresql.auth.database Name for a custom database to create
@@ -970,6 +971,7 @@ keycloakConfigCli:
 postgresql:
   enabled: true
   auth:
+    postgresPassword: ""  
     username: bn_keycloak
     password: ""
     database: bitnami_keycloak


### PR DESCRIPTION
…lues to expose this to the user.

Signed-off-by: Jesper Gadegaard <jesper.gadegaard@gmail.com>

### Description of the change

Expose the default value needed to set a specific password for PostgreSQL when using a KeyCloak chart.

### Benefits

This allows the user to specify a password to use in the PostgreSQL database for KeyCloak.
Without this, a random password will be set every time the manifest files are generated.

### Possible drawbacks

### Applicable issues

No issues created.

### Additional information

This is my first PR on github. Please be kind :)
I have manually updated the documentation in values.yaml with the same notation and ordering as in the referenced postgresql chart.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
