### PR TITLE
[bitnami/mongodb] Change endpoint for metrics liveness and readiness probes

### DIFF
--- a/bitnami/mongodb/Chart.yaml
+++ b/bitnami/mongodb/Chart.yaml
@@ -26,4 +26,4 @@ name: mongodb
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mongodb
   - https://mongodb.org
-version: 13.6.6
+version: 13.6.7

--- a/bitnami/mongodb/templates/hidden/statefulset.yaml
+++ b/bitnami/mongodb/templates/hidden/statefulset.yaml
@@ -443,7 +443,7 @@ spec:
           {{- else if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /
               port: metrics
           {{- end }}
           {{- if .Values.metrics.customReadinessProbe }}
@@ -451,7 +451,7 @@ spec:
           {{- else if .Values.metrics.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /
               port: metrics
           {{- end }}
           {{- if .Values.metrics.customStartupProbe }}

--- a/bitnami/mongodb/templates/replicaset/statefulset.yaml
+++ b/bitnami/mongodb/templates/replicaset/statefulset.yaml
@@ -450,7 +450,7 @@ spec:
           {{- else if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /
               port: metrics
           {{- end }}
           {{- if .Values.metrics.customReadinessProbe }}
@@ -458,7 +458,7 @@ spec:
           {{- else if .Values.metrics.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /
               port: metrics
           {{- end }}
           {{- if .Values.metrics.customStartupProbe }}

--- a/bitnami/mongodb/templates/standalone/dep-sts.yaml
+++ b/bitnami/mongodb/templates/standalone/dep-sts.yaml
@@ -382,7 +382,7 @@ spec:
           {{- else if .Values.metrics.livenessProbe.enabled }}
           livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.livenessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /
               port: metrics
           {{- end }}
           {{- if .Values.metrics.customReadinessProbe }}
@@ -390,7 +390,7 @@ spec:
           {{- else if .Values.metrics.readinessProbe.enabled }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.metrics.readinessProbe "enabled") "context" $) | nindent 12 }}
             httpGet:
-              path: /metrics
+              path: /
               port: metrics
           {{- end }}
           {{- if .Values.metrics.customStartupProbe }}


### PR DESCRIPTION
Fixes bitnami/charts#14466

Signed-off-by: Anselm Eberhardt <aeberhardt@dg-i.net>

### Description of the change

This switches the endpoints for readiness and liveness probes of the metrics container back to `/`.
The readiness and liveness probes currently query `/metrics` due to upstream changes in the mongodb-exporter v0.33.0: https://github.com/bitnami/charts/pull/11398

### Benefits

The readiness and liveness probes of the metrics container should no longer run into timeouts when the response time of the current endpoint `/metrics` starts increasing due to the amount of data in the database.

### Possible drawbacks

None.

### Applicable issues

  - fixes #14466 

### Additional information

Release [v0.36.0 of the mongodb-exporter](https://github.com/percona/mongodb_exporter/releases/tag/v0.36.0) added [a handler for /](https://github.com/percona/mongodb_exporter/pull/530) and this version is already distributed since the [bitnami/mongodb chart v13.6.3](https://github.com/bitnami/charts/commit/5a71013c500b5dd87cac5691f1a7e864569220e4#diff-356163fdc04375a6cab87502496007e834cb52ccaae2d00b1dce924b6bd46ba8R1877).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
