### PR TITLE
[bitnami/wordpress-intel] Deprecate Helm chart

### DIFF
--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -28,4 +28,4 @@ name: haproxy-intel
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/haproxy-intel
   - https://github.com/haproxytech/haproxy
-version: 0.2.10
+version: 0.2.11

--- a/bitnami/haproxy-intel/Chart.yaml
+++ b/bitnami/haproxy-intel/Chart.yaml
@@ -28,4 +28,4 @@ name: haproxy-intel
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/haproxy-intel
   - https://github.com/haproxytech/haproxy
-version: 0.2.11
+version: 0.2.10

--- a/bitnami/wordpress-intel/Chart.yaml
+++ b/bitnami/wordpress-intel/Chart.yaml
@@ -18,7 +18,9 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x.x
-description: WordPress for Intel is the most popular blogging application combined with cryptography acceleration for 3rd gen Xeon Scalable Processors (Ice Lake) to get a breakthrough performance improvement.
+# The WordPress for Intel chart is deprecated and no longer maintained.
+deprecated: true
+description: DEPRECATED WordPress for Intel is the most popular blogging application combined with cryptography acceleration for 3rd gen Xeon Scalable Processors (Ice Lake) to get a breakthrough performance improvement.
 home: https://github.com/bitnami/charts/tree/main/bitnami/wordpress-intel
 icon: https://bitnami.com/assets/stacks/wordpress/img/wordpress-stack-220x234.png
 keywords:
@@ -29,9 +31,7 @@ keywords:
   - php
   - web
   - wordpress
-maintainers:
-  - name: Bitnami
-    url: https://github.com/bitnami/charts
+maintainers: []
 name: wordpress-intel
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wordpress-intel

--- a/bitnami/wordpress-intel/Chart.yaml
+++ b/bitnami/wordpress-intel/Chart.yaml
@@ -36,4 +36,4 @@ name: wordpress-intel
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wordpress-intel
   - https://wordpress.org/
-version: 2.1.30
+version: 2.1.31

--- a/bitnami/wordpress-intel/README.md
+++ b/bitnami/wordpress-intel/README.md
@@ -7,7 +7,11 @@ WordPress for Intel is the most popular blogging application combined with crypt
 [Overview of WordPress for Intel](http://www.wordpress.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
+## This Helm chart is deprecated
+
+The project has been discontinued and no new features will be added.
+
 ## TL;DR
 
 ```console

--- a/bitnami/wordpress-intel/templates/NOTES.txt
+++ b/bitnami/wordpress-intel/templates/NOTES.txt
@@ -1,3 +1,7 @@
+This Helm chart is deprecated
+
+The project has been discontinued and no new features will be added.
+
 CHART NAME: {{ .Chart.Name }}
 CHART VERSION: {{ .Chart.Version }}
 APP VERSION: {{ .Chart.AppVersion }}


### PR DESCRIPTION
Deprecate the bitnami/wordpress-intel Helm chart