### PR TITLE
[bitnami/harbor]: Fix chart installation

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -36,4 +36,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registry
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registryctl
   - https://goharbor.io/
-version: 16.1.1
+version: 16.1.2

--- a/bitnami/harbor/README.md
+++ b/bitnami/harbor/README.md
@@ -1144,6 +1144,9 @@ Additionally, if `persistence.resourcePolicy` is set to `keep`, you should manua
 | `redis.auth.password`                     | Redis&reg; password                                                    | `""`         |
 | `redis.auth.existingSecret`               | The name of an existing secret with Redis&reg; credentials             | `""`         |
 | `redis.architecture`                      | Redis&reg; architecture. Allowed values: `standalone` or `replication` | `standalone` |
+| `redis.sentinel.enabled`                  | Use Redis&reg; Sentinel on Redis&reg; pods.                            | `false`      |
+| `redis.sentinel.masterSet`                | Master set name                                                        | `mymaster`   |
+| `redis.sentinel.service.ports.sentinel`   | Redis&reg; service port for Redis&reg; Sentinel                        | `26379`      |
 | `externalRedis.host`                      | Redis&reg; host                                                        | `localhost`  |
 | `externalRedis.port`                      | Redis&reg; port number                                                 | `6379`       |
 | `externalRedis.password`                  | Redis&reg; password                                                    | `""`         |

--- a/bitnami/harbor/values.yaml
+++ b/bitnami/harbor/values.yaml
@@ -3752,6 +3752,9 @@ externalDatabase:
 ## @param redis.auth.password Redis&reg; password
 ## @param redis.auth.existingSecret The name of an existing secret with Redis&reg; credentials
 ## @param redis.architecture Redis&reg; architecture. Allowed values: `standalone` or `replication`
+## @param redis.sentinel.enabled Use Redis&reg; Sentinel on Redis&reg; pods.
+## @param redis.sentinel.masterSet Master set name
+## @param redis.sentinel.service.ports.sentinel Redis&reg; service port for Redis&reg; Sentinel
 ##
 redis:
   enabled: true
@@ -3765,6 +3768,12 @@ redis:
     password: ""
     existingSecret: ""
   architecture: standalone
+  sentinel:
+    enabled: false
+    masterSet: mymaster
+    service:
+      ports:
+        sentinel: 26379
 
 ## External Redis&reg; configuration
 ## All of these values are only used when redis.enabled is set to false


### PR DESCRIPTION
Version 16.0.1 of this chart introduced support for Redis sentinel. This added references to some `redis.sentinel.*` variables without providing default values for them in the values.yaml file. If the user does not supply these values then the chart installation fails.
This PR provides the defaults matching the default values used in the bitnami/redis chart so that the error does not happen.

Signed-off-by: Jim Barber <jim.barber@healthengine.com.au>

### Description of the change

Fixes the installation of the harbor chart when the user doesn't supply any `redis.sentinel.*` variables because they are not using it.

### Benefits

Fixes the installation breakage introduced in version 16.0.1 of the chart.

### Applicable issues

  - fixes #14054

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
