### PR TITLE
[bitnami/geode] Mark chart as deprecated

### DIFF
--- a/bitnami/geode/Chart.yaml
+++ b/bitnami/geode/Chart.yaml
@@ -8,18 +8,18 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x.x
-description: Apache Geode is a data management platform that provides advanced capabilities for data-intensive applications.
+# The Geode chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED Apache Geode is a data management platform that provides advanced capabilities for data-intensive applications.
 home: https://github.com/bitnami/charts/tree/main/bitnami/geode
 icon: https://bitnami.com/assets/stacks/geode/img/geode-stack-220x234.png
 keywords:
   - apache
   - geode
   - database
-maintainers:
-  - name: Bitnami
-    url: https://github.com/bitnami/charts
+maintainers: []
 name: geode
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/geode
   - https://github.com/apache/geode
-version: 1.1.7
+version: 1.1.8

--- a/bitnami/geode/README.md
+++ b/bitnami/geode/README.md
@@ -7,7 +7,11 @@ Apache Geode is a data management platform that provides advanced capabilities f
 [Overview of Apache Geode](https://geode.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
+## This Helm chart is deprecated
+
+The bitnami/geode chart is deprecated and no longer maintained.
+
 ## TL;DR
 
 ```console

--- a/bitnami/geode/templates/NOTES.txt
+++ b/bitnami/geode/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The bitnami/geode chart is deprecated and no longer maintained.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

### Description of the change

The bitnami/geode chart will be deprecated and won't receive new updates.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
