### PR TITLE
[bitnami/grafana-operator] Revert #14181 and #14103

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -24,4 +24,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/containers/tree/main/bitnami/grafana-operator
-version: 2.7.14
+version: 2.7.15

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -270,7 +270,6 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.updateStrategy`                                    | Set up update strategy for Grafana installation.                                                           | `{}`                     |
 | `grafana.extraVolumes`                                      | Optionally specify extra list of additional volumes for the grafana pod(s)                                 | `[]`                     |
 | `grafana.extraVolumeMounts`                                 | Optionally specify extra list of additional volumeMounts for the grafana container(s)                      | `[]`                     |
-| `grafana.initContainers`                                    | Add additional init containers to the grafana pods                                                         | `[]`                     |
 | `grafana.sidecars`                                          | Add additional sidecar containers to the grafana pod(s)                                                    | `[]`                     |
 
 

--- a/bitnami/grafana-operator/crds/grafanas.integreatly.org.yaml
+++ b/bitnami/grafana-operator/crds/grafanas.integreatly.org.yaml
@@ -3261,13 +3261,6 @@ spec:
                       required:
                         - enabled
                       type: object
-                    initContainers:
-                      items:
-                        description: A single application container that you want to run within a pod.
-                        required:
-                          - name
-                        type: object
-                      type: array
                     labels:
                       additionalProperties:
                         type: string

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -69,9 +69,6 @@ spec:
   {{- end }}
   {{- $imagePullSecrets | nindent 4 }}
   {{- end }}
-  {{- if .Values.grafana.initContainers }}
-  initContainers: {{- include "common.tplvalues.render" (dict "value" .Values.grafana.initContainers "context" $) | nindent 4 }}
-  {{- end }}
   {{- if .Values.grafana.sidecars }}
   containers:
     {{- include "common.tplvalues.render" ( dict "value" .Values.grafana.sidecars "context" $) | nindent 4 }}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -804,17 +804,6 @@ grafana:
   ## @param grafana.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the grafana container(s)
   ##
   extraVolumeMounts: []
-  ## @param grafana.initContainers [array] Add additional init containers to the grafana pods
-  ## e.g:
-  ## initContainers:
-  ##   - name: your-image-name
-  ##     image: your-image
-  ##     imagePullPolicy: Always
-  ##     ports:
-  ##       - name: portname
-  ##         containerPort: 1234
-  ##
-  initContainers: []
   ## @param grafana.sidecars Add additional sidecar containers to the grafana pod(s)
   ## e.g:
   ## sidecars:


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>
### Description of the change

Reverts #14181 and #14103

The value `grafana.initContainers` is not supported by the upstream grafana-operator, therefore can't be added to the chart.

### Applicable issues

  - relates to https://github.com/bitnami/charts/issues/14104

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
