### PR TITLE
[bitnami/wordpress] fix: Wordpress ingress bad indentation

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wordpress
   - https://wordpress.org/
-version: 15.2.32
+version: 15.2.33

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -52,7 +52,7 @@ spec:
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
         {{- if or (.Values.ingress.tlsWwwPrefix) (eq (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/from-to-www-redirect") "true" ) }}
-          - {{ print "www.%s" .Values.ingress.hostname }}
+        - {{ print "www.%s" .Values.ingress.hostname }}
         {{- end }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}


### PR DESCRIPTION
Fixed a problem that made `Values.ingress.tlsWwwPrefix` or `nginx.ingress.kubernetes.io/from-to-www-redirect` break the ingress creation

### Description of the change

Change made for the wordpress chart and especially for the ingress part.
The ingress section wasn't working when setting `Values.ingress.tlsWwwPrefix` to `true` or when setting `nginx.ingress.kubernetes.io/from-to-www-redirect` in the ingress annotation

### Benefits

Make the ingress resource deployable when enabling `Values.ingress.tlsWwwPrefix` to `true` or when setting `nginx.ingress.kubernetes.io/from-to-www-redirect` in the ingress annotation.

### Possible drawbacks

I think not applicable

### Applicable issues

N/A

### Additional information

Nothing else

### Checklist


- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)