### PR TITLE
[bitnami/*] Update serviceAccount Goss' test

### DIFF
--- a/.vib/appsmith/goss/goss.yaml
+++ b/.vib/appsmith/goss/goss.yaml
@@ -1,16 +1,3 @@
-command:
-  {{- $uid := .Vars.client.containerSecurityContext.runAsUser }}
-  {{- $gid := .Vars.client.podSecurityContext.fsGroup }}
-  check-user-info:
-    # The UID and GID should always be either the one specified as vars (always a bigger number that the default)
-    # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
-    exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
-    exit-status: 0
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 http:
   http://appsmith:{{ .Vars.client.service.ports.http }}:
     status: 200
@@ -28,3 +15,18 @@ http:
     status: 200
   http://appsmith-rts:{{ .Vars.rts.service.ports.http }}/rts-api/v1/health-check:
     status: 200
+command:
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}
+  {{- $uid := .Vars.client.containerSecurityContext.runAsUser }}
+  {{- $gid := .Vars.client.podSecurityContext.fsGroup }}
+  check-user-info:
+    # The UID and GID should always be either the one specified as vars (always a bigger number that the default)
+    # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
+    exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
+    exit-status: 0

--- a/.vib/argo-cd/goss/goss.yaml
+++ b/.vib/argo-cd/goss/goss.yaml
@@ -18,10 +18,6 @@ file:
     filetype: directory
     mode: "3777"
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.server.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $password := .Vars.server.secret.argocdServerAdminPassword }}
   check-argocd-cli:
@@ -43,3 +39,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.server.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/aspnet-core/goss/goss.yaml
+++ b/.vib/aspnet-core/goss/goss.yaml
@@ -5,7 +5,11 @@ file:
     mode: "0777"
     owner: root
     group: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ and .Vars.serviceAccount.create .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "1777"
+command:
+  {{ if and .Vars.serviceAccount.create .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/cassandra/goss/goss.yaml
+++ b/.vib/cassandra/goss/goss.yaml
@@ -11,10 +11,6 @@ file:
     group: root
     contains:
       - /num_tokens.*{{ .Vars.cluster.numTokens }}/
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $dbUser := .Vars.dbUser.user }}
   {{- $dbPassword := .Vars.dbUser.password }}
@@ -36,3 +32,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/cert-manager/goss/goss.yaml
+++ b/.vib/cert-manager/goss/goss.yaml
@@ -1,8 +1,3 @@
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.controller.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.controller.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.controller.podSecurityContext.fsGroup }}
@@ -11,3 +6,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.controller.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/clickhouse/goss/goss.yaml
+++ b/.vib/clickhouse/goss/goss.yaml
@@ -1,8 +1,4 @@
 file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
   /opt/bitnami/clickhouse/etc/conf.d/00_default_overrides.xml:
     mode: "0644"
     filetype: file
@@ -42,3 +38,10 @@ command:
     exit-status: 0
     stdout:
       - {{ $insertValue }}
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/concourse/goss/web/goss.yaml
+++ b/.vib/concourse/goss/web/goss.yaml
@@ -1,8 +1,3 @@
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.web.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $user := .Vars.secrets.localUser }}
   {{- $pwd := .Vars.secrets.localPassword }}
@@ -28,3 +23,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.web.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/concourse/goss/worker/goss.yaml
+++ b/.vib/concourse/goss/worker/goss.yaml
@@ -4,10 +4,6 @@ file:
     filetype: directory
     mode: "2777"
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.worker.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $user := .Vars.secrets.localUser }}
   {{- $pwd := .Vars.secrets.localPassword }}
@@ -28,3 +24,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.worker.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/contour/goss/goss.yaml
+++ b/.vib/contour/goss/goss.yaml
@@ -10,10 +10,6 @@ file:
     filetype: directory
     mode: "3777"
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.contour.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.contour.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.contour.podSecurityContext.fsGroup }}
@@ -22,3 +18,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.contour.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/drupal/goss/goss.yaml
+++ b/.vib/drupal/goss/goss.yaml
@@ -10,16 +10,19 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}
 file:
   /bitnami/drupal:
     exists: true
     filetype: directory
     mode: '2775'
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
   /etc/hosts:
     exists: true
     filetype: file

--- a/.vib/ghost/goss/goss.yaml
+++ b/.vib/ghost/goss/goss.yaml
@@ -2,10 +2,10 @@ http:
   http://localhost:{{ .Vars.containerPorts.http }}:
     status: 200
 command:
-{{- $checkCmd := "ghost config get %s -d /opt/bitnami/ghost | grep -q %d" }}
-{{- $dbCheck := printf $checkCmd "database.connection.database" .Vars.mysql.auth.database }}
-{{- $userCheck := printf $checkCmd "database.connection.user" .Vars.mysql.auth.username }}
-{{- $passCheck := printf $checkCmd "database.connection.password" .Vars.mysql.auth.password }}
+  {{- $checkCmd := "ghost config get %s -d /opt/bitnami/ghost | grep -q %d" }}
+  {{- $dbCheck := printf $checkCmd "database.connection.database" .Vars.mysql.auth.database }}
+  {{- $userCheck := printf $checkCmd "database.connection.user" .Vars.mysql.auth.username }}
+  {{- $passCheck := printf $checkCmd "database.connection.password" .Vars.mysql.auth.password }}
   check-db-config:
     exec: ($dbCheck) && ($userCheck) && ($passCheck)
     exit-status: 0
@@ -16,13 +16,16 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}
 file:
   /bitnami/ghost:
     exists: true
     filetype: directory
     mode: '2775'
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"

--- a/.vib/gitea/goss/goss.yaml
+++ b/.vib/gitea/goss/goss.yaml
@@ -13,11 +13,14 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}
 file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
   /bitnami/gitea/custom/conf/app.ini:
     exists: true
     filetype: file

--- a/.vib/grafana-loki/goss/promtail/goss.yaml
+++ b/.vib/grafana-loki/goss/promtail/goss.yaml
@@ -6,10 +6,6 @@ file:
     owner: root
     contains:
     - /http_listen_port.*{{ .Vars.promtail.containerPorts.http }}/
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.promtail.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 http:
   http://grafana-loki-promtail:{{ .Vars.promtail.service.ports.http }}/config:
     status: 200
@@ -23,3 +19,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.promtail.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/grafana-operator/goss/goss.yaml
+++ b/.vib/grafana-operator/goss/goss.yaml
@@ -1,11 +1,6 @@
 http:
   http://grafana-service:3000:
     status: 200
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.operator.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.operator.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.operator.containerSecurityContext.runAsGroup }}
@@ -14,3 +9,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.operator.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/haproxy/goss/goss.yaml
+++ b/.vib/haproxy/goss/goss.yaml
@@ -1,8 +1,3 @@
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}
@@ -11,3 +6,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/influxdb/goss/goss.yaml
+++ b/.vib/influxdb/goss/goss.yaml
@@ -4,18 +4,7 @@ file:
     filetype: directory
     mode: "2775"
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
-  {{- $uid := .Vars.influxdb.containerSecurityContext.runAsUser }}
-  {{- $gid := .Vars.influxdb.podSecurityContext.fsGroup }}
-  check-user-info:
-    # The UID and GID should always be either the one specified as vars (always a bigger number that the default)
-    # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
-    exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
-    exit-status: 0
   {{- $org := .Vars.auth.user.org }}
   {{- $bucket := .Vars.auth.user.bucket }}
   {{- $port := .Vars.influxdb.service.ports.http }}
@@ -27,3 +16,17 @@ command:
     exit-status: 0
     stdout:
       - {{ $msg }}
+  {{- $uid := .Vars.influxdb.containerSecurityContext.runAsUser }}
+  {{- $gid := .Vars.influxdb.podSecurityContext.fsGroup }}
+  check-user-info:
+    # The UID and GID should always be either the one specified as vars (always a bigger number that the default)
+    # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
+    exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
+    exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/jaeger/goss/goss.yaml
+++ b/.vib/jaeger/goss/goss.yaml
@@ -16,11 +16,6 @@ http:
       - Server available
   http://localhost:{{ .Vars.agent.containerPorts.admin }}/:
     status: 200
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.agent.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   check-cassandra-auth:
     exec: \[ $CASSANDRA_USERNAME = {{ .Vars.cassandra.dbUser.user }} ] && [ $CASSANDRA_PASSWORD = {{ .Vars.cassandra.dbUser.password }} ] && [ $CASSANDRA_KEYSPACE = {{ .Vars.cassandra.keyspace }} ];

--- a/.vib/jaeger/goss/vars.yaml
+++ b/.vib/jaeger/goss/vars.yaml
@@ -17,8 +17,6 @@ agent:
     fsGroup: 1002
   containerSecurityContext:
     runAsUser: 1002
-  serviceAccount:
-    automountServiceAccountToken: true
 cassandra:
   keyspace: bitnami_test_jaeger
   dbUser:

--- a/.vib/jupyterhub/goss/goss.yaml
+++ b/.vib/jupyterhub/goss/goss.yaml
@@ -26,10 +26,6 @@ file:
     - /uid.*{{ .Vars.singleuser.containerSecurityContext.runAsUser }}/
     - /fsGid.*{{ .Vars.singleuser.podSecurityContext.fsGroup }}/
     - /type.*dynamic/
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.hub.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.hub.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.hub.podSecurityContext.fsGroup }}
@@ -38,3 +34,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.hub.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/kafka/goss/goss.yaml
+++ b/.vib/kafka/goss/goss.yaml
@@ -1,9 +1,4 @@
 file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
-    owner: root
   {{ .Vars.persistence.mountPath }}:
     exists: true
     filetype: directory
@@ -35,3 +30,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/keycloak/goss/goss.yaml
+++ b/.vib/keycloak/goss/goss.yaml
@@ -6,7 +6,11 @@ file:
     contains:
     - /http-port.*{{ .Vars.containerPorts.http }}/
     - /log-console-output.*{{ .Vars.logging.output }}/
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    mode: "3777"
-    filetype: directory
-    exists: true
+command:
+  {{ if and .Vars.serviceAccount.create .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/keycloak/goss/vars.yaml
+++ b/.vib/keycloak/goss/vars.yaml
@@ -2,3 +2,6 @@ containerPorts:
   http: 8080
 logging:
   output: default
+serviceAccount:
+  create: true
+  automountServiceAccountToken: true

--- a/.vib/keycloak/vib-publish.json
+++ b/.vib/keycloak/vib-publish.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/keycloak"
         },
-        "runtime_parameters": "YXV0aDoKICBhZG1pblVzZXI6IHVzZXIKICBhZG1pblBhc3N3b3JkOiBDb21wbGljYXRlZFBhc3N3b3JkMTIzITQKY29udGFpbmVyUG9ydHM6CiAgaHR0cDogODA4MApwb3N0Z3Jlc3FsOgogIGF1dGg6CiAgICB1c2VybmFtZTogYm5fa2V5Y2xvYWsKbG9nZ2luZzoKICBvdXRwdXQ6IGRlZmF1bHQKc2VydmljZToKICB0eXBlOiBMb2FkQmFsYW5jZXIKICBwb3J0czoKICAgIGh0dHA6IDgwCg==",
+        "runtime_parameters": "YXV0aDoKICBhZG1pblVzZXI6IHVzZXIKICBhZG1pblBhc3N3b3JkOiBDb21wbGljYXRlZFBhc3N3b3JkMTIzITQKY29udGFpbmVyUG9ydHM6CiAgaHR0cDogODA4MApwb3N0Z3Jlc3FsOgogIGF1dGg6CiAgICB1c2VybmFtZTogYm5fa2V5Y2xvYWsKbG9nZ2luZzoKICBvdXRwdXQ6IGRlZmF1bHQKc2VydmljZToKICB0eXBlOiBMb2FkQmFsYW5jZXIKICBwb3J0czoKICAgIGh0dHA6IDgwCnNlcnZpY2VBY2NvdW50OgogIGNyZWF0ZTogdHJ1ZQogIGF1dG9tb3VudFNlcnZpY2VBY2NvdW50VG9rZW46IHRydWU=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {

--- a/.vib/keycloak/vib-verify.json
+++ b/.vib/keycloak/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/keycloak"
         },
-        "runtime_parameters": "YXV0aDoKICBhZG1pblVzZXI6IHVzZXIKICBhZG1pblBhc3N3b3JkOiBDb21wbGljYXRlZFBhc3N3b3JkMTIzITQKY29udGFpbmVyUG9ydHM6CiAgaHR0cDogODA4MApwb3N0Z3Jlc3FsOgogIGF1dGg6CiAgICB1c2VybmFtZTogYm5fa2V5Y2xvYWsKbG9nZ2luZzoKICBvdXRwdXQ6IGRlZmF1bHQKc2VydmljZToKICB0eXBlOiBMb2FkQmFsYW5jZXIKICBwb3J0czoKICAgIGh0dHA6IDgwCg==",
+        "runtime_parameters": "YXV0aDoKICBhZG1pblVzZXI6IHVzZXIKICBhZG1pblBhc3N3b3JkOiBDb21wbGljYXRlZFBhc3N3b3JkMTIzITQKY29udGFpbmVyUG9ydHM6CiAgaHR0cDogODA4MApwb3N0Z3Jlc3FsOgogIGF1dGg6CiAgICB1c2VybmFtZTogYm5fa2V5Y2xvYWsKbG9nZ2luZzoKICBvdXRwdXQ6IGRlZmF1bHQKc2VydmljZToKICB0eXBlOiBMb2FkQmFsYW5jZXIKICBwb3J0czoKICAgIGh0dHA6IDgwCnNlcnZpY2VBY2NvdW50OgogIGNyZWF0ZTogdHJ1ZQogIGF1dG9tb3VudFNlcnZpY2VBY2NvdW50VG9rZW46IHRydWU=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {

--- a/.vib/kibana/goss/goss.yaml
+++ b/.vib/kibana/goss/goss.yaml
@@ -1,8 +1,4 @@
 file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
   /bitnami/kibana:
     exists: true
     filetype: directory
@@ -28,3 +24,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/kube-prometheus/goss/goss.yaml
+++ b/.vib/kube-prometheus/goss/goss.yaml
@@ -1,8 +1,3 @@
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.operator.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   check-no-capabilities:
     exec: cat /proc/1/status
@@ -20,3 +15,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.operator.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/kube-state-metrics/goss/goss.yaml
+++ b/.vib/kube-state-metrics/goss/goss.yaml
@@ -4,12 +4,6 @@ http:
     body:
     - /kube_deployment_status_replicas_ready.*kube-state-metrics.*{{ .Vars.replicaCount }}/
     - "!kube_secret_"
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
-    owner: root
 command:
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}
@@ -18,3 +12,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/kubeapps/goss/goss.yaml
+++ b/.vib/kubeapps/goss/goss.yaml
@@ -19,10 +19,6 @@ file:
       - /domain.*{{ .domain }}/
       - /name.*{{ .name }}/
     {{ end }}
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.kubeappsapis.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.kubeappsapis.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.kubeappsapis.podSecurityContext.fsGroup }}
@@ -31,3 +27,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.kubeappsapis.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/kubernetes-event-exporter/goss/goss.yaml
+++ b/.vib/kubernetes-event-exporter/goss/goss.yaml
@@ -6,10 +6,6 @@ file:
     owner: root
     contains:
       - /logLevel.*{{ .Vars.config.logLevel }}/
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   check-no-capabilities:
     exec: cat /proc/1/status
@@ -27,3 +23,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/logstash/goss/goss.yaml
+++ b/.vib/logstash/goss/goss.yaml
@@ -14,10 +14,6 @@ file:
     owner: root
     contains:
     - /port.*{{ .Vars.containerPorts.http }}/
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $rnd_ip := printf "%s.%s.%s.%s" (randNumeric 2) (randNumeric 2) (randNumeric 2) (randNumeric 2) }}
   {{- $rnd_address := printf "http://%s.com" (randAlpha 5) }}
@@ -37,3 +33,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/mastodon/goss/goss.yaml
+++ b/.vib/mastodon/goss/goss.yaml
@@ -27,12 +27,13 @@ command:
     - /REDIS_HOST.*mastodon-redis/
     - /REDIS_PORT.*{{ .Vars.redis.master.service.ports.redis }}/
     - /S3_ENDPOINT.*http://mastodon-minio:{{ .Vars.minio.service.ports.api }}/
-
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}
 http:
   http://127.0.0.1:{{ .Vars.web.containerPorts.http }}/health:
     status: 200

--- a/.vib/metallb/goss/goss.yaml
+++ b/.vib/metallb/goss/goss.yaml
@@ -1,8 +1,3 @@
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.controller.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   check-no-capabilities:
     exec: cat /proc/1/status
@@ -20,3 +15,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.controller.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/metrics-server/goss/goss.yaml
+++ b/.vib/metrics-server/goss/goss.yaml
@@ -4,12 +4,6 @@ http:
     allow-insecure: true
     body:
     - metrics_server_storage_points
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "1777"
-    owner: root
 command:
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   check-user-info:
@@ -17,3 +11,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/minio/goss/goss.yaml
+++ b/.vib/minio/goss/goss.yaml
@@ -24,14 +24,16 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
-
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}
 file:
   {{ .Vars.persistence.mountPath }}:
     filetype: directory
     exists: true
     mode: "2775"
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"

--- a/.vib/mongodb/goss/goss.yaml
+++ b/.vib/mongodb/goss/goss.yaml
@@ -10,10 +10,6 @@ file:
     mode: "0660"
     contains:
       - /port:.*{{ .Vars.containerPorts.mongodb }}/
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $conn_opts := printf "--quiet --username %s --password '%s' --host mongodb --port %d" .Vars.auth.rootUser .Vars.auth.rootPassword .Vars.service.ports.mongodb }}
   admin-command:
@@ -33,3 +29,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/nginx-ingress-controller/goss/goss.yaml
+++ b/.vib/nginx-ingress-controller/goss/goss.yaml
@@ -2,11 +2,6 @@ http:
   https://nginx-ingress-controller:{{ .Vars.service.ports.https }}:
     status: 404
     allow-insecure: true
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}
@@ -20,3 +15,10 @@ command:
     exit-status: 0
     stdout:
       - Bounding set ={{ .Vars.containerSecurityContext.capabilities.add }}
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/node-exporter/goss/goss.yaml
+++ b/.vib/node-exporter/goss/goss.yaml
@@ -9,10 +9,6 @@ file:
     filetype: directory
     mode: "0555"
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}
@@ -21,3 +17,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/oauth2-proxy/goss/goss.yaml
+++ b/.vib/oauth2-proxy/goss/goss.yaml
@@ -1,11 +1,6 @@
 http:
   http://localhost:{{ .Vars.containerPort }}:
     status: 403
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   check-redis-auth:
     exec: \[ $OAUTH2_PROXY_REDIS_PASSWORD = {{ .Vars.redis.auth.password }} ]
@@ -17,3 +12,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/parse/goss/dashboard/goss.yaml
+++ b/.vib/parse/goss/dashboard/goss.yaml
@@ -12,10 +12,6 @@ file:
       - /masterKey.*{{ .Vars.server.masterKey }}/
       - /user.*{{ .Vars.dashboard.username }}/
       - /pass.*{{ .Vars.dashboard.password }}/
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.dashboard.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.dashboard.podSecurityContext.fsGroup }}
@@ -24,3 +20,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*parse-server/
+  {{ end }}

--- a/.vib/parse/goss/server/goss.yaml
+++ b/.vib/parse/goss/server/goss.yaml
@@ -11,10 +11,6 @@ file:
     contains:
       - /port.*{{ .Vars.server.containerPorts.http }}/
       - /database.*{{ .Vars.mongodb.auth.username }}.*{{ .Vars.mongodb.auth.password }}.*{{ .Vars.mongodb.auth.database }}/
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.server.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.server.podSecurityContext.fsGroup }}
@@ -23,3 +19,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/rabbitmq-cluster-operator/goss/goss.yaml
+++ b/.vib/rabbitmq-cluster-operator/goss/goss.yaml
@@ -6,11 +6,6 @@ http:
     status: 400
   http://ve-testing:{{ .Vars.rabbitmq.service.ports.manager }}:
     status: 200
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: true
-    filetype: directory
-    mode: "3777"
 command:
   rabbitmqctl-cluster-status:
     exec: rabbitmqctl cluster_status
@@ -19,3 +14,8 @@ command:
     {{ range $e, $i := until .Vars.rabbitmq.replicaCount }}
       - /ve-testing-server-{{ $i }}.ve-testing-nodes/
     {{ end }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*ve-testing-server/

--- a/.vib/rabbitmq/goss/goss.yaml
+++ b/.vib/rabbitmq/goss/goss.yaml
@@ -16,10 +16,6 @@ file:
     filetype: directory
     mode: "3777"
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $nodes := .Vars.replicaCount }}
   rabbitmqctl-cluster-status:
@@ -45,3 +41,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/redis/goss/goss.yaml
+++ b/.vib/redis/goss/goss.yaml
@@ -35,6 +35,13 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}
 file:
   {{ .Vars.master.persistence.path }}:
     filetype: directory
@@ -51,7 +58,3 @@ file:
     exists: true
     mode: "2777"
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"

--- a/.vib/schema-registry/goss/goss.yaml
+++ b/.vib/schema-registry/goss/goss.yaml
@@ -6,7 +6,11 @@ file:
     contains:
       - "listeners = {{ .Vars.listeners }}"
       - "avro.compatibility.level = {{ .Vars.avroCompatibilityLevel }}"
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    mode: "3777"
-    filetype: directory
-    exists: true
+command:
+  {{ if and .Vars.serviceAccount.create .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/schema-registry/goss/vars.yaml
+++ b/.vib/schema-registry/goss/vars.yaml
@@ -1,2 +1,5 @@
 listeners: "http://0.0.0.0:8081"
 avroCompatibilityLevel: "backward"
+serviceAccount:
+  create: true
+  automountServiceAccountToken: true

--- a/.vib/schema-registry/vib-publish.json
+++ b/.vib/schema-registry/vib-publish.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/schema-registry"
         },
-        "runtime_parameters": "c2VydmljZToKICB0eXBlOiBMb2FkQmFsYW5jZXIKICBwb3J0czoKICAgIGh0dHA6IDgwCmF2cm9Db21wYXRpYmlsaXR5TGV2ZWw6IGJhY2t3YXJkCgo=",
+        "runtime_parameters": "c2VydmljZToKICB0eXBlOiBMb2FkQmFsYW5jZXIKICBwb3J0czoKICAgIGh0dHA6IDgwCmF2cm9Db21wYXRpYmlsaXR5TGV2ZWw6IGJhY2t3YXJkCnNlcnZpY2VBY2NvdW50OgogIGNyZWF0ZTogdHJ1ZQogIGF1dG9tb3VudFNlcnZpY2VBY2NvdW50VG9rZW46IHRydWU=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {

--- a/.vib/schema-registry/vib-verify.json
+++ b/.vib/schema-registry/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/schema-registry"
         },
-        "runtime_parameters": "c2VydmljZToKICB0eXBlOiBMb2FkQmFsYW5jZXIKICBwb3J0czoKICAgIGh0dHA6IDgwCmF2cm9Db21wYXRpYmlsaXR5TGV2ZWw6IGJhY2t3YXJkCgo=",
+        "runtime_parameters": "c2VydmljZToKICB0eXBlOiBMb2FkQmFsYW5jZXIKICBwb3J0czoKICAgIGh0dHA6IDgwCmF2cm9Db21wYXRpYmlsaXR5TGV2ZWw6IGJhY2t3YXJkCnNlcnZpY2VBY2NvdW50OgogIGNyZWF0ZTogdHJ1ZQogIGF1dG9tb3VudFNlcnZpY2VBY2NvdW50VG9rZW46IHRydWU=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {

--- a/.vib/sonarqube/goss/goss.yaml
+++ b/.vib/sonarqube/goss/goss.yaml
@@ -13,10 +13,6 @@ file:
      - /postgresql.*{{ .Vars.postgresql.service.ports.postgresql }}/{{ .Vars.postgresql.auth.database }}/
      - /jdbc.*username.*{{ .Vars.postgresql.auth.username }}/
      - /jdbc.*password.*{{ .Vars.postgresql.auth.password }}/
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.podSecurityContext.fsGroup }}
@@ -25,3 +21,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/spring-cloud-dataflow/goss/goss.yaml
+++ b/.vib/spring-cloud-dataflow/goss/goss.yaml
@@ -17,11 +17,6 @@ file:
     filetype: directory
     mode: "3777"
     owner: root
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
-    owner: root
 command:
   {{- $uid := .Vars.server.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.server.podSecurityContext.fsGroup }}
@@ -30,3 +25,10 @@ command:
     # or the one randomly defined by openshift (larger values). Otherwise, the chart is still using the default value.
     exec: if [ $(id -u) -lt {{ $uid }} ] || [ $(id -G | awk '{print $2}') -lt {{ $gid }} ]; then exit 1; fi
     exit-status: 0
+  {{ if .Vars.serviceAccount.automountServiceAccountToken }}
+  check-sa:
+    exec: cat /var/run/secrets/kubernetes.io/serviceaccount/token | cut -d '.' -f 2 | xargs -I '{}' echo '{}====' | fold -w 4 | sed '$ d' | tr -d '\n' | base64 -d
+    exit-status: 0
+    stdout:
+    - /serviceaccount.*name.*{{.Env.BITNAMI_APP_NAME }}/
+  {{ end }}

--- a/.vib/wavefront/goss/goss.yaml
+++ b/.vib/wavefront/goss/goss.yaml
@@ -1,11 +1,6 @@
 http:
   http://wavefront-proxy:{{ .Vars.proxy.port }}:
     status: 202
-file:
-  /var/run/secrets/kubernetes.io/serviceaccount:
-    exists: {{ .Vars.serviceAccount.automountServiceAccountToken }}
-    filetype: directory
-    mode: "3777"
 command:
   {{- $uid := .Vars.proxy.containerSecurityContext.runAsUser }}
   {{- $gid := .Vars.proxy.podSecurityContext.fsGroup }}

--- a/.vib/wavefront/goss/vars.yaml
+++ b/.vib/wavefront/goss/vars.yaml
@@ -1,5 +1,3 @@
-serviceAccount:
-  automountServiceAccountToken: true
 proxy:
   containerSecurityContext:
     runAsUser: 1002


### PR DESCRIPTION
Signed-off-by: FraPazGal <fdepaz@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Until now, our Goss test that checks the mounted serviceAccounts only makes sure that the related directory is mounted. The issue with this is that Kubernetes will always mount the SA metadata into every pod, be it the one created by default by the cluster or the one created by the chart itself.

That makes this test useless, as there will always exist the `/var/run/secrets/kubernetes.io/serviceaccount` directory. The revamp of the test now checks for the mounted SA name and compares it to the app's name via its env.

Reviewing the affected tests, it has been found 2 instances where the test wasn't necessary:

- The `bitnami/wavefront` deployment of the tested pod (wavefront-proxy) does not use the custom SA
- The SAs of the `bitnami/jaeger` chart are not used. An internal task has been created to address this.
- Both `bitnami/keycloak` and `bitnami/schema-registry` runtime parameters and vars were updated to use SA-related params.

### Benefits

- The test now works as expected.

### Possible drawbacks

- There may be charts where the SA name is not the same as the `BITNAMI_APP_NAME`. See: `bitnami/parse` changes.
- Added complexity to the test logic.

### Additional information

Change tested at https://github.com/FraPazGal/charts/pull/140

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
