### PR TITLE
[bitnami/argo-cd] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/argo-cd/Chart.yaml
+++ b/bitnami/argo-cd/Chart.yaml
@@ -30,4 +30,4 @@ sources:
   - https://github.com/argoproj/argo-cd/
   - https://github.com/bitnami/containers/tree/main/bitnami/dex
   - https://github.com/dexidp/dex
-version: 4.4.4
+version: 4.4.5

--- a/bitnami/argo-cd/templates/server/grpc-tls-secret.yaml
+++ b/bitnami/argo-cd/templates/server/grpc-tls-secret.yaml
@@ -22,12 +22,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.server.ingressGrpc.tls .Values.server.ingressGrpc.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.server.ingressGrpc.hostname }}
 {{- $ca := genCA "server-ca" 365 }}
 {{- $cert := genSignedCert .Values.server.ingressGrpc.hostname nil (list .Values.server.ingressGrpc.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.server.ingressGrpc.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
@@ -39,8 +40,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}

--- a/bitnami/argo-cd/templates/server/tls-secret.yaml
+++ b/bitnami/argo-cd/templates/server/tls-secret.yaml
@@ -22,12 +22,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.server.ingress.tls .Values.server.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.server.ingress.hostname }}
 {{- $ca := genCA "server-ca" 365 }}
 {{- $cert := genSignedCert .Values.server.ingress.hostname nil (list .Values.server.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.server.ingress.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: server
@@ -39,8 +40,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
