### PR TITLE
[bitnami/mastodon] Update default Admin email

### DIFF
--- a/.vib/mastodon/cypress/cypress.json
+++ b/.vib/mastodon/cypress/cypress.json
@@ -1,6 +1,6 @@
 {
   "env": {
-    "username": "vib-user@gmail.com",
+    "username": "vib-user@changeme.com",
     "password": "bitnami!1234"
   },
   "hosts": {

--- a/.vib/mastodon/vib-publish.json
+++ b/.vib/mastodon/vib-publish.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/mastodon"
         },
-        "runtime_parameters": "YWRtaW5FbWFpbDogInZpYi11c2VyQGdtYWlsLmNvbSIKYWRtaW5QYXNzd29yZDogImJpdG5hbWkhMTIzNCIKCndlYkRvbWFpbjogYml0bmFtaS1tYXN0b2Rvbi5teQoKc2VydmljZUFjY291bnQ6CiAgY3JlYXRlOiB0cnVlCiAgYXV0b21vdW50U2VydmljZUFjY291bnRUb2tlbjogdHJ1ZQoKd2ViOgogIGNvbnRhaW5lclBvcnRzOgogICAgaHR0cDogODEyMwogIGNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICAgIGVuYWJsZWQ6IHRydWUKICAgIHJ1bkFzVXNlcjogMTAwMgogICAgY2FwYWJpbGl0aWVzOgogICAgICBkcm9wOiBbIkFMTCJdCiAgcG9kU2VjdXJpdHlDb250ZXh0OgogICAgZW5hYmxlZDogdHJ1ZQogICAgZnNHcm91cDogMTAwMgogICAgc2VjY29tcFByb2ZpbGU6CiAgICAgIHR5cGU6ICJSdW50aW1lRGVmYXVsdCIKICBzZXJ2aWNlOgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDg1MDAKCnN0cmVhbWluZzoKICBzZXJ2aWNlOgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDg2MDAKCmFwYWNoZToKICBlbmFibGVkOiB0cnVlCiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDgwCgpwb3N0Z3Jlc3FsOgogIGVuYWJsZWQ6IHRydWUKICBwcmltYXJ5OgogICAgc2VydmljZToKICAgICAgcG9ydHM6CiAgICAgICAgcG9zdGdyZXNxbDogOTM5MwoKbWluaW86CiAgZW5hYmxlZDogdHJ1ZQogIHNlcnZpY2U6CiAgICBwb3J0czoKICAgICAgYXBpOiA4MDExCgpyZWRpczoKICBlbmFibGVkOiB0cnVlCiAgbWFzdGVyOgogICAgc2VydmljZToKICAgICAgcG9ydHM6CiAgICAgICAgcmVkaXM6IDY4MDAKCmVsYXN0aWNzZWFyY2g6CiAgZW5hYmxlZDogdHJ1ZQogIHNlcnZpY2U6CiAgICBwb3J0czoKICAgICAgcmVzdEFQSTogNzc3Nwo=",
+        "runtime_parameters": "YWRtaW5FbWFpbDogInZpYi11c2VyQGNoYW5nZW1lLmNvbSIKYWRtaW5QYXNzd29yZDogImJpdG5hbWkhMTIzNCIKCndlYkRvbWFpbjogYml0bmFtaS1tYXN0b2Rvbi5teQoKc2VydmljZUFjY291bnQ6CiAgY3JlYXRlOiB0cnVlCiAgYXV0b21vdW50U2VydmljZUFjY291bnRUb2tlbjogdHJ1ZQoKd2ViOgogIGNvbnRhaW5lclBvcnRzOgogICAgaHR0cDogODEyMwogIGNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICAgIGVuYWJsZWQ6IHRydWUKICAgIHJ1bkFzVXNlcjogMTAwMgogICAgY2FwYWJpbGl0aWVzOgogICAgICBkcm9wOiBbIkFMTCJdCiAgcG9kU2VjdXJpdHlDb250ZXh0OgogICAgZW5hYmxlZDogdHJ1ZQogICAgZnNHcm91cDogMTAwMgogICAgc2VjY29tcFByb2ZpbGU6CiAgICAgIHR5cGU6ICJSdW50aW1lRGVmYXVsdCIKICBzZXJ2aWNlOgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDg1MDAKCnN0cmVhbWluZzoKICBzZXJ2aWNlOgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDg2MDAKCmFwYWNoZToKICBlbmFibGVkOiB0cnVlCiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDgwCgpwb3N0Z3Jlc3FsOgogIGVuYWJsZWQ6IHRydWUKICBwcmltYXJ5OgogICAgc2VydmljZToKICAgICAgcG9ydHM6CiAgICAgICAgcG9zdGdyZXNxbDogOTM5MwoKbWluaW86CiAgZW5hYmxlZDogdHJ1ZQogIHNlcnZpY2U6CiAgICBwb3J0czoKICAgICAgYXBpOiA4MDExCgpyZWRpczoKICBlbmFibGVkOiB0cnVlCiAgbWFzdGVyOgogICAgc2VydmljZToKICAgICAgcG9ydHM6CiAgICAgICAgcmVkaXM6IDY4MDAKCmVsYXN0aWNzZWFyY2g6CiAgZW5hYmxlZDogdHJ1ZQogIHNlcnZpY2U6CiAgICBwb3J0czoKICAgICAgcmVzdEFQSTogNzc3Nwo=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -59,7 +59,7 @@
             "endpoint": "lb-mastodon-apache-http",
             "app_protocol": "HTTP",
             "env": {
-              "user": "vib-user@gmail.com",
+              "user": "vib-user@changeme.com",
               "password": "bitnami!1234"
             }
           }

--- a/.vib/mastodon/vib-verify.json
+++ b/.vib/mastodon/vib-verify.json
@@ -22,7 +22,7 @@
           "url": "{SHA_ARCHIVE}",
           "path": "/bitnami/mastodon"
         },
-        "runtime_parameters": "YWRtaW5FbWFpbDogInZpYi11c2VyQGdtYWlsLmNvbSIKYWRtaW5QYXNzd29yZDogImJpdG5hbWkhMTIzNCIKCndlYkRvbWFpbjogYml0bmFtaS1tYXN0b2Rvbi5teQoKc2VydmljZUFjY291bnQ6CiAgY3JlYXRlOiB0cnVlCiAgYXV0b21vdW50U2VydmljZUFjY291bnRUb2tlbjogdHJ1ZQoKd2ViOgogIGNvbnRhaW5lclBvcnRzOgogICAgaHR0cDogODEyMwogIGNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICAgIGVuYWJsZWQ6IHRydWUKICAgIHJ1bkFzVXNlcjogMTAwMgogICAgY2FwYWJpbGl0aWVzOgogICAgICBkcm9wOiBbIkFMTCJdCiAgcG9kU2VjdXJpdHlDb250ZXh0OgogICAgZW5hYmxlZDogdHJ1ZQogICAgZnNHcm91cDogMTAwMgogICAgc2VjY29tcFByb2ZpbGU6CiAgICAgIHR5cGU6ICJSdW50aW1lRGVmYXVsdCIKICBzZXJ2aWNlOgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDg1MDAKCnN0cmVhbWluZzoKICBzZXJ2aWNlOgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDg2MDAKCmFwYWNoZToKICBlbmFibGVkOiB0cnVlCiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDgwCgpwb3N0Z3Jlc3FsOgogIGVuYWJsZWQ6IHRydWUKICBwcmltYXJ5OgogICAgc2VydmljZToKICAgICAgcG9ydHM6CiAgICAgICAgcG9zdGdyZXNxbDogOTM5MwoKbWluaW86CiAgZW5hYmxlZDogdHJ1ZQogIHNlcnZpY2U6CiAgICBwb3J0czoKICAgICAgYXBpOiA4MDExCgpyZWRpczoKICBlbmFibGVkOiB0cnVlCiAgbWFzdGVyOgogICAgc2VydmljZToKICAgICAgcG9ydHM6CiAgICAgICAgcmVkaXM6IDY4MDAKCmVsYXN0aWNzZWFyY2g6CiAgZW5hYmxlZDogdHJ1ZQogIHNlcnZpY2U6CiAgICBwb3J0czoKICAgICAgcmVzdEFQSTogNzc3Nwo=",
+        "runtime_parameters": "YWRtaW5FbWFpbDogInZpYi11c2VyQGNoYW5nZW1lLmNvbSIKYWRtaW5QYXNzd29yZDogImJpdG5hbWkhMTIzNCIKCndlYkRvbWFpbjogYml0bmFtaS1tYXN0b2Rvbi5teQoKc2VydmljZUFjY291bnQ6CiAgY3JlYXRlOiB0cnVlCiAgYXV0b21vdW50U2VydmljZUFjY291bnRUb2tlbjogdHJ1ZQoKd2ViOgogIGNvbnRhaW5lclBvcnRzOgogICAgaHR0cDogODEyMwogIGNvbnRhaW5lclNlY3VyaXR5Q29udGV4dDoKICAgIGVuYWJsZWQ6IHRydWUKICAgIHJ1bkFzVXNlcjogMTAwMgogICAgY2FwYWJpbGl0aWVzOgogICAgICBkcm9wOiBbIkFMTCJdCiAgcG9kU2VjdXJpdHlDb250ZXh0OgogICAgZW5hYmxlZDogdHJ1ZQogICAgZnNHcm91cDogMTAwMgogICAgc2VjY29tcFByb2ZpbGU6CiAgICAgIHR5cGU6ICJSdW50aW1lRGVmYXVsdCIKICBzZXJ2aWNlOgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDg1MDAKCnN0cmVhbWluZzoKICBzZXJ2aWNlOgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDg2MDAKCmFwYWNoZToKICBlbmFibGVkOiB0cnVlCiAgc2VydmljZToKICAgIHR5cGU6IExvYWRCYWxhbmNlcgogICAgcG9ydHM6CiAgICAgIGh0dHA6IDgwCgpwb3N0Z3Jlc3FsOgogIGVuYWJsZWQ6IHRydWUKICBwcmltYXJ5OgogICAgc2VydmljZToKICAgICAgcG9ydHM6CiAgICAgICAgcG9zdGdyZXNxbDogOTM5MwoKbWluaW86CiAgZW5hYmxlZDogdHJ1ZQogIHNlcnZpY2U6CiAgICBwb3J0czoKICAgICAgYXBpOiA4MDExCgpyZWRpczoKICBlbmFibGVkOiB0cnVlCiAgbWFzdGVyOgogICAgc2VydmljZToKICAgICAgcG9ydHM6CiAgICAgICAgcmVkaXM6IDY4MDAKCmVsYXN0aWNzZWFyY2g6CiAgZW5hYmxlZDogdHJ1ZQogIHNlcnZpY2U6CiAgICBwb3J0czoKICAgICAgcmVzdEFQSTogNzc3Nwo=",
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
@@ -59,7 +59,7 @@
             "endpoint": "lb-mastodon-apache-http",
             "app_protocol": "HTTP",
             "env": {
-              "user": "vib-user@gmail.com",
+              "user": "vib-user@changeme.com",
               "password": "bitnami!1234"
             }
           }

--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -42,4 +42,4 @@ name: mastodon
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mastodon
   - https://github.com/mastodon/mastodon/
-version: 1.0.0
+version: 1.0.1

--- a/bitnami/mastodon/README.md
+++ b/bitnami/mastodon/README.md
@@ -91,23 +91,23 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Mastodon common parameters
 
-| Name                           | Description                                                                    | Value              |
-| ------------------------------ | ------------------------------------------------------------------------------ | ------------------ |
-| `adminUser`                    | Mastodon admin username                                                        | `user`             |
-| `adminEmail`                   | Mastodon admin email                                                           | `user@example.com` |
-| `adminPassword`                | Mastodon admin password                                                        | `""`               |
-| `defaultConfig`                | Default configuration for Mastodon in the form of environment variables        | `""`               |
-| `defaultSecretConfig`          | Default secret configuration for Mastodon in the form of environment variables | `""`               |
-| `extraConfig`                  | Extra configuration for Mastodon in the form of environment variables          | `{}`               |
-| `extraSecretConfig`            | Extra secret configuration for Mastodon in the form of environment variables   | `{}`               |
-| `existingConfigmap`            | The name of an existing ConfigMap with your default configuration for Mastodon | `""`               |
-| `existingSecret`               | The name of an existing Secret with your default configuration for Mastodon    | `""`               |
-| `extraConfigExistingConfigmap` | The name of an existing ConfigMap with your extra configuration for Mastodon   | `""`               |
-| `extraConfigExistingSecret`    | The name of an existing Secret with your extra configuration for Mastodon      | `""`               |
-| `enableSearches`               | Enable the search engine (uses Elasticsearch under the hood)                   | `true`             |
-| `enableS3`                     | Enable the S3 storage engine                                                   | `true`             |
-| `webDomain`                    | Web domain for Mastodon                                                        | `""`               |
-| `s3AliasHost`                  | S3 alias host for Mastodon (will use http://webDomain/bucket if not set)       | `""`               |
+| Name                           | Description                                                                    | Value               |
+| ------------------------------ | ------------------------------------------------------------------------------ | ------------------- |
+| `adminUser`                    | Mastodon admin username                                                        | `user`              |
+| `adminEmail`                   | Mastodon admin email                                                           | `user@changeme.com` |
+| `adminPassword`                | Mastodon admin password                                                        | `""`                |
+| `defaultConfig`                | Default configuration for Mastodon in the form of environment variables        | `""`                |
+| `defaultSecretConfig`          | Default secret configuration for Mastodon in the form of environment variables | `""`                |
+| `extraConfig`                  | Extra configuration for Mastodon in the form of environment variables          | `{}`                |
+| `extraSecretConfig`            | Extra secret configuration for Mastodon in the form of environment variables   | `{}`                |
+| `existingConfigmap`            | The name of an existing ConfigMap with your default configuration for Mastodon | `""`                |
+| `existingSecret`               | The name of an existing Secret with your default configuration for Mastodon    | `""`                |
+| `extraConfigExistingConfigmap` | The name of an existing ConfigMap with your extra configuration for Mastodon   | `""`                |
+| `extraConfigExistingSecret`    | The name of an existing Secret with your extra configuration for Mastodon      | `""`                |
+| `enableSearches`               | Enable the search engine (uses Elasticsearch under the hood)                   | `true`              |
+| `enableS3`                     | Enable the S3 storage engine                                                   | `true`              |
+| `webDomain`                    | Web domain for Mastodon                                                        | `""`                |
+| `s3AliasHost`                  | S3 alias host for Mastodon (will use http://webDomain/bucket if not set)       | `""`                |
 
 
 ### Mastodon Web Parameters
@@ -152,7 +152,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `web.args`                                              | Override default container args (useful when using custom images)                                                        | `[]`             |
 | `web.hostAliases`                                       | Mastodon web pods host aliases                                                                                           | `[]`             |
 | `web.podLabels`                                         | Extra labels for Mastodon web pods                                                                                       | `{}`             |
-
+| `web.podAnnotations`                                    | Annotations for Mastodon web pods                                                                                        | `{}`             |
 | `web.podAffinityPreset`                                 | Pod affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                                  | `""`             |
 | `web.podAntiAffinityPreset`                             | Pod anti-affinity preset. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                             | `soft`           |
 | `web.nodeAffinityPreset.type`                           | Node affinity preset type. Ignored if `web.affinity` is set. Allowed values: `soft` or `hard`                            | `""`             |

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -100,7 +100,7 @@ image:
 adminUser: "user"
 ## @param adminEmail Mastodon admin email
 ##
-adminEmail: "user@example.com"
+adminEmail: "user@changeme.com"
 ## @param adminPassword Mastodon admin password
 ##
 adminPassword: ""


### PR DESCRIPTION
Signed-off-by: Miguel Ruiz <miruiz@vmware.com>

### Description of the change

Starting version 4.0.2-debian-11-r14 (https://github.com/bitnami/containers/pull/19154/files) of the `bitnami/mastodon` image, the email domain `example.com` is no longer supported, as Mastodon blocks it by default.

It is necessary to change the Mastodon admin email, otherwise deploying the chart using default values will fail.

### Benefits

Chart deployment using default values won't fail

### Possible drawbacks

None known.

### Applicable issues

  - related to #14485

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
