### PR TITLE
[bitnami/jaeger] Reorder chart dependencies

### DIFF
--- a/bitnami/jaeger/Chart.lock
+++ b/bitnami/jaeger/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
-- name: cassandra
-  repository: https://charts.bitnami.com/bitnami
-  version: 9.7.7
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.2.2
-digest: sha256:67b8e92719d59da97775177e0447b474932e508cbc520d894b1dd9e38a1c4f44
-generated: "2022-12-15T13:51:30.913117+01:00"
+- name: cassandra
+  repository: https://charts.bitnami.com/bitnami
+  version: 9.7.7
+digest: sha256:a517943e9c9f99a7f2548d6b78a71274796143ebc6d0a4626c2738057b2fe2af
+generated: "2022-12-21T17:33:51.44335+01:00"

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -3,15 +3,15 @@ annotations:
 apiVersion: v2
 appVersion: 1.40.0
 dependencies:
-  - condition: cassandra.enabled
-    name: cassandra
-    repository: https://charts.bitnami.com/bitnami
-    version: 9.x.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
     version: 2.x.x
+  - condition: cassandra.enabled
+    name: cassandra
+    repository: https://charts.bitnami.com/bitnami
+    version: 9.x.x
 description: Jaeger is a distributed tracing system. It is used for monitoring and troubleshooting microservices-based distributed systems.
 engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/jaeger
@@ -27,4 +27,4 @@ name: jaeger
 sources:
   - https://github.com/jaegertracing/jaeger
   - https://www.jaegertracing.io/
-version: 0.1.1
+version: 0.1.2


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

It seems there is an issue when working with OCI registries and the definition order of the subcharts.
While the issue is solved in the Helm CLI, we are reordering the dependencies.

### Possible drawbacks

None

### Related issues

- #9297

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
