### PR TITLE
[bitnami/minio]: Check for existing password only in minio NOTES.txt for validation

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -26,4 +26,4 @@ name: minio
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/minio
   - https://min.io
-version: 11.10.25
+version: 11.10.26

--- a/bitnami/minio/templates/NOTES.txt
+++ b/bitnami/minio/templates/NOTES.txt
@@ -81,7 +81,8 @@ To access the MinIO&reg; web UI:
 
 {{- $requiredPasswords := list -}}
 {{- $secretName := include "minio.secretName" . -}}
-{{- if and (not .Values.auth.existingSecret) (not .Values.auth.forceNewKeys) (not .Values.gateway.enabled) -}}
+{{- $rootPassword := include "minio.secret.existingPassword" . -}}
+{{- if not $rootPassword }}
   {{- $requiredRootUser := dict "valueKey" "auth.rootUser" "secret" $secretName "field" "root-user" -}}
   {{- $requiredRootPassword := dict "valueKey" "auth.rootPassword" "secret" $secretName "field" "root-password" -}}
   {{- $requiredPasswords = append $requiredPasswords $requiredRootUser -}}

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -118,6 +118,18 @@ Get the password to use to access MinIO&reg;
 {{- end -}}
 
 {{/*
+Get existing password to access MinIO&reg without generating a new password;
+*/}}
+{{- define "minio.secret.existingPassword" -}}
+{{- $obj := (lookup "v1" "Secret" .Release.Namespace (include "minio.secretName" .)).data -}}
+{{- if $obj }}
+{{- index $obj "root-password" | b64dec -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Get the credentials secret.
 */}}
 {{- define "minio.secretName" -}}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

- In minio chart's NOTES.txt file, the validation of password has been changed to check for existing password in minio secret instead of a combination of Values which do not cover all the scenarios

### Benefits

- No errors during upgrade when auto-created secret already exists. 

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #14069 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
