### PR TITLE
[bitnami/kubeapps] wrap ASSET_SYNCER_DB_URL in conditional with no mutation when using externalDatabase

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 12.1.5
+version: 12.1.6

--- a/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeappsapis/deployment.yaml
@@ -147,7 +147,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ASSET_SYNCER_DB_URL
+              {{- if .Values.postgresql.enabled }}
               value: {{ printf "%s-hl:%d" (include "kubeapps.postgresql.host" .) (int (include "kubeapps.postgresql.port" .)) }}
+              {{- else }}
+              value: {{ printf "%s:%d" (include "kubeapps.postgresql.host" .) (int (include "kubeapps.postgresql.port" .)) }}
+              {{- end }}
             - name: ASSET_SYNCER_DB_NAME
               value: {{ .Values.postgresql.auth.database | quote }}
             - name: ASSET_SYNCER_DB_USERNAME


### PR DESCRIPTION
Signed-off-by: Kevin DiMichel <kdimiche@gmail.com>

### Description of the change

While using the kubeapps chart with these values:

* `postgresql.enabled` to `false`
* `externalDatabase.host` to a cloud managed postgresql database
* `externalDatabase.port` to `"5432"`

the deployment template for `kubeapps-internal-kubeappsapis` constructs the value for `ASSET_SYNCER_DB_URL` including a `-hl`.  With this value, the KubeApps Catalog displays an error:

> An error occurred while fetching the catalog: Unable to fetch chart categories: dial tcp: lookup <KUBEAPPS_POSTGRESQL_HOST>-hl on 10.0.0.10:53: no such host.

This can be worked around via a Helm postrenderer Kustomize patch, but it better that the chart supports it.

### Benefits

Extends the functionality to allow the use of an external postgresql database.

### Possible drawbacks

None. It only applies when `postgresql.enabled` to `false`.

### Applicable issues

Instead of creating an issue, I figured it was best to just submit a PR.

### Additional information

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
