### PR TITLE
[bitnami/mastodon]: Fix chart installation issues

### DIFF
--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -42,4 +42,4 @@ name: mastodon
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mastodon
   - https://github.com/mastodon/mastodon/
-version: 0.1.1
+version: 0.1.2

--- a/bitnami/mastodon/templates/externalelasticsearch-secret.yaml
+++ b/bitnami/mastodon/templates/externalelasticsearch-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-externalelasticsearch" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: mastodon
     {{- if .Values.commonLabels }}

--- a/bitnami/mastodon/templates/externalredis-secret.yaml
+++ b/bitnami/mastodon/templates/externalredis-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-externalredis" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: mastodon
     {{- if .Values.commonLabels }}

--- a/bitnami/mastodon/templates/externals3-secret.yaml
+++ b/bitnami/mastodon/templates/externals3-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ printf "%s-externals3" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ include "common.names.namespace" | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/part-of: mastodon
     {{- if .Values.commonLabels }}


### PR DESCRIPTION
Version **0.1.1** of the mastodon helm chart is using the `include "common.names.namespace"` directive in several templates. The `include` function requires the current context argument to be passed. Some templates (such as `externals3-secret.yaml`, `externalredis-secret.yaml`, etc. ) are missing the current context argument, hence chart installation fails when enabling external components such as **S3**, **Redis**, etc.

Signed-off-by: Cristian Marius Tiutiu <v-ctiutiu@digitalocean.com>

### Description of the change

The Helm chart installation doesn't fail when enabling external components such as **S3**, **Redis**, etc.

### Benefits

Fixes the installation breakage introduced in version **0.1.1** of the chart.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
