### PR TITLE
[bitnami/postgresql] allow auth.database to be templated

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
-version: 12.1.6
+version: 12.1.7

--- a/bitnami/postgresql/templates/_helpers.tpl
+++ b/bitnami/postgresql/templates/_helpers.tpl
@@ -80,9 +80,9 @@ Return the name for a custom database to create
 */}}
 {{- define "postgresql.database" -}}
 {{- if .Values.global.postgresql.auth.database }}
-    {{- .Values.global.postgresql.auth.database -}}
+    {{- printf "%s" (tpl .Values.global.postgresql.auth.database $) -}}
 {{- else if .Values.auth.database -}}
-    {{- .Values.auth.database -}}
+    {{- printf "%s" (tpl .Values.auth.database $) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### Description of the change

The `auth.database` parameter can now include Helm templating.

### Benefits

This allows users of the chart to derive the name of the database from other variables, like the release name.

### Possible drawbacks

N/A

### Applicable issues

  - fixes #14165

### Additional information

N/A

### Checklist


- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
