### PR TITLE
[bitnami/pinniped] Separate service configuration for supervisor api and aggregator server

### DIFF
--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -22,4 +22,4 @@ name: pinniped
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/pinniped
   - https://github.com/vmware-tanzu/pinniped/
-version: 0.4.7
+version: 1.0.0

--- a/bitnami/pinniped/README.md
+++ b/bitnami/pinniped/README.md
@@ -19,7 +19,7 @@ $ helm install my-release my-repo/pinniped
 
 Bitnami charts for Helm are carefully engineered, actively maintained and are the quickest and easiest way to deploy containers on a Kubernetes cluster that are ready to handle production workloads.
 
-This chart bootstraps a [Grafana Loki](https://github.com/grafana/loki) Deployment in a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Pinniped](https://pinniped.dev/) Deployment in a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 Bitnami charts can be used with [Kubeapps](https://kubeapps.com/) for deployment and management of Helm Charts in clusters. This Helm chart has been tested on top of [Bitnami Kubernetes Production Runtime](https://kubeprod.io/) (BKPR). Deploy BKPR to get automated TLS certificates, logging and monitoring for your applications.
 

--- a/bitnami/pinniped/README.md
+++ b/bitnami/pinniped/README.md
@@ -367,6 +367,12 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
+### To 1.0.0
+
+This version brings a breaking change into the configuration, eliminating abused reuse of Pinniped service parameters.
+The `supervisor.service` object is now separated into `supervisor.service.api` which configures the service used by Pinniped internally, and `supervisor.service.public` which configures the service the users interact with.
+In case configuration was specified in the `supervisor.service` object, now it needs to be redistributed into the two new objects. Keep in mind that the API service default service type was also changed to `ClusterIP` to reflect more on how the API service is used by default. Also the formerly `supervisor.service.ports.aggregatedAPIService` parameter is now only available under the API service configuration, because it is not a relevant parameter for the user-facing service.
+
 ### To 0.4.0
 
 This version updates Pinniped to its newest version, 0.20.x. For more information, please refer to [the release notes](https://github.com/vmware-tanzu/pinniped/releases/tag/v0.20.0).

--- a/bitnami/pinniped/README.md
+++ b/bitnami/pinniped/README.md
@@ -273,35 +273,47 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Supervisor Traffic Exposure Parameters
 
-| Name                                           | Description                                                                                                                      | Value                       |
-| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
-| `supervisor.service.type`                      | Supervisor service type                                                                                                          | `LoadBalancer`              |
-| `supervisor.service.ports.https`               | Supervisor service HTTPS port                                                                                                    | `443`                       |
-| `supervisor.service.ports.aggregatedAPIServer` | Supervisor aggregated API server port                                                                                            | `10250`                     |
-| `supervisor.service.nodePorts.https`           | Node port for HTTPS                                                                                                              | `""`                        |
-| `supervisor.service.clusterIP`                 | Supervisor service Cluster IP                                                                                                    | `""`                        |
-| `supervisor.service.labels`                    | Add labels to the service                                                                                                        | `{}`                        |
-| `supervisor.service.loadBalancerIP`            | Supervisor service Load Balancer IP                                                                                              | `""`                        |
-| `supervisor.service.loadBalancerSourceRanges`  | Supervisor service Load Balancer sources                                                                                         | `[]`                        |
-| `supervisor.service.externalTrafficPolicy`     | Supervisor service external traffic policy                                                                                       | `Cluster`                   |
-| `supervisor.service.annotations`               | Additional custom annotations for Supervisor service                                                                             | `{}`                        |
-| `supervisor.service.extraPorts`                | Extra ports to expose in Supervisor service (normally used with the `sidecars` value)                                            | `[]`                        |
-| `supervisor.service.sessionAffinity`           | Control where client requests go, to the same pod or round-robin                                                                 | `None`                      |
-| `supervisor.service.sessionAffinityConfig`     | Additional settings for the sessionAffinity                                                                                      | `{}`                        |
-| `supervisor.ingress.enabled`                   | Enable ingress record generation for Pinniped Supervisor                                                                         | `false`                     |
-| `supervisor.ingress.pathType`                  | Ingress path type                                                                                                                | `ImplementationSpecific`    |
-| `supervisor.ingress.apiVersion`                | Force Ingress API version (automatically detected if not set)                                                                    | `""`                        |
-| `supervisor.ingress.ingressClassName`          | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                        |
-| `supervisor.ingress.hostname`                  | Default host for the ingress record                                                                                              | `pinniped-supervisor.local` |
-| `supervisor.ingress.path`                      | Default path for the ingress record                                                                                              | `/`                         |
-| `supervisor.ingress.annotations`               | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                        |
-| `supervisor.ingress.tls`                       | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                     |
-| `supervisor.ingress.selfSigned`                | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                     |
-| `supervisor.ingress.extraHosts`                | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                        |
-| `supervisor.ingress.extraPaths`                | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                        |
-| `supervisor.ingress.extraTls`                  | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                        |
-| `supervisor.ingress.secrets`                   | Custom TLS certificates as secrets                                                                                               | `[]`                        |
-| `supervisor.ingress.extraRules`                | Additional rules to be covered with this ingress record                                                                          | `[]`                        |
+| Name                                                 | Description                                                                                                                      | Value                       |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| `supervisor.service.api.type`                        | Supervisor API service type                                                                                                      | `ClusterIP`                 |
+| `supervisor.service.api.ports.https`                 | Supervisor API service HTTPS port                                                                                                | `443`                       |
+| `supervisor.service.api.ports.aggregatedAPIServer`   | Supervisor aggregated API server port                                                                                            | `10250`                     |
+| `supervisor.service.api.nodePorts.https`             | Node port for HTTPS                                                                                                              | `""`                        |
+| `supervisor.service.api.clusterIP`                   | Supervisor service Cluster IP                                                                                                    | `""`                        |
+| `supervisor.service.api.labels`                      | Add labels to the service                                                                                                        | `{}`                        |
+| `supervisor.service.api.loadBalancerIP`              | Supervisor service Load Balancer IP                                                                                              | `""`                        |
+| `supervisor.service.api.loadBalancerSourceRanges`    | Supervisor service Load Balancer sources                                                                                         | `[]`                        |
+| `supervisor.service.api.externalTrafficPolicy`       | Supervisor service external traffic policy                                                                                       | `Cluster`                   |
+| `supervisor.service.api.annotations`                 | Additional custom annotations for Supervisor service                                                                             | `{}`                        |
+| `supervisor.service.api.extraPorts`                  | Extra ports to expose in Supervisor service (normally used with the `sidecars` value)                                            | `[]`                        |
+| `supervisor.service.api.sessionAffinity`             | Control where client requests go, to the same pod or round-robin                                                                 | `None`                      |
+| `supervisor.service.api.sessionAffinityConfig`       | Additional settings for the sessionAffinity                                                                                      | `{}`                        |
+| `supervisor.service.public.type`                     | Supervisor user-facing service type                                                                                              | `LoadBalancer`              |
+| `supervisor.service.public.ports.https`              | Supervisor user-facing service HTTPS port                                                                                        | `443`                       |
+| `supervisor.service.public.nodePorts.https`          | Node port for HTTPS                                                                                                              | `""`                        |
+| `supervisor.service.public.clusterIP`                | Supervisor service Cluster IP                                                                                                    | `""`                        |
+| `supervisor.service.public.labels`                   | Add labels to the service                                                                                                        | `{}`                        |
+| `supervisor.service.public.loadBalancerIP`           | Supervisor service Load Balancer IP                                                                                              | `""`                        |
+| `supervisor.service.public.loadBalancerSourceRanges` | Supervisor service Load Balancer sources                                                                                         | `[]`                        |
+| `supervisor.service.public.externalTrafficPolicy`    | Supervisor service external traffic policy                                                                                       | `Cluster`                   |
+| `supervisor.service.public.annotations`              | Additional custom annotations for Supervisor service                                                                             | `{}`                        |
+| `supervisor.service.public.extraPorts`               | Extra ports to expose in Supervisor service (normally used with the `sidecars` value)                                            | `[]`                        |
+| `supervisor.service.public.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                                                 | `None`                      |
+| `supervisor.service.public.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                      | `{}`                        |
+| `supervisor.ingress.enabled`                         | Enable ingress record generation for Pinniped Supervisor                                                                         | `false`                     |
+| `supervisor.ingress.pathType`                        | Ingress path type                                                                                                                | `ImplementationSpecific`    |
+| `supervisor.ingress.apiVersion`                      | Force Ingress API version (automatically detected if not set)                                                                    | `""`                        |
+| `supervisor.ingress.ingressClassName`                | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                        |
+| `supervisor.ingress.hostname`                        | Default host for the ingress record                                                                                              | `pinniped-supervisor.local` |
+| `supervisor.ingress.path`                            | Default path for the ingress record                                                                                              | `/`                         |
+| `supervisor.ingress.annotations`                     | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                        |
+| `supervisor.ingress.tls`                             | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                     |
+| `supervisor.ingress.selfSigned`                      | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                     |
+| `supervisor.ingress.extraHosts`                      | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                        |
+| `supervisor.ingress.extraPaths`                      | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                        |
+| `supervisor.ingress.extraTls`                        | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                        |
+| `supervisor.ingress.secrets`                         | Custom TLS certificates as secrets                                                                                               | `[]`                        |
+| `supervisor.ingress.extraRules`                      | Additional rules to be covered with this ingress record                                                                          | `[]`                        |
 
 
 See https://github.com/bitnami-labs/readme-generator-for-helm to create the table

--- a/bitnami/pinniped/templates/NOTES.txt
+++ b/bitnami/pinniped/templates/NOTES.txt
@@ -33,18 +33,18 @@ Follow the official documentation to configure an authenticator in Concierge: ht
 
 1. Get the Pinniped Supervisor URL by running these commands:
 
-{{- if contains "NodePort" .Values.supervisor.service.type }}
+{{- if contains "NodePort" .Values.supervisor.service.public.type }}
     export NODE_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "pinniped.supervisor.fullname" . }})
     export NODE_IP=$(kubectl get nodes --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
     echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.supervisor.service.type }}
+{{- else if contains "LoadBalancer" .Values.supervisor.service.public.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ include "common.names.namespace" . }} svc -w {{ template "common.names.fullname" . }}
     export SERVICE_IP=$(kubectl get svc --namespace {{ include "common.names.namespace" . }} {{ template "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-    echo http://$SERVICE_IP:{{ .Values.supervisor.service.ports.https }}
-{{- else if contains "ClusterIP" .Values.supervisor.service.type }}
-    echo "The Supervisor is available at http://127.0.0.1:{{ .Values.supervisor.service.ports.https }}"
-    kubectl port-forward svc/{{ template "pinniped.supervisor.fullname" . }} {{ .Values.supervisor.service.ports.https }}:{{ .Values.supervisor.service.ports.https }} &
+    echo http://$SERVICE_IP:{{ .Values.supervisor.service.public.ports.https }}
+{{- else if contains "ClusterIP" .Values.supervisor.service.public.type }}
+    echo "The Supervisor is available at http://127.0.0.1:{{ .Values.supervisor.service.public.ports.https }}"
+    kubectl port-forward svc/{{ template "pinniped.supervisor.fullname" . }} {{ .Values.supervisor.service.public.ports.https }}:{{ .Values.supervisor.service.public.ports.https }} &
 {{- end }}
 {{- end }}
 

--- a/bitnami/pinniped/templates/supervisor/service-api.yaml
+++ b/bitnami/pinniped/templates/supervisor/service-api.yaml
@@ -7,23 +7,23 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: supervisor
-    {{- if .Values.supervisor.service.labels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.supervisor.service.labels "context" $ ) | nindent 4 }}
+    {{- if .Values.supervisor.service.api.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.supervisor.service.api.labels "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.supervisor.service.annotations .Values.commonAnnotations }}
+  {{- if or .Values.supervisor.service.api.annotations .Values.commonAnnotations }}
   annotations:
-    {{- if .Values.supervisor.service.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.supervisor.service.annotations "context" $) | nindent 4 }}
+    {{- if .Values.supervisor.service.api.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.supervisor.service.api.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:
-  {{- with .Values.supervisor.service }}
+  {{- with .Values.supervisor.service.api }}
   type: {{ .type }}
   {{- if and .clusterIP (eq .type "ClusterIP") }}
   clusterIP: {{ .clusterIP }}

--- a/bitnami/pinniped/templates/supervisor/service-api.yaml
+++ b/bitnami/pinniped/templates/supervisor/service-api.yaml
@@ -23,38 +23,40 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  type: {{ .Values.supervisor.service.type }}
-  {{- if and .Values.supervisor.service.clusterIP (eq .Values.supervisor.service.type "ClusterIP") }}
-  clusterIP: {{ .Values.supervisor.service.clusterIP }}
+  {{- with .Values.supervisor.service }}
+  type: {{ .type }}
+  {{- if and .clusterIP (eq .type "ClusterIP") }}
+  clusterIP: {{ .clusterIP }}
   {{- end }}
-  {{- if .Values.supervisor.service.sessionAffinity }}
-  sessionAffinity: {{ .Values.supervisor.service.sessionAffinity }}
+  {{- if .sessionAffinity }}
+  sessionAffinity: {{ .sessionAffinity }}
   {{- end }}
-  {{- if .Values.supervisor.service.sessionAffinityConfig }}
-  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- if .sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
-  {{- if or (eq .Values.supervisor.service.type "LoadBalancer") (eq .Values.supervisor.service.type "NodePort") }}
-  externalTrafficPolicy: {{ .Values.supervisor.service.externalTrafficPolicy | quote }}
+  {{- if or (eq .type "LoadBalancer") (eq .type "NodePort") }}
+  externalTrafficPolicy: {{ .externalTrafficPolicy | quote }}
   {{- end }}
-  {{- if and (eq .Values.supervisor.service.type "LoadBalancer") (not (empty .Values.supervisor.service.loadBalancerSourceRanges)) }}
-  loadBalancerSourceRanges: {{ .Values.supervisor.service.loadBalancerSourceRanges }}
+  {{- if and (eq .type "LoadBalancer") (not (empty .loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{ .loadBalancerSourceRanges }}
   {{- end }}
-  {{- if and (eq .Values.supervisor.service.type "LoadBalancer") (not (empty .Values.supervisor.service.loadBalancerIP)) }}
-  loadBalancerIP: {{ .Values.supervisor.service.loadBalancerIP }}
+  {{- if and (eq .type "LoadBalancer") (not (empty .loadBalancerIP)) }}
+  loadBalancerIP: {{ .loadBalancerIP }}
   {{- end }}
   ports:
     - name: https
-      port: {{ .Values.supervisor.service.ports.https }}
+      port: {{ .ports.https }}
       protocol: TCP
-      targetPort: {{ .Values.supervisor.service.ports.aggregatedAPIServer }}
-      {{- if and (or (eq .Values.supervisor.service.type "NodePort") (eq .Values.supervisor.service.type "LoadBalancer")) (not (empty .Values.supervisor.service.nodePorts.https)) }}
-      nodePort: {{ .Values.supervisor.service.nodePorts.https }}
-      {{- else if eq .Values.supervisor.service.type "ClusterIP" }}
+      targetPort: {{ .ports.aggregatedAPIServer }}
+      {{- if and (or (eq .type "NodePort") (eq .type "LoadBalancer")) (not (empty .nodePorts.https)) }}
+      nodePort: {{ .nodePorts.https }}
+      {{- else if eq .type "ClusterIP" }}
       nodePort: null
       {{- end }}
-    {{- if .Values.supervisor.service.extraPorts }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.service.extraPorts "context" $) | nindent 4 }}
+    {{- if .extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .extraPorts "context" $) | nindent 4 }}
     {{- end }}
+  {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: supervisor
 {{- end }}

--- a/bitnami/pinniped/templates/supervisor/service.yaml
+++ b/bitnami/pinniped/templates/supervisor/service.yaml
@@ -7,23 +7,23 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: pinniped
     app.kubernetes.io/component: supervisor
-    {{- if .Values.supervisor.service.labels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.supervisor.service.labels "context" $ ) | nindent 4 }}
+    {{- if .Values.supervisor.service.public.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.supervisor.service.public.labels "context" $ ) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.supervisor.service.annotations .Values.commonAnnotations }}
+  {{- if or .Values.supervisor.service.public.annotations .Values.commonAnnotations }}
   annotations:
-    {{- if .Values.supervisor.service.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.supervisor.service.annotations "context" $) | nindent 4 }}
+    {{- if .Values.supervisor.service.public.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.supervisor.service.public.annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:
-  {{- with .Values.supervisor.service }}
+  {{- with .Values.supervisor.service.public }}
   type: {{ .type }}
   {{- if and .clusterIP (eq .type "ClusterIP") }}
   clusterIP: {{ .clusterIP }}

--- a/bitnami/pinniped/templates/supervisor/service.yaml
+++ b/bitnami/pinniped/templates/supervisor/service.yaml
@@ -23,38 +23,40 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-  type: {{ .Values.supervisor.service.type }}
-  {{- if and .Values.supervisor.service.clusterIP (eq .Values.supervisor.service.type "ClusterIP") }}
-  clusterIP: {{ .Values.supervisor.service.clusterIP }}
+  {{- with .Values.supervisor.service }}
+  type: {{ .type }}
+  {{- if and .clusterIP (eq .type "ClusterIP") }}
+  clusterIP: {{ .clusterIP }}
   {{- end }}
-  {{- if .Values.supervisor.service.sessionAffinity }}
-  sessionAffinity: {{ .Values.supervisor.service.sessionAffinity }}
+  {{- if .sessionAffinity }}
+  sessionAffinity: {{ .sessionAffinity }}
   {{- end }}
-  {{- if .Values.supervisor.service.sessionAffinityConfig }}
-  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- if .sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .sessionAffinityConfig "context" $) | nindent 4 }}
   {{- end }}
-  {{- if or (eq .Values.supervisor.service.type "LoadBalancer") (eq .Values.supervisor.service.type "NodePort") }}
-  externalTrafficPolicy: {{ .Values.supervisor.service.externalTrafficPolicy | quote }}
+  {{- if or (eq .type "LoadBalancer") (eq .type "NodePort") }}
+  externalTrafficPolicy: {{ .externalTrafficPolicy | quote }}
   {{- end }}
-  {{- if and (eq .Values.supervisor.service.type "LoadBalancer") (not (empty .Values.supervisor.service.loadBalancerSourceRanges)) }}
-  loadBalancerSourceRanges: {{ .Values.supervisor.service.loadBalancerSourceRanges }}
+  {{- if and (eq .type "LoadBalancer") (not (empty .loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{ .loadBalancerSourceRanges }}
   {{- end }}
-  {{- if and (eq .Values.supervisor.service.type "LoadBalancer") (not (empty .Values.supervisor.service.loadBalancerIP)) }}
-  loadBalancerIP: {{ .Values.supervisor.service.loadBalancerIP }}
+  {{- if and (eq .type "LoadBalancer") (not (empty .loadBalancerIP)) }}
+  loadBalancerIP: {{ .loadBalancerIP }}
   {{- end }}
   ports:
     - name: https
-      port: {{ .Values.supervisor.service.ports.https }}
+      port: {{ .ports.https }}
       protocol: TCP
       targetPort: https
-      {{- if and (or (eq .Values.supervisor.service.type "NodePort") (eq .Values.supervisor.service.type "LoadBalancer")) (not (empty .Values.supervisor.service.nodePorts.https)) }}
-      nodePort: {{ .Values.supervisor.service.nodePorts.https }}
-      {{- else if eq .Values.supervisor.service.type "ClusterIP" }}
+      {{- if and (or (eq .type "NodePort") (eq .type "LoadBalancer")) (not (empty .nodePorts.https)) }}
+      nodePort: {{ .nodePorts.https }}
+      {{- else if eq .type "ClusterIP" }}
       nodePort: null
       {{- end }}
-    {{- if .Values.supervisor.service.extraPorts }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.supervisor.service.extraPorts "context" $) | nindent 4 }}
+    {{- if .extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .extraPorts "context" $) | nindent 4 }}
     {{- end }}
+  {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: supervisor
 {{- end }}

--- a/bitnami/pinniped/values.yaml
+++ b/bitnami/pinniped/values.yaml
@@ -717,64 +717,120 @@ supervisor:
   ## Supervisor proxy service parameters
   ##
   service:
-    ## @param supervisor.service.type Supervisor service type
-    ##
-    type: LoadBalancer
-    ## @param supervisor.service.ports.https Supervisor service HTTPS port
-    ##
-    ports:
-      https: 443
-      ## pinniped-supervisor aggregated api server currently listens on port 10250
-      ## https://github.com/vmware-tanzu/pinniped/blob/4951cbe5d4c6bb1b1bb04b2981c10b1ae7504c01/internal/config/supervisor/config.go
-      ## @param supervisor.service.ports.aggregatedAPIServer Supervisor aggregated API server port
+    api:
+      ## @param supervisor.service.api.type Supervisor API service type
       ##
-      aggregatedAPIServer: 10250
-    ## Node ports to expose
-    ## @param supervisor.service.nodePorts.https Node port for HTTPS
-    ## NOTE: choose port between <30000-32767>
-    ##
-    nodePorts:
-      https: ""
-    ## @param supervisor.service.clusterIP Supervisor service Cluster IP
-    ## e.g.:
-    ## clusterIP: None
-    ##
-    clusterIP: ""
-    ## @param supervisor.service.labels Add labels to the service
-    ##
-    labels: {}
-    ## @param supervisor.service.loadBalancerIP Supervisor service Load Balancer IP
-    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
-    ##
-    loadBalancerIP: ""
-    ## @param supervisor.service.loadBalancerSourceRanges Supervisor service Load Balancer sources
-    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
-    ## e.g:
-    ## loadBalancerSourceRanges:
-    ##   - 10.10.10.0/24
-    ##
-    loadBalancerSourceRanges: []
-    ## @param supervisor.service.externalTrafficPolicy Supervisor service external traffic policy
-    ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
-    ##
-    externalTrafficPolicy: Cluster
-    ## @param supervisor.service.annotations Additional custom annotations for Supervisor service
-    ##
-    annotations: {}
-    ## @param supervisor.service.extraPorts Extra ports to expose in Supervisor service (normally used with the `sidecars` value)
-    ##
-    extraPorts: []
-    ## @param supervisor.service.sessionAffinity Control where client requests go, to the same pod or round-robin
-    ## Values: ClientIP or None
-    ## ref: https://kubernetes.io/docs/user-guide/services/
-    ##
-    sessionAffinity: None
-    ## @param supervisor.service.sessionAffinityConfig Additional settings for the sessionAffinity
-    ## sessionAffinityConfig:
-    ##   clientIP:
-    ##     timeoutSeconds: 300
-    ##
-    sessionAffinityConfig: {}
+      type: ClusterIP
+      ## @param supervisor.service.api.ports.https Supervisor API service HTTPS port
+      ##
+      ports:
+        https: 443
+        ## pinniped-supervisor aggregated api server currently listens on port 10250
+        ## https://github.com/vmware-tanzu/pinniped/blob/4951cbe5d4c6bb1b1bb04b2981c10b1ae7504c01/internal/config/supervisor/config.go
+        ## @param supervisor.service.api.ports.aggregatedAPIServer Supervisor aggregated API server port
+        ##
+        aggregatedAPIServer: 10250
+      ## Node ports to expose
+      ## @param supervisor.service.api.nodePorts.https Node port for HTTPS
+      ## NOTE: choose port between <30000-32767>
+      ##
+      nodePorts:
+        https: ""
+      ## @param supervisor.service.api.clusterIP Supervisor service Cluster IP
+      ## e.g.:
+      ## clusterIP: None
+      ##
+      clusterIP: ""
+      ## @param supervisor.service.api.labels Add labels to the service
+      ##
+      labels: {}
+      ## @param supervisor.service.api.loadBalancerIP Supervisor service Load Balancer IP
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+      ##
+      loadBalancerIP: ""
+      ## @param supervisor.service.api.loadBalancerSourceRanges Supervisor service Load Balancer sources
+      ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+      ## e.g:
+      ## loadBalancerSourceRanges:
+      ##   - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []
+      ## @param supervisor.service.api.externalTrafficPolicy Supervisor service external traffic policy
+      ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+      ##
+      externalTrafficPolicy: Cluster
+      ## @param supervisor.service.api.annotations Additional custom annotations for Supervisor service
+      ##
+      annotations: {}
+      ## @param supervisor.service.api.extraPorts Extra ports to expose in Supervisor service (normally used with the `sidecars` value)
+      ##
+      extraPorts: []
+      ## @param supervisor.service.api.sessionAffinity Control where client requests go, to the same pod or round-robin
+      ## Values: ClientIP or None
+      ## ref: https://kubernetes.io/docs/user-guide/services/
+      ##
+      sessionAffinity: None
+      ## @param supervisor.service.api.sessionAffinityConfig Additional settings for the sessionAffinity
+      ## sessionAffinityConfig:
+      ##   clientIP:
+      ##     timeoutSeconds: 300
+      ##
+      sessionAffinityConfig: {}
+
+    public:
+      ## @param supervisor.service.public.type Supervisor user-facing service type
+      ##
+      type: LoadBalancer
+      ## @param supervisor.service.public.ports.https Supervisor user-facing service HTTPS port
+      ##
+      ports:
+        https: 443
+      ## Node ports to expose
+      ## @param supervisor.service.public.nodePorts.https Node port for HTTPS
+      ## NOTE: choose port between <30000-32767>
+      ##
+      nodePorts:
+        https: ""
+      ## @param supervisor.service.public.clusterIP Supervisor service Cluster IP
+      ## e.g.:
+      ## clusterIP: None
+      ##
+      clusterIP: ""
+      ## @param supervisor.service.public.labels Add labels to the service
+      ##
+      labels: {}
+      ## @param supervisor.service.public.loadBalancerIP Supervisor service Load Balancer IP
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+      ##
+      loadBalancerIP: ""
+      ## @param supervisor.service.public.loadBalancerSourceRanges Supervisor service Load Balancer sources
+      ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+      ## e.g:
+      ## loadBalancerSourceRanges:
+      ##   - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []
+      ## @param supervisor.service.public.externalTrafficPolicy Supervisor service external traffic policy
+      ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+      ##
+      externalTrafficPolicy: Cluster
+      ## @param supervisor.service.public.annotations Additional custom annotations for Supervisor service
+      ##
+      annotations: {}
+      ## @param supervisor.service.public.extraPorts Extra ports to expose in Supervisor service (normally used with the `sidecars` value)
+      ##
+      extraPorts: []
+      ## @param supervisor.service.public.sessionAffinity Control where client requests go, to the same pod or round-robin
+      ## Values: ClientIP or None
+      ## ref: https://kubernetes.io/docs/user-guide/services/
+      ##
+      sessionAffinity: None
+      ## @param supervisor.service.public.sessionAffinityConfig Additional settings for the sessionAffinity
+      ## sessionAffinityConfig:
+      ##   clientIP:
+      ##     timeoutSeconds: 300
+      ##
+      sessionAffinityConfig: {}
 
   ## Configure the ingress resource that allows you to access the Pinniped Supervisor installation
   ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/


### PR DESCRIPTION
One single configuration is in parallel for two services. This PR separates them so that the can be configured separately. 

Fixes #13875 