### PR TITLE
[bitnami/sonarqube] Fix sonarqube to scale to more than one running pod

### DIFF
--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -28,4 +28,4 @@ name: sonarqube
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/sonarqube
   - https://github.com/SonarSource/sonarqube
-version: 2.0.3
+version: 2.0.4

--- a/bitnami/sonarqube/README.md
+++ b/bitnami/sonarqube/README.md
@@ -25,8 +25,6 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment
 
 - Kubernetes 1.19+
 - Helm 3.2.0+
-- PV provisioner support in the underlying infrastructure
-- ReadWriteMany volumes for deployment scaling
 
 ## Installing the Chart
 

--- a/bitnami/sonarqube/README.md
+++ b/bitnami/sonarqube/README.md
@@ -317,7 +317,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `postgresql.auth.username`             | Username to create when deploying the PostgreSQL chart                             | `bn_sonarqube`      |
 | `postgresql.auth.database`             | Database to create when deploying the PostgreSQL chart                             | `bitnami_sonarqube` |
 | `postgresql.service.ports.postgresql`  | PostgreSQL service port                                                            | `5432`              |
-| `postgresql.persistence.enabled`       | Use PVCs when deploying the PostgreSQL chart                                       | `true`              |
+| `postgresql.persistence.enabled`       | Use PVCs when deploying the PostgreSQL chart                                       | `false`             |
 | `postgresql.persistence.existingClaim` | Use an existing PVC when deploying the PostgreSQL chart                            | `""`                |
 | `postgresql.persistence.storageClass`  | storageClass of the created PVCs                                                   | `""`                |
 | `postgresql.persistence.accessMode`    | Access mode of the created PVCs                                                    | `ReadWriteOnce`     |

--- a/bitnami/sonarqube/values.yaml
+++ b/bitnami/sonarqube/values.yaml
@@ -913,7 +913,7 @@ postgresql:
   persistence:
     ## @param postgresql.persistence.enabled Use PVCs when deploying the PostgreSQL chart
     ##
-    enabled: true
+    enabled: false
     ## @param postgresql.persistence.existingClaim Use an existing PVC when deploying the PostgreSQL chart
     ##
     existingClaim: ""


### PR DESCRIPTION
### Description of the change

As in https://docs.sonarqube.org/latest/setup-and-upgrade/deploy-on-kubernetes/deploy-sonarqube-on-kubernetes/#helm-chart-specifics stated, the persistency is only used for elasticsearch to speed up the index generation and not really needed. As with the defaults set as is, a container restart or scaling is not possible at all.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #13865

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
