### PR TITLE
[bitnami/*] Update publishing workflow to VIB Action v0.4.19

### DIFF
--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -178,7 +178,7 @@ jobs:
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
           echo "verification_mode=${verification_mode}" >> $GITHUB_OUTPUT
-      - uses: vmware-labs/vmware-image-builder-action@0.4.18
+      - uses: vmware-labs/vmware-image-builder-action@main
         name: Verify and publish ${{ needs.get-chart.outputs.chart }}
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-publish.json

--- a/.github/workflows/cd-pipeline.yml
+++ b/.github/workflows/cd-pipeline.yml
@@ -221,10 +221,10 @@ jobs:
       - id: update-index
         name: Fetch chart and update index
         run: |
-          # Extract chart release metadata from the publish result file
-          vib_publish_result_file=$(find ~/artifacts -name "result.json" -print -quit)
-          chart_name=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.name' $vib_publish_result_file)
-          chart_version=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.version' $vib_publish_result_file)
+          # Extract chart release metadata from the publish report file
+          vib_publish_report_file=$(find ~/artifacts -name "report.json" -print -quit)
+          chart_name=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.name' $vib_publish_report_file)
+          chart_version=$(jq -re '.actions|map(select(.action_id == "helm-publish"))[0] | .application.version' $vib_publish_report_file)
           # Download published asset
           mkdir download
           aws s3 cp s3://${{ secrets.AWS_S3_BUCKET }}/bitnami/${chart_name}-${chart_version}.tgz download/

--- a/.github/workflows/ci-pipeline-extra-thanos.yml
+++ b/.github/workflows/ci-pipeline-extra-thanos.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - uses: vmware-labs/vmware-image-builder-action@0.4.18
+      - uses: vmware-labs/vmware-image-builder-action@main
         with:
           pipeline: thanos/bucketweb/vib-verify.json
         env:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -117,7 +117,7 @@ jobs:
             verification_mode="$(cat $config_file | grep 'verification-mode' | cut -d'=' -f2)"
           fi
           echo "verification_mode=${verification_mode}" >> $GITHUB_OUTPUT
-      - uses: vmware-labs/vmware-image-builder-action@0.4.18
+      - uses: vmware-labs/vmware-image-builder-action@main
         name: Verify ${{ needs.get-chart.outputs.chart }}
         with:
           pipeline: ${{ needs.get-chart.outputs.chart }}/vib-verify.json


### PR DESCRIPTION
### Description of the change

The name of the file from which the metadata is obtained for the publishing process was updated to the new naming, as per the new version v0.4.19 of the VIB Action in https://github.com/vmware-labs/vmware-image-builder-action/pull/110

### Benefits

The publishing workflow works again with the latest published version if the VIB Action.

### Possible drawbacks

None.

### Applicable issues

NA.

### Additional information

Follow-up of https://github.com/bitnami/charts/pull/14285

### Checklist

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)