### PR TITLE
[bitnami/consul] Support templating for ingress urls

### DIFF
--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -23,4 +23,4 @@ name: consul
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/consul
   - https://www.consul.io/
-version: 10.9.7
+version: 10.9.8

--- a/bitnami/consul/templates/NOTES.txt
+++ b/bitnami/consul/templates/NOTES.txt
@@ -35,8 +35,8 @@ In order to access to the Consul Web UI:
 1. Get the Consul URL and associate its hostname to your cluster external IP:
 
    export CLUSTER_IP=$(minikube ip) # On Minikube. Use: `kubectl cluster-info` on others K8s clusters
-   echo "Consul URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.hostname }}"
-   echo "$CLUSTER_IP  {{ .Values.ingress.hostname }}" | sudo tee -a /etc/hosts
+   echo "Consul URL: http{{ if .Values.ingress.tls }}s{{ end }}://{{ tpl .Values.ingress.hostname . }}"
+   echo "$CLUSTER_IP  {{ tpl .Values.ingress.hostname . }}" | sudo tee -a /etc/hosts
 
 {{- else }}
 

--- a/bitnami/consul/templates/ingress.yaml
+++ b/bitnami/consul/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
   {{- end }}
   rules:
     {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    - host: {{ tpl .Values.ingress.hostname . }}
       http:
         paths:
           {{- if .Values.ingress.extraPaths }}
@@ -53,11 +53,11 @@ spec:
   tls:
     {{- if and .Values.ingress.tls (or .Values.ingress.existingSecret (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
     - hosts:
-        - {{ .Values.ingress.hostname | quote }}
+        - {{ tpl .Values.ingress.hostname . | quote }}
       {{- if .Values.ingress.existingSecret }}
       secretName: {{ .Values.ingress.existingSecret }}
       {{- else }}
-      secretName: {{ printf "%s-tls" .Values.ingress.hostname | trunc 63 | trimSuffix "-" }}
+      secretName: {{ printf "%s-tls" (tpl .Values.ingress.hostname .) | trunc 63 | trimSuffix "-" }}
       {{- end }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}

--- a/bitnami/consul/templates/tls-secrets.yaml
+++ b/bitnami/consul/templates/tls-secrets.yaml
@@ -21,11 +21,11 @@ data:
 {{- end }}
 {{- else if and .Values.ingress.tls .Values.ingress.selfSigned }}
 {{- $ca := genCA "consul-ca" 365 }}
-{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+{{- $cert := genSignedCert (tpl .Values.ingress.hostname .) nil (list (tpl .Values.ingress.hostname .)) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.ingress.hostname | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-tls" (tpl .Values.ingress.hostname .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}


### PR DESCRIPTION
### Description of the change

The change is adding an additional tpl call before using the configured `.Values.ingress.hostname` parameter.

### Benefits

Currently, you have to provide dedicated _values.yaml_ files for the deployment of a consul where the ingress URL only differs with a small part connected with the deployed namespace: 
e.g. having the namespaces "product-dev" and "product-test" you currently need different _values.yaml_ to prevent a clash in the used ingress URLs.
- _values.dev.yaml_ including
```yaml
consul:
    ingress:
      enabled: true
      hostname: some-consul-url-for-product-dev.org
```
- and a _values.test.yaml_ including
```yaml
consul:
    ingress:
      enabled: true
      hostname: some-consul-url-for-product-test.org
```

With the additional tpl call, one can have one _values.yaml_ which includes the namespace used during deployment. 
E.g.
```yaml
consul:
    ingress:
      enabled: true
      hostname: "some-consul-url-for-{{ .Release.Namespace }}.org"
```

### Possible drawbacks

Currently no known drawbacks.

### Applicable issues

Currently, no known issue raised for this.

### Additional information

n/a

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
