### PR TITLE
[bitnami/mariadb-galera] Check WSREP is sync on readinessProbe

### DIFF
--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 7.4.9
+version: 7.5.0

--- a/bitnami/mariadb-galera/templates/statefulset.yaml
+++ b/bitnami/mariadb-galera/templates/statefulset.yaml
@@ -285,7 +285,11 @@ spec:
                   if [[ -f "${MARIADB_ROOT_PASSWORD_FILE:-}" ]]; then
                       password_aux=$(cat "$MARIADB_ROOT_PASSWORD_FILE")
                   fi
-                  exec mysqladmin status -u"${MARIADB_ROOT_USER}" -p"${password_aux}"
+                  # If wsrep_local_state != 4, would mean the node is not yet synced and therefore not ready to receive connections
+                  if [[ ! $(mysqladmin extended-status -u"${MARIADB_ROOT_USER}" -p"${password_aux}" | grep " wsrep_local_state " | grep " 4 ") ]]; then
+                    echo "Node is not in synced status"
+                    exit 1
+                  fi
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

### Description of the change

Extends MariaDB Galera readiness probe to check node is synced.

### Benefits

Desynced nodes won't receive traffic.

### Applicable issues

  - fixes #13730

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
