### PR TITLE
[bitnami/minio] Allow templates override for ingress hosts

### DIFF
--- a/bitnami/minio/Chart.yaml
+++ b/bitnami/minio/Chart.yaml
@@ -25,4 +25,4 @@ name: minio
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/minio
   - https://min.io
-version: 12.0.2
+version: 12.0.3

--- a/bitnami/minio/templates/_helpers.tpl
+++ b/bitnami/minio/templates/_helpers.tpl
@@ -337,3 +337,31 @@ Provisioning job labels (exclude matchLabels from standard labels)
 {{- end -}}
 {{- print ($provisioningLabels | toYaml) -}}
 {{- end -}}
+
+{{/*
+Return the ingress anotation
+*/}}
+{{- define "minio.ingress.annotations" -}}
+{{ .Values.ingress.annotations | toYaml }}
+{{- end -}}
+
+{{/*
+Return the api ingress anotation
+*/}}
+{{- define "minio.apiIngress.annotations" -}}
+{{ .Values.apiIngress.annotations | toYaml }}
+{{- end -}}
+
+{{/*
+Return the ingress hostname
+*/}}
+{{- define "minio.ingress.hostname" -}}
+{{- .Values.ingress.hostname -}}
+{{- end -}}
+
+{{/*
+Return the api ingress hostname
+*/}}
+{{- define "minio.apiIngress.hostname" -}}
+{{- .Values.apiIngress.hostname -}}
+{{- end -}}

--- a/bitnami/minio/templates/api-ingress.yaml
+++ b/bitnami/minio/templates/api-ingress.yaml
@@ -9,8 +9,9 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
-    {{- if .Values.apiIngress.annotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.apiIngress.annotations "context" $) | nindent 4 }}
+    {{- $annotations := fromYaml (include "minio.apiIngress.annotations" .) -}}
+    {{- if $annotations }}
+    {{- include "common.tplvalues.render" (dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -20,8 +21,8 @@ spec:
   ingressClassName: {{ .Values.apiIngress.ingressClassName | quote }}
   {{- end }}
   rules:
-    {{- if .Values.apiIngress.hostname }}
-    - host: {{ .Values.apiIngress.hostname }}
+    {{- if (include "minio.apiIngress.hostname" .) }}
+    - host: {{ include "minio.apiIngress.hostname" . }}
       http:
         paths:
           {{- if .Values.apiIngress.extraPaths }}
@@ -46,12 +47,12 @@ spec:
     {{- if .Values.apiIngress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.apiIngress.extraRules "context" $) | nindent 4 }}
     {{- end }}
-  {{- if or (and .Values.apiIngress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.apiIngress.annotations )) .Values.apiIngress.selfSigned)) .Values.apiIngress.extraTls }}
+  {{- if or (and .Values.apiIngress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" $annotations )) .Values.apiIngress.selfSigned)) .Values.apiIngress.extraTls }}
   tls:
-    {{- if and .Values.apiIngress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.apiIngress.annotations )) .Values.apiIngress.selfSigned) }}
+    {{- if and .Values.apiIngress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" $annotations )) .Values.apiIngress.selfSigned) }}
     - hosts:
-        - {{ .Values.apiIngress.hostname }}
-      secretName: {{ printf "%s-tls" .Values.apiIngress.hostname }}
+        - {{ include "minio.apiIngress.hostname" . }}
+      secretName: {{ printf "%s-tls" (include "minio.apiIngress.hostname" .) }}
     {{- end }}
     {{- if .Values.apiIngress.extraTls }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.apiIngress.extraTls "context" $ ) | nindent 4 }}

--- a/bitnami/minio/templates/ingress.yaml
+++ b/bitnami/minio/templates/ingress.yaml
@@ -9,8 +9,9 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
   annotations:
-    {{- if .Values.ingress.annotations }}
-    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- $annotations := fromYaml (include "minio.ingress.annotations" .) -}}
+    {{- if $annotations }}
+    {{- include "common.tplvalues.render" (dict "value" $annotations "context" $) | nindent 4 }}
     {{- end }}
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -20,8 +21,8 @@ spec:
   ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
   {{- end }}
   rules:
-    {{- if .Values.ingress.hostname }}
-    - host: {{ .Values.ingress.hostname }}
+    {{- if (include "minio.ingress.hostname" .) }}
+    - host: {{ include "minio.ingress.hostname" . }}
       http:
         paths:
           {{- if .Values.ingress.extraPaths }}
@@ -46,12 +47,12 @@ spec:
     {{- if .Values.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}
     {{- end }}
-  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" $annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
   tls:
-    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
+    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" $annotations )) .Values.ingress.selfSigned) }}
     - hosts:
-        - {{ .Values.ingress.hostname }}
-      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+        - {{ include "minio.ingress.hostname" . }}
+      secretName: {{ printf "%s-tls" (include "minio.ingress.hostname" .) }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}


### PR DESCRIPTION
Signed-off-by: Remy Trompier <remy.trompier@gmail.com>

### Description of the change

Use template to define ingress hosts.

### Benefits

This change allow a root chart to override host thanks to template usage.

### Applicable issues

Previous version allow only to set ingress hosts via the values file, but not programmatically in a parent chart.

