### PR TITLE
[bitnami/elasticsearch] Resolve immutable field error due to empty string clusterIP being set

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -25,4 +25,4 @@ name: elasticsearch
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/elasticsearch
   - https://www.elastic.co/products/elasticsearch
-version: 19.5.7
+version: 19.5.8

--- a/bitnami/elasticsearch/templates/coordinating/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/coordinating/svc-headless.yaml
@@ -14,7 +14,6 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
-  clusterIP: ""
   publishNotReadyAddresses: true
   ports:
     - name: tcp-rest-api

--- a/bitnami/elasticsearch/templates/data/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/data/svc-headless.yaml
@@ -14,7 +14,6 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
-  clusterIP: ""
   publishNotReadyAddresses: true
   ports:
     - name: tcp-rest-api

--- a/bitnami/elasticsearch/templates/ingest/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/ingest/svc-headless.yaml
@@ -14,7 +14,6 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
-  clusterIP: ""
   publishNotReadyAddresses: true
   ports:
     - name: tcp-rest-api

--- a/bitnami/elasticsearch/templates/master/svc-headless.yaml
+++ b/bitnami/elasticsearch/templates/master/svc-headless.yaml
@@ -14,7 +14,6 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
-  clusterIP: ""
   publishNotReadyAddresses: true
   ports:
     - name: tcp-rest-api


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Ever since https://github.com/bitnami/charts/pull/12349 was introduced, the chart is no longer upgradeable. The chart throws errors 

```
upgrade.go:434: [debug] warning: Upgrade "elasticsearch" failed: 
cannot patch "elasticsearch-coordinating-hl" with kind Service: Service "elasticsearch-coordinating-hl" is invalid: spec.clusterIP: Invalid value: "": field is immutable 
&& 
cannot patch "elasticsearch-data-hl" with kind Service: Service "elasticsearch-data-hl" is invalid: spec.clusterIP: Invalid value: "": field is immutable 
&& 
cannot patch "elasticsearch-ingest-hl" with kind Service: Service "elasticsearch-ingest-hl" is invalid: spec.clusterIP: Invalid value: "": field is immutable 
&& 
cannot patch "elasticsearch-master-hl" with kind Service: Service "elasticsearch-master-hl" is invalid: spec.clusterIP: Invalid value: "": field is immutable
```

In order to fix the errors and allow upgrades to work, we have to work around this breaking change. We have to convert all the previously headless services to regular clusterIP services by deleting the old ones. However, the empty string clusterIP being set caused the above errors and blocks upgrades. By removing the empty string entirely, we allow the service to get upgraded even after the clusterIP is generated.

### Benefits

<!-- What benefits will be realized by the code change? -->
Resolves a breaking change introduced in https://github.com/bitnami/charts/pull/12349

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
