### PR TITLE
[bitnami/contour] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -25,4 +25,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/containers/tree/main/bitnami/contour
   - https://projectcontour.io
-version: 10.2.0
+version: 10.2.1

--- a/bitnami/contour/templates/default-backend/tls-secrets.yaml
+++ b/bitnami/contour/templates/default-backend/tls-secrets.yaml
@@ -21,12 +21,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.ingress.hostname }}
 {{- $ca := genCA "odoo-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  name: {{ $secretName }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -37,8 +38,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
