### PR TITLE
[clickhouse] update clickhouse zk cluster replica to 3

### DIFF
--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -25,4 +25,4 @@ name: clickhouse
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/clickhouse
   - https://github.com/ClickHouse/ClickHouse
-version: 2.1.2
+version: 2.2.0

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -25,4 +25,4 @@ name: clickhouse
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/clickhouse
   - https://github.com/ClickHouse/ClickHouse
-version: 2.1.1
+version: 2.1.2

--- a/bitnami/clickhouse/README.md
+++ b/bitnami/clickhouse/README.md
@@ -333,7 +333,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                             | Description                   | Value  |
 | -------------------------------- | ----------------------------- | ------ |
 | `zookeeper.enabled`              | Deploy Zookeeper subchart     | `true` |
-| `zookeeper.replicaCount`         | Number of Zookeeper instances | `2`    |
+| `zookeeper.replicaCount`         | Number of Zookeeper instances | `3`    |
 | `zookeeper.service.ports.client` | Zookeeper client port         | `2181` |
 
 

--- a/bitnami/clickhouse/values.yaml
+++ b/bitnami/clickhouse/values.yaml
@@ -1043,7 +1043,7 @@ externalZookeeper:
 ##
 zookeeper:
   enabled: true
-  replicaCount: 2
+  replicaCount: 3
   service:
     ports:
       client: 2181


### PR DESCRIPTION
Signed-off-by: lusson <lusson@foxmail.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

zookeeper cluster replica is 2 will cause cluster split brain, zookeeper cluster least replica is 3.

### Benefits

zookeeper cluster No split-brain

### Possible drawbacks

no

### Applicable issues

  - fixes #13954

### Additional information

no

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
