### PR TITLE
[bitnami/mongodb] Increase timeout for probes

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.6.5
+version: 13.6.6

--- a/bitnami/mongodb/README.md
+++ b/bitnami/mongodb/README.md
@@ -528,13 +528,13 @@ Refer to the [chart documentation for more information on each of these architec
 | `metrics.livenessProbe.enabled`              | Enable livenessProbe                                                                                                  | `true`                     |
 | `metrics.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                               | `15`                       |
 | `metrics.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                      | `5`                        |
-| `metrics.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                     | `5`                        |
+| `metrics.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                     | `10`                       |
 | `metrics.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                   | `3`                        |
 | `metrics.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                   | `1`                        |
 | `metrics.readinessProbe.enabled`             | Enable readinessProbe                                                                                                 | `true`                     |
 | `metrics.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                              | `5`                        |
 | `metrics.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                     | `5`                        |
-| `metrics.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                    | `1`                        |
+| `metrics.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                    | `10`                       |
 | `metrics.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                  | `3`                        |
 | `metrics.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                  | `1`                        |
 | `metrics.startupProbe.enabled`               | Enable startupProbe                                                                                                   | `false`                    |

--- a/bitnami/mongodb/values.yaml
+++ b/bitnami/mongodb/values.yaml
@@ -1960,7 +1960,7 @@ metrics:
     enabled: true
     initialDelaySeconds: 15
     periodSeconds: 5
-    timeoutSeconds: 5
+    timeoutSeconds: 10
     failureThreshold: 3
     successThreshold: 1
   ## Metrics exporter readiness probe
@@ -1976,7 +1976,7 @@ metrics:
     enabled: true
     initialDelaySeconds: 5
     periodSeconds: 5
-    timeoutSeconds: 1
+    timeoutSeconds: 10
     failureThreshold: 3
     successThreshold: 1
   ## Slow starting containers can be protected through startup probes


### PR DESCRIPTION
Signed-off-by: David Gomez <dgomezleon@vmware.com>

### Description of the change

Increase  `timeoutSeconds` for livenesProbe and readinessProbe after detecting several cases where they are very small.

### Benefits

Avoid issues when enabling the metrics with default values.

### Possible drawbacks

None.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #14515 and #12717 

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
