### PR TITLE
[bitnami/odoo] Fix health api

### DIFF
--- a/bitnami/odoo/values.yaml
+++ b/bitnami/odoo/values.yaml
@@ -217,7 +217,7 @@ containerSecurityContext:
 ##
 livenessProbe:
   enabled: true
-  path: /
+  path: /web/health
   initialDelaySeconds: 600
   periodSeconds: 30
   timeoutSeconds: 5
@@ -233,7 +233,7 @@ livenessProbe:
 ##
 readinessProbe:
   enabled: true
-  path: /
+  path: /web/health
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5
@@ -249,7 +249,7 @@ readinessProbe:
 ##
 startupProbe:
   enabled: false
-  path: /
+  path: /web/health
   initialDelaySeconds: 300
   periodSeconds: 10
   timeoutSeconds: 5


### PR DESCRIPTION
### Description of the change
Fix health API for Odoo

### Benefits
Currently Kubernetes checking health by request to /, it always returns 1 redirect to /web/login, and handling 2 such requests is probably not suitable for health

### Possible drawbacks
None

### Applicable issues


### Additional information
https://github.com/odoo/odoo/blob/16.0/addons/web/controllers/home.py#L149-L156

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
