### PR TITLE
[bitnami/spring-cloud-dataflow] Removes hibernated dialect

### DIFF
--- a/bitnami/spring-cloud-dataflow/Chart.yaml
+++ b/bitnami/spring-cloud-dataflow/Chart.yaml
@@ -39,4 +39,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-dataflow
   - https://github.com/bitnami/containers/tree/main/bitnami/spring-cloud-skipper
   - https://dataflow.spring.io/
-version: 15.0.1
+version: 15.0.2

--- a/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
+++ b/bitnami/spring-cloud-dataflow/templates/_helpers.tpl
@@ -318,17 +318,6 @@ Return the RabbitMQ host
 {{- end -}}
 
 {{/*
-Return the Hibernate dialect
-*/}}
-{{- define "scdf.database.hibernate.dialect" -}}
-  {{- if .Values.mariadb.enabled -}}
-    {{- printf "org.hibernate.dialect.MariaDB102Dialect" -}}
-  {{- else -}}
-    {{- .Values.externalDatabase.hibernateDialect -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
 Compile all warnings into a single message, and call fail.
 */}}
 {{- define "scdf.validateValues" -}}

--- a/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/server/configmap.yaml
@@ -93,12 +93,11 @@ data:
           {{- end }}
         task:
           closecontextEnabled: true
-      {{- $hibernateDialect := include "scdf.database.hibernate.dialect" .  }}
-      {{- if $hibernateDialect }}
+      {{- if .Values.externalDatabase.hibernateDialect }}
       jpa:
         properties:
           hibernate:
-            dialect: {{ $hibernateDialect }}
+            dialect: {{- printf "%s" .Values.externalDatabase.hibernateDialect -}}
       {{- end }}
       datasource:
         url: '{{ include "scdf.database.dataflow.url" . }}'

--- a/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
+++ b/bitnami/spring-cloud-dataflow/templates/skipper/configmap.yaml
@@ -108,12 +108,11 @@ data:
                     {{- if .Values.deployer.imagePullPolicy }}
                     imagePullPolicy: {{ .Values.deployer.imagePullPolicy }}
                     {{- end }}
-      {{- $hibernateDialect := include "scdf.database.hibernate.dialect" .  }}
-      {{- if $hibernateDialect }}
+      {{- if .Values.externalDatabase.hibernateDialect }}
       jpa:
         properties:
           hibernate:
-            dialect: {{ $hibernateDialect }}
+            dialect: {{- printf "%s" .Values.externalDatabase.hibernateDialect -}}
       {{- end }}
       datasource:
         url: '{{ include "scdf.database.skipper.url" . }}'

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -1,5 +1,3 @@
-
-
 ## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value

--- a/bitnami/spring-cloud-dataflow/values.yaml
+++ b/bitnami/spring-cloud-dataflow/values.yaml
@@ -1,3 +1,5 @@
+
+
 ## @section Global parameters
 ## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

With the new container image spring-cloud-dataflow v2.10, the mysql dialect is not needed and causing an error in the skipper pod.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
