### PR TITLE
[bitnami/wordpress] fix: wordpress ingress tls www domain

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wordpress
   - https://wordpress.org/
-version: 15.2.33
+version: 15.2.34

--- a/bitnami/wordpress/templates/ingress.yaml
+++ b/bitnami/wordpress/templates/ingress.yaml
@@ -52,7 +52,7 @@ spec:
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
         {{- if or (.Values.ingress.tlsWwwPrefix) (eq (index .Values.ingress.annotations "nginx.ingress.kubernetes.io/from-to-www-redirect") "true" ) }}
-        - {{ print "www.%s" .Values.ingress.hostname }}
+        - {{ printf "www.%s" .Values.ingress.hostname | quote }}
         {{- end }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
     {{- end }}


### PR DESCRIPTION
### Description of the change
Fixes generation of www domain in wordpress ingress.
Currently it is not rendering.

### Benefits
Ingress will have a www domain if needed.

### Possible drawbacks
Not rendering chart if tls is used.

### Checklist
- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
