### PR TITLE
[bitnami/kubeapps] Allow to use existing secret from authProxy.existi…

### DIFF
--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 12.1.7
+version: 12.2.0

--- a/bitnami/kubeapps/Chart.yaml
+++ b/bitnami/kubeapps/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: kubeapps
 sources:
   - https://github.com/vmware-tanzu/kubeapps
-version: 12.1.6
+version: 12.1.7

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -349,43 +349,43 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 
 ### Auth Proxy parameters
 
-| Name                                              | Description                                                                                                  | Value                  |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------- |
-| `authProxy.enabled`                               | Specifies whether Kubeapps should configure OAuth login/logout                                               | `false`                |
-| `authProxy.image.registry`                        | OAuth2 Proxy image registry                                                                                  | `docker.io`            |
-| `authProxy.image.repository`                      | OAuth2 Proxy image repository                                                                                | `bitnami/oauth2-proxy` |
-| `authProxy.image.tag`                             | OAuth2 Proxy image tag (immutable tags are recommended)                                                      | `7.4.0-debian-11-r22`  |
-| `authProxy.image.digest`                          | OAuth2 Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag | `""`                   |
-| `authProxy.image.pullPolicy`                      | OAuth2 Proxy image pull policy                                                                               | `IfNotPresent`         |
-| `authProxy.image.pullSecrets`                     | OAuth2 Proxy image pull secrets                                                                              | `[]`                   |
-| `authProxy.external`                              | Use an external Auth Proxy instead of deploying its own one                                                  | `false`                |
-| `authProxy.oauthLoginURI`                         | OAuth Login URI to which the Kubeapps frontend redirects for authn                                           | `/oauth2/start`        |
-| `authProxy.oauthLogoutURI`                        | OAuth Logout URI to which the Kubeapps frontend redirects for authn                                          | `/oauth2/sign_out`     |
-| `authProxy.skipKubeappsLoginPage`                 | Skip the Kubeapps login page when using OIDC and directly redirect to the IdP                                | `false`                |
-| `authProxy.provider`                              | OAuth provider                                                                                               | `""`                   |
-| `authProxy.clientID`                              | OAuth Client ID                                                                                              | `""`                   |
-| `authProxy.clientSecret`                          | OAuth Client secret                                                                                          | `""`                   |
-| `authProxy.cookieSecret`                          | Secret used by oauth2-proxy to encrypt any credentials                                                       | `""`                   |
-| `authProxy.existingOauth2Secret`                  | Name of an existing secret to use for Kubeapps credentials                                                   | `""`                   |
-| `authProxy.cookieRefresh`                         | Duration after which to refresh the cookie                                                                   | `2m`                   |
-| `authProxy.scope`                                 | OAuth scope specification                                                                                    | `openid email groups`  |
-| `authProxy.emailDomain`                           | Allowed email domains                                                                                        | `*`                    |
-| `authProxy.extraFlags`                            | Additional command line flags for oauth2-proxy                                                               | `[]`                   |
-| `authProxy.lifecycleHooks`                        | for the Auth Proxy container(s) to automate configuration before or after startup                            | `{}`                   |
-| `authProxy.command`                               | Override default container command (useful when using custom images)                                         | `[]`                   |
-| `authProxy.args`                                  | Override default container args (useful when using custom images)                                            | `[]`                   |
-| `authProxy.extraEnvVars`                          | Array with extra environment variables to add to the Auth Proxy container                                    | `[]`                   |
-| `authProxy.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for Auth Proxy containers(s)                            | `""`                   |
-| `authProxy.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for Auth Proxy containers(s)                               | `""`                   |
-| `authProxy.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Auth Proxy container(s)                     | `[]`                   |
-| `authProxy.containerPorts.proxy`                  | Auth Proxy HTTP container port                                                                               | `3000`                 |
-| `authProxy.containerSecurityContext.enabled`      | Enabled Auth Proxy containers' Security Context                                                              | `true`                 |
-| `authProxy.containerSecurityContext.runAsUser`    | Set Auth Proxy container's Security Context runAsUser                                                        | `1001`                 |
-| `authProxy.containerSecurityContext.runAsNonRoot` | Set Auth Proxy container's Security Context runAsNonRoot                                                     | `true`                 |
-| `authProxy.resources.limits.cpu`                  | The CPU limits for the OAuth2 Proxy container                                                                | `250m`                 |
-| `authProxy.resources.limits.memory`               | The memory limits for the OAuth2 Proxy container                                                             | `128Mi`                |
-| `authProxy.resources.requests.cpu`                | The requested CPU for the OAuth2 Proxy container                                                             | `25m`                  |
-| `authProxy.resources.requests.memory`             | The requested memory for the OAuth2 Proxy container                                                          | `32Mi`                 |
+| Name                                              | Description                                                                                                                         | Value                  |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `authProxy.enabled`                               | Specifies whether Kubeapps should configure OAuth login/logout                                                                      | `false`                |
+| `authProxy.image.registry`                        | OAuth2 Proxy image registry                                                                                                         | `docker.io`            |
+| `authProxy.image.repository`                      | OAuth2 Proxy image repository                                                                                                       | `bitnami/oauth2-proxy` |
+| `authProxy.image.tag`                             | OAuth2 Proxy image tag (immutable tags are recommended)                                                                             | `7.4.0-debian-11-r22`  |
+| `authProxy.image.digest`                          | OAuth2 Proxy image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag                        | `""`                   |
+| `authProxy.image.pullPolicy`                      | OAuth2 Proxy image pull policy                                                                                                      | `IfNotPresent`         |
+| `authProxy.image.pullSecrets`                     | OAuth2 Proxy image pull secrets                                                                                                     | `[]`                   |
+| `authProxy.external`                              | Use an external Auth Proxy instead of deploying its own one                                                                         | `false`                |
+| `authProxy.oauthLoginURI`                         | OAuth Login URI to which the Kubeapps frontend redirects for authn                                                                  | `/oauth2/start`        |
+| `authProxy.oauthLogoutURI`                        | OAuth Logout URI to which the Kubeapps frontend redirects for authn                                                                 | `/oauth2/sign_out`     |
+| `authProxy.skipKubeappsLoginPage`                 | Skip the Kubeapps login page when using OIDC and directly redirect to the IdP                                                       | `false`                |
+| `authProxy.provider`                              | OAuth provider                                                                                                                      | `""`                   |
+| `authProxy.clientID`                              | OAuth Client ID                                                                                                                     | `""`                   |
+| `authProxy.clientSecret`                          | OAuth Client secret                                                                                                                 | `""`                   |
+| `authProxy.cookieSecret`                          | Secret used by oauth2-proxy to encrypt any credentials                                                                              | `""`                   |
+| `authProxy.existingOauth2Secret`                  | Name of an existing secret containing the OAuth client secrets, it should contain the keys clientID, clientSecret, and cookieSecret | `""`                   |
+| `authProxy.cookieRefresh`                         | Duration after which to refresh the cookie                                                                                          | `2m`                   |
+| `authProxy.scope`                                 | OAuth scope specification                                                                                                           | `openid email groups`  |
+| `authProxy.emailDomain`                           | Allowed email domains                                                                                                               | `*`                    |
+| `authProxy.extraFlags`                            | Additional command line flags for oauth2-proxy                                                                                      | `[]`                   |
+| `authProxy.lifecycleHooks`                        | for the Auth Proxy container(s) to automate configuration before or after startup                                                   | `{}`                   |
+| `authProxy.command`                               | Override default container command (useful when using custom images)                                                                | `[]`                   |
+| `authProxy.args`                                  | Override default container args (useful when using custom images)                                                                   | `[]`                   |
+| `authProxy.extraEnvVars`                          | Array with extra environment variables to add to the Auth Proxy container                                                           | `[]`                   |
+| `authProxy.extraEnvVarsCM`                        | Name of existing ConfigMap containing extra env vars for Auth Proxy containers(s)                                                   | `""`                   |
+| `authProxy.extraEnvVarsSecret`                    | Name of existing Secret containing extra env vars for Auth Proxy containers(s)                                                      | `""`                   |
+| `authProxy.extraVolumeMounts`                     | Optionally specify extra list of additional volumeMounts for the Auth Proxy container(s)                                            | `[]`                   |
+| `authProxy.containerPorts.proxy`                  | Auth Proxy HTTP container port                                                                                                      | `3000`                 |
+| `authProxy.containerSecurityContext.enabled`      | Enabled Auth Proxy containers' Security Context                                                                                     | `true`                 |
+| `authProxy.containerSecurityContext.runAsUser`    | Set Auth Proxy container's Security Context runAsUser                                                                               | `1001`                 |
+| `authProxy.containerSecurityContext.runAsNonRoot` | Set Auth Proxy container's Security Context runAsNonRoot                                                                            | `true`                 |
+| `authProxy.resources.limits.cpu`                  | The CPU limits for the OAuth2 Proxy container                                                                                       | `250m`                 |
+| `authProxy.resources.limits.memory`               | The memory limits for the OAuth2 Proxy container                                                                                    | `128Mi`                |
+| `authProxy.resources.requests.cpu`                | The requested CPU for the OAuth2 Proxy container                                                                                    | `25m`                  |
+| `authProxy.resources.requests.memory`             | The requested memory for the OAuth2 Proxy container                                                                                 | `32Mi`                 |
 
 
 ### Pinniped Proxy parameters

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -351,7 +351,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 
 | Name                                              | Description                                                                                                  | Value                  |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------- |
-| `authProxy.enabled`                               | Specifies whether Kubeapps should configure OAuth login/logout                                               | `false`                |
+| `authProxy.enabled`                               | Specifies whether Kubeapps should configure OAuth login/logout                                               | `true`                 |
 | `authProxy.image.registry`                        | OAuth2 Proxy image registry                                                                                  | `docker.io`            |
 | `authProxy.image.repository`                      | OAuth2 Proxy image repository                                                                                | `bitnami/oauth2-proxy` |
 | `authProxy.image.tag`                             | OAuth2 Proxy image tag (immutable tags are recommended)                                                      | `7.4.0-debian-11-r22`  |
@@ -362,10 +362,11 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `authProxy.oauthLoginURI`                         | OAuth Login URI to which the Kubeapps frontend redirects for authn                                           | `/oauth2/start`        |
 | `authProxy.oauthLogoutURI`                        | OAuth Logout URI to which the Kubeapps frontend redirects for authn                                          | `/oauth2/sign_out`     |
 | `authProxy.skipKubeappsLoginPage`                 | Skip the Kubeapps login page when using OIDC and directly redirect to the IdP                                | `false`                |
-| `authProxy.provider`                              | OAuth provider                                                                                               | `""`                   |
-| `authProxy.clientID`                              | OAuth Client ID                                                                                              | `""`                   |
-| `authProxy.clientSecret`                          | OAuth Client secret                                                                                          | `""`                   |
-| `authProxy.cookieSecret`                          | Secret used by oauth2-proxy to encrypt any credentials                                                       | `""`                   |
+| `authProxy.provider`                              | OAuth provider                                                                                               | `test`                 |
+| `authProxy.clientID`                              | OAuth Client ID                                                                                              | `test`                 |
+| `authProxy.clientSecret`                          | OAuth Client secret                                                                                          | `test`                 |
+| `authProxy.cookieSecret`                          | Secret used by oauth2-proxy to encrypt any credentials                                                       | `test`                 |
+| `authProxy.existingOauth2Secret`                  | Name of an existing secret to use for Kubeapps credentials                                                   | `""`                   |
 | `authProxy.cookieRefresh`                         | Duration after which to refresh the cookie                                                                   | `2m`                   |
 | `authProxy.scope`                                 | OAuth scope specification                                                                                    | `openid email groups`  |
 | `authProxy.emailDomain`                           | Allowed email domains                                                                                        | `*`                    |

--- a/bitnami/kubeapps/README.md
+++ b/bitnami/kubeapps/README.md
@@ -351,7 +351,7 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 
 | Name                                              | Description                                                                                                  | Value                  |
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------- |
-| `authProxy.enabled`                               | Specifies whether Kubeapps should configure OAuth login/logout                                               | `true`                 |
+| `authProxy.enabled`                               | Specifies whether Kubeapps should configure OAuth login/logout                                               | `false`                |
 | `authProxy.image.registry`                        | OAuth2 Proxy image registry                                                                                  | `docker.io`            |
 | `authProxy.image.repository`                      | OAuth2 Proxy image repository                                                                                | `bitnami/oauth2-proxy` |
 | `authProxy.image.tag`                             | OAuth2 Proxy image tag (immutable tags are recommended)                                                      | `7.4.0-debian-11-r22`  |
@@ -362,10 +362,10 @@ Once you have installed Kubeapps follow the [Getting Started Guide](https://gith
 | `authProxy.oauthLoginURI`                         | OAuth Login URI to which the Kubeapps frontend redirects for authn                                           | `/oauth2/start`        |
 | `authProxy.oauthLogoutURI`                        | OAuth Logout URI to which the Kubeapps frontend redirects for authn                                          | `/oauth2/sign_out`     |
 | `authProxy.skipKubeappsLoginPage`                 | Skip the Kubeapps login page when using OIDC and directly redirect to the IdP                                | `false`                |
-| `authProxy.provider`                              | OAuth provider                                                                                               | `test`                 |
-| `authProxy.clientID`                              | OAuth Client ID                                                                                              | `test`                 |
-| `authProxy.clientSecret`                          | OAuth Client secret                                                                                          | `test`                 |
-| `authProxy.cookieSecret`                          | Secret used by oauth2-proxy to encrypt any credentials                                                       | `test`                 |
+| `authProxy.provider`                              | OAuth provider                                                                                               | `""`                   |
+| `authProxy.clientID`                              | OAuth Client ID                                                                                              | `""`                   |
+| `authProxy.clientSecret`                          | OAuth Client secret                                                                                          | `""`                   |
+| `authProxy.cookieSecret`                          | Secret used by oauth2-proxy to encrypt any credentials                                                       | `""`                   |
 | `authProxy.existingOauth2Secret`                  | Name of an existing secret to use for Kubeapps credentials                                                   | `""`                   |
 | `authProxy.cookieRefresh`                         | Duration after which to refresh the cookie                                                                   | `2m`                   |
 | `authProxy.scope`                                 | OAuth scope specification                                                                                    | `openid email groups`  |

--- a/bitnami/kubeapps/templates/_helpers.tpl
+++ b/bitnami/kubeapps/templates/_helpers.tpl
@@ -173,7 +173,11 @@ Create proxy_pass for the kubeappsapis
 Create name for the secrets related to oauth2_proxy
 */}}
 {{- define "kubeapps.oauth2_proxy-secret.name" -}}
+{{- if .Values.authProxy.existingOauth2Secret -}}
+{{- printf "%s" (tpl .Values.authProxy.existingOauth2Secret $) -}}
+{{- else -}}
 {{- printf "%s-oauth2" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/bitnami/kubeapps/templates/frontend/oauth2-secret.yaml
+++ b/bitnami/kubeapps/templates/frontend/oauth2-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.authProxy.enabled (not .Values.authProxy.external) }}
+{{- if and .Values.authProxy.enabled (not .Values.authProxy.external) (not .Values.authProxy.existingOauth2Secret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1129,7 +1129,7 @@ apprepository:
 authProxy:
   ## @param authProxy.enabled Specifies whether Kubeapps should configure OAuth login/logout
   ##
-  enabled: false
+  enabled: true
   ## Bitnami OAuth2 Proxy image
   ## ref: https://hub.docker.com/r/bitnami/oauth2-proxy/tags/
   ## @param authProxy.image.registry OAuth2 Proxy image registry
@@ -1173,16 +1173,20 @@ authProxy:
   ## @param authProxy.clientSecret OAuth Client secret
   ## NOTE: Mandatory parameters for the internal auth-proxy
   ##
-  provider: ""
-  clientID: ""
-  clientSecret: ""
+  provider: "test"
+  clientID: "test"
+  clientSecret: "test"
   ## @param authProxy.cookieSecret Secret used by oauth2-proxy to encrypt any credentials
   ## NOTE: It must be a particular number of bytes. It's recommended using the following
   ## script to generate a cookieSecret:
   ##   python -c 'import os,base64; print base64.urlsafe_b64encode(os.urandom(16))'
   ## ref: https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#generating-a-cookie-secret
   ##
-  cookieSecret: ""
+  cookieSecret: "test"
+  ## @param authProxy.existingOauth2Secret Name of an existing secret to use for Kubeapps credentials
+  ## `authProxy.provider`, `authProxy.clientID`, `authProxy.clientSecret` will be ignored
+  ##
+  existingOauth2Secret: ""
   ## @param authProxy.cookieRefresh Duration after which to refresh the cookie
   ##
   cookieRefresh: 2m

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1183,8 +1183,8 @@ authProxy:
   ## ref: https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#generating-a-cookie-secret
   ##
   cookieSecret: ""
-  ## @param authProxy.existingOauth2Secret Name of an existing secret to use for Kubeapps credentials
-  ## `authProxy.provider`, `authProxy.clientID`, `authProxy.clientSecret` will be ignored
+  ## @param authProxy.existingOauth2Secret Name of an existing secret containing the OAuth client secrets, it should contain the keys clientID, clientSecret, and cookieSecret
+  ##  If set, the values `authProxy.provider`, `authProxy.clientID`, `authProxy.clientSecret` will be ignored
   ##
   existingOauth2Secret: ""
   ## @param authProxy.cookieRefresh Duration after which to refresh the cookie

--- a/bitnami/kubeapps/values.yaml
+++ b/bitnami/kubeapps/values.yaml
@@ -1129,7 +1129,7 @@ apprepository:
 authProxy:
   ## @param authProxy.enabled Specifies whether Kubeapps should configure OAuth login/logout
   ##
-  enabled: true
+  enabled: false
   ## Bitnami OAuth2 Proxy image
   ## ref: https://hub.docker.com/r/bitnami/oauth2-proxy/tags/
   ## @param authProxy.image.registry OAuth2 Proxy image registry
@@ -1173,16 +1173,16 @@ authProxy:
   ## @param authProxy.clientSecret OAuth Client secret
   ## NOTE: Mandatory parameters for the internal auth-proxy
   ##
-  provider: "test"
-  clientID: "test"
-  clientSecret: "test"
+  provider: ""
+  clientID: ""
+  clientSecret: ""
   ## @param authProxy.cookieSecret Secret used by oauth2-proxy to encrypt any credentials
   ## NOTE: It must be a particular number of bytes. It's recommended using the following
   ## script to generate a cookieSecret:
   ##   python -c 'import os,base64; print base64.urlsafe_b64encode(os.urandom(16))'
   ## ref: https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#generating-a-cookie-secret
   ##
-  cookieSecret: "test"
+  cookieSecret: ""
   ## @param authProxy.existingOauth2Secret Name of an existing secret to use for Kubeapps credentials
   ## `authProxy.provider`, `authProxy.clientID`, `authProxy.clientSecret` will be ignored
   ##


### PR DESCRIPTION
Signed-off-by: Celia Garcia Marquez <gcelia@vmware.com>

### Description of the change

After looking at the changes on this [PR](https://github.com/bitnami/charts/pull/14423), I considered opening a new suggestion that is a bit more standard to our templates.

Inspired by #14423 

### Benefits

Allow to use existing secret from authProxy.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
