### PR TITLE
Cluster auth fix

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -25,4 +25,4 @@ name: clickhouse
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/clickhouse
   - https://github.com/ClickHouse/ClickHouse
-version: 2.1.0
+version: 2.1.1

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -260,6 +260,8 @@ defaultConfigurationOverrides: |
             <replica>
                 <host>{{ printf "%s-shard%d-%d.%s.%s.svc.%s" (include "common.names.fullname" $ ) $shard $i (include "clickhouse.headlessServiceName" $) (include "common.names.namespace" $) $.Values.clusterDomain }}</host>
                 <port>{{ $.Values.service.ports.tcp }}</port>
+                <user>{{ $.Values.auth.username }}</user>
+                <password>{{ $.Values.auth.username }}</password>
             </replica>
             {{- end }}
         </shard>

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -261,7 +261,7 @@ defaultConfigurationOverrides: |
                 <host>{{ printf "%s-shard%d-%d.%s.%s.svc.%s" (include "common.names.fullname" $ ) $shard $i (include "clickhouse.headlessServiceName" $) (include "common.names.namespace" $) $.Values.clusterDomain }}</host>
                 <port>{{ $.Values.service.ports.tcp }}</port>
                 <user>{{ $.Values.auth.username }}</user>
-                <password>{{ $.Values.auth.username }}</password>
+                <password>{{ $.Values.auth.password }}</password>
             </replica>
             {{- end }}
         </shard>


### PR DESCRIPTION
### Description of the change

Added user/pass to remote_servers/default/shard/replica in values.yaml.

### Benefits

This allows for cluster authentication using the configured admin user/pass.

### Possible drawbacks

N/A

### Applicable issues

https://github.com/bitnami/charts/issues/13541

### Additional information

N/A

### Checklist
- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
