### PR TITLE
[bitnami/postgresql] skip empty annotations and initContainers

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
-version: 12.1.12
+version: 12.1.13

--- a/bitnami/postgresql/templates/primary/metrics-svc.yaml
+++ b/bitnami/postgresql/templates/primary/metrics-svc.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- if or .Values.commonAnnotations .Values.metrics.service.annotations }}
   annotations:
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -16,6 +17,7 @@ metadata:
     {{- if .Values.metrics.service.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.service.annotations "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   sessionAffinity: {{ .Values.metrics.service.sessionAffinity }}

--- a/bitnami/postgresql/templates/primary/statefulset.yaml
+++ b/bitnami/postgresql/templates/primary/statefulset.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- if .Values.primary.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.primary.labels "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- if or .Values.commonAnnotations .Values.primary.annotations }}
   annotations:
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -19,6 +20,7 @@ metadata:
     {{- if .Values.primary.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.primary.annotations "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   replicas: 1
   serviceName: {{ include "postgresql.primary.svc.headless" . }}
@@ -39,6 +41,7 @@ spec:
         {{- if .Values.primary.podLabels }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.primary.podLabels "context" $ ) | nindent 8 }}
         {{- end }}
+      {{- if or (include "postgresql.primary.createConfigmap" .) (include "postgresql.primary.createExtendedConfigmap" .) .Values.primary.podAnnotations }}
       annotations:
         {{- if (include "postgresql.primary.createConfigmap" .) }}
         checksum/configuration: {{ include (print $.Template.BasePath "/primary/configmap.yaml") . | sha256sum }}
@@ -49,6 +52,7 @@ spec:
         {{- if .Values.primary.podAnnotations }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.primary.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
+      {{- end }}
     spec:
       {{- if .Values.primary.extraPodSpec }}
       {{- include "common.tplvalues.render" (dict "value" .Values.primary.extraPodSpec "context" $) | nindent 6 }}
@@ -89,6 +93,7 @@ spec:
       {{- end }}
       hostNetwork: {{ .Values.primary.hostNetwork }}
       hostIPC: {{ .Values.primary.hostIPC }}
+      {{- if or (and .Values.tls.enabled (not .Values.volumePermissions.enabled)) (and .Values.volumePermissions.enabled (or .Values.primary.persistence.enabled .Values.shmVolume.enabled)) .Values.primary.initContainers }}
       initContainers:
         {{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
         - name: copy-certs
@@ -177,6 +182,7 @@ spec:
         {{- if .Values.primary.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.primary.initContainers "context" $ ) | nindent 8 }}
         {{- end }}
+      {{- end }}
       containers:
         - name: postgresql
           image: {{ include "postgresql.image" . }}

--- a/bitnami/postgresql/templates/primary/svc.yaml
+++ b/bitnami/postgresql/templates/primary/svc.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
     app.kubernetes.io/component: primary
+  {{- if or .Values.commonAnnotations .Values.primary.service.annotations }}
   annotations:
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -15,6 +16,7 @@ metadata:
     {{- if .Values.primary.service.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.primary.service.annotations "context" $) | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.primary.service.type }}
   {{- if or (eq .Values.primary.service.type "LoadBalancer") (eq .Values.primary.service.type "NodePort") }}

--- a/bitnami/postgresql/templates/read/metrics-svc.yaml
+++ b/bitnami/postgresql/templates/read/metrics-svc.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- if or .Values.commonAnnotations .Values.metrics.service.annotations }}
   annotations:
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -16,6 +17,7 @@ metadata:
     {{- if .Values.metrics.service.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.service.annotations "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   sessionAffinity: {{ .Values.metrics.service.sessionAffinity }}

--- a/bitnami/postgresql/templates/read/statefulset.yaml
+++ b/bitnami/postgresql/templates/read/statefulset.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- if .Values.readReplicas.labels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.readReplicas.labels "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- if or .Values.commonAnnotations .Values.readReplicas.annotations }}
   annotations:
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -20,6 +21,7 @@ metadata:
     {{- if .Values.readReplicas.annotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.readReplicas.annotations "context" $ ) | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   replicas: {{ .Values.readReplicas.replicaCount }}
   serviceName: {{ include "postgresql.readReplica.svc.headless" . }}
@@ -40,6 +42,7 @@ spec:
         {{- if .Values.readReplicas.podLabels }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.readReplicas.podLabels "context" $ ) | nindent 8 }}
         {{- end }}
+      {{- if or (include "postgresql.readReplicas.createExtendedConfigmap" .) .Values.readReplicas.podAnnotations }}
       annotations:
         {{- if (include "postgresql.readReplicas.createExtendedConfigmap" .) }}
         checksum/extended-configuration: {{ include (print $.Template.BasePath "/read/extended-configmap.yaml") . | sha256sum }}
@@ -47,6 +50,7 @@ spec:
         {{- if .Values.readReplicas.podAnnotations }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.readReplicas.podAnnotations "context" $ ) | nindent 8 }}
         {{- end }}
+      {{- end }}
     spec:
       {{- if .Values.readReplicas.extraPodSpec }}
       {{- include "common.tplvalues.render" (dict "value" .Values.readReplicas.extraPodSpec "context" $) | nindent 6 }}
@@ -87,6 +91,7 @@ spec:
       {{- end }}
       hostNetwork: {{ .Values.readReplicas.hostNetwork }}
       hostIPC: {{ .Values.readReplicas.hostIPC }}
+      {{- if or (and .Values.tls.enabled (not .Values.volumePermissions.enabled)) (and .Values.volumePermissions.enabled (or .Values.readReplicas.persistence.enabled .Values.shmVolume.enabled)) .Values.readReplicas.initContainers }}
       initContainers:
         {{- if and .Values.tls.enabled (not .Values.volumePermissions.enabled) }}
         - name: copy-certs
@@ -175,6 +180,7 @@ spec:
         {{- if .Values.readReplicas.initContainers }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.readReplicas.initContainers "context" $ ) | nindent 8 }}
         {{- end }}
+      {{- end }}
       containers:
         - name: postgresql
           image: {{ include "postgresql.image" . }}

--- a/bitnami/postgresql/templates/read/svc.yaml
+++ b/bitnami/postgresql/templates/read/svc.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
     app.kubernetes.io/component: read
+  {{- if or .Values.commonAnnotations .Values.readReplicas.service.annotations }}
   annotations:
     {{- if .Values.commonAnnotations }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
@@ -16,6 +17,7 @@ metadata:
     {{- if .Values.readReplicas.service.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.readReplicas.service.annotations "context" $) | nindent 4 }}
     {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.readReplicas.service.type }}
   {{- if or (eq .Values.readReplicas.service.type "LoadBalancer") (eq .Values.readReplicas.service.type "NodePort") }}


### PR DESCRIPTION
Signed-off-by: bakito <github@bakito.ch>


This PR prevents empty annotations  and initContainers from being added to the generated resources.

### Description of the change

Annotation -  and initContainer values are checked if set and only added if non empty

### Benefits

- The generated annotations and initContainers are not empty
- Cli checks with kyverno and it's default Pos Security Policies will not fail due to incomplete resoruces. https://kyverno.io/policies/pod-security/

### Possible drawbacks

-

### Applicable issues

-

### Additional information

-

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
