### PR TITLE
[bitnami/kubernetes-event-exporter] Use custom ClusterRole with wider read permissions

### DIFF
--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -26,4 +26,4 @@ name: kubernetes-event-exporter
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kubernetes-event-exporter
   - https://github.com/resmoio/kubernetes-event-exporter
-version: 2.1.4
+version: 2.1.5

--- a/bitnami/kubernetes-event-exporter/templates/clusterrole.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create -}}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ template "common.names.fullname.namespace" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "watch", "list"]
+{{- end }}

--- a/bitnami/kubernetes-event-exporter/templates/rbac.yaml
+++ b/bitnami/kubernetes-event-exporter/templates/rbac.yaml
@@ -14,7 +14,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view
+  name: {{ include "common.names.fullname.namespace" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubernetes-event-exporter.serviceAccountName" . }}


### PR DESCRIPTION
Signed-off-by: Tuan Anh Nguyen <tuananh.nguyen-ext@commercetools.de>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Use custom ClusterRole with wider read permissions to account for CRs, following https://github.com/resmoio/kubernetes-event-exporter/pull/39

### Benefits

We had issue similar to https://github.com/resmoio/kubernetes-event-exporter/issues/14 but a different error `cannot get resource "nodes" in API group "" at the cluster scope`.

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
