### PR TITLE
[bitnami/kube-prometheus] Added namespaceOverride parameter to subcharts

### DIFF
--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -35,4 +35,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/prometheus
   - https://github.com/bitnami/containers/tree/main/bitnami/alertmanager
   - https://github.com/prometheus-operator/kube-prometheus
-version: 8.3.2
+version: 8.3.3

--- a/bitnami/kube-prometheus/values.yaml
+++ b/bitnami/kube-prometheus/values.yaml
@@ -1910,6 +1910,9 @@ exporters:
 ## @param node-exporter [object] Node Exporter deployment configuration
 ##
 node-exporter:
+  ## @param node-exporter.namespaceOverride String to fully override common.names.namespace
+  ##
+  namespaceOverride: ""
   service:
     labels:
       jobLabel: node-exporter
@@ -1922,6 +1925,9 @@ node-exporter:
 ## @param kube-state-metrics [object] Kube State Metrics deployment configuration
 ##
 kube-state-metrics:
+  ## @param kube-state-metrics.namespaceOverride String to fully override common.names.namespace
+  ##
+  namespaceOverride: ""
   serviceMonitor:
     enabled: true
     honorLabels: true


### PR DESCRIPTION
### Description of the change

Added the namespaceOverride parameter for kube-prometheus subcharts to specify the desired namespace.

### Benefits

You can now specify a specific namespace for kube-prometheus suibcharts instead of always having the default value.

### Applicable issues

  - fixes #13618

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
