### PR TITLE
[bitnami/sealed-secrets] add port name to sealed secrets service

### DIFF
--- a/.vib/sealed-secrets/vib-verify.json
+++ b/.vib/sealed-secrets/vib-verify.json
@@ -34,7 +34,7 @@
         {
           "action_id": "health-check",
           "params": {
-            "endpoint": "lb-sealed-secrets-80",
+            "endpoint": "lb-sealed-secrets-http",
             "app_protocol": "HTTP"
           }
         },
@@ -44,7 +44,7 @@
             "resources": {
               "path": "/.vib/sealed-secrets/cypress"
             },
-            "endpoint": "lb-sealed-secrets-80",
+            "endpoint": "lb-sealed-secrets-http",
             "app_protocol": "HTTP"
           }
         },

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -23,4 +23,4 @@ name: sealed-secrets
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/sealed-secrets
   - https://github.com/bitnami-labs/sealed-secrets
-version: 1.2.1
+version: 1.2.2

--- a/bitnami/sealed-secrets/templates/service.yaml
+++ b/bitnami/sealed-secrets/templates/service.yaml
@@ -38,6 +38,7 @@ spec:
   {{- end }}
   ports:
     - port: {{ .Values.service.ports.http }}
+      name: {{ .Values.service.ports.name }}
       targetPort: {{ .Values.service.ports.name }}
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http)) }}
       nodePort: {{ .Values.service.nodePorts.http }}


### PR DESCRIPTION
Signed-off-by: Mateusz Drab <mateuszd@outlook.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Add port name in service ports spec.
Resolves an issue with servicemonitor not working due to a reference to the port name which was missing in the service:
```yaml
spec:                                                                                                                            
  endpoints:
   - port: {{ .Values.service.ports.name }}
```

### Benefits

Fixes servicemonitor

### Possible drawbacks

N/A

### Applicable issues

N/A

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
