### PR TITLE
[bitnami/wordpress] Fix `kubectl` flag in `NOTES.txt`

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wordpress
   - https://wordpress.org/
-version: 15.2.34
+version: 15.2.35

--- a/bitnami/wordpress/templates/NOTES.txt
+++ b/bitnami/wordpress/templates/NOTES.txt
@@ -55,7 +55,7 @@ To access your WordPress site from outside the cluster follow the steps below:
   NOTE: It may take a few minutes for the LoadBalancer IP to be available.
         Watch the status with: 'kubectl get svc --namespace {{ .Release.Namespace }} -w {{ include "common.names.fullname" . }}'
 
-   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} --include "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "common.names.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
    echo "WordPress URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.ports.http }}{{ end }}/"
    echo "WordPress Admin URL: http://$SERVICE_IP{{- if ne $port "80" }}:{{ .Values.service.ports.http }}{{ end }}/admin"
 


### PR DESCRIPTION
### Description of the change

The instructions given in the `NOTES.txt` file for the `wordpress` chart were incorrect. They contained a non-existent `--include` flag for the `kubectl` command. Trying to create a release from this chart prints the following message:

```
...
To access your WordPress site from outside the cluster follow the steps below:

1. Get the WordPress URL by running these commands:

  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
        Watch the status with: 'kubectl get svc --namespace wordpress -w my-blog-wordpress'

   export SERVICE_IP=$(kubectl get svc --namespace wordpress my-blog-wordpress --include "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}")
   echo "WordPress URL: http://$SERVICE_IP/"
   echo "WordPress Admin URL: http://$SERVICE_IP/admin"
...
```

Running the suggested command (`kubectl get svc --namespace wordpress my-blog-wordpress --include "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}"`) gives the following error:

```
error: unknown flag: --include
See 'kubectl get --help' for usage.
```

The correct flag is probably `--template`, so the correct command would be: `kubectl get svc --namespace wordpress my-blog-wordpress --template "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}"`.
Running the above command does, in fact, give the correct output.

This patch replaces the `--include` flag with the `--template` flag in the `NOTES.txt` file for the `wordpress` chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
