### PR TITLE
bitnami/keycloak: Document possible use of MSSQL as an external DB

### DIFF
--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -387,6 +387,12 @@ Refer to the [chart documentation on using an external database](https://docs.bi
 It is not supported but possible to run Keycloak with an external MSSQL database with the following settings:
 
 ```yaml
+externalDatabase:
+  host: "mssql.example.com"
+  port: 1433
+  user: keycloak
+  database: keycloak
+  existingSecret: passwords
 extraEnvVars:
   - name: KC_DB # override values from the conf file
     value: 'mssql'

--- a/bitnami/keycloak/README.md
+++ b/bitnami/keycloak/README.md
@@ -384,6 +384,16 @@ Refer to the [chart documentation on using an external database](https://docs.bi
 
 > NOTE: Only PostgreSQL database server is supported as external database
 
+It is not supported but possible to run Keycloak with an external MSSQL database with the following settings:
+
+```yaml
+extraEnvVars:
+  - name: KC_DB # override values from the conf file
+    value: 'mssql'
+  - name: KC_DB_URL
+    value: 'jdbc:sqlserver://mssql.example.com:1433;databaseName=keycloak;'
+```
+
 ### Add extra environment variables
 
 In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnvVars` property.


### PR DESCRIPTION
I was able to run KC with a MSSQL 2019 and the bitnami Keycloak chart, so decided to add this to the documentation. 

Proposed works because KeyCloak gives preferences to the environment compared to the statements in the configuration file. I think it could be useful for other chart users.

Signed-off-by: Alex Samorukov <samm@net-art.cz>

### Description of the change

Update Keycloak chart readme to document possible use of MSSQL as an external DB

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
