### PR TITLE
[bitnami/postgresql-ha] backwards compat postgres-password

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -29,4 +29,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
-version: 10.0.6
+version: 10.0.7

--- a/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/statefulset.yaml
@@ -191,7 +191,15 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "postgresql-ha.postgresqlSecretName" . }}
+                  {{- if (include "postgresql-ha.postgresqlCreateSecret" .) }}
                   key: password
+                  {{- else }}
+                  {{- if ( index ( lookup "v1" "Secret" (include "common.names.namespace" .) (include "postgresql-ha.postgresqlSecretName" .) ) ".data.postgres-password" ) }}
+                  key: postgres-password
+                  {{- else }}
+                  key: password
+                  {{- end }}
+                  {{- end }}
             {{- end }}
             {{- if not (empty (include "postgresql-ha.postgresqlDatabase" .)) }}
             - name: POSTGRES_DB


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

First determine if this charts will create the secret (a.k.a no `postgresql.existingSecret` is defined, using [ `postgresql-ha.postgresqlCreateSecret`](https://github.com/bitnami/charts/blob/main/bitnami/postgresql-ha/templates/_helpers.tpl#L304)), if so it will use the new `password` envFrom key. In case there is a custom secret provided it will lookup the secret and ONLY if it has a `postgres-password` key this will be used. Otherwise it will default to the new `password` key.

### Benefits

Backward compatibility with users that provide an existing secret with the old `postgres-password` key. Otherwise this lead to create container errors.

### Possible drawbacks

None, default to the new `password` key.

### Applicable issues

- Fixes #13800

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
