### PR TITLE
[bitnami/*] Add licenses annotation and remove obsolete engine parameter

### DIFF
--- a/bitnami/airflow/Chart.yaml
+++ b/bitnami/airflow/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: WorkFlow
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.5.0
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Airflow is a tool to express and execute workflows as directed acyclic graphs (DAGs). It includes utilities to schedule tasks, monitor task progress and handle task dependencies.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/airflow
 icon: https://bitnami.com/assets/stacks/airflow/img/airflow-stack-220x234.png
 keywords:

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.4.54
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache HTTP Server is an open-source HTTP server. The goal of this project is to provide a secure, efficient and extensible server that provides HTTP services in sync with the current HTTP standards.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/apache
 icon: https://bitnami.com/assets/stacks/apache/img/apache-stack-220x234.png
 keywords:

--- a/bitnami/appsmith/Chart.yaml
+++ b/bitnami/appsmith/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.9.2
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Appsmith is an open source platform for building and maintaining internal tools, such as custom dashboards, admin panels or CRUD apps.
-engine: gotpl
 home: https://www.appsmith.com/
 icon: https://bitnami.com/assets/stacks/appsmith/img/appsmith-stack-220x234.png
 keywords:

--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.5.6
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Argo CD is a continuous delivery tool for Kubernetes based on GitOps.
-engine: gotpl
 home: https://argoproj.github.io/argo-cd/
 icon: https://bitnami.com/assets/stacks/argo-cd/img/argo-cd-stack-220x234.png
 keywords:

--- a/bitnami/argo-workflows/Chart.yaml
+++ b/bitnami/argo-workflows/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.4.4
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Argo Workflows is meant to orchestrate Kubernetes jobs in parallel. It uses DAG and step-based workflows
-engine: gotpl
 home: https://argoproj.github.io/workflows/
 icon: https://bitnami.com/assets/stacks/argo-workflows/img/argo-workflows-stack-220x234.png
 keywords:

--- a/bitnami/aspnet-core/Chart.yaml
+++ b/bitnami/aspnet-core/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.0.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: ASP.NET Core is an open-source framework for web application development created by Microsoft. It runs on both the full .NET Framework, on Windows, and the cross-platform .NET Core.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/aspnet-core
 icon: https://bitnami.com/assets/stacks/aspnet-core/img/aspnet-core-stack-220x234.png
 keywords:

--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Cassandra is an open source distributed database management system designed to handle large amounts of data across many servers, providing high availability with no single point of failure.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/cassandra
 icon: https://bitnami.com/assets/stacks/cassandra/img/cassandra-stack-220x234.png
 keywords:

--- a/bitnami/cert-manager/Chart.yaml
+++ b/bitnami/cert-manager/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CertificateAuthority
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.10.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
-engine: gotpl
 home: https://github.com/jetstack/cert-manager
 icon: https://bitnami.com/assets/stacks/cert-manager/img/cert-manager-stack-220x234.png
 keywords:

--- a/bitnami/clickhouse/Chart.yaml
+++ b/bitnami/clickhouse/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 22.12.3
 dependencies:

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
 appVersion: 2.2.2

--- a/bitnami/concourse/Chart.yaml
+++ b/bitnami/concourse/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.8.3
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Concourse is an automation system written in Go. It is most commonly used for CI/CD, and is built to scale to any kind of automation pipeline, from simple to complex.
-engine: gotpl
 home: https://github.com/concourse/concourse
 icon: https://bitnami.com/assets/stacks/concourse/img/concourse-stack-220x234.png
 keywords:

--- a/bitnami/consul/Chart.yaml
+++ b/bitnami/consul/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.14.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: HashiCorp Consul is a tool for discovering and configuring services in your infrastructure.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/consul
 icon: https://bitnami.com/assets/stacks/consul/img/consul-stack-220x234.png
 keywords:

--- a/bitnami/contour-operator/Chart.yaml
+++ b/bitnami/contour-operator/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.23.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: The Contour Operator extends the Kubernetes API to create, configure and manage instances of Contour on behalf of users.
-engine: gotpl
 home: https://github.com/projectcontour/contour-operator
 icon: https://bitnami.com/assets/stacks/contour-operator/img/contour-operator-stack-220x234.png
 keywords:

--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.23.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Contour is an open source Kubernetes ingress controller that works by deploying the Envoy proxy as a reverse proxy and load balancer.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/contour
 icon: https://bitnami.com/assets/stacks/contour/img/contour-stack-220x234.png
 keywords:

--- a/bitnami/discourse/Chart.yaml
+++ b/bitnami/discourse/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Forum
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.8.13
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Discourse is an open source discussion platform with built-in moderation and governance systems that let discussion communities protect themselves from bad actors even without official moderators.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/discourse
 icon: https://bitnami.com/assets/stacks/discourse/img/discourse-stack-220x234.png
 keywords:

--- a/bitnami/dokuwiki/Chart.yaml
+++ b/bitnami/dokuwiki/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Wiki
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 20220731.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: DokuWiki is a standards-compliant wiki optimized for creating documentation. Designed to be simple to use for small organizations, it stores all data in plain text files so no database is required.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/dokuwiki
 icon: https://bitnami.com/assets/stacks/dokuwiki/img/dokuwiki-stack-220x234.png
 keywords:

--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 9.4.9
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Drupal is one of the most versatile open source content management systems in the world. It is pre-configured with the Ctools and Views modules, Drush and Let's Encrypt auto-configuration support.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/drupal
 icon: https://bitnami.com/assets/stacks/drupal/img/drupal-stack-220x234.png
 keywords:

--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CertificateAuthority
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.10.0-2
 dependencies:
@@ -15,7 +17,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: EJBCA is an enterprise class PKI Certificate Authority software, built using Java (JEE) technology.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/ejbca
 icon: https://bitnami.com/assets/stacks/ejbca/img/ejbca-stack-220x234.png
 keywords:

--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.6.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Elasticsearch is a distributed search and analytics engine. It is used for web search, log monitoring, and real-time analytics. Ideal for Big Data applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
 icon: https://bitnami.com/assets/stacks/elasticsearch/img/elasticsearch-stack-220x234.png
 keywords:

--- a/bitnami/etcd/Chart.yaml
+++ b/bitnami/etcd/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.5.6
 dependencies:

--- a/bitnami/external-dns/Chart.yaml
+++ b/bitnami/external-dns/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.13.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: ExternalDNS is a Kubernetes addon that configures public DNS servers with information about exposed Kubernetes services to make them discoverable.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/external-dns
 icon: https://bitnami.com/assets/stacks/external-dns/img/external-dns-stack-220x234.png
 keywords:

--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.15.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Fluentd collects events from various data sources and writes them to files, RDBMS, NoSQL, IaaS, SaaS, Hadoop and so on.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/fluentd
 icon: https://bitnami.com/assets/stacks/fluentd/img/fluentd-stack-220x234.png
 keywords:

--- a/bitnami/ghost/Chart.yaml
+++ b/bitnami/ghost/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 5.29.0
 dependencies:
@@ -15,7 +17,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Ghost is an open source publishing platform designed to create blogs, magazines, and news sites. It includes a simple markdown editor with preview, theming, and SEO built-in to simplify editing.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/ghost
 icon: https://bitnami.com/assets/stacks/ghost/img/ghost-stack-220x234.png
 keywords:

--- a/bitnami/gitea/Chart.yaml
+++ b/bitnami/gitea/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.18.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Gitea is a lightweight code hosting solution. Written in Go, features low resource consumption, easy upgrades and multiple databases.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/gitea
 icon: https://bitnami.com/assets/stacks/gitea/img/gitea-stack-220x234.png
 keywords:

--- a/bitnami/grafana-loki/Chart.yaml
+++ b/bitnami/grafana-loki/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.7.1
 dependencies:
@@ -29,7 +31,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Grafana Loki is a horizontally scalable, highly available, and multi-tenant log aggregation system. It provides real-time long tailing and full persistence to object storage.
-engine: gotpl
 home: https://github.com/grafana/loki/
 icon: https://bitnami.com/assets/stacks/grafana-loki/img/grafana-loki-stack-220x234.png
 keywords:

--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.8.0
 dependencies:

--- a/bitnami/grafana-tempo/Chart.yaml
+++ b/bitnami/grafana-tempo/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.5.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Grafana Tempo is a distributed tracing system that has out-of-the-box integration with Grafana. It is highly scalable and works with many popular tracing protocols.
-engine: gotpl
 home: https://github.com/grafana/tempo/
 icon: https://bitnami.com/assets/stacks/grafana-tempo/img/grafana-tempo-stack-220x234.png
 keywords:

--- a/bitnami/grafana/Chart.yaml
+++ b/bitnami/grafana/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 9.3.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Grafana is an open source metric analytics and visualization suite for visualizing time series data that supports various types of data sources.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/grafana
 icon: https://bitnami.com/assets/stacks/grafana/img/grafana-stack-220x234.png
 keywords:

--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.7.1
 dependencies:

--- a/bitnami/haproxy/Chart.yaml
+++ b/bitnami/haproxy/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.7.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: HAProxy is a TCP proxy and a HTTP reverse proxy. It supports SSL termination and offloading, TCP and HTTP normalization, traffic regulation, caching and protection against DDoS attacks.
-engine: gotpl
 home: https://www.haproxy.org/
 icon: https://bitnami.com/assets/stacks/haproxy/img/haproxy-stack-220x234.png
 keywords:

--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.7.0
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Harbor is an open source trusted cloud-native registry to store, sign, and scan content. It adds functionalities like security, identity, and management to the open source Docker distribution.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/harbor
 icon: https://bitnami.com/assets/stacks/harbor-core/img/harbor-core-stack-220x234.png
 keywords:

--- a/bitnami/influxdb/Chart.yaml
+++ b/bitnami/influxdb/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.6.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: InfluxDB(TM) is an open source time-series database. It is a core component of the TICK (Telegraf, InfluxDB(TM), Chronograf, Kapacitor) stack.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/influxdb
 icon: https://bitnami.com/assets/stacks/influxdb/img/influxdb-stack-220x234.png
 keywords:

--- a/bitnami/jaeger/Chart.yaml
+++ b/bitnami/jaeger/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.41.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 9.x.x
 description: Jaeger is a distributed tracing system. It is used for monitoring and troubleshooting microservices-based distributed systems.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/jaeger
 icon: https://bitnami.com/assets/stacks/jaeger/img/jaeger-stack-220x234.png
 keywords:

--- a/bitnami/jasperreports/Chart.yaml
+++ b/bitnami/jasperreports/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.1.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: JasperReports Server is a stand-alone and embeddable reporting server. It is a central information hub, with reporting and analytics that can be embedded into web and mobile applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/jasperreports
 icon: https://bitnami.com/assets/stacks/jasperserver/img/jasperserver-stack-220x234.png
 keywords:

--- a/bitnami/jenkins/Chart.yaml
+++ b/bitnami/jenkins/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.375.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Jenkins is an open source Continuous Integration and Continuous Delivery (CI/CD) server designed to automate the building, testing, and deploying of any software project.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/jenkins
 icon: https://bitnami.com/assets/stacks/jenkins/img/jenkins-stack-220x234.png
 keywords:

--- a/bitnami/joomla/Chart.yaml
+++ b/bitnami/joomla/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.2.6
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Joomla! is an award winning open source CMS platform for building websites and applications. It includes page caching, page compression and Let's Encrypt auto-configuration support.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/joomla
 icon: https://bitnami.com/assets/stacks/joomla/img/joomla-stack-220x234.png
 keywords:

--- a/bitnami/jupyterhub/Chart.yaml
+++ b/bitnami/jupyterhub/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: MachineLearning
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.0.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: JupyterHub brings the power of notebooks to groups of users. It gives users access to computational environments and resources without burdening the users with installation and maintenance tasks.
-engine: gotpl
 home: https://jupyter.org/hub
 icon: https://bitnami.com/assets/stacks/jupyterhub/img/jupyterhub-stack-220x234.png
 keywords:

--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.3.1
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Kafka is a distributed streaming platform designed to build real-time pipelines and can be used as a message broker or as a replacement for a log aggregation solution for big data applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kafka
 icon: https://bitnami.com/assets/stacks/kafka/img/kafka-stack-220x234.png
 keywords:

--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 20.0.2
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Keycloak is a high performance Java-based identity and access management solution. It lets developers add an authentication layer to their applications with minimum effort.
-engine: gotpl
 home: https://www.keycloak.org
 icon: https://bitnami.com/assets/stacks/keycloak/img/keycloak-stack-220x234.png
 keywords:

--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.2.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: kiam is a proxy that captures AWS Metadata API requests. It allows AWS IAM roles to be set for Kubernetes workloads.
-engine: gotpl
 home: https://github.com/uswitch/kiam
 icon: https://bitnami.com/assets/stacks/kiam/img/kiam-stack-220x234.png
 keywords:

--- a/bitnami/kibana/Chart.yaml
+++ b/bitnami/kibana/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.6.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Kibana is an open source, browser based analytics and search dashboard for Elasticsearch. Kibana strives to be easy to get started with, while also being flexible and powerful.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kibana
 icon: https://bitnami.com/assets/stacks/kibana/img/kibana-stack-220x234.png
 keywords:

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.1.1
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 9.x.x
 description: Kong is an open source Microservice API gateway and platform designed for managing microservices requests of high-availability, fault-tolerance, and distributed systems.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kong
 icon: https://bitnami.com/assets/stacks/kong/img/kong-stack-220x234.png
 keywords:

--- a/bitnami/kube-prometheus/Chart.yaml
+++ b/bitnami/kube-prometheus/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.62.0
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Prometheus Operator provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kube-prometheus
 icon: https://bitnami.com/assets/stacks/prometheus-operator/img/prometheus-operator-stack-220x234.png
 keywords:

--- a/bitnami/kube-state-metrics/Chart.yaml
+++ b/bitnami/kube-state-metrics/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.7.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: kube-state-metrics is a simple service that listens to the Kubernetes API server and generates metrics about the state of the objects.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kube-state-metrics
 icon: https://bitnami.com/assets/stacks/kube-state-metrics/img/kube-state-metrics-stack-220x234.png
 keywords:

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.6.2
 dependencies:

--- a/bitnami/kubernetes-event-exporter/Chart.yaml
+++ b/bitnami/kubernetes-event-exporter/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Kubernetes Event Exporter makes it easy to export Kubernetes events to other tools, thereby enabling better event observability, custom alerts and aggregation.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/kubernetes-event-exporter
 icon: https://bitnami.com/assets/stacks/kubernetes-event-exporter/img/kubernetes-event-exporter-stack-220x234.png
 keywords:

--- a/bitnami/logstash/Chart.yaml
+++ b/bitnami/logstash/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: LogManagement
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.6.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Logstash is an open source data processing engine. It ingests data from multiple sources, processes it, and sends the output to final destination in real-time. It is a core component of the ELK stack.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/logstash
 icon: https://bitnami.com/assets/stacks/logstash/img/logstash-stack-220x234.png
 keywords:

--- a/bitnami/magento/Chart.yaml
+++ b/bitnami/magento/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: E-Commerce
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.4.5-p1
 dependencies:
@@ -19,7 +21,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Magento is a powerful open source e-commerce platform. With easy customizations and rich features, it allows retailers to grow their online businesses in a cost-effective way.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/magento
 icon: https://bitnami.com/assets/stacks/magento/img/magento-stack-220x234.png
 keywords:

--- a/bitnami/mariadb-galera/Chart.yaml
+++ b/bitnami/mariadb-galera/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 10.6.11
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MariaDB Galera is a multi-primary database cluster solution for synchronous replication and high availability.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mariadb-galera
 icon: https://bitnami.com/assets/stacks/mariadb-galera/img/mariadb-galera-stack-220x234.png
 keywords:

--- a/bitnami/mariadb/Chart.yaml
+++ b/bitnami/mariadb/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 10.6.11
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MariaDB is an open source, community-developed SQL database server that is widely in use around the world due to its enterprise features, flexibility, and collaboration with leading tech firms.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mariadb
 icon: https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png
 keywords:

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.0.2
 dependencies:
@@ -29,7 +31,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Mastodon is self-hosted social network server based on ActivityPub. Written in Ruby, features real-time updates, multimedia attachments and no vendor lock-in.
-engine: gotpl
 home: https://joinmastodon.org/
 icon: https://bitnami.com/assets/stacks/mastodon/img/mastodon-stack-220x234.png
 keywords:

--- a/bitnami/matomo/Chart.yaml
+++ b/bitnami/matomo/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.13.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Matomo, formerly known as Piwik, is a real time web analytics program. It provides detailed reports on website visitors.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/matomo
 icon: https://bitnami.com/assets/stacks/matomo/img/matomo-stack-220x234.png
 keywords:

--- a/bitnami/mediawiki/Chart.yaml
+++ b/bitnami/mediawiki/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Wiki
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.39.1
 dependencies:
@@ -15,7 +17,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MediaWiki is the free and open source wiki software that powers Wikipedia. Used by thousands of organizations, it is extremely powerful, scalable software and a feature-rich wiki implementation.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mediawiki
 icon: https://bitnami.com/assets/stacks/mediawiki/img/mediawiki-stack-220x234.png
 keywords:

--- a/bitnami/memcached/Chart.yaml
+++ b/bitnami/memcached/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.6.18
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Memcached is an high-performance, distributed memory object caching system, generic in nature, but intended for use in speeding up dynamic web applications by alleviating database load.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/memcached
 icon: https://bitnami.com/assets/stacks/memcached/img/memcached-stack-220x234.png
 keywords:

--- a/bitnami/metallb/Chart.yaml
+++ b/bitnami/metallb/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.13.7
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MetalLB is a load-balancer implementation for bare metal Kubernetes clusters, using standard routing protocols.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/metallb
 icon: https://bitnami.com/assets/stacks/metallb-speaker/img/metallb-speaker-stack-220x234.png
 keywords:

--- a/bitnami/metrics-server/Chart.yaml
+++ b/bitnami/metrics-server/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.6.2
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Metrics Server aggregates resource usage data, such as container CPU and memory usage, in a Kubernetes cluster and makes it available via the Metrics API.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/metrics-server
 icon: https://bitnami.com/assets/stacks/metrics-server/img/metrics-server-stack-220x234.png
 keywords:

--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2022.12.12
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MinIO(R) is an object storage server, compatible with Amazon S3 cloud storage service, mainly used for storing unstructured data (such as photos, videos, log files, etc.).
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/minio
 icon: https://bitnami.com/assets/stacks/minio/img/minio-stack-220x234.png
 keywords:

--- a/bitnami/mongodb-sharded/Chart.yaml
+++ b/bitnami/mongodb-sharded/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 6.0.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MongoDB(R) is an open source NoSQL database that uses JSON for data storage. MongoDB(TM) Sharded improves scalability and reliability for large datasets by distributing data across multiple machines.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded
 icon: https://bitnami.com/assets/stacks/mongodb/img/mongodb-stack-220x234.png
 keywords:

--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 6.0.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MongoDB(R) is a relational open source NoSQL database. Easy to use, it stores data in JSON-like documents. Automated scalability and high-performance. Ideal for developing cloud native applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mongodb
 icon: https://bitnami.com/assets/stacks/mongodb/img/mongodb-stack-220x234.png
 keywords:

--- a/bitnami/moodle/Chart.yaml
+++ b/bitnami/moodle/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: E-Learning
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.1.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Moodle(TM) LMS is an open source online Learning Management System widely used at universities, schools, and corporations. It is modular and highly adaptable to any type of online learning.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/moodle
 icon: https://bitnami.com/assets/stacks/moodle/img/moodle-stack-220x234.png
 keywords:

--- a/bitnami/mxnet/Chart.yaml
+++ b/bitnami/mxnet/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: MachineLearning
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.9.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache MXNet (Incubating) is a flexible and efficient library for deep learning designed to work as a neural network. Bitnami image ships OpenBLAS as math library.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mxnet
 icon: https://bitnami.com/assets/stacks/mxnet/img/mxnet-stack-220x234.png
 keywords:

--- a/bitnami/mysql/Chart.yaml
+++ b/bitnami/mysql/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.0.31
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: MySQL is a fast, reliable, scalable, and easy to use open source relational database system. Designed to handle mission-critical, heavy-load production applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/mysql
 icon: https://bitnami.com/assets/stacks/mysql/img/mysql-stack-220x234.png
 keywords:

--- a/bitnami/nats/Chart.yaml
+++ b/bitnami/nats/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.9.11
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: NATS is an open source, lightweight and high-performance messaging system. It is ideal for distributed systems and supports modern cloud architectures and pub-sub, request-reply and queuing models.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/nats
 icon: https://bitnami.com/assets/stacks/nats/img/nats-stack-220x234.png
 keywords:

--- a/bitnami/nginx-ingress-controller/Chart.yaml
+++ b/bitnami/nginx-ingress-controller/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.6.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: NGINX Ingress Controller is an Ingress controller that manages external access to HTTP services in a Kubernetes cluster using NGINX.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller
 icon: https://bitnami.com/assets/stacks/nginx-ingress-controller/img/nginx-ingress-controller-stack-220x234.png
 keywords:

--- a/bitnami/nginx-intel/Chart.yaml
+++ b/bitnami/nginx-intel/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.4.9
 dependencies:

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.23.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: NGINX Open Source is a web server that can be also used as a reverse proxy, load balancer, and HTTP cache. Recommended for high-demanding sites due to its ability to provide faster content.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/nginx
 icon: https://bitnami.com/assets/stacks/nginx/img/nginx-stack-220x234.png
 keywords:

--- a/bitnami/node-exporter/Chart.yaml
+++ b/bitnami/node-exporter/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.5.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Prometheus exporter for hardware and OS metrics exposed by UNIX kernels, with pluggable metric collectors.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/node-exporter
 icon: https://bitnami.com/assets/stacks/node-exporter/img/node-exporter-stack-220x234.png
 keywords:

--- a/bitnami/oauth2-proxy/Chart.yaml
+++ b/bitnami/oauth2-proxy/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.4.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: A reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/oauth2-proxy
 icon: https://bitnami.com/assets/stacks/oauth2-proxy/img/oauth2-proxy-stack-220x234.png
 keywords:

--- a/bitnami/odoo/Chart.yaml
+++ b/bitnami/odoo/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CRM
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 16.0.20221115
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Odoo is an open source ERP and CRM platform, formerly known as OpenERP, that can connect a wide variety of business operations such as sales, supply chain, finance, and project management.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/odoo
 icon: https://bitnami.com/assets/stacks/odoo/img/odoo-stack-220x234.png
 keywords:

--- a/bitnami/opencart/Chart.yaml
+++ b/bitnami/opencart/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: E-Commerce
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 4.0.1-1
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: OpenCart is free open source ecommerce platform for online merchants. OpenCart provides a professional and reliable foundation from which to build a successful online store.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/opencart
 icon: https://bitnami.com/assets/stacks/opencart/img/opencart-stack-220x234.png
 keywords:

--- a/bitnami/osclass/Chart.yaml
+++ b/bitnami/osclass/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.0.2
 dependencies:
@@ -15,7 +17,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Osclass allows you to easily create a classifieds site without any technical knowledge. It provides support for presenting general ads or specialized ads, is customizable, extensible and multilingual.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/osclass
 icon: https://bitnami.com/assets/stacks/osclass/img/osclass-stack-220x234.png
 keywords:

--- a/bitnami/owncloud/Chart.yaml
+++ b/bitnami/owncloud/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 10.11.0
 dependencies:
@@ -16,7 +18,6 @@ dependencies:
     version: 2.x.x
 deprecated: true
 description: ownCloud is an open source content collaboration platform used to store and share files from any device. It grants data privacy, synchronization between devices, and file access control.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/owncloud
 icon: https://bitnami.com/assets/stacks/owncloud/img/owncloud-stack-220x234.png
 keywords:

--- a/bitnami/parse/Chart.yaml
+++ b/bitnami/parse/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 5.4.0
 dependencies:
@@ -12,7 +14,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Parse is a platform that enables users to add a scalable and powerful backend to launch a full-featured app for iOS, Android, JavaScript, Windows, Unity, and more.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/parse
 icon: https://bitnami.com/assets/stacks/parse/img/parse-stack-220x234.png
 keywords:

--- a/bitnami/phpbb/Chart.yaml
+++ b/bitnami/phpbb/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Forum
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.3.9
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: phpBB is a popular bulletin board that features robust messaging capabilities such as flat message structure, subforums, topic split/merge/lock, user groups, full-text search, and attachments.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/phpbb
 icon: https://bitnami.com/assets/stacks/phpbb/img/phpbb-stack-220x234.png
 keywords:

--- a/bitnami/phpmyadmin/Chart.yaml
+++ b/bitnami/phpmyadmin/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 5.2.0
 dependencies:
@@ -15,7 +17,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: phpMyAdmin is a free software tool written in PHP, intended to handle the administration of MySQL over the Web. phpMyAdmin supports a wide range of operations on MySQL and MariaDB.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/phpmyadmin
 icon: https://bitnami.com/assets/stacks/phpmyadmin/img/phpmyadmin-stack-220x234.png
 keywords:

--- a/bitnami/pinniped/Chart.yaml
+++ b/bitnami/pinniped/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.21.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Pinniped is an identity service provider for Kubernetes. It supplies a consistent and unified login experience across all your clusters. Pinniped is securely integrated with enterprise IDP protocols.
-engine: gotpl
 home: https://pinniped.dev/
 icon: https://bitnami.com/assets/stacks/pinniped/img/pinniped-stack-220x234.png
 keywords:

--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 15.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: This PostgreSQL cluster solution includes the PostgreSQL replication manager, an open-source tool for managing replication and failover on PostgreSQL clusters.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/postgresql-ha
 icon: https://bitnami.com/assets/stacks/postgresql/img/postgresql-stack-220x234.png
 keywords:

--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 15.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: PostgreSQL (Postgres) is an open source object-relational database known for reliability and data integrity. ACID-compliant, it supports foreign keys, joins, views, triggers and stored procedures.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/postgresql
 icon: https://bitnami.com/assets/stacks/postgresql/img/postgresql-stack-220x234.png
 keywords:

--- a/bitnami/prestashop/Chart.yaml
+++ b/bitnami/prestashop/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: E-Commerce
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 8.0.1
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: PrestaShop is a powerful open source eCommerce platform used by over 250,000 online storefronts worldwide. It is easily customizable, responsive, and includes powerful tools to drive online sales.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/prestashop
 icon: https://bitnami.com/assets/stacks/prestashop/img/prestashop-stack-220x234.png
 keywords:

--- a/bitnami/pytorch/Chart.yaml
+++ b/bitnami/pytorch/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: MachineLearning
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.13.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: PyTorch is a deep learning platform that accelerates the transition from research prototyping to production deployment. Bitnami image includes Torchvision for specific computer vision support.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/pytorch
 icon: https://bitnami.com/assets/stacks/pytorch/img/pytorch-stack-220x234.png
 keywords:

--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.1.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: The RabbitMQ Cluster Kubernetes Operator automates provisioning, management, and operations of RabbitMQ clusters running on Kubernetes.
-engine: gotpl
 home: https://github.com/rabbitmq/cluster-operator
 icon: https://bitnami.com/assets/stacks/rabbitmq-cluster-operator/img/rabbitmq-cluster-operator-stack-220x234.png
 keywords:

--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.11.6
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: RabbitMQ is an open source general-purpose message broker that is designed for consistent, highly-available messaging scenarios (both synchronous and asynchronous).
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/rabbitmq
 icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
 keywords:

--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.0.7
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Redis(R) is an open source, scalable, distributed in-memory cache for applications. It can be used to store and serve data in the form of strings, hashes, lists, sets and sorted sets.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/redis-cluster
 icon: https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png
 keywords:

--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Database
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.0.7
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Redis(R) is an open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/redis
 icon: https://bitnami.com/assets/stacks/redis/img/redis-stack-220x234.png
 keywords:

--- a/bitnami/redmine/Chart.yaml
+++ b/bitnami/redmine/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: ProjectManagement
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 5.0.4
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Redmine is an open source management application. It includes a tracking issue system, Gantt charts for a visual view of projects and deadlines, and supports SCM integration for version control.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/redmine
 icon: https://bitnami.com/assets/stacks/redmine/img/redmine-stack-220x234.png
 keywords:

--- a/bitnami/schema-registry/Chart.yaml
+++ b/bitnami/schema-registry/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.3.1
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Confluent Schema Registry provides a RESTful interface by adding a serving layer for your metadata on top of Kafka. It expands Kafka enabling support for Apache Avro, JSON, and Protobuf schemas.
-engine: gotpl
 home: https://confluent.io/
 icon: https://bitnami.com/assets/stacks/schema-registry/img/schema-registry-stack-220x234.png
 keywords:

--- a/bitnami/sealed-secrets/Chart.yaml
+++ b/bitnami/sealed-secrets/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.19.3
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Sealed Secrets are "one-way" encrypted K8s Secrets that can be created by anyone, but can only be decrypted by the controller running in the target cluster recovering the original object.
-engine: gotpl
 home: https://github.com/bitnami-labs/sealed-secrets
 icon: https://bitnami.com/assets/stacks/sealed-secrets/img/sealed-secrets-stack-220x234.png
 keywords:

--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 9.1.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Solr is an extremely powerful, open source enterprise search platform built on Apache Lucene. It is highly reliable and flexible, scalable, and designed to add value very quickly after launch.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/solr
 icon: https://bitnami.com/assets/stacks/solr/img/solr-stack-220x234.png
 keywords:

--- a/bitnami/sonarqube/Chart.yaml
+++ b/bitnami/sonarqube/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 9.8.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: SonarQube(TM) is an open source quality management platform that analyzes and measures code's technical quality. It enables developers to detect code issues, vulnerabilities, and bugs in early stages.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/sonarqube
 icon: https://bitnami.com/assets/stacks/sonarqube/img/sonarqube-stack-220x234.png
 keywords:

--- a/bitnami/spark/Chart.yaml
+++ b/bitnami/spark/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.3.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Spark is a high-performance engine for large-scale computing tasks, such as data processing, machine learning and real-time data streaming. It includes APIs for Java, Python, Scala and R.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/spark
 icon: https://bitnami.com/assets/stacks/spark/img/spark-stack-220x234.png
 keywords:

--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: DeveloperTools
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.9.6
 dependencies:
@@ -23,7 +25,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Spring Cloud Data Flow is a microservices-based toolkit for building streaming and batch data processing pipelines in Cloud Foundry and Kubernetes.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/spring-cloud-dataflow
 icon: https://bitnami.com/assets/stacks/spring-cloud-dataflow/img/spring-cloud-dataflow-stack-220x234.png
 keywords:

--- a/bitnami/suitecrm/Chart.yaml
+++ b/bitnami/suitecrm/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CRM
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 7.12.8
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: SuiteCRM is a completely open source, enterprise-grade Customer Relationship Management (CRM) application. SuiteCRM is a fork of the popular SugarCRM application.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/suitecrm
 icon: https://bitnami.com/assets/stacks/suitecrm/img/suitecrm-stack-220x234.png
 keywords:

--- a/bitnami/tensorflow-resnet/Chart.yaml
+++ b/bitnami/tensorflow-resnet/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: MachineLearning
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 2.11.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: TensorFlow ResNet is a client utility for use with TensorFlow Serving and ResNet models.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/tensorflow-resnet
 icon: https://bitnami.com/assets/stacks/tensorflow-inception/img/tensorflow-inception-stack-220x234.png
 keywords:

--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.30.1
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Thanos is a highly available metrics system that can be added on top of existing Prometheus deployments, providing a global query view across all Prometheus installations.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/thanos
 icon: https://bitnami.com/assets/stacks/thanos/img/thanos-stack-220x234.png
 keywords:

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: ApplicationServer
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 10.1.4
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache Tomcat is an open-source web server designed to host and run Java-based web applications. It is a lightweight server with a good performance for applications running in production environments.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/tomcat
 icon: https://bitnami.com/assets/stacks/tomcat/img/tomcat-stack-220x234.png
 keywords:

--- a/bitnami/wavefront-hpa-adapter/Chart.yaml
+++ b/bitnami/wavefront-hpa-adapter/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 0.9.9
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Wavefront HPA Adapter for Kubernetes is a Kubernetes Horizontal Pod Autoscaler adapter. It allows to scale your Kubernetes workloads based on Wavefront metrics.
-engine: gotpl
 home: https://github.com/wavefrontHQ/wavefront-kubernetes-adapter
 icon: https://bitnami.com/assets/stacks/wavefront-hpa-adapter/img/wavefront-hpa-adapter-stack-220x234.png
 keywords:

--- a/bitnami/wavefront-prometheus-storage-adapter/Chart.yaml
+++ b/bitnami/wavefront-prometheus-storage-adapter/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.0.5
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Wavefront Storage Adapter is a Prometheus integration to transfer metrics from Prometheus to Wavefront. It lets you save Prometheus data in Wavefront without changing your existing Prometheus setup.
-engine: gotpl
 home: https://github.com/wavefrontHQ/prometheus-storage-adapter
 icon: https://bitnami.com/assets/stacks/wavefront-prometheus-storage-adapter/img/wavefront-prometheus-storage-adapter-stack-220x234.png
 keywords:

--- a/bitnami/wavefront/Chart.yaml
+++ b/bitnami/wavefront/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Analytics
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 1.13.0
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Wavefront is a high-performance streaming analytics platform for monitoring and optimizing your environment and applications.
-engine: gotpl
 home: https://www.wavefront.com
 icon: https://bitnami.com/assets/stacks/wavefront/img/wavefront-stack-220x234.png
 keywords:

--- a/bitnami/wildfly/Chart.yaml
+++ b/bitnami/wildfly/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: ApplicationServer
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 27.0.1
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Wildfly is a lightweight, open source application server, formerly known as JBoss, that implements the latest enterprise Java standards.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/wildfly
 icon: https://bitnami.com/assets/stacks/wildfly/img/wildfly-stack-220x234.png
 keywords:

--- a/bitnami/wordpress-intel/Chart.yaml
+++ b/bitnami/wordpress-intel/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 6.1.1
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: WordPress for Intel is the most popular blogging application combined with cryptography acceleration for 3rd gen Xeon Scalable Processors (Ice Lake) to get a breakthrough performance improvement.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/wordpress-intel
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:

--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: CMS
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 6.1.1
 dependencies:
@@ -17,7 +19,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: WordPress is the world's most popular blogging and content management platform. Powerful yet simple, everyone from students to global corporations use it to build beautiful, functional websites.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/wordpress
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:

--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: Infrastructure
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: 3.8.0
 dependencies:
@@ -9,7 +11,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: Apache ZooKeeper provides a reliable, centralized register of configuration data and services for distributed applications.
-engine: gotpl
 home: https://github.com/bitnami/charts/tree/main/bitnami/zookeeper
 icon: https://bitnami.com/assets/stacks/zookeeper/img/zookeeper-stack-220x234.png
 keywords:

--- a/template/CHART_NAME/Chart.yaml
+++ b/template/CHART_NAME/Chart.yaml
@@ -1,5 +1,7 @@
 annotations:
   category: %%CHOOSE_ONE_FROM_CHART_CATEGORIES_FILE%%
+  licenses: |
+    - Apache-2.0
 apiVersion: v2
 appVersion: %%UPSTREAM_PROJECT_VERSION%%
 dependencies:
@@ -13,7 +15,6 @@ dependencies:
       - bitnami-common
     version: 2.x.x
 description: %%DESCRIPTION%%
-engine: gotpl
 home: %%UPSTREAM_PROJECT_URL%%
 icon: https://bitnami.com/assets/stacks/%%IMAGE_NAME%%/img/%%IMAGE_NAME%%-stack-220x234.png
 keywords:


### PR DESCRIPTION
This PR adds the `licenses` annotations as a list of [SPDX licenses](https://spdx.org/licenses/):
```yaml
annotations: 
  licenses: |
    - Apache-2.0
```

In the same way, it removes the `engine` parameter that was optional in Helm 2 (https://v2.helm.sh/docs/charts/#the-chart-yaml-file) but removed in Helm 3 (https://helm.sh/docs/topics/charts/#the-chartyaml-file), see https://github.com/helm/helm/pull/5260

-----------------

PS: CI/CD failure is expected since there is more than one chart included in the same PR