### PR TITLE
[bitnami/template] PodDisruptionBudget template now works alongside autoscaling

### DIFF
--- a/template/CHART_NAME/templates/pdb.yaml
+++ b/template/CHART_NAME/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- $replicaCount := int .Values.%%MAIN_OBJECT_BLOCK%%.replicaCount }}
-{{- if and .Values.%%MAIN_OBJECT_BLOCK%%.pdb.create (gt $replicaCount 1) }}
+{{- if and .Values.%%MAIN_OBJECT_BLOCK%%.pdb.create (or (gt $replicaCount 1) .Values.%%MAIN_OBJECT_BLOCK%%.autoscaling.enabled) }}
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
### Description of the change

The PodDisruptionBudget (PDB) template can now be generated alongside the HorizontalPodAutoscaling (HPA) template without illogically setting ".Values.replicaCount" to a value greater than 1.

PDB and HPA are both fairly generic API resources which can both be applied to a large number of applications, so it makes sense for the templates to assume that a chart may want to deploy both/one-of/neither of these resources.

### Benefits

Templates are more flexible

### Possible drawbacks

If a user only wants a PDB in their chart, and not a HPA, the PDB template requires additional modification.

### Applicable issues

- fixes #14407

### Additional information

I looked through the current Bitnami charts and didn't see any charts this would fix, but if the Kafka chart and the Zookeeper chart want to add a HorizontalPodAutoscaler template in the future then they should be sure to update their `poddisruptionbudget.yaml` or `pdb.yaml` files.

### Checklist

- [ X ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ X ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
