### PR TITLE
[bitnami/fluentd] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/fluentd/Chart.yaml
+++ b/bitnami/fluentd/Chart.yaml
@@ -25,4 +25,4 @@ name: fluentd
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/fluentd
   - https://www.fluentd.org/
-version: 5.5.12
+version: 5.5.13

--- a/bitnami/fluentd/templates/tls-certs.yaml
+++ b/bitnami/fluentd/templates/tls-certs.yaml
@@ -27,12 +27,13 @@ data:
 {{- $headlessServiceName := printf "%s-headless" ( include "common.names.fullname" . ) | trunc 63 | trimSuffix "-" }}
 {{- $aggregatorServiceName := printf "%s-aggregator" ( include "common.names.fullname" . ) | trunc 63 | trimSuffix "-"  }}
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $aggregatorServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $aggregatorServiceName $releaseNamespace $clusterDomain) $fullname }}
-{{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
+{{- $cert := genSignedCert $fullname nil $altNames 365 $ca }}
 {{- if .Values.aggregator.enabled }}
+{{- $secretName := printf "%s-agg-crt" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-agg-crt" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -43,19 +44,20 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $crt.Cert | b64enc | quote }}
-  tls.key: {{ $crt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- if .Values.forwarder.enabled }}
+{{- $secretName := printf "%s-fwd-crt" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- $forwarderServiceName := printf "%s-forwarder" ( include "common.names.fullname" . ) | trunc 63 | trimSuffix "-" }}
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $forwarderServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $forwarderServiceName $releaseNamespace $clusterDomain) $fullname }}
-{{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
+{{- $cert := genSignedCert $fullname nil $altNames 365 $ca }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-fwd-crt" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -66,8 +68,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $crt.Cert | b64enc | quote }}
-  tls.key: {{ $crt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
