### PR TITLE
[bitnami/grafana] Catch typeError in Cypress test

### DIFF
--- a/.vib/grafana/cypress/cypress/support/commands.js
+++ b/.vib/grafana/cypress/cypress/support/commands.js
@@ -12,6 +12,16 @@ for (const command of ['click']) {
   });
 }
 
+Cypress.on('uncaught:exception', (err, runnable) => {
+  // In Grafana 9.3.0 the console throws a typeError with message
+  //'Cannot read properties of undefined (reading 'eventTrackingNamespace')'.
+  // An issue has been created:
+  // https://github.com/grafana/grafana/issues/60377
+  if (err.message.includes("Cannot read properties of undefined (reading 'eventTrackingNamespace')")) {
+    return false
+  }
+})
+
 Cypress.Commands.add(
   'login',
   (username = Cypress.env('username'), password = Cypress.env('password')) => {

--- a/.vib/grafana/cypress/cypress/support/commands.js
+++ b/.vib/grafana/cypress/cypress/support/commands.js
@@ -14,7 +14,7 @@ for (const command of ['click']) {
 
 Cypress.on('uncaught:exception', (err, runnable) => {
   // In Grafana 9.3.0 the console throws a typeError with message
-  //'Cannot read properties of undefined (reading 'eventTrackingNamespace')'.
+  // 'Cannot read properties of undefined (reading 'eventTrackingNamespace')'.
   // An issue has been created:
   // https://github.com/grafana/grafana/issues/60377
   if (err.message.includes("Cannot read properties of undefined (reading 'eventTrackingNamespace')")) {


### PR DESCRIPTION
Signed-off-by: Michiel <michield@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

It's a workaround for a typeError thrown in the console, which makes the Cypress test fail. An issue has been created:
https://github.com/grafana/grafana/issues/60377

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

(https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
