### PR TITLE
[bitnami/cassandra] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/cassandra/Chart.yaml
+++ b/bitnami/cassandra/Chart.yaml
@@ -23,4 +23,4 @@ name: cassandra
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/cassandra
   - http://cassandra.apache.org
-version: 10.0.1
+version: 10.0.2

--- a/bitnami/cassandra/templates/_helpers.tpl
+++ b/bitnami/cassandra/templates/_helpers.tpl
@@ -220,39 +220,6 @@ otherwise it generates a random value.
     {{- end }}
 {{- end -}}
 
-
-{{/*
-Returns the available TLS Cert in an existing secret (if it exists),
-otherwise it generates a new one.
-*/}}
-{{- define "cassandra.getTlsCertStrFromSecret" }}
-    {{- $len := (default 365 .Length) | int -}}
-    {{- $ca := "" -}}
-    {{- $crt := "" -}}
-    {{- $key := "" -}}
-    {{- $tlsCert := (lookup "v1" "Secret" .Release.Namespace (printf "%s-%s" (include "common.names.fullname" .) "crt" | trunc 63 | trimSuffix "-")).data -}}
-
-    {{- if $tlsCert }}
-        {{- $ca = (get $tlsCert "ca.crt" | b64dec) -}}
-        {{- $crt = (get $tlsCert "tls.crt" | b64dec) -}}
-        {{- $key = (get $tlsCert "tls.key" | b64dec) -}}
-    {{- else -}}
-        {{- $caFull := genCA "cassandra-ca" 365 }}
-        {{- $fullname := include "common.names.fullname" . }}
-        {{- $releaseNamespace := .Release.Namespace }}
-        {{- $clusterDomain := .Values.clusterDomain }}
-        {{- $serviceName := include "common.names.fullname" . }}
-        {{- $headlessServiceName := printf "%s-headless" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
-        {{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) "localhost" "127.0.0.1" $fullname }}
-        {{- $cert := genSignedCert $fullname nil $altNames 365 $caFull }}
-        {{- $ca = $caFull.Cert -}}
-        {{- $crt = $cert.Cert -}}
-        {{- $key = $cert.Key -}}
-    {{- end -}}
-
-    {{- printf "%s###%s###%s" $ca $crt $key -}}
-{{- end }}
-
 {{/*
 Get the metrics config map name.
 */}}

--- a/bitnami/cassandra/templates/tls-secret.yaml
+++ b/bitnami/cassandra/templates/tls-secret.yaml
@@ -1,14 +1,17 @@
 {{- if (include "cassandra.createTlsSecret" . ) }}
-
-{{- $tlsCertStr := regexSplit "###" (include "cassandra.getTlsCertStrFromSecret" .) -1 }}
-{{- $ca := index $tlsCertStr 0 }}
-{{- $crt := index $tlsCertStr 1 }}
-{{- $key := index $tlsCertStr 2 }}
-
+{{- $secretName := printf "%s-crt" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $ca := genCA "cassandra-ca" 365 }}
+{{- $fullname := include "common.names.fullname" . }}
+{{- $releaseNamespace := .Release.Namespace }}
+{{- $clusterDomain := .Values.clusterDomain }}
+{{- $serviceName := include "common.names.fullname" . }}
+{{- $headlessServiceName := printf "%s-headless" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) "localhost" "127.0.0.1" $fullname }}
+{{- $cert := genSignedCert $fullname nil $altNames 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-crt" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -19,7 +22,7 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca | b64enc | quote }}
-  tls.crt: {{ $crt | b64enc | quote }}
-  tls.key: {{ $key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
