### PR TITLE
[bitnami/kafka] Support the service "NodePort" feature "externalIPs" for external access

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -178,7 +178,7 @@ jobs:
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
           echo "verification_mode=${verification_mode}" >> $GITHUB_OUTPUT
-      - uses: vmware-labs/vmware-image-builder-action@0.4.18
+      - uses: vmware-labs/vmware-image-builder-action@main
         name: Verify and publish ${{ needs.get-chart.outputs.chart }}
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-publish.json
@@ -221,10 +221,10 @@ jobs:
       - id: update-index
         name: Fetch chart and update index
         run: |
-          # Extract chart release metadata from the publish result file
-          vib_publish_result_file=$(find ~/artifacts -name "result.json" -print -quit)
-          chart_name=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.name' $vib_publish_result_file)
-          chart_version=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.version' $vib_publish_result_file)
+          # Extract chart release metadata from the publish report file
+          vib_publish_report_file=$(find ~/artifacts -name "report.json" -print -quit)
+          chart_name=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.name' $vib_publish_report_file)
+          chart_version=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.version' $vib_publish_report_file)
           # Download published asset
           mkdir download
           aws s3 cp s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/${chart_name}-${chart_version}.tgz download/

--- a/.github/workflows/ci-pipeline-extra-thanos.yml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - uses: vmware-labs/vmware-image-builder-action@0.4.18
+      - uses: vmware-labs/vmware-image-builder-action@main
         with:
           pipeline: thanos/bucketweb/vib-verify.json
         env:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -117,7 +117,7 @@ jobs:
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
           echo "verification_mode=${verification_mode}" >> $GITHUB_OUTPUT
-      - uses: vmware-labs/vmware-image-builder-action@0.4.18
+      - uses: vmware-labs/vmware-image-builder-action@main
         name: Verify ${{ needs.get-chart.outputs.chart }}
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-verify.json

--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: WorkFlow
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.5.0
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Airflow is a tool to express and execute workflows as directed acyclic graphs (DAGs). It includes utilities to schedule tasks, monitor task progress and handle task dependencies.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/airflow
 icon: https://bitnami.com/assets/stacks/airflow/img/airflow-stack-220x234.png
 keywords:

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.4.54
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache HTTP Server is an open-source HTTP server. The goal of this project is to provide a secure, efficient and extensible server that provides HTTP services in sync with the current HTTP standards.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/apache
 icon: https://bitnami.com/assets/stacks/apache/img/apache-stack-220x234.png
 keywords:

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.9.2
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Appsmith is an open source platform for building and maintaining internal tools, such as custom dashboards, admin panels or CRUD apps.
-engine: gotpl
 home: https://www.appsmith.com/
 icon: https://bitnami.com/assets/stacks/appsmith/img/appsmith-stack-220x234.png
 keywords:

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.5.6
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Argo CD is a continuous delivery tool for Kubernetes based on GitOps.
-engine: gotpl
 home: https://argoproj.github.io/argo-cd/
 icon: https://bitnami.com/assets/stacks/argo-cd/img/argo-cd-stack-220x234.png
 keywords:

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.4.4
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Argo Workflows is meant to orchestrate Kubernetes jobs in parallel. It uses DAG and step-based workflows
-engine: gotpl
 home: https://argoproj.github.io/workflows/
 icon: https://bitnami.com/assets/stacks/argo-workflows/img/argo-workflows-stack-220x234.png
 keywords:

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.0.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: ASP.NET Core is an open-source framework for web application development created by Microsoft. It runs on both the full .NET Framework, on Windows, and the cross-platform .NET Core.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/aspnet-core
 icon: https://bitnami.com/assets/stacks/aspnet-core/img/aspnet-core-stack-220x234.png
 keywords:

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Cassandra is an open source distributed database management system designed to handle large amounts of data across many servers, providing high availability with no single point of failure.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/cassandra
 icon: https://bitnami.com/assets/stacks/cassandra/img/cassandra-stack-220x234.png
 keywords:

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CertificateAuthority
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.10.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
-engine: gotpl
 home: https://github.com/jetstack/cert-manager
 icon: https://bitnami.com/assets/stacks/cert-manager/img/cert-manager-stack-220x234.png
 keywords:

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   licenses: |
     - Apache-2.0
 apiVersion: v2
-appVersion: 1.10.2
+appVersion: 1.11.0
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/cert-manager-webhook
   - https://github.com/bitnami/containers/tree/main/bitnami/cainjector
   - https://github.com/jetstack/cert-manager
-version: 0.8.11
+version: 0.8.12

--- a/bitnami/cert-manager/README.md
+++ b/bitnami/cert-manager/README.md
@@ -85,7 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `controller.replicaCount`                                | Number of Controller replicas                                                                              | `1`                    |
 | `controller.image.registry`                              | Controller image registry                                                                                  | `docker.io`            |
 | `controller.image.repository`                            | Controller image repository                                                                                | `bitnami/cert-manager` |
-| `controller.image.tag`                                   | Controller image tag (immutable tags are recommended)                                                      | `1.10.2-debian-11-r0`  |
+| `controller.image.tag`                                   | Controller image tag (immutable tags are recommended)                                                      | `1.11.0-debian-11-r0`  |
 | `controller.image.digest`                                | Controller image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
 | `controller.image.pullPolicy`                            | Controller image pull policy                                                                               | `IfNotPresent`         |
 | `controller.image.pullSecrets`                           | Controller image pull secrets                                                                              | `[]`                   |

--- a/bitnami/cert-manager/values.yaml
+++ b/bitnami/cert-manager/values.yaml
@@ -69,7 +69,7 @@ controller:
   image:
     registry: docker.io
     repository: bitnami/cert-manager
-    tag: 1.10.2-debian-11-r0
+    tag: 1.11.0-debian-11-r0
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 22.12.3
 dependencies:

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
 appVersion: 2.2.2

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.8.3
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Concourse is an automation system written in Go. It is most commonly used for CI/CD, and is built to scale to any kind of automation pipeline, from simple to complex.
-engine: gotpl
 home: https://github.com/concourse/concourse
 icon: https://bitnami.com/assets/stacks/concourse/img/concourse-stack-220x234.png
 keywords:

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.14.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: HashiCorp Consul is a tool for discovering and configuring services in your infrastructure.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/consul
 icon: https://bitnami.com/assets/stacks/consul/img/consul-stack-220x234.png
 keywords:

--- a/bitnami/contour-operator/Chart.yaml
+++ b/bitnami/contour-operator/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.23.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: The Contour Operator extends the Kubernetes API to create, configure and manage instances of Contour on behalf of users.
-engine: gotpl
 home: https://github.com/projectcontour/contour-operator
 icon: https://bitnami.com/assets/stacks/contour-operator/img/contour-operator-stack-220x234.png
 keywords:

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -26,4 +26,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/containers/tree/main/bitnami/contour
   - https://projectcontour.io
-version: 10.1.3
+version: 10.1.4

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.23.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Contour is an open source Kubernetes ingress controller that works by deploying the Envoy proxy as a reverse proxy and load balancer.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/contour
 icon: https://bitnami.com/assets/stacks/contour/img/contour-stack-220x234.png
 keywords:

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -92,7 +92,7 @@ $ helm uninstall my-release
 | `contour.enabled`                                             | Contour Deployment creation.                                                                                                       | `true`                |
 | `contour.image.registry`                                      | Contour image registry                                                                                                             | `docker.io`           |
 | `contour.image.repository`                                    | Contour image name                                                                                                                 | `bitnami/contour`     |
-| `contour.image.tag`                                           | Contour image tag                                                                                                                  | `1.23.2-debian-11-r0` |
+| `contour.image.tag`                                           | Contour image tag                                                                                                                  | `1.23.2-debian-11-r9` |
 | `contour.image.digest`                                        | Contour image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                            | `""`                  |
 | `contour.image.pullPolicy`                                    | Contour Image pull policy                                                                                                          | `IfNotPresent`        |
 | `contour.image.pullSecrets`                                   | Contour Image pull secrets                                                                                                         | `[]`                  |
@@ -189,117 +189,117 @@ $ helm uninstall my-release
 
 ### Envoy parameters
 
-| Name                                                | Description                                                                                                           | Value                 |
-| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------- |
-| `envoy.enabled`                                     | Envoy Proxy creation                                                                                                  | `true`                |
-| `envoy.image.registry`                              | Envoy Proxy image registry                                                                                            | `docker.io`           |
-| `envoy.image.repository`                            | Envoy Proxy image repository                                                                                          | `bitnami/envoy`       |
-| `envoy.image.tag`                                   | Envoy Proxy image tag (immutable tags are recommended)                                                                | `1.24.1-debian-11-r2` |
-| `envoy.image.digest`                                | Envoy Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag           | `""`                  |
-| `envoy.image.pullPolicy`                            | Envoy image pull policy                                                                                               | `IfNotPresent`        |
-| `envoy.image.pullSecrets`                           | Envoy image pull secrets                                                                                              | `[]`                  |
-| `envoy.priorityClassName`                           | Priority class assigned to the pods                                                                                   | `""`                  |
-| `envoy.schedulerName`                               | Name of the k8s scheduler (other than default)                                                                        | `""`                  |
-| `envoy.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                                        | `[]`                  |
-| `envoy.extraArgs`                                   | Extra arguments passed to Envoy container                                                                             | `[]`                  |
-| `envoy.hostAliases`                                 | Add deployment host aliases                                                                                           | `[]`                  |
-| `envoy.resources.limits`                            | Specify resource limits which the container is not allowed to succeed.                                                | `{}`                  |
-| `envoy.resources.requests`                          | Specify resource requests which the container needs to spawn.                                                         | `{}`                  |
-| `envoy.command`                                     | Override default command                                                                                              | `[]`                  |
-| `envoy.args`                                        | Override default args                                                                                                 | `[]`                  |
-| `envoy.shutdownManager.enabled`                     | Contour shutdownManager sidecar                                                                                       | `true`                |
-| `envoy.shutdownManager.resources.limits`            | Specify resource limits which the container is not allowed to succeed.                                                | `{}`                  |
-| `envoy.shutdownManager.resources.requests`          | Specify resource requests which the container needs to spawn.                                                         | `{}`                  |
-| `envoy.kind`                                        | Install as deployment or daemonset                                                                                    | `daemonset`           |
-| `envoy.replicaCount`                                | Desired number of Controller pods                                                                                     | `1`                   |
-| `envoy.lifecycleHooks`                              | lifecycleHooks for the container to automate configuration before or after startup.                                   | `{}`                  |
-| `envoy.updateStrategy`                              | Strategy to use to update Pods                                                                                        | `{}`                  |
-| `envoy.minReadySeconds`                             | The minimum number of seconds for which a newly created Pod should be ready                                           | `0`                   |
-| `envoy.revisionHistoryLimit`                        | The number of old history to retain to allow rollback                                                                 | `10`                  |
-| `envoy.autoscaling.enabled`                         | Enable autoscaling for Controller                                                                                     | `false`               |
-| `envoy.autoscaling.minReplicas`                     | Minimum number of Controller replicas                                                                                 | `1`                   |
-| `envoy.autoscaling.maxReplicas`                     | Maximum number of Controller replicas                                                                                 | `11`                  |
-| `envoy.autoscaling.targetCPU`                       | Target CPU utilization percentage                                                                                     | `""`                  |
-| `envoy.autoscaling.targetMemory`                    | Target Memory utilization percentage                                                                                  | `""`                  |
-| `envoy.podAffinityPreset`                           | Envoy Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                  |
-| `envoy.podAntiAffinityPreset`                       | Envoy Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `""`                  |
-| `envoy.nodeAffinityPreset.type`                     | Envoy Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                       | `""`                  |
-| `envoy.nodeAffinityPreset.key`                      | Envoy Node label key to match Ignored if `affinity` is set.                                                           | `""`                  |
-| `envoy.nodeAffinityPreset.values`                   | Envoy Node label values to match. Ignored if `affinity` is set.                                                       | `[]`                  |
-| `envoy.affinity`                                    | Affinity for Envoy pod assignment                                                                                     | `{}`                  |
-| `envoy.nodeSelector`                                | Node labels for Envoy pod assignment                                                                                  | `{}`                  |
-| `envoy.tolerations`                                 | Tolerations for Envoy pod assignment                                                                                  | `[]`                  |
-| `envoy.podAnnotations`                              | Envoy Pod annotations                                                                                                 | `{}`                  |
-| `envoy.podLabels`                                   | Extra labels for Envoy pods                                                                                           | `{}`                  |
-| `envoy.podSecurityContext.enabled`                  | Envoy Pod securityContext                                                                                             | `false`               |
-| `envoy.podSecurityContext.fsGroup`                  | User ID for the for the mounted volumes                                                                               | `0`                   |
-| `envoy.podSecurityContext.sysctls`                  | Array of sysctl options to allow                                                                                      | `[]`                  |
-| `envoy.containerSecurityContext.enabled`            | Envoy Container securityContext                                                                                       | `true`                |
-| `envoy.containerSecurityContext.runAsUser`          | User ID for the Envoy container (to change this, http and https containerPorts must be set to >1024)                  | `1001`                |
-| `envoy.containerSecurityContext.runAsNonRoot`       | Run as non root                                                                                                       | `true`                |
-| `envoy.hostNetwork`                                 | Envoy Pod host network access                                                                                         | `false`               |
-| `envoy.dnsPolicy`                                   | Envoy Pod Dns Policy's DNS Policy                                                                                     | `ClusterFirst`        |
-| `envoy.tlsExistingSecret`                           | Name of the existingSecret to be use in Envoy deployment                                                              | `""`                  |
-| `envoy.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                  | `true`                |
-| `envoy.serviceAccount.name`                         | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `""`                  |
-| `envoy.serviceAccount.automountServiceAccountToken` | Whether to auto mount API credentials for a service account                                                           | `false`               |
-| `envoy.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                            | `{}`                  |
-| `envoy.livenessProbe.enabled`                       | Enable livenessProbe                                                                                                  | `true`                |
-| `envoy.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                               | `120`                 |
-| `envoy.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                                      | `20`                  |
-| `envoy.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                                     | `5`                   |
-| `envoy.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                                   | `6`                   |
-| `envoy.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                                   | `1`                   |
-| `envoy.readinessProbe.enabled`                      | Enable/disable the readiness probe                                                                                    | `true`                |
-| `envoy.readinessProbe.initialDelaySeconds`          | Delay before readiness probe is initiated                                                                             | `10`                  |
-| `envoy.readinessProbe.periodSeconds`                | How often to perform the probe                                                                                        | `3`                   |
-| `envoy.readinessProbe.timeoutSeconds`               | When the probe times out                                                                                              | `1`                   |
-| `envoy.readinessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.                            | `3`                   |
-| `envoy.readinessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed.                          | `1`                   |
-| `envoy.startupProbe.enabled`                        | Enable/disable the startup probe                                                                                      | `false`               |
-| `envoy.startupProbe.initialDelaySeconds`            | Delay before startup probe is initiated                                                                               | `15`                  |
-| `envoy.startupProbe.periodSeconds`                  | How often to perform the probe                                                                                        | `10`                  |
-| `envoy.startupProbe.timeoutSeconds`                 | When the probe times out                                                                                              | `5`                   |
-| `envoy.startupProbe.failureThreshold`               | Minimum consecutive failures for the probe to be considered failed after having succeeded.                            | `3`                   |
-| `envoy.startupProbe.successThreshold`               | Minimum consecutive successes for the probe to be considered successful after having failed.                          | `1`                   |
-| `envoy.customLivenessProbe`                         | Override default liveness probe                                                                                       | `{}`                  |
-| `envoy.customReadinessProbe`                        | Override default readiness probe                                                                                      | `{}`                  |
-| `envoy.customStartupProbe`                          | Override default startup probe                                                                                        | `{}`                  |
-| `envoy.terminationGracePeriodSeconds`               | Envoy termination grace period in seconds                                                                             | `300`                 |
-| `envoy.logLevel`                                    | Envoy log level                                                                                                       | `info`                |
-| `envoy.service.targetPorts`                         | Map the controller service HTTP/HTTPS port                                                                            | `{}`                  |
-| `envoy.service.type`                                | Type of Envoy service to create                                                                                       | `LoadBalancer`        |
-| `envoy.service.externalTrafficPolicy`               | Envoy Service external cluster policy. If `envoy.service.type` is NodePort or LoadBalancer                            | `Local`               |
-| `envoy.service.labels`                              | Labels to add to te envoy service                                                                                     | `{}`                  |
-| `envoy.service.clusterIP`                           | Internal envoy cluster service IP                                                                                     | `""`                  |
-| `envoy.service.externalIPs`                         | Envoy service external IP addresses                                                                                   | `[]`                  |
-| `envoy.service.loadBalancerIP`                      | IP address to assign to load balancer (if supported)                                                                  | `""`                  |
-| `envoy.service.loadBalancerSourceRanges`            | List of IP CIDRs allowed access to load balancer (if supported)                                                       | `[]`                  |
-| `envoy.service.loadBalancerClass`                   | Envoy service Load Balancer Class                                                                                     | `""`                  |
-| `envoy.service.ipFamilyPolicy`                      | , support SingleStack, PreferDualStack and RequireDualStack                                                           | `""`                  |
-| `envoy.service.annotations`                         | Annotations for Envoy service                                                                                         | `{}`                  |
-| `envoy.service.ports.http`                          | Sets service http port                                                                                                | `80`                  |
-| `envoy.service.ports.https`                         | Sets service https port                                                                                               | `443`                 |
-| `envoy.service.nodePorts.http`                      | HTTP Port. If `envoy.service.type` is NodePort and this is non-empty                                                  | `""`                  |
-| `envoy.service.nodePorts.https`                     | HTTPS Port. If `envoy.service.type` is NodePort and this is non-empty                                                 | `""`                  |
-| `envoy.service.extraPorts`                          | Extra ports to expose (normally used with the `sidecar` value)                                                        | `[]`                  |
-| `envoy.service.sessionAffinity`                     | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                  | `None`                |
-| `envoy.service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                                           | `{}`                  |
-| `envoy.useHostPort`                                 | Enable/disable `hostPort` for TCP/80 and TCP/443                                                                      | `true`                |
-| `envoy.useHostIP`                                   | Enable/disable `hostIP`                                                                                               | `false`               |
-| `envoy.hostPorts.http`                              | Sets `hostPort` http port                                                                                             | `80`                  |
-| `envoy.hostPorts.https`                             | Sets `hostPort` https port                                                                                            | `443`                 |
-| `envoy.hostIPs.http`                                | Sets `hostIP` http IP                                                                                                 | `127.0.0.1`           |
-| `envoy.hostIPs.https`                               | Sets `hostIP` https IP                                                                                                | `127.0.0.1`           |
-| `envoy.containerPorts.http`                         | Sets http port inside Envoy pod  (change this to >1024 to run envoy as a non-root user)                               | `8080`                |
-| `envoy.containerPorts.https`                        | Sets https port inside Envoy pod  (change this to >1024 to run envoy as a non-root user)                              | `8443`                |
-| `envoy.initContainers`                              | Attach additional init containers to Envoy pods                                                                       | `[]`                  |
-| `envoy.sidecars`                                    | Add additional sidecar containers to the Envoy pods                                                                   | `[]`                  |
-| `envoy.extraVolumes`                                | Array to add extra volumes                                                                                            | `[]`                  |
-| `envoy.extraVolumeMounts`                           | Array to add extra mounts (normally used with extraVolumes)                                                           | `[]`                  |
-| `envoy.extraEnvVars`                                | Array containing extra env vars to be added to all Envoy containers                                                   | `[]`                  |
-| `envoy.extraEnvVarsCM`                              | ConfigMap containing extra env vars to be added to all Envoy containers                                               | `""`                  |
-| `envoy.extraEnvVarsSecret`                          | Secret containing extra env vars to be added to all Envoy containers                                                  | `""`                  |
+| Name                                                | Description                                                                                                           | Value                  |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `envoy.enabled`                                     | Envoy Proxy creation                                                                                                  | `true`                 |
+| `envoy.image.registry`                              | Envoy Proxy image registry                                                                                            | `docker.io`            |
+| `envoy.image.repository`                            | Envoy Proxy image repository                                                                                          | `bitnami/envoy`        |
+| `envoy.image.tag`                                   | Envoy Proxy image tag (immutable tags are recommended)                                                                | `1.24.1-debian-11-r11` |
+| `envoy.image.digest`                                | Envoy Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag           | `""`                   |
+| `envoy.image.pullPolicy`                            | Envoy image pull policy                                                                                               | `IfNotPresent`         |
+| `envoy.image.pullSecrets`                           | Envoy image pull secrets                                                                                              | `[]`                   |
+| `envoy.priorityClassName`                           | Priority class assigned to the pods                                                                                   | `""`                   |
+| `envoy.schedulerName`                               | Name of the k8s scheduler (other than default)                                                                        | `""`                   |
+| `envoy.topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment                                                                        | `[]`                   |
+| `envoy.extraArgs`                                   | Extra arguments passed to Envoy container                                                                             | `[]`                   |
+| `envoy.hostAliases`                                 | Add deployment host aliases                                                                                           | `[]`                   |
+| `envoy.resources.limits`                            | Specify resource limits which the container is not allowed to succeed.                                                | `{}`                   |
+| `envoy.resources.requests`                          | Specify resource requests which the container needs to spawn.                                                         | `{}`                   |
+| `envoy.command`                                     | Override default command                                                                                              | `[]`                   |
+| `envoy.args`                                        | Override default args                                                                                                 | `[]`                   |
+| `envoy.shutdownManager.enabled`                     | Contour shutdownManager sidecar                                                                                       | `true`                 |
+| `envoy.shutdownManager.resources.limits`            | Specify resource limits which the container is not allowed to succeed.                                                | `{}`                   |
+| `envoy.shutdownManager.resources.requests`          | Specify resource requests which the container needs to spawn.                                                         | `{}`                   |
+| `envoy.kind`                                        | Install as deployment or daemonset                                                                                    | `daemonset`            |
+| `envoy.replicaCount`                                | Desired number of Controller pods                                                                                     | `1`                    |
+| `envoy.lifecycleHooks`                              | lifecycleHooks for the container to automate configuration before or after startup.                                   | `{}`                   |
+| `envoy.updateStrategy`                              | Strategy to use to update Pods                                                                                        | `{}`                   |
+| `envoy.minReadySeconds`                             | The minimum number of seconds for which a newly created Pod should be ready                                           | `0`                    |
+| `envoy.revisionHistoryLimit`                        | The number of old history to retain to allow rollback                                                                 | `10`                   |
+| `envoy.autoscaling.enabled`                         | Enable autoscaling for Controller                                                                                     | `false`                |
+| `envoy.autoscaling.minReplicas`                     | Minimum number of Controller replicas                                                                                 | `1`                    |
+| `envoy.autoscaling.maxReplicas`                     | Maximum number of Controller replicas                                                                                 | `11`                   |
+| `envoy.autoscaling.targetCPU`                       | Target CPU utilization percentage                                                                                     | `""`                   |
+| `envoy.autoscaling.targetMemory`                    | Target Memory utilization percentage                                                                                  | `""`                   |
+| `envoy.podAffinityPreset`                           | Envoy Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                             | `""`                   |
+| `envoy.podAntiAffinityPreset`                       | Envoy Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                        | `""`                   |
+| `envoy.nodeAffinityPreset.type`                     | Envoy Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                       | `""`                   |
+| `envoy.nodeAffinityPreset.key`                      | Envoy Node label key to match Ignored if `affinity` is set.                                                           | `""`                   |
+| `envoy.nodeAffinityPreset.values`                   | Envoy Node label values to match. Ignored if `affinity` is set.                                                       | `[]`                   |
+| `envoy.affinity`                                    | Affinity for Envoy pod assignment                                                                                     | `{}`                   |
+| `envoy.nodeSelector`                                | Node labels for Envoy pod assignment                                                                                  | `{}`                   |
+| `envoy.tolerations`                                 | Tolerations for Envoy pod assignment                                                                                  | `[]`                   |
+| `envoy.podAnnotations`                              | Envoy Pod annotations                                                                                                 | `{}`                   |
+| `envoy.podLabels`                                   | Extra labels for Envoy pods                                                                                           | `{}`                   |
+| `envoy.podSecurityContext.enabled`                  | Envoy Pod securityContext                                                                                             | `false`                |
+| `envoy.podSecurityContext.fsGroup`                  | User ID for the for the mounted volumes                                                                               | `0`                    |
+| `envoy.podSecurityContext.sysctls`                  | Array of sysctl options to allow                                                                                      | `[]`                   |
+| `envoy.containerSecurityContext.enabled`            | Envoy Container securityContext                                                                                       | `true`                 |
+| `envoy.containerSecurityContext.runAsUser`          | User ID for the Envoy container (to change this, http and https containerPorts must be set to >1024)                  | `1001`                 |
+| `envoy.containerSecurityContext.runAsNonRoot`       | Run as non root                                                                                                       | `true`                 |
+| `envoy.hostNetwork`                                 | Envoy Pod host network access                                                                                         | `false`                |
+| `envoy.dnsPolicy`                                   | Envoy Pod Dns Policy's DNS Policy                                                                                     | `ClusterFirst`         |
+| `envoy.tlsExistingSecret`                           | Name of the existingSecret to be use in Envoy deployment                                                              | `""`                   |
+| `envoy.serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                  | `true`                 |
+| `envoy.serviceAccount.name`                         | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `""`                   |
+| `envoy.serviceAccount.automountServiceAccountToken` | Whether to auto mount API credentials for a service account                                                           | `false`                |
+| `envoy.serviceAccount.annotations`                  | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                            | `{}`                   |
+| `envoy.livenessProbe.enabled`                       | Enable livenessProbe                                                                                                  | `true`                 |
+| `envoy.livenessProbe.initialDelaySeconds`           | Initial delay seconds for livenessProbe                                                                               | `120`                  |
+| `envoy.livenessProbe.periodSeconds`                 | Period seconds for livenessProbe                                                                                      | `20`                   |
+| `envoy.livenessProbe.timeoutSeconds`                | Timeout seconds for livenessProbe                                                                                     | `5`                    |
+| `envoy.livenessProbe.failureThreshold`              | Failure threshold for livenessProbe                                                                                   | `6`                    |
+| `envoy.livenessProbe.successThreshold`              | Success threshold for livenessProbe                                                                                   | `1`                    |
+| `envoy.readinessProbe.enabled`                      | Enable/disable the readiness probe                                                                                    | `true`                 |
+| `envoy.readinessProbe.initialDelaySeconds`          | Delay before readiness probe is initiated                                                                             | `10`                   |
+| `envoy.readinessProbe.periodSeconds`                | How often to perform the probe                                                                                        | `3`                    |
+| `envoy.readinessProbe.timeoutSeconds`               | When the probe times out                                                                                              | `1`                    |
+| `envoy.readinessProbe.failureThreshold`             | Minimum consecutive failures for the probe to be considered failed after having succeeded.                            | `3`                    |
+| `envoy.readinessProbe.successThreshold`             | Minimum consecutive successes for the probe to be considered successful after having failed.                          | `1`                    |
+| `envoy.startupProbe.enabled`                        | Enable/disable the startup probe                                                                                      | `false`                |
+| `envoy.startupProbe.initialDelaySeconds`            | Delay before startup probe is initiated                                                                               | `15`                   |
+| `envoy.startupProbe.periodSeconds`                  | How often to perform the probe                                                                                        | `10`                   |
+| `envoy.startupProbe.timeoutSeconds`                 | When the probe times out                                                                                              | `5`                    |
+| `envoy.startupProbe.failureThreshold`               | Minimum consecutive failures for the probe to be considered failed after having succeeded.                            | `3`                    |
+| `envoy.startupProbe.successThreshold`               | Minimum consecutive successes for the probe to be considered successful after having failed.                          | `1`                    |
+| `envoy.customLivenessProbe`                         | Override default liveness probe                                                                                       | `{}`                   |
+| `envoy.customReadinessProbe`                        | Override default readiness probe                                                                                      | `{}`                   |
+| `envoy.customStartupProbe`                          | Override default startup probe                                                                                        | `{}`                   |
+| `envoy.terminationGracePeriodSeconds`               | Envoy termination grace period in seconds                                                                             | `300`                  |
+| `envoy.logLevel`                                    | Envoy log level                                                                                                       | `info`                 |
+| `envoy.service.targetPorts`                         | Map the controller service HTTP/HTTPS port                                                                            | `{}`                   |
+| `envoy.service.type`                                | Type of Envoy service to create                                                                                       | `LoadBalancer`         |
+| `envoy.service.externalTrafficPolicy`               | Envoy Service external cluster policy. If `envoy.service.type` is NodePort or LoadBalancer                            | `Local`                |
+| `envoy.service.labels`                              | Labels to add to te envoy service                                                                                     | `{}`                   |
+| `envoy.service.clusterIP`                           | Internal envoy cluster service IP                                                                                     | `""`                   |
+| `envoy.service.externalIPs`                         | Envoy service external IP addresses                                                                                   | `[]`                   |
+| `envoy.service.loadBalancerIP`                      | IP address to assign to load balancer (if supported)                                                                  | `""`                   |
+| `envoy.service.loadBalancerSourceRanges`            | List of IP CIDRs allowed access to load balancer (if supported)                                                       | `[]`                   |
+| `envoy.service.loadBalancerClass`                   | Envoy service Load Balancer Class                                                                                     | `""`                   |
+| `envoy.service.ipFamilyPolicy`                      | , support SingleStack, PreferDualStack and RequireDualStack                                                           | `""`                   |
+| `envoy.service.annotations`                         | Annotations for Envoy service                                                                                         | `{}`                   |
+| `envoy.service.ports.http`                          | Sets service http port                                                                                                | `80`                   |
+| `envoy.service.ports.https`                         | Sets service https port                                                                                               | `443`                  |
+| `envoy.service.nodePorts.http`                      | HTTP Port. If `envoy.service.type` is NodePort and this is non-empty                                                  | `""`                   |
+| `envoy.service.nodePorts.https`                     | HTTPS Port. If `envoy.service.type` is NodePort and this is non-empty                                                 | `""`                   |
+| `envoy.service.extraPorts`                          | Extra ports to expose (normally used with the `sidecar` value)                                                        | `[]`                   |
+| `envoy.service.sessionAffinity`                     | Session Affinity for Kubernetes service, can be "None" or "ClientIP"                                                  | `None`                 |
+| `envoy.service.sessionAffinityConfig`               | Additional settings for the sessionAffinity                                                                           | `{}`                   |
+| `envoy.useHostPort`                                 | Enable/disable `hostPort` for TCP/80 and TCP/443                                                                      | `true`                 |
+| `envoy.useHostIP`                                   | Enable/disable `hostIP`                                                                                               | `false`                |
+| `envoy.hostPorts.http`                              | Sets `hostPort` http port                                                                                             | `80`                   |
+| `envoy.hostPorts.https`                             | Sets `hostPort` https port                                                                                            | `443`                  |
+| `envoy.hostIPs.http`                                | Sets `hostIP` http IP                                                                                                 | `127.0.0.1`            |
+| `envoy.hostIPs.https`                               | Sets `hostIP` https IP                                                                                                | `127.0.0.1`            |
+| `envoy.containerPorts.http`                         | Sets http port inside Envoy pod  (change this to >1024 to run envoy as a non-root user)                               | `8080`                 |
+| `envoy.containerPorts.https`                        | Sets https port inside Envoy pod  (change this to >1024 to run envoy as a non-root user)                              | `8443`                 |
+| `envoy.initContainers`                              | Attach additional init containers to Envoy pods                                                                       | `[]`                   |
+| `envoy.sidecars`                                    | Add additional sidecar containers to the Envoy pods                                                                   | `[]`                   |
+| `envoy.extraVolumes`                                | Array to add extra volumes                                                                                            | `[]`                   |
+| `envoy.extraVolumeMounts`                           | Array to add extra mounts (normally used with extraVolumes)                                                           | `[]`                   |
+| `envoy.extraEnvVars`                                | Array containing extra env vars to be added to all Envoy containers                                                   | `[]`                   |
+| `envoy.extraEnvVarsCM`                              | ConfigMap containing extra env vars to be added to all Envoy containers                                               | `""`                   |
+| `envoy.extraEnvVarsSecret`                          | Secret containing extra env vars to be added to all Envoy containers                                                  | `""`                   |
 
 
 ### Default backend parameters
@@ -309,7 +309,7 @@ $ helm uninstall my-release
 | `defaultBackend.enabled`                               | Enable a default backend based on NGINX                                                                         | `false`                  |
 | `defaultBackend.image.registry`                        | Default backend image registry                                                                                  | `docker.io`              |
 | `defaultBackend.image.repository`                      | Default backend image name                                                                                      | `bitnami/nginx`          |
-| `defaultBackend.image.tag`                             | Default backend image tag                                                                                       | `1.23.2-debian-11-r18`   |
+| `defaultBackend.image.tag`                             | Default backend image tag                                                                                       | `1.23.3-debian-11-r9`    |
 | `defaultBackend.image.digest`                          | Default backend image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
 | `defaultBackend.image.pullPolicy`                      | Image pull policy                                                                                               | `IfNotPresent`           |
 | `defaultBackend.image.pullSecrets`                     | Specify docker-registry secret names as an array                                                                | `[]`                     |

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -93,7 +93,7 @@ contour:
   image:
     registry: docker.io
     repository: bitnami/contour
-    tag: 1.23.2-debian-11-r0
+    tag: 1.23.2-debian-11-r9
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -472,7 +472,7 @@ envoy:
   image:
     registry: docker.io
     repository: bitnami/envoy
-    tag: 1.24.1-debian-11-r2
+    tag: 1.24.1-debian-11-r11
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -895,7 +895,7 @@ defaultBackend:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.23.2-debian-11-r18
+    tag: 1.23.3-debian-11-r9
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Forum
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.8.13
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Discourse is an open source discussion platform with built-in moderation and governance systems that let discussion communities protect themselves from bad actors even without official moderators.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/discourse
 icon: https://bitnami.com/assets/stacks/discourse/img/discourse-stack-220x234.png
 keywords:

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -36,4 +36,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/discourse
   - https://github.com/spinnaker
   - https://www.discourse.org/
-version: 9.0.6
+version: 9.0.7

--- a/bitnami/discourse/README.md
+++ b/bitnami/discourse/README.md
@@ -329,7 +329,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `redis.architecture`                      | Redis&reg; architecture. Allowed values: `standalone` or `replication`     | `standalone`     |
 | `externalRedis.host`                      | Redis&reg; host                                                            | `localhost`      |
 | `externalRedis.port`                      | Redis&reg; port number                                                     | `6379`           |
-| `externalRedis.username`                  | Redis&reg; username                                                        | `""`             |
 | `externalRedis.password`                  | Redis&reg; password                                                        | `""`             |
 | `externalRedis.existingSecret`            | Name of an existing secret resource containing the Redis&trade credentials | `""`             |
 | `externalRedis.existingSecretPasswordKey` | Name of an existing secret key containing the Redis&trade credentials      | `redis-password` |

--- a/bitnami/discourse/values.yaml
+++ b/bitnami/discourse/values.yaml
@@ -865,7 +865,6 @@ redis:
 ## All of these values are only used when redis.enabled is set to false
 ## @param externalRedis.host Redis&reg; host
 ## @param externalRedis.port Redis&reg; port number
-## @param externalRedis.username Redis&reg; username
 ## @param externalRedis.password Redis&reg; password
 ## @param externalRedis.existingSecret Name of an existing secret resource containing the Redis&trade credentials
 ## @param externalRedis.existingSecretPasswordKey Name of an existing secret key containing the Redis&trade credentials
@@ -873,9 +872,6 @@ redis:
 externalRedis:
   host: localhost
   port: 6379
-  ## Most Redis&reg; implementations do not require a username
-  ## to authenticate and it should be enough with the password
-  username: ""
   password: ""
   existingSecret: ""
   existingSecretPasswordKey: "redis-password"

--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -27,4 +27,4 @@ name: dokuwiki
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/dokuwiki
   - http://www.dokuwiki.org/
-version: 13.1.11
+version: 13.1.12

--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Wiki
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 20220731.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: DokuWiki is a standards-compliant wiki optimized for creating documentation. Designed to be simple to use for small organizations, it stores all data in plain text files so no database is required.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/dokuwiki
 icon: https://bitnami.com/assets/stacks/dokuwiki/img/dokuwiki-stack-220x234.png
 keywords:

--- a/bitnami/dokuwiki/README.md
+++ b/bitnami/dokuwiki/README.md
@@ -80,7 +80,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
 | `image.registry`                        | DokuWiki image registry                                                                                               | `docker.io`                  |
 | `image.repository`                      | DokuWiki image repository                                                                                             | `bitnami/dokuwiki`           |
-| `image.tag`                             | DokuWiki image tag                                                                                                    | `20220731.1.0-debian-11-r40` |
+| `image.tag`                             | DokuWiki image tag                                                                                                    | `20220731.1.0-debian-11-r42` |
 | `image.digest`                          | DokuWiki image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag              | `""`                         |
 | `image.pullPolicy`                      | Image pull policy                                                                                                     | `IfNotPresent`               |
 | `image.pullSecrets`                     | Image pull policy                                                                                                     | `[]`                         |
@@ -195,7 +195,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`            | Enable init container that changes volume permissions in the data directory (for cases where the default k8s `runAsUser` and `fsUser` values do not work) | `false`                 |
 | `volumePermissions.image.registry`     | Init container volume-permissions image registry                                                                                                          | `docker.io`             |
 | `volumePermissions.image.repository`   | Init container volume-permissions image name                                                                                                              | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `11-debian-11-r70`      |
+| `volumePermissions.image.tag`          | Init container volume-permissions image tag                                                                                                               | `11-debian-11-r71`      |
 | `volumePermissions.image.digest`       | Init container volume-permissions image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                         | `""`                    |
 | `volumePermissions.image.pullPolicy`   | Init container volume-permissions image pull policy                                                                                                       | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`  | Specify docker-registry secret names as an array                                                                                                          | `[]`                    |
@@ -210,7 +210,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`           | Start a exporter side-car                                                                                       | `false`                   |
 | `metrics.image.registry`    | Apache exporter image registry                                                                                  | `docker.io`               |
 | `metrics.image.repository`  | Apache exporter image name                                                                                      | `bitnami/apache-exporter` |
-| `metrics.image.tag`         | Apache exporter image tag                                                                                       | `0.11.0-debian-11-r80`    |
+| `metrics.image.tag`         | Apache exporter image tag                                                                                       | `0.11.0-debian-11-r81`    |
 | `metrics.image.digest`      | Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                      |
 | `metrics.image.pullPolicy`  | Image pull policy                                                                                               | `IfNotPresent`            |
 | `metrics.image.pullSecrets` | Specify docker-registry secret names as an array                                                                | `[]`                      |
@@ -236,7 +236,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `certificates.extraEnvVarsSecret`                    | Secret containing extra env vars (in case of sensitive data)                                                      | `""`                                     |
 | `certificates.image.registry`                        | Container sidecar registry                                                                                        | `docker.io`                              |
 | `certificates.image.repository`                      | Container sidecar image                                                                                           | `bitnami/bitnami-shell`                  |
-| `certificates.image.tag`                             | Container sidecar image tag                                                                                       | `11-debian-11-r70`                       |
+| `certificates.image.tag`                             | Container sidecar image tag                                                                                       | `11-debian-11-r71`                       |
 | `certificates.image.digest`                          | Container sidecar image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                                     |
 | `certificates.image.pullPolicy`                      | Container sidecar image pull policy                                                                               | `IfNotPresent`                           |
 | `certificates.image.pullSecrets`                     | Container sidecar image pull secrets                                                                              | `[]`                                     |

--- a/bitnami/dokuwiki/values.yaml
+++ b/bitnami/dokuwiki/values.yaml
@@ -58,7 +58,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/dokuwiki
-  tag: 20220731.1.0-debian-11-r40
+  tag: 20220731.1.0-debian-11-r42
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -521,7 +521,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 11-debian-11-r70
+    tag: 11-debian-11-r71
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -572,7 +572,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.11.0-debian-11-r80
+    tag: 0.11.0-debian-11-r81
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -645,7 +645,7 @@ certificates:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 11-debian-11-r70
+    tag: 11-debian-11-r71
     digest: ""
     ## Specify a imagePullPolicy
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 9.4.9
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Drupal is one of the most versatile open source content management systems in the world. It is pre-configured with the Ctools and Views modules, Drush and Let's Encrypt auto-configuration support.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/drupal
 icon: https://bitnami.com/assets/stacks/drupal/img/drupal-stack-220x234.png
 keywords:

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CertificateAuthority
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.10.0-2
 dependencies:
@@ -15,7 +17,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: EJBCA is an enterprise class PKI Certificate Authority software, built using Java (JEE) technology.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/ejbca
 icon: https://bitnami.com/assets/stacks/ejbca/img/ejbca-stack-220x234.png
 keywords:

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.6.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Elasticsearch is a distributed search and analytics engine. It is used for web search, log monitoring, and real-time analytics. Ideal for Big Data applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
 icon: https://bitnami.com/assets/stacks/elasticsearch/img/elasticsearch-stack-220x234.png
 keywords:

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.5.6
 dependencies:

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.13.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/external-dns
 icon: https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-220x234.png
 keywords:

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.15.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Fluentd collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/fluentd
 icon: https://bitnami.com/assets/stacks/fluentd/img/fluentd-stack-220x234.png
 keywords:

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -33,4 +33,4 @@ name: ghost
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/ghost
   - https://www.ghost.org/
-version: 19.1.56
+version: 19.1.57

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 5.29.0
 dependencies:
@@ -15,7 +17,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Ghost is an open source publishing platform designed to create blogs, magazines, and news sites. It includes a simple markdown editor with preview, theming, and SEO built-in to simplify editing.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/ghost
 icon: https://bitnami.com/assets/stacks/ghost/img/ghost-stack-220x234.png
 keywords:

--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.18.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Gitea is a lightweight code hosting solution. Written in Go, features low resource consumption, easy upgrades and multiple databases.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/gitea
 icon: https://bitnami.com/assets/stacks/gitea/img/gitea-stack-220x234.png
 keywords:

--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -30,4 +30,4 @@ name: gitea
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/gitea
   - https://gitea.io/
-version: 0.1.4
+version: 0.1.5

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.7.1
 dependencies:
@@ -29,7 +31,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage.
-engine: gotpl
 home: https://github.com/grafana/loki/
 icon: https://bitnami.com/assets/stacks/grafana-loki/img/grafana-loki-stack-220x234.png
 keywords:

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.8.0
 dependencies:

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.5.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Grafana Tempo is a distributed tracing system that has out-of-the-box integration with Grafana. It is highly scalable and works with many popular tracing protocols.
-engine: gotpl
 home: https://github.com/grafana/tempo/
 icon: https://bitnami.com/assets/stacks/grafana-tempo/img/grafana-tempo-stack-220x234.png
 keywords:

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 9.3.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Grafana is an open source metric analytics and visualization suite for visualizing time series data that supports various types of data sources.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/grafana
 icon: https://bitnami.com/assets/stacks/grafana/img/grafana-stack-220x234.png
 keywords:

--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.7.1
 dependencies:

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.7.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: HAProxy is a TCP proxy and a HTTP reverse proxy. It supports SSL termination and offloading, TCP and HTTP normalization, traffic regulation, caching and protection against DDoS attacks.
-engine: gotpl
 home: https://www.haproxy.org/
 icon: https://bitnami.com/assets/stacks/haproxy/img/haproxy-stack-220x234.png
 keywords:

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.7.0
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Harbor is an open source trusted cloud-native registry to store, sign, and scan content. It adds functionalities like security, identity, and management to the open source Docker distribution.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/harbor
 icon: https://bitnami.com/assets/stacks/harbor-core/img/harbor-core-stack-220x234.png
 keywords:

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.6.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: InfluxDB(TM) is an open source time-series database. It is a core component of the TICK (Telegraf, InfluxDB(TM), Chronograf, Kapacitor) stack.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/influxdb
 icon: https://bitnami.com/assets/stacks/influxdb/img/influxdb-stack-220x234.png
 keywords:

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.41.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 9.x.x
 description: Jaeger is a distributed tracing system. It is used for monitoring and troubleshooting microservices-based distributed systems.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/jaeger
 icon: https://bitnami.com/assets/stacks/jaeger/img/jaeger-stack-220x234.png
 keywords:

--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.1.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: JasperReports Server is a stand-alone and embeddable reporting server. It is a central information hub, with reporting and analytics that can be embedded into web and mobile applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/jasperreports
 icon: https://bitnami.com/assets/stacks/jasperserver/img/jasperserver-stack-220x234.png
 keywords:

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 2.375.1
+appVersion: 2.375.2
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -26,4 +26,4 @@ name: jenkins
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/jenkins
   - https://jenkins.io/
-version: 11.0.11
+version: 11.0.12

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.375.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Jenkins is an open source Continuous Integration and Continuous Delivery (CI/CD) server designed to automate the building, testing, and deploying of any software project.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/jenkins
 icon: https://bitnami.com/assets/stacks/jenkins/img/jenkins-stack-220x234.png
 keywords:

--- a/bitnami/jenkins/README.md
+++ b/bitnami/jenkins/README.md
@@ -84,7 +84,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------- | ------------------------------------------------------------------------------------------------------- | ---------------------- |
 | `image.registry`    | Jenkins image registry                                                                                  | `docker.io`            |
 | `image.repository`  | Jenkins image repository                                                                                | `bitnami/jenkins`      |
-| `image.tag`         | Jenkins image tag (immutable tags are recommended)                                                      | `2.375.1-debian-11-r9` |
+| `image.tag`         | Jenkins image tag (immutable tags are recommended)                                                      | `2.375.2-debian-11-r0` |
 | `image.digest`      | Jenkins image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
 | `image.pullPolicy`  | Jenkins image pull policy                                                                               | `IfNotPresent`         |
 | `image.pullSecrets` | Jenkins image pull secrets                                                                              | `[]`                   |
@@ -212,7 +212,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                   | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`               | `false`                 |
 | `volumePermissions.image.registry`            | Bitnami Shell image registry                                                                                  | `docker.io`             |
 | `volumePermissions.image.repository`          | Bitnami Shell image repository                                                                                | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                                      | `11-debian-11-r68`      |
+| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                                      | `11-debian-11-r70`      |
 | `volumePermissions.image.digest`              | Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
 | `volumePermissions.image.pullPolicy`          | Bitnami Shell image pull policy                                                                               | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`         | Bitnami Shell image pull secrets                                                                              | `[]`                    |

--- a/bitnami/jenkins/values.yaml
+++ b/bitnami/jenkins/values.yaml
@@ -69,7 +69,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/jenkins
-  tag: 2.375.1-debian-11-r9
+  tag: 2.375.2-debian-11-r0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -560,7 +560,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 11-debian-11-r68
+    tag: 11-debian-11-r70
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/bitnami/joomla/Chart.yaml
+++ b/bitnami/joomla/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.2.6
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Joomla! is an award winning open source CMS platform for building websites and applications. It includes page caching, page compression and Let's Encrypt auto-configuration support.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/joomla
 icon: https://bitnami.com/assets/stacks/joomla/img/joomla-stack-220x234.png
 keywords:

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: MachineLearning
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.0.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: JupyterHub brings the power of notebooks to groups of users. It gives users access to computational environments and resources without burdening the users with installation and maintenance tasks.
-engine: gotpl
 home: https://jupyter.org/hub
 icon: https://bitnami.com/assets/stacks/jupyterhub/img/jupyterhub-stack-220x234.png
 keywords:

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.3.1
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Kafka is a distributed streaming platform designed to build real-time pipelines and can be used as a message broker or as a replacement for a log aggregation solution for big data applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kafka
 icon: https://bitnami.com/assets/stacks/kafka/img/kafka-stack-220x234.png
 keywords:

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kafka
   - https://kafka.apache.org/
-version: 20.0.2
+version: 20.1.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -7,7 +7,7 @@ Apache Kafka is a distributed streaming platform designed to build real-time pip
 [Overview of Apache Kafka](http://kafka.apache.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -233,54 +233,55 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Traffic Exposure parameters
 
-| Name                                              | Description                                                                                                              | Value                 |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------- |
-| `service.type`                                    | Kubernetes Service type                                                                                                  | `ClusterIP`           |
-| `service.ports.client`                            | Kafka svc port for client connections                                                                                    | `9092`                |
-| `service.ports.internal`                          | Kafka svc port for inter-broker connections                                                                              | `9093`                |
-| `service.ports.external`                          | Kafka svc port for external connections                                                                                  | `9094`                |
-| `service.nodePorts.client`                        | Node port for the Kafka client connections                                                                               | `""`                  |
-| `service.nodePorts.external`                      | Node port for the Kafka external connections                                                                             | `""`                  |
-| `service.sessionAffinity`                         | Control where client requests go, to the same pod or round-robin                                                         | `None`                |
-| `service.sessionAffinityConfig`                   | Additional settings for the sessionAffinity                                                                              | `{}`                  |
-| `service.clusterIP`                               | Kafka service Cluster IP                                                                                                 | `""`                  |
-| `service.loadBalancerIP`                          | Kafka service Load Balancer IP                                                                                           | `""`                  |
-| `service.loadBalancerSourceRanges`                | Kafka service Load Balancer sources                                                                                      | `[]`                  |
-| `service.externalTrafficPolicy`                   | Kafka service external traffic policy                                                                                    | `Cluster`             |
-| `service.annotations`                             | Additional custom annotations for Kafka service                                                                          | `{}`                  |
-| `service.headless.publishNotReadyAddresses`       | Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready | `false`               |
-| `service.headless.annotations`                    | Annotations for the headless service.                                                                                    | `{}`                  |
-| `service.headless.labels`                         | Labels for the headless service.                                                                                         | `{}`                  |
-| `service.extraPorts`                              | Extra ports to expose in the Kafka service (normally used with the `sidecar` value)                                      | `[]`                  |
-| `externalAccess.enabled`                          | Enable Kubernetes external cluster access to Kafka brokers                                                               | `false`               |
-| `externalAccess.autoDiscovery.enabled`            | Enable using an init container to auto-detect external IPs/ports by querying the K8s API                                 | `false`               |
-| `externalAccess.autoDiscovery.image.registry`     | Init container auto-discovery image registry                                                                             | `docker.io`           |
-| `externalAccess.autoDiscovery.image.repository`   | Init container auto-discovery image repository                                                                           | `bitnami/kubectl`     |
-| `externalAccess.autoDiscovery.image.tag`          | Init container auto-discovery image tag (immutable tags are recommended)                                                 | `1.25.5-debian-11-r2` |
-| `externalAccess.autoDiscovery.image.digest`       | Petete image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                   | `""`                  |
-| `externalAccess.autoDiscovery.image.pullPolicy`   | Init container auto-discovery image pull policy                                                                          | `IfNotPresent`        |
-| `externalAccess.autoDiscovery.image.pullSecrets`  | Init container auto-discovery image pull secrets                                                                         | `[]`                  |
-| `externalAccess.autoDiscovery.resources.limits`   | The resources limits for the auto-discovery init container                                                               | `{}`                  |
-| `externalAccess.autoDiscovery.resources.requests` | The requested resources for the auto-discovery init container                                                            | `{}`                  |
-| `externalAccess.service.type`                     | Kubernetes Service type for external access. It can be NodePort, LoadBalancer or ClusterIP                               | `LoadBalancer`        |
-| `externalAccess.service.ports.external`           | Kafka port used for external access when service type is LoadBalancer                                                    | `9094`                |
-| `externalAccess.service.loadBalancerIPs`          | Array of load balancer IPs for each Kafka broker. Length must be the same as replicaCount                                | `[]`                  |
-| `externalAccess.service.loadBalancerNames`        | Array of load balancer Names for each Kafka broker. Length must be the same as replicaCount                              | `[]`                  |
-| `externalAccess.service.loadBalancerAnnotations`  | Array of load balancer annotations for each Kafka broker. Length must be the same as replicaCount                        | `[]`                  |
-| `externalAccess.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                                                | `[]`                  |
-| `externalAccess.service.nodePorts`                | Array of node ports used for each Kafka broker. Length must be the same as replicaCount                                  | `[]`                  |
-| `externalAccess.service.useHostIPs`               | Use service host IPs to configure Kafka external listener when service type is NodePort                                  | `false`               |
-| `externalAccess.service.usePodIPs`                | using the MY_POD_IP address for external access.                                                                         | `false`               |
-| `externalAccess.service.domain`                   | Domain or external ip used to configure Kafka external listener when service type is NodePort or ClusterIP               | `""`                  |
-| `externalAccess.service.publishNotReadyAddresses` | Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready | `false`               |
-| `externalAccess.service.labels`                   | Service labels for external access                                                                                       | `{}`                  |
-| `externalAccess.service.annotations`              | Service annotations for external access                                                                                  | `{}`                  |
-| `externalAccess.service.extraPorts`               | Extra ports to expose in the Kafka external service                                                                      | `[]`                  |
-| `networkPolicy.enabled`                           | Specifies whether a NetworkPolicy should be created                                                                      | `false`               |
-| `networkPolicy.allowExternal`                     | Don't require client label for connections                                                                               | `true`                |
-| `networkPolicy.explicitNamespacesSelector`        | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                           | `{}`                  |
-| `networkPolicy.externalAccess.from`               | customize the from section for External Access on tcp-external port                                                      | `[]`                  |
-| `networkPolicy.egressRules.customRules`           | Custom network policy rule                                                                                               | `{}`                  |
+| Name                                              | Description                                                                                                                               | Value                 |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `service.type`                                    | Kubernetes Service type                                                                                                                   | `ClusterIP`           |
+| `service.ports.client`                            | Kafka svc port for client connections                                                                                                     | `9092`                |
+| `service.ports.internal`                          | Kafka svc port for inter-broker connections                                                                                               | `9093`                |
+| `service.ports.external`                          | Kafka svc port for external connections                                                                                                   | `9094`                |
+| `service.nodePorts.client`                        | Node port for the Kafka client connections                                                                                                | `""`                  |
+| `service.nodePorts.external`                      | Node port for the Kafka external connections                                                                                              | `""`                  |
+| `service.sessionAffinity`                         | Control where client requests go, to the same pod or round-robin                                                                          | `None`                |
+| `service.sessionAffinityConfig`                   | Additional settings for the sessionAffinity                                                                                               | `{}`                  |
+| `service.clusterIP`                               | Kafka service Cluster IP                                                                                                                  | `""`                  |
+| `service.loadBalancerIP`                          | Kafka service Load Balancer IP                                                                                                            | `""`                  |
+| `service.loadBalancerSourceRanges`                | Kafka service Load Balancer sources                                                                                                       | `[]`                  |
+| `service.externalTrafficPolicy`                   | Kafka service external traffic policy                                                                                                     | `Cluster`             |
+| `service.annotations`                             | Additional custom annotations for Kafka service                                                                                           | `{}`                  |
+| `service.headless.publishNotReadyAddresses`       | Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready                  | `false`               |
+| `service.headless.annotations`                    | Annotations for the headless service.                                                                                                     | `{}`                  |
+| `service.headless.labels`                         | Labels for the headless service.                                                                                                          | `{}`                  |
+| `service.extraPorts`                              | Extra ports to expose in the Kafka service (normally used with the `sidecar` value)                                                       | `[]`                  |
+| `externalAccess.enabled`                          | Enable Kubernetes external cluster access to Kafka brokers                                                                                | `false`               |
+| `externalAccess.autoDiscovery.enabled`            | Enable using an init container to auto-detect external IPs/ports by querying the K8s API                                                  | `false`               |
+| `externalAccess.autoDiscovery.image.registry`     | Init container auto-discovery image registry                                                                                              | `docker.io`           |
+| `externalAccess.autoDiscovery.image.repository`   | Init container auto-discovery image repository                                                                                            | `bitnami/kubectl`     |
+| `externalAccess.autoDiscovery.image.tag`          | Init container auto-discovery image tag (immutable tags are recommended)                                                                  | `1.25.5-debian-11-r2` |
+| `externalAccess.autoDiscovery.image.digest`       | Petete image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                                    | `""`                  |
+| `externalAccess.autoDiscovery.image.pullPolicy`   | Init container auto-discovery image pull policy                                                                                           | `IfNotPresent`        |
+| `externalAccess.autoDiscovery.image.pullSecrets`  | Init container auto-discovery image pull secrets                                                                                          | `[]`                  |
+| `externalAccess.autoDiscovery.resources.limits`   | The resources limits for the auto-discovery init container                                                                                | `{}`                  |
+| `externalAccess.autoDiscovery.resources.requests` | The requested resources for the auto-discovery init container                                                                             | `{}`                  |
+| `externalAccess.service.type`                     | Kubernetes Service type for external access. It can be NodePort, LoadBalancer or ClusterIP                                                | `LoadBalancer`        |
+| `externalAccess.service.ports.external`           | Kafka port used for external access when service type is LoadBalancer                                                                     | `9094`                |
+| `externalAccess.service.loadBalancerIPs`          | Array of load balancer IPs for each Kafka broker. Length must be the same as replicaCount                                                 | `[]`                  |
+| `externalAccess.service.loadBalancerNames`        | Array of load balancer Names for each Kafka broker. Length must be the same as replicaCount                                               | `[]`                  |
+| `externalAccess.service.loadBalancerAnnotations`  | Array of load balancer annotations for each Kafka broker. Length must be the same as replicaCount                                         | `[]`                  |
+| `externalAccess.service.loadBalancerSourceRanges` | Address(es) that are allowed when service is LoadBalancer                                                                                 | `[]`                  |
+| `externalAccess.service.nodePorts`                | Array of node ports used for each Kafka broker. Length must be the same as replicaCount                                                   | `[]`                  |
+| `externalAccess.service.externalIPs`              | Use distinct service host IPs to configure Kafka external listener when service type is NodePort. Length must be the same as replicaCount | `[]`                  |
+| `externalAccess.service.useHostIPs`               | Use service host IPs to configure Kafka external listener when service type is NodePort                                                   | `false`               |
+| `externalAccess.service.usePodIPs`                | using the MY_POD_IP address for external access.                                                                                          | `false`               |
+| `externalAccess.service.domain`                   | Domain or external ip used to configure Kafka external listener when service type is NodePort or ClusterIP                                | `""`                  |
+| `externalAccess.service.publishNotReadyAddresses` | Indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready                  | `false`               |
+| `externalAccess.service.labels`                   | Service labels for external access                                                                                                        | `{}`                  |
+| `externalAccess.service.annotations`              | Service annotations for external access                                                                                                   | `{}`                  |
+| `externalAccess.service.extraPorts`               | Extra ports to expose in the Kafka external service                                                                                       | `[]`                  |
+| `networkPolicy.enabled`                           | Specifies whether a NetworkPolicy should be created                                                                                       | `false`               |
+| `networkPolicy.allowExternal`                     | Don't require client label for connections                                                                                                | `true`                |
+| `networkPolicy.explicitNamespacesSelector`        | A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed                                            | `{}`                  |
+| `networkPolicy.externalAccess.from`               | customize the from section for External Access on tcp-external port                                                                       | `[]`                  |
+| `networkPolicy.egressRules.customRules`           | Custom network policy rule                                                                                                                | `{}`                  |
 
 
 ### Persistence parameters
@@ -676,28 +677,40 @@ You have two alternatives to use NodePort services:
 
 - Option A) Use random node ports using an **initContainer** that discover them automatically.
 
-```console
-externalAccess.enabled=true
-externalAccess.service.type=NodePort
-externalAccess.autoDiscovery.enabled=true
-serviceAccount.create=true
-rbac.create=true
-```
+  ```console
+  externalAccess.enabled=true
+  externalAccess.service.type=NodePort
+  externalAccess.autoDiscovery.enabled=true
+  serviceAccount.create=true
+  rbac.create=true
+  ```
 
-Note: This option requires creating RBAC rules on clusters where RBAC policies are enabled.
+  Note: This option requires creating RBAC rules on clusters where RBAC policies are enabled.
 
 - Option B) Manually specify the node ports:
 
-```console
-externalAccess.enabled=true
-externalAccess.service.type=NodePort
-externalAccess.service.nodePorts[0]='node-port-1'
-externalAccess.service.nodePorts[1]='node-port-2'
-```
+  ```console
+  externalAccess.enabled=true
+  externalAccess.service.type=NodePort
+  externalAccess.service.nodePorts[0]='node-port-1'
+  externalAccess.service.nodePorts[1]='node-port-2'
+  ```
 
-Note: You need to know in advance the node ports that will be exposed so each Kafka broker advertised listener is configured with it.
+  Note: You need to know in advance the node ports that will be exposed so each Kafka broker advertised listener is configured with it.
 
-The pod will try to get the external ip of the node using `curl -s https://ipinfo.io/ip` unless `externalAccess.service.domain` or `externalAccess.service.useHostIPs` is provided.
+  The pod will try to get the external ip of the node using `curl -s https://ipinfo.io/ip` unless `externalAccess.service.domain` or `externalAccess.service.useHostIPs` is provided.
+
+- Option C) Manually specify distinct external IPs
+
+  ```
+  externalAccess.enabled=true
+  externalAccess.service.type=NodePort
+  externalAccess.service.externalIPs[0]='172.16.0.20'
+  externalAccess.service.externalIPs[1]='172.16.0.21'
+  externalAccess.service.externalIPs[2]='172.16.0.22'
+  ```
+
+  Note: You need to know in advance the available IP of your cluster that will be exposed so each Kafka broker advertised listener is configured with it.
 
 #### Using ClusterIP services
 

--- a/bitnami/kafka/templates/NOTES.txt
+++ b/bitnami/kafka/templates/NOTES.txt
@@ -164,13 +164,17 @@ To create a pod that you can use as a Kafka client run the following commands:
 
     PRODUCER:
         kafka-console-producer.sh \
-            {{ if or (include "kafka.client.saslAuthentication" .) (include "kafka.client.tlsEncryption" .) }}--producer.config /tmp/client.properties \{{ end }}
+            {{- if or (include "kafka.client.saslAuthentication" .) (include "kafka.client.tlsEncryption" .) }}
+            --producer.config /tmp/client.properties \
+            {{- end }}
             --broker-list {{ join "," $brokerList }} \
             --topic test
 
     CONSUMER:
         kafka-console-consumer.sh \
-            {{ if or (include "kafka.client.saslAuthentication" .) (include "kafka.client.tlsEncryption" .) }}--consumer.config /tmp/client.properties \{{ end }}
+            {{- if or (include "kafka.client.saslAuthentication" .) (include "kafka.client.tlsEncryption" .) }}
+            --consumer.config /tmp/client.properties \
+            {{- end }}
             --bootstrap-server {{ $fullname }}.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ .Values.service.ports.client }} \
             --topic test \
             --from-beginning

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -100,6 +100,8 @@ data:
     export EXTERNAL_ACCESS_HOST="${MY_POD_IP}"
     {{- else if or .Values.externalAccess.service.useHostIPs .Values.externalAccess.autoDiscovery.enabled }}
     export EXTERNAL_ACCESS_HOST="${HOST_IP}"
+    {{- else if and .Values.externalAccess.service.externalIPs (not .Values.externalAccess.autoDiscovery.enabled) }}
+    export EXTERNAL_ACCESS_HOST=$(echo '{{ .Values.externalAccess.service.externalIPs }}' | tr -d '[]' | cut -d ' ' -f "$(($ID + 1))")
     {{- else if .Values.externalAccess.service.domain }}
     export EXTERNAL_ACCESS_HOST={{ .Values.externalAccess.service.domain }}
     {{- else }}
@@ -107,6 +109,8 @@ data:
     {{- end }}
     {{- if .Values.externalAccess.autoDiscovery.enabled }}
     export EXTERNAL_ACCESS_PORT="$(<${SHARED_FILE})"
+    {{- else if and .Values.externalAccess.service.externalIPs (empty .Values.externalAccess.service.nodePorts)}}
+    export EXTERNAL_ACCESS_PORT="{{ .Values.externalAccess.service.ports.external }}"
     {{- else }}
     export EXTERNAL_ACCESS_PORT=$(echo '{{ .Values.externalAccess.service.nodePorts }}' | tr -d '[]' | cut -d ' ' -f "$(($ID + 1))")
     {{- end }}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -2,8 +2,6 @@
 {{- $fullname := include "common.names.fullname" . }}
 {{- $releaseNamespace := .Release.Namespace }}
 {{- $clusterDomain := .Values.clusterDomain }}
-{{- $interBrokerPort := .Values.service.ports.internal }}
-{{- $clientPort := .Values.service.ports.client }}
 {{- $interBrokerProtocol := include "kafka.listenerType" (dict "protocol" .Values.auth.interBrokerProtocol) -}}
 {{- $clientProtocol := include "kafka.listenerType" (dict "protocol" .Values.auth.clientProtocol) -}}
 {{- $externalClientProtocol := include "kafka.listenerType" (dict "protocol" (include "kafka.externalClientProtocol" . )) -}}
@@ -203,9 +201,9 @@ spec:
               {{- if .Values.listeners }}
               value: {{ join "," .Values.listeners }}
               {{- else if .Values.externalAccess.enabled }}
-              value: "INTERNAL://:{{ $interBrokerPort }},CLIENT://:9092,EXTERNAL://:9094"
+              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},EXTERNAL://:{{ .Values.containerPorts.external }}"
               {{- else }}
-              value: "INTERNAL://:{{ $interBrokerPort }},CLIENT://:9092"
+              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }}"
               {{- end }}
             {{- if .Values.externalAccess.enabled }}
             {{- if .Values.externalAccess.autoDiscovery.enabled }}
@@ -223,7 +221,7 @@ spec:
               {{- if .Values.advertisedListeners }}
               value: {{ join "," .Values.advertisedListeners }}
               {{- else }}
-              value: "INTERNAL://$(MY_POD_NAME).{{ $fullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ $interBrokerPort }},CLIENT://$(MY_POD_NAME).{{ $fullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ $clientPort }}"
+              value: "INTERNAL://$(MY_POD_NAME).{{ $fullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ .Values.service.ports.internal }},CLIENT://$(MY_POD_NAME).{{ $fullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ .Values.service.ports.client }}"
               {{- end }}
             {{- end }}
             - name: ALLOW_PLAINTEXT_LISTENER

--- a/bitnami/kafka/templates/svc-external-access.yaml
+++ b/bitnami/kafka/templates/svc-external-access.yaml
@@ -46,7 +46,7 @@ spec:
   ports:
     - name: tcp-kafka
       port: {{ $root.Values.externalAccess.service.ports.external }}
-      {{- if not (empty $root.Values.externalAccess.service.nodePorts) }}
+      {{- if le (add $i 1) (len $root.Values.externalAccess.service.nodePorts) }}
       nodePort: {{ index $root.Values.externalAccess.service.nodePorts $i }}
       {{- else }}
       nodePort: null
@@ -55,6 +55,10 @@ spec:
     {{- if $root.Values.externalAccess.service.extraPorts }}
     {{- include "common.tplvalues.render" (dict "value" $root.Values.externalAccess.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
+  {{- if and (eq $root.Values.externalAccess.service.type "NodePort") (le (add $i 1) (len $root.Values.externalAccess.service.externalIPs)) }}
+  externalIPs:
+    - {{- index $root.Values.externalAccess.service.externalIPs $i | quote }}
+  {{- end }}
   selector: {{- include "common.labels.matchLabels" $ | nindent 4 }}
     app.kubernetes.io/component: kafka
     statefulset.kubernetes.io/pod-name: {{ $targetPod }}

--- a/bitnami/kafka/templates/svc-external-access.yaml
+++ b/bitnami/kafka/templates/svc-external-access.yaml
@@ -56,8 +56,7 @@ spec:
     {{- include "common.tplvalues.render" (dict "value" $root.Values.externalAccess.service.extraPorts "context" $) | nindent 4 }}
     {{- end }}
   {{- if and (eq $root.Values.externalAccess.service.type "NodePort") (le (add $i 1) (len $root.Values.externalAccess.service.externalIPs)) }}
-  externalIPs:
-    - {{- index $root.Values.externalAccess.service.externalIPs $i | quote }}
+  externalIPs: [{{ index $root.Values.externalAccess.service.externalIPs $i | quote }}]
   {{- end }}
   selector: {{- include "common.labels.matchLabels" $ | nindent 4 }}
     app.kubernetes.io/component: kafka

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -830,6 +830,13 @@ externalAccess:
     ##   - 30002
     ##
     nodePorts: []
+    ## @param externalAccess.service.externalIPs Use distinct service host IPs to configure Kafka external listener when service type is NodePort. Length must be the same as replicaCount
+    ## e.g:
+    ## externalIPs:
+    ##   - X.X.X.X
+    ##   - Y.Y.Y.Y
+    ##
+    externalIPs: []
     ## @param externalAccess.service.useHostIPs Use service host IPs to configure Kafka external listener when service type is NodePort
     ##
     useHostIPs: false

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 20.0.2
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Keycloak is a high performance Java-based identity and access management solution. It lets developers add an authentication layer to their applications with minimum effort.
-engine: gotpl
 home: https://www.keycloak.org
 icon: https://bitnami.com/assets/stacks/keycloak/img/keycloak-stack-220x234.png
 keywords:

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.2.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: kiam is a proxy that captures AWS Metadata API requests. It allows AWS IAM roles to be set for Kubernetes workloads.
-engine: gotpl
 home: https://github.com/uswitch/kiam
 icon: https://bitnami.com/assets/stacks/kiam/img/kiam-stack-220x234.png
 keywords:

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.6.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch. Kibana strives to be easy to get started with, while also being flexible and powerful.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kibana
 icon: https://bitnami.com/assets/stacks/kibana/img/kibana-stack-220x234.png
 keywords:

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.1.1
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 9.x.x
 description: Kong is an open source Microservice API gateway and platform designed for managing microservices requests of high-availability, fault-tolerance, and distributed systems.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kong
 icon: https://bitnami.com/assets/stacks/kong/img/kong-stack-220x234.png
 keywords:

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.62.0
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Prometheus Operator provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
 icon: https://bitnami.com/assets/stacks/prometheus-operator/img/prometheus-operator-stack-220x234.png
 keywords:

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.7.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kube-state-metrics
 icon: https://bitnami.com/assets/stacks/kube-state-metrics/img/kube-state-metrics-stack-220x234.png
 keywords:

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.6.2
 dependencies:

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Kubernetes Event Exporter makes it easy to export Kubernetes events to other tools, thereby enabling better event observability, custom alerts and aggregation.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
 icon: https://bitnami.com/assets/stacks/kubernetes-event-exporter/img/kubernetes-event-exporter-stack-220x234.png
 keywords:

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: LogManagement
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.6.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Logstash is an open source data processing engine. It ingests data from multiple sources, processes it, and sends the output to final destination in real-time. It is a core component of the ELK stack.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/logstash
 icon: https://bitnami.com/assets/stacks/logstash/img/logstash-stack-220x234.png
 keywords:

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: E-Commerce
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.4.5-p1
 dependencies:
@@ -19,7 +21,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Magento is a powerful open source e-commerce platform. With easy customizations and rich features, it allows retailers to grow their online businesses in a cost-effective way.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/magento
 icon: https://bitnami.com/assets/stacks/magento/img/magento-stack-220x234.png
 keywords:

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -28,4 +28,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 7.4.10
+version: 7.4.11

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 10.6.11
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MariaDB Galera is a multi-primary database cluster solution for synchronous replication and high availability.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mariadb-galera
 icon: https://bitnami.com/assets/stacks/mariadb-galera/img/mariadb-galera-stack-220x234.png
 keywords:

--- a/bitnami/mariadb-galera/templates/headless-svc.yaml
+++ b/bitnami/mariadb-galera/templates/headless-svc.yaml
@@ -20,14 +20,24 @@ spec:
   type: ClusterIP
   clusterIP: None
   ports:
+    {{- $appProtocolAvailable := (semverCompare ">=1.20-0" (include "common.capabilities.kubeVersion" .)) }}
     - name: galera
       port: 4567
       targetPort: galera
+      {{- if $appProtocolAvailable }}
+      appProtocol: mysql
+      {{- end }}
     - name: ist
       port: 4568
       targetPort: ist
+      {{- if $appProtocolAvailable }}
+      appProtocol: mysql
+      {{- end }}
     - name: sst
       port: 4444
       targetPort: sst
+      {{- if $appProtocolAvailable }}
+      appProtocol: mysql
+      {{- end }}
   publishNotReadyAddresses: {{ .Values.service.headless.publishNotReadyAddresses }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}

--- a/bitnami/mariadb-galera/templates/svc.yaml
+++ b/bitnami/mariadb-galera/templates/svc.yaml
@@ -43,6 +43,10 @@ spec:
     - name: mysql
       port: {{ .Values.service.ports.mysql }}
       targetPort: mysql
+      {{- $appProtocolAvailable := (semverCompare ">=1.20-0" (include "common.capabilities.kubeVersion" .)) }}
+      {{- if $appProtocolAvailable }}
+      appProtocol: mysql
+      {{- end }}
       {{- if and .Values.service.nodePorts.mysql (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
       nodePort: {{ .Values.service.nodePorts.mysql }}
       {{- else if eq .Values.service.type "ClusterIP" }}

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 10.6.11
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MariaDB is an open source, community-developed SQL database server that is widely in use around the world due to its enterprise features, flexibility, and collaboration with leading tech firms.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mariadb
 icon: https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png
 keywords:

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.0.2
 dependencies:
@@ -29,7 +31,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Mastodon is self-hosted social network server based on ActivityPub. Written in Ruby, features real-time updates, multimedia attachments and no vendor lock-in.
-engine: gotpl
 home: https://joinmastodon.org/
 icon: https://bitnami.com/assets/stacks/mastodon/img/mastodon-stack-220x234.png
 keywords:

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.13.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Matomo, formerly known as Piwik, is a real time web analytics program. It provides detailed reports on website visitors.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/matomo
 icon: https://bitnami.com/assets/stacks/matomo/img/matomo-stack-220x234.png
 keywords:

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Wiki
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.39.1
 dependencies:
@@ -15,7 +17,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MediaWiki is the free and open source wiki software that powers Wikipedia. Used by thousands of organizations, it is extremely powerful, scalable software and a feature-rich wiki implementation.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mediawiki
 icon: https://bitnami.com/assets/stacks/mediawiki/img/mediawiki-stack-220x234.png
 keywords:

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.6.18
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Memcached is an high-performance, distributed memory object caching system, generic in nature, but intended for use in speeding up dynamic web applications by alleviating database load.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/memcached
 icon: https://bitnami.com/assets/stacks/memcached/img/memcached-stack-220x234.png
 keywords:

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.13.7
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters, using standard routing protocols.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/metallb
 icon: https://bitnami.com/assets/stacks/metallb-speaker/img/metallb-speaker-stack-220x234.png
 keywords:

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.6.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Metrics Server aggregates resource usage data, such as container CPU and memory usage, in a Kubernetes cluster and makes it available via the Metrics API.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/metrics-server
 icon: https://bitnami.com/assets/stacks/metrics-server/img/metrics-server-stack-220x234.png
 keywords:

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2022.12.12
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MinIO(R) is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.).
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/minio
 icon: https://bitnami.com/assets/stacks/minio/img/minio-stack-220x234.png
 keywords:

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 6.0.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MongoDB(R) is an open source NoSQL database that uses JSON for data storage. MongoDB(TM) Sharded improves scalability and reliability for large datasets by distributing data across multiple machines.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
 icon: https://bitnami.com/assets/stacks/mongodb/img/mongodb-stack-220x234.png
 keywords:

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 6.0.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MongoDB(R) is a relational open source NoSQL database. Easy to use, it stores data in JSON-like documents. Automated scalability and high-performance. Ideal for developing cloud native applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mongodb
 icon: https://bitnami.com/assets/stacks/mongodb/img/mongodb-stack-220x234.png
 keywords:

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: E-Learning
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.1.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Moodle(TM) LMS is an open source online Learning Management System widely used at universities, schools, and corporations. It is modular and highly adaptable to any type of online learning.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/moodle
 icon: https://bitnami.com/assets/stacks/moodle/img/moodle-stack-220x234.png
 keywords:

--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: MachineLearning
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.9.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache MXNet (Incubating) is a flexible and efficient library for deep learning designed to work as a neural network. Bitnami image ships OpenBLAS as math library.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mxnet
 icon: https://bitnami.com/assets/stacks/mxnet/img/mxnet-stack-220x234.png
 keywords:

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.0.31
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MySQL is a fast, reliable, scalable, and easy to use open source relational database system. Designed to handle mission-critical, heavy-load production applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mysql
 icon: https://bitnami.com/assets/stacks/mysql/img/mysql-stack-220x234.png
 keywords:

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.9.11
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: NATS is an open source, lightweight and high-performance messaging system. It is ideal for distributed systems and supports modern cloud architectures and pub-sub, request-reply and queuing models.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/nats
 icon: https://bitnami.com/assets/stacks/nats/img/nats-stack-220x234.png
 keywords:

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.6.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: NGINX Ingress Controller is an Ingress controller that manages external access to HTTP services in a Kubernetes cluster using NGINX.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
 icon: https://bitnami.com/assets/stacks/nginx-ingress-controller/img/nginx-ingress-controller-stack-220x234.png
 keywords:

--- a/bitnami/nginx-intel/Chart.yaml
+++ b/bitnami/nginx-intel/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.4.9
 dependencies:

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.23.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: NGINX Open Source is a web server that can be also used as a reverse proxy, load balancer, and HTTP cache. Recommended for high-demanding sites due to its ability to provide faster content.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/nginx
 icon: https://bitnami.com/assets/stacks/nginx/img/nginx-stack-220x234.png
 keywords:

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.5.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Prometheus exporter for hardware and OS metrics exposed by UNIX kernels, with pluggable metric collectors.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/node-exporter
 icon: https://bitnami.com/assets/stacks/node-exporter/img/node-exporter-stack-220x234.png
 keywords:

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.4.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: A reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
 icon: https://bitnami.com/assets/stacks/oauth2-proxy/img/oauth2-proxy-stack-220x234.png
 keywords:

--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CRM
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 16.0.20221115
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Odoo is an open source ERP and CRM platform, formerly known as OpenERP, that can connect a wide variety of business operations such as sales, supply chain, finance, and project management.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/odoo
 icon: https://bitnami.com/assets/stacks/odoo/img/odoo-stack-220x234.png
 keywords:

--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: E-Commerce
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.0.1-1
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: OpenCart is free open source ecommerce platform for online merchants. OpenCart provides a professional and reliable foundation from which to build a successful online store.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/opencart
 icon: https://bitnami.com/assets/stacks/opencart/img/opencart-stack-220x234.png
 keywords:

--- a/bitnami/osclass/Chart.yaml
+++ b/bitnami/osclass/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.0.2
 dependencies:
@@ -15,7 +17,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Osclass allows you to easily create a classifieds site without any technical knowledge. It provides support for presenting general ads or specialized ads, is customizable, extensible and multilingual.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/osclass
 icon: https://bitnami.com/assets/stacks/osclass/img/osclass-stack-220x234.png
 keywords:

--- a/bitnami/owncloud/Chart.yaml
+++ b/bitnami/owncloud/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 10.11.0
 dependencies:
@@ -16,7 +18,6 @@ dependencies:
     version: 2.x.x
 deprecated: true
 description: ownCloud is an open source content collaboration platform used to store and share files from any device. It grants data privacy, synchronization between devices, and file access control.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/owncloud
 icon: https://bitnami.com/assets/stacks/owncloud/img/owncloud-stack-220x234.png
 keywords:

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 5.4.0
 dependencies:
@@ -12,7 +14,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/parse
 icon: https://bitnami.com/assets/stacks/parse/img/parse-stack-220x234.png
 keywords:

--- a/bitnami/phpbb/Chart.yaml
+++ b/bitnami/phpbb/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Forum
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.3.9
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: phpBB is a popular bulletin board that features robust messaging capabilities such as flat message structure, subforums, topic split/merge/lock, user groups, full-text search, and attachments.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/phpbb
 icon: https://bitnami.com/assets/stacks/phpbb/img/phpbb-stack-220x234.png
 keywords:

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -29,4 +29,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/phpmyadmin
   - https://www.phpmyadmin.net/
-version: 10.3.9
+version: 10.3.10

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -30,4 +30,4 @@ name: phpmyadmin
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/phpmyadmin
   - https://www.phpmyadmin.net/
-version: 10.3.10
+version: 10.4.0

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 5.2.0
 dependencies:
@@ -15,7 +17,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: phpMyAdmin is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/phpmyadmin
 icon: https://bitnami.com/assets/stacks/phpmyadmin/img/phpmyadmin-stack-220x234.png
 keywords:

--- a/bitnami/phpmyadmin/README.md
+++ b/bitnami/phpmyadmin/README.md
@@ -204,6 +204,16 @@ The command removes all the Kubernetes components associated with the chart and 
 | `mariadb`                  | MariaDB chart configuration                                       | `{}`    |
 
 
+### Other Parameters
+
+| Name                                          | Description                                                            | Value   |
+| --------------------------------------------- | ---------------------------------------------------------------------- | ------- |
+| `serviceAccount.create`                       | Enable creation of ServiceAccount for PhpMyAdmin pod                   | `false` |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                 | `""`    |
+| `serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created | `true`  |
+| `serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                   | `{}`    |
+
+
 ### Metrics parameters
 
 | Name                                       | Description                                                                                                     | Value                     |

--- a/bitnami/phpmyadmin/templates/_helpers.tpl
+++ b/bitnami/phpmyadmin/templates/_helpers.tpl
@@ -22,6 +22,17 @@ Return the proper Docker Image Registry Secret Names
 {{- end -}}
 
 {{/*
+ Create the name of the service account to use
+ */}}
+{{- define "phpmyadmin.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/bitnami/phpmyadmin/templates/deployment.yaml
+++ b/bitnami/phpmyadmin/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "phpmyadmin.serviceAccountName" . }}
+      {{- end }}
       {{- if .Values.initContainers }}
       initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}

--- a/bitnami/phpmyadmin/templates/serviceaccount.yaml
+++ b/bitnami/phpmyadmin/templates/serviceaccount.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ template "phpmyadmin.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.serviceAccount.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/bitnami/phpmyadmin/values.yaml
+++ b/bitnami/phpmyadmin/values.yaml
@@ -540,6 +540,27 @@ db:
 ##
 mariadb: {}
 
+## @section Other Parameters
+
+## Service account for PhpMyAdmin to use.
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+##
+serviceAccount:
+  ## @param serviceAccount.create Enable creation of ServiceAccount for PhpMyAdmin pod
+  ##
+  create: false
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created
+  ## Can be set to false if pods using this serviceAccount do not need to use K8s API
+  ##
+  automountServiceAccountToken: true
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  ##
+  annotations: {}
+
 ## @section Metrics parameters
 
 ## Prometheus Exporter / Metrics

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -22,4 +22,4 @@ name: pinniped
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/pinniped
   - https://github.com/vmware-tanzu/pinniped/
-version: 1.0.0
+version: 1.0.1

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.21.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Pinniped is an identity service provider for Kubernetes. It supplies a consistent and unified login experience across all your clusters. Pinniped is securely integrated with enterprise IDP protocols.
-engine: gotpl
 home: https://pinniped.dev/
 icon: https://bitnami.com/assets/stacks/pinniped/img/pinniped-stack-220x234.png
 keywords:

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 15.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: This PostgreSQL cluster solution includes the PostgreSQL replication manager, an open-source tool for managing replication and failover on PostgreSQL clusters.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
 icon: https://bitnami.com/assets/stacks/postgresql/img/postgresql-stack-220x234.png
 keywords:

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 15.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: PostgreSQL (Postgres) is an open source object-relational database known for reliability and data integrity. ACID-compliant, it supports foreign keys, joins, views, triggers and stored procedures.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/postgresql
 icon: https://bitnami.com/assets/stacks/postgresql/img/postgresql-stack-220x234.png
 keywords:

--- a/bitnami/prestashop/Chart.yaml
+++ b/bitnami/prestashop/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: E-Commerce
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.0.1
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: PrestaShop is a powerful open source eCommerce platform used by over 250,000 online storefronts worldwide. It is easily customizable, responsive, and includes powerful tools to drive online sales.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/prestashop
 icon: https://bitnami.com/assets/stacks/prestashop/img/prestashop-stack-220x234.png
 keywords:

--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: MachineLearning
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.13.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: PyTorch is a deep learning platform that accelerates the transition from research prototyping to production deployment. Bitnami image includes Torchvision for specific computer vision support.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/pytorch
 icon: https://bitnami.com/assets/stacks/pytorch/img/pytorch-stack-220x234.png
 keywords:

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: The RabbitMQ Cluster Kubernetes Operator automates provisioning, management, and operations of RabbitMQ clusters running on Kubernetes.
-engine: gotpl
 home: https://github.com/rabbitmq/cluster-operator
 icon: https://bitnami.com/assets/stacks/rabbitmq-cluster-operator/img/rabbitmq-cluster-operator-stack-220x234.png
 keywords:

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.11.6
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: RabbitMQ is an open source general-purpose message broker that is designed for consistent, highly-available messaging scenarios (both synchronous and asynchronous).
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
 icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
 keywords:

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -23,4 +23,4 @@ name: rabbitmq
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq
   - https://www.rabbitmq.com
-version: 11.3.1
+version: 11.3.2

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -409,7 +409,7 @@ configuration: |-
   {{- if .Values.metrics.enabled }}
   ## Prometheus metrics
   ##
-  prometheus.tcp.port = 9419
+  prometheus.tcp.port = {{ .Values.containerPorts.metrics }}
   {{- end }}
   {{- if .Values.memoryHighWatermark.enabled }}
   ## Memory Threshold

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.0.7
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Redis(R) is an open source, scalable, distributed in-memory cache for applications. It can be used to store and serve data in the form of strings, hashes, lists, sets and sorted sets.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
 icon: https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png
 keywords:

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.0.7
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Redis(R) is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/redis
 icon: https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png
 keywords:

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: ProjectManagement
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 5.0.4
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Redmine is an open source management application. It includes a tracking issue system, Gantt charts for a visual view of projects and deadlines, and supports SCM integration for version control.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/redmine
 icon: https://bitnami.com/assets/stacks/redmine/img/redmine-stack-220x234.png
 keywords:

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.3.1
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Confluent Schema Registry provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
-engine: gotpl
 home: https://confluent.io/
 icon: https://bitnami.com/assets/stacks/schema-registry/img/schema-registry-stack-220x234.png
 keywords:

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.19.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Sealed Secrets are "one-way" encrypted K8s Secrets that can be created by anyone, but can only be decrypted by the controller running in the target cluster recovering the original object.
-engine: gotpl
 home: https://github.com/bitnami-labs/sealed-secrets
 icon: https://bitnami.com/assets/stacks/sealed-secrets/img/sealed-secrets-stack-220x234.png
 keywords:

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 9.1.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Solr is an extremely powerful, open source enterprise search platform built on Apache Lucene. It is highly reliable and flexible, scalable, and designed to add value very quickly after launch.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/solr
 icon: https://bitnami.com/assets/stacks/solr/img/solr-stack-220x234.png
 keywords:

--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 9.8.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: SonarQube(TM) is an open source quality management platform that analyzes and measures code's technical quality. It enables developers to detect code issues, vulnerabilities, and bugs in early stages.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
 icon: https://bitnami.com/assets/stacks/sonarqube/img/sonarqube-stack-220x234.png
 keywords:

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.3.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Spark is a high-performance engine for large-scale computing tasks, such as data processing, machine learning and real-time data streaming. It includes APIs for Java, Python, Scala and R.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/spark
 icon: https://bitnami.com/assets/stacks/spark/img/spark-stack-220x234.png
 keywords:

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.9.6
 dependencies:
@@ -23,7 +25,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
 icon: https://bitnami.com/assets/stacks/spring-cloud-dataflow/img/spring-cloud-dataflow-stack-220x234.png
 keywords:

--- a/bitnami/suitecrm/Chart.yaml
+++ b/bitnami/suitecrm/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CRM
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.12.8
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: SuiteCRM is a completely open source, enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a fork of the popular SugarCRM application.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/suitecrm
 icon: https://bitnami.com/assets/stacks/suitecrm/img/suitecrm-stack-220x234.png
 keywords:

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: MachineLearning
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.11.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: TensorFlow ResNet is a client utility for use with TensorFlow Serving and ResNet models.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/tensorflow-resnet
 icon: https://bitnami.com/assets/stacks/tensorflow-inception/img/tensorflow-inception-stack-220x234.png
 keywords:

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.30.1
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/thanos
 icon: https://bitnami.com/assets/stacks/thanos/img/thanos-stack-220x234.png
 keywords:

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: ApplicationServer
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 10.1.4
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Tomcat is an open-source web server designed to host and run Java-based web applications. It is a lightweight server with a good performance for applications running in production environments.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/tomcat
 icon: https://bitnami.com/assets/stacks/tomcat/img/tomcat-stack-220x234.png
 keywords:

--- a/bitnami/wavefront-hpa-adapter/Chart.yaml
+++ b/bitnami/wavefront-hpa-adapter/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.9.9
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Wavefront HPA Adapter for Kubernetes is a Kubernetes Horizontal Pod Autoscaler adapter. It allows to scale your Kubernetes workloads based on Wavefront metrics.
-engine: gotpl
 home: https://github.com/wavefrontHQ/wavefront-kubernetes-adapter
 icon: https://bitnami.com/assets/stacks/wavefront-hpa-adapter/img/wavefront-hpa-adapter-stack-220x234.png
 keywords:

--- a/bitnami/wavefront-prometheus-storage-adapter/Chart.yaml
+++ b/bitnami/wavefront-prometheus-storage-adapter/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.0.5
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Wavefront Storage Adapter is a Prometheus integration to transfer metrics from Prometheus to Wavefront. It lets you save Prometheus data in Wavefront without changing your existing Prometheus setup.
-engine: gotpl
 home: https://github.com/wavefrontHQ/prometheus-storage-adapter
 icon: https://bitnami.com/assets/stacks/wavefront-prometheus-storage-adapter/img/wavefront-prometheus-storage-adapter-stack-220x234.png
 keywords:

--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.13.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Wavefront is a high-performance streaming analytics platform for monitoring and optimizing your environment and applications.
-engine: gotpl
 home: https://www.wavefront.com
 icon: https://bitnami.com/assets/stacks/wavefront/img/wavefront-stack-220x234.png
 keywords:

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: ApplicationServer
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 27.0.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Wildfly is a lightweight, open source application server, formerly known as JBoss, that implements the latest enterprise Java standards.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/wildfly
 icon: https://bitnami.com/assets/stacks/wildfly/img/wildfly-stack-220x234.png
 keywords:

--- a/bitnami/wordpress-intel/Chart.lock
+++ b/bitnami/wordpress-intel/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.3.4
+  version: 6.3.5
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 11.4.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.2.2
-digest: sha256:6b3f92e13150e37428dd648d202f6fa1fb25001630712fcc1f1487c5eb79e20d
-generated: "2023-01-10T17:31:38.285851073Z"
+digest: sha256:7df06a17b6b76bfb399bf69534222f051413cedbc09ed4bdeb1e72259cb3ce92
+generated: "2023-01-11T23:34:59.045319377Z"

--- a/bitnami/wordpress-intel/Chart.yaml
+++ b/bitnami/wordpress-intel/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 6.1.1
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: WordPress for Intel is the most popular blogging application combined with cryptography acceleration for 3rd gen Xeon Scalable Processors (Ice Lake) to get a breakthrough performance improvement.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/wordpress-intel
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:

--- a/bitnami/wordpress-intel/Chart.yaml
+++ b/bitnami/wordpress-intel/Chart.yaml
@@ -36,4 +36,4 @@ name: wordpress-intel
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wordpress-intel
   - https://wordpress.org/
-version: 2.1.29
+version: 2.1.30

--- a/bitnami/wordpress-intel/README.md
+++ b/bitnami/wordpress-intel/README.md
@@ -93,7 +93,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------- |
 | `image.registry`    | WordPress image registry                                                                                  | `docker.io`               |
 | `image.repository`  | WordPress image repository                                                                                | `bitnami/wordpress-intel` |
-| `image.tag`         | WordPress image tag (immutable tags are recommended)                                                      | `6.1.1-debian-11-r23`     |
+| `image.tag`         | WordPress image tag (immutable tags are recommended)                                                      | `6.1.1-debian-11-r24`     |
 | `image.digest`      | WordPress image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                      |
 | `image.pullPolicy`  | WordPress image pull policy                                                                               | `IfNotPresent`            |
 | `image.pullSecrets` | WordPress image pull secrets                                                                              | `[]`                      |
@@ -242,7 +242,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                   | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`               | `false`                 |
 | `volumePermissions.image.registry`            | Bitnami Shell image registry                                                                                  | `docker.io`             |
 | `volumePermissions.image.repository`          | Bitnami Shell image repository                                                                                | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                                      | `11-debian-11-r70`      |
+| `volumePermissions.image.tag`                 | Bitnami Shell image tag (immutable tags are recommended)                                                      | `11-debian-11-r71`      |
 | `volumePermissions.image.digest`              | Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
 | `volumePermissions.image.pullPolicy`          | Bitnami Shell image pull policy                                                                               | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`         | Bitnami Shell image pull secrets                                                                              | `[]`                    |
@@ -273,7 +273,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.port`                            | NGINX Container Status Port scraped by Prometheus Exporter                                                                | `""`                     |
 | `metrics.image.registry`                  | NGINX Prometheus exporter image registry                                                                                  | `docker.io`              |
 | `metrics.image.repository`                | NGINX Prometheus exporter image repository                                                                                | `bitnami/nginx-exporter` |
-| `metrics.image.tag`                       | NGINX Prometheus exporter image tag (immutable tags are recommended)                                                      | `0.11.0-debian-11-r39`   |
+| `metrics.image.tag`                       | NGINX Prometheus exporter image tag (immutable tags are recommended)                                                      | `0.11.0-debian-11-r40`   |
 | `metrics.image.digest`                    | NGINX Prometheus exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                     |
 | `metrics.image.pullPolicy`                | NGINX Prometheus exporter image pull policy                                                                               | `IfNotPresent`           |
 | `metrics.image.pullSecrets`               | Specify docker-registry secret names as an array                                                                          | `[]`                     |

--- a/bitnami/wordpress-intel/values.yaml
+++ b/bitnami/wordpress-intel/values.yaml
@@ -70,7 +70,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/wordpress-intel
-  tag: 6.1.1-debian-11-r23
+  tag: 6.1.1-debian-11-r24
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -651,7 +651,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 11-debian-11-r70
+    tag: 11-debian-11-r71
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -729,7 +729,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/nginx-exporter
-    tag: 0.11.0-debian-11-r39
+    tag: 0.11.0-debian-11-r40
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/bitnami/wordpress/Chart.lock
+++ b/bitnami/wordpress/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: memcached
   repository: https://charts.bitnami.com/bitnami
-  version: 6.3.4
+  version: 6.3.5
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 11.4.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.2.2
-digest: sha256:6b3f92e13150e37428dd648d202f6fa1fb25001630712fcc1f1487c5eb79e20d
-generated: "2023-01-10T17:24:42.87971797Z"
+digest: sha256:7df06a17b6b76bfb399bf69534222f051413cedbc09ed4bdeb1e72259cb3ce92
+generated: "2023-01-11T23:58:16.786753035Z"

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -36,4 +36,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wordpress
   - https://wordpress.org/
-version: 15.2.23
+version: 15.2.24

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 6.1.1
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: WordPress is the world's most popular blogging and content management platform. Powerful yet simple, everyone from students to global corporations use it to build beautiful, functional websites.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/wordpress
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -85,7 +85,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------- | --------------------------------------------------------------------------------------------------------- | --------------------- |
 | `image.registry`    | WordPress image registry                                                                                  | `docker.io`           |
 | `image.repository`  | WordPress image repository                                                                                | `bitnami/wordpress`   |
-| `image.tag`         | WordPress image tag (immutable tags are recommended)                                                      | `6.1.1-debian-11-r23` |
+| `image.tag`         | WordPress image tag (immutable tags are recommended)                                                      | `6.1.1-debian-11-r24` |
 | `image.digest`      | WordPress image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                  |
 | `image.pullPolicy`  | WordPress image pull policy                                                                               | `IfNotPresent`        |
 | `image.pullSecrets` | WordPress image pull secrets                                                                              | `[]`                  |
@@ -255,7 +255,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.enabled`                            | Enable init container that changes the owner/group of the PV mount point to `runAsUser:fsGroup`               | `false`                 |
 | `volumePermissions.image.registry`                     | Bitnami Shell image registry                                                                                  | `docker.io`             |
 | `volumePermissions.image.repository`                   | Bitnami Shell image repository                                                                                | `bitnami/bitnami-shell` |
-| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                                      | `11-debian-11-r70`      |
+| `volumePermissions.image.tag`                          | Bitnami Shell image tag (immutable tags are recommended)                                                      | `11-debian-11-r71`      |
 | `volumePermissions.image.digest`                       | Bitnami Shell image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                    |
 | `volumePermissions.image.pullPolicy`                   | Bitnami Shell image pull policy                                                                               | `IfNotPresent`          |
 | `volumePermissions.image.pullSecrets`                  | Bitnami Shell image pull secrets                                                                              | `[]`                    |
@@ -289,7 +289,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.enabled`                            | Start a sidecar prometheus exporter to expose metrics                                                           | `false`                   |
 | `metrics.image.registry`                     | Apache exporter image registry                                                                                  | `docker.io`               |
 | `metrics.image.repository`                   | Apache exporter image repository                                                                                | `bitnami/apache-exporter` |
-| `metrics.image.tag`                          | Apache exporter image tag (immutable tags are recommended)                                                      | `0.11.0-debian-11-r80`    |
+| `metrics.image.tag`                          | Apache exporter image tag (immutable tags are recommended)                                                      | `0.11.0-debian-11-r81`    |
 | `metrics.image.digest`                       | Apache exporter image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                      |
 | `metrics.image.pullPolicy`                   | Apache exporter image pull policy                                                                               | `IfNotPresent`            |
 | `metrics.image.pullSecrets`                  | Apache exporter image pull secrets                                                                              | `[]`                      |

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -73,7 +73,7 @@ diagnosticMode:
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 6.1.1-debian-11-r23
+  tag: 6.1.1-debian-11-r24
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -755,7 +755,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 11-debian-11-r70
+    tag: 11-debian-11-r71
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -849,7 +849,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.11.0-debian-11-r80
+    tag: 0.11.0-debian-11-r81
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.8.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache ZooKeeper provides a reliable, centralized register of configuration data and services for distributed applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/zookeeper
 icon: https://bitnami.com/assets/stacks/zookeeper/img/zookeeper-stack-220x234.png
 keywords:

--- a/template/CHART_NAME/Chart.yaml
+++ b/template/CHART_NAME/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: %%CHOOSE_ONE_FROM_CHART_CATEGORIES_FILE%%
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: %%UPSTREAM_PROJECT_VERSION%%
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: %%DESCRIPTION%%
-engine: gotpl
 home: %%UPSTREAM_PROJECT_URL%%
 icon: https://bitnami.com/assets/stacks/%%IMAGE_NAME%%/img/%%IMAGE_NAME%%-stack-220x234.png
 keywords:


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

Support the Kubernetes feature to bind the Kafka external access [service to `externalIPs`](https://kubernetes.io/docs/concepts/services-networking/service/#external-ips)

### Description of the change

Adds a new configuration value `externalAccess.service.externalIPs`. 
This is an empty list be default.
If given it must contain a list with same length as `replicaCount`

It updates validation of both, `externalAccess.service.externalIPs` and `externalAccess.service.nodePorts` since one of both is enough now.

Slicing validation improved in template.

### Benefits

Supports now another official Kubernetes feature.
E.g. small clusters with fixed IP's can be built this way.

### Possible drawbacks

A cluster with fixed IPs is needed, if this is not the case the service type loadBalancer need to be used.

### Applicable issues

  - fixes #14222

### Additional information

N/A

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
