### PR TITLE
[bitnami/memcached] Correct typo in README.md

### DIFF
--- a/bitnami/memcached/README.md
+++ b/bitnami/memcached/README.md
@@ -327,7 +327,7 @@ Find more information about how to deal with common errors related to Bitnami's 
 
 ## Upgrading
 
-### To 5.0.0
+### To 6.0.0
 
 This major release renames several values in this chart and adds missing features, in order to be inline with the rest of assets in the Bitnami charts repository.
 


### PR DESCRIPTION
It seems extremely likely that this line is a typo, based on:
* investigation in [this SO question](https://stackoverflow.com/questions/75001357/different-name-required-to-override-value-in-helm-subchart/75002389)
* the fact that [the PR where this line was introduced](https://github.com/bitnami/charts/pull/8668) updated the actual `Chart.yaml` to
[6.0.0](https://github.com/bitnami/charts/pull/8668/commits/4ed25c0b776ee688d20fddb67f7d63c5356aa5ff)
* the fact that [5.0.0 is referenced twice in this file](https://github.com/bitnami/charts/blob/main/bitnami/memcached/README.md?plain=1#L330-L348)

Signed-off-by: Jack Jackson <scubbojj@gmail.com>

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
