### PR TITLE
[bitnami/pinniped] Impersonation proxy fix

### DIFF
--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -22,4 +22,4 @@ name: pinniped
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/pinniped
   - https://github.com/vmware-tanzu/pinniped/
-version: 0.4.7
+version: 0.4.8

--- a/bitnami/pinniped/templates/concierge/deployment.yaml
+++ b/bitnami/pinniped/templates/concierge/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.concierge.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
       labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app: pinniped-concierge
         app.kubernetes.io/component: concierge
         {{- if .Values.concierge.podLabels }}
         {{- include "common.tplvalues.render" (dict "value" .Values.concierge.podLabels "context" $) | nindent 8 }}

--- a/bitnami/pinniped/values.yaml
+++ b/bitnami/pinniped/values.yaml
@@ -88,7 +88,7 @@ concierge:
   ##
   containerPorts:
     api: 10250
-    proxy: 8443
+    proxy: 8444
 
   ## @param concierge.configurationPorts.aggregatedAPIServerPort Concierge API configuration port
   ## @param concierge.configurationPorts.impersonationProxyServerPort Concierge Proxy configuration port

--- a/bitnami/pinniped/values.yaml
+++ b/bitnami/pinniped/values.yaml
@@ -482,7 +482,7 @@ supervisor:
     names:
       defaultTLSCertificateSecret: {{ printf "%s-%s" (include "pinniped.supervisor.fullname" .) "default-tls-certificate" | trunc 63 | trimSuffix "-" }}
       apiService: {{ template "pinniped.supervisor.api.fullname" . }}
-    labels: {"app.kubernetes.io/part-of":"pinniped", "app.kubernetes.io/component": "supervisor", "app.kubernetes.io/instance": "{{ .Release.Name }}"}
+    labels: {"app: pinniped-concierge", "app.kubernetes.io/part-of":"pinniped", "app.kubernetes.io/component": "supervisor", "app.kubernetes.io/instance": "{{ .Release.Name }}"}
     insecureAcceptExternalUnencryptedHttpRequests: false
 
   ## Configure extra options for Supervisor containers' liveness and readiness probes


### PR DESCRIPTION
### Description of the change

To fix #11054 (incorrect creation of the ImpersonationProxy LoadBalancer/ClusterIP service) we:
1. add the correct label (app: pinniped-concierge) to the concierge deployment pods and to the concierge configuration file (pinniped.yaml, defined in the values)
2. use port 8444 for the ImpersonationProxy
both are needed by upstream, since they are hardcoded in

### Applicable issues

  - fixes #11054 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
