### PR TITLE
Revert "[bitnami/redis] Add minReadySeconds configuration"

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 17.3.12
+version: 17.3.11

--- a/bitnami/redis/README.md
+++ b/bitnami/redis/README.md
@@ -166,7 +166,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `master.kind`                                        | Use either Deployment or StatefulSet (default)                                                        | `StatefulSet`            |
 | `master.schedulerName`                               | Alternate scheduler for Redis&reg; master pods                                                        | `""`                     |
 | `master.updateStrategy.type`                         | Redis&reg; master statefulset strategy type                                                           | `RollingUpdate`          |
-| `master.minReadySeconds`                             | How many seconds a pod needs to be ready before killing the next, during update                       | `0`                      |
 | `master.priorityClassName`                           | Redis&reg; master pods' priorityClassName                                                             | `""`                     |
 | `master.hostAliases`                                 | Redis&reg; master pods host aliases                                                                   | `[]`                     |
 | `master.podLabels`                                   | Extra labels for Redis&reg; master pods                                                               | `{}`                     |
@@ -267,7 +266,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `replica.containerSecurityContext.runAsUser`          | Set Redis&reg; replicas containers' Security Context runAsUser                                          | `1001`                   |
 | `replica.schedulerName`                               | Alternate scheduler for Redis&reg; replicas pods                                                        | `""`                     |
 | `replica.updateStrategy.type`                         | Redis&reg; replicas statefulset strategy type                                                           | `RollingUpdate`          |
-| `replica.minReadySeconds`                             | How many seconds a pod needs to be ready before killing the next, during update                         | `0`                      |
 | `replica.priorityClassName`                           | Redis&reg; replicas pods' priorityClassName                                                             | `""`                     |
 | `replica.podManagementPolicy`                         | podManagementPolicy to manage scaling operation of %%MAIN_CONTAINER_NAME%% pods                         | `""`                     |
 | `replica.hostAliases`                                 | Redis&reg; replicas pods host aliases                                                                   | `[]`                     |

--- a/bitnami/redis/templates/master/application.yaml
+++ b/bitnami/redis/templates/master/application.yaml
@@ -26,9 +26,6 @@ spec:
   {{- else }}
   updateStrategy: {{- toYaml .Values.master.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- if .Values.master.minReadySeconds }}
-  minReadySeconds: {{ .Values.master.minReadySeconds }}
-  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/bitnami/redis/templates/replicas/statefulset.yaml
+++ b/bitnami/redis/templates/replicas/statefulset.yaml
@@ -23,9 +23,6 @@ spec:
   {{- if .Values.replica.updateStrategy }}
   updateStrategy: {{- toYaml .Values.replica.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- if .Values.replica.minReadySeconds }}
-  minReadySeconds: {{ .Values.replica.minReadySeconds }}
-  {{- end }}
   {{- if .Values.replica.podManagementPolicy }}
   podManagementPolicy: {{ .Values.replica.podManagementPolicy | quote }}
   {{- end }}

--- a/bitnami/redis/templates/sentinel/statefulset.yaml
+++ b/bitnami/redis/templates/sentinel/statefulset.yaml
@@ -22,9 +22,6 @@ spec:
   {{- if .Values.replica.updateStrategy }}
   updateStrategy: {{- toYaml .Values.replica.updateStrategy | nindent 4 }}
   {{- end }}
-  {{- if .Values.replica.minReadySeconds }}
-  minReadySeconds: {{ .Values.replica.minReadySeconds }}
-  {{- end }}
   {{- if .Values.replica.podManagementPolicy }}
   podManagementPolicy: {{ .Values.replica.podManagementPolicy | quote }}
   {{- end }}

--- a/bitnami/redis/values.yaml
+++ b/bitnami/redis/values.yaml
@@ -289,9 +289,6 @@ master:
     ##
     type: RollingUpdate
     rollingUpdate: {}
-  ## @param master.minReadySeconds How many seconds a pod needs to be ready before killing the next, during update
-  ##
-  minReadySeconds: 0
   ## @param master.priorityClassName Redis&reg; master pods' priorityClassName
   ##
   priorityClassName: ""
@@ -690,9 +687,6 @@ replica:
     ##
     type: RollingUpdate
     rollingUpdate: {}
-  ## @param replica.minReadySeconds How many seconds a pod needs to be ready before killing the next, during update
-  ##
-  minReadySeconds: 0
   ## @param replica.priorityClassName Redis&reg; replicas pods' priorityClassName
   ##
   priorityClassName: ""


### PR DESCRIPTION
Reverts bitnami/charts#13596

I revert this because we need to support k8s 1.19+ and this feature was not in stable until 1.25. So, k8s version checking is needed and I missed it.