### PR TITLE
[bitnami/harbor] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -36,4 +36,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registry
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registryctl
   - https://goharbor.io/
-version: 16.3.1
+version: 16.3.2

--- a/bitnami/harbor/templates/ingress/tls-secret.yaml
+++ b/bitnami/harbor/templates/ingress/tls-secret.yaml
@@ -20,11 +20,12 @@ data:
 ---
 {{- end }}
 {{- if and .Values.ingress.core.tls .Values.ingress.core.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.ingress.core.hostname }}
 {{- $cert := genSignedCert .Values.ingress.core.hostname nil (list .Values.ingress.core.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.ingress.core.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -35,9 +36,9 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 ---
 {{- end }}
 {{- if .Values.notary.enabled }}
@@ -61,11 +62,12 @@ data:
 ---
 {{- end }}
 {{- if and .Values.ingress.notary.tls .Values.ingress.notary.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.ingress.notary.hostname }}
 {{- $cert := genSignedCert .Values.ingress.notary.hostname nil (list .Values.ingress.notary.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.ingress.notary.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -76,9 +78,9 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/bitnami/harbor/templates/internal/internal-crt-secret.yaml
+++ b/bitnami/harbor/templates/internal/internal-crt-secret.yaml
@@ -2,12 +2,13 @@
 {{- $ca := genCA "harbor-internal-ca" 365 }}
 
 {{- if not .Values.core.tls.existingSecret }}
-{{- $coreCN := include "harbor.core" . }}
-{{- $coreCrt := genSignedCert $coreCN (list "127.0.0.1") (list "localhost" $coreCN) 365 $ca }}
+{{- $secretName := printf "%s-crt" (include "harbor.core" .) }}
+{{- $cn := include "harbor.core" . }}
+{{- $cert := genSignedCert $cn (list "127.0.0.1") (list "localhost" $cn) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "harbor.core" . }}-crt
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -16,18 +17,19 @@ metadata:
     app.kubernetes.io/component: core
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $coreCrt.Cert | b64enc | quote }}
-  tls.key: {{ $coreCrt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- if not .Values.jobservice.tls.existingSecret }}
-{{- $jsCN := include "harbor.jobservice" . }}
-{{- $jsCrt := genSignedCert $jsCN nil (list $jsCN) 365 $ca }}
+{{- $secretName := printf "%s-crt" (include "harbor.jobservice" .) }}
+{{- $cn := include "harbor.jobservice" . }}
+{{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "harbor.jobservice" . }}-crt
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -36,18 +38,19 @@ metadata:
     app.kubernetes.io/component: jobservice
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $jsCrt.Cert | b64enc | quote }}
-  tls.key: {{ $jsCrt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- if not .Values.registry.tls.existingSecret }}
-{{- $regCN := include "harbor.registry" . }}
-{{- $regCrt := genSignedCert $regCN nil (list $regCN) 365 $ca }}
+{{- $secretName := printf "%s-crt" (include "harbor.registry" .) }}
+{{- $cn := include "harbor.registry" . }}
+{{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "harbor.registry" . }}-crt
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -56,18 +59,19 @@ metadata:
     app.kubernetes.io/component: registry
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $regCrt.Cert | b64enc | quote }}
-  tls.key: {{ $regCrt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- if not .Values.portal.tls.existingSecret }}
-{{- $portalCN := include "harbor.portal" . }}
-{{- $portalCrt := genSignedCert $portalCN nil (list $portalCN) 365 $ca }}
+{{- $secretName := printf "%s-crt" (include "harbor.portal" .) }}
+{{- $cn := include "harbor.portal" . }}
+{{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "harbor.portal" . }}-crt
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -76,18 +80,19 @@ metadata:
     app.kubernetes.io/component: portal
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $portalCrt.Cert | b64enc | quote }}
-  tls.key: {{ $portalCrt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- if and .Values.chartmuseum.enabled (not .Values.chartmuseum.tls.existingSecret) }}
-{{- $chartCN := include "harbor.chartmuseum" . }}
-{{- $chartCrt := genSignedCert $chartCN nil (list $chartCN) 365 $ca }}
+{{- $secretName := printf "%s-crt" (include "harbor-chartmuseum" .) }}
+{{- $cn := include "harbor.chartmuseum" . }}
+{{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "harbor.chartmuseum" . }}-crt
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -96,19 +101,20 @@ metadata:
     app.kubernetes.io/component: chartmuseum
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $chartCrt.Cert | b64enc | quote }}
-  tls.key: {{ $chartCrt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 
 {{- if and .Values.trivy.enabled (not .Values.trivy.tls.existingSecret) }}
-{{- $trivyCN := include "harbor.trivy" . }}
-{{- $trivyCrt := genSignedCert $trivyCN nil (list $trivyCN) 365 $ca }}
+{{- $secretName := printf "%s-crt" (include "harbor.trivy" .) }}
+{{- $cn := include "harbor.trivy" . }}
+{{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "harbor.trivy" . }}-crt
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -117,8 +123,8 @@ metadata:
     app.kubernetes.io/component: trivy
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $trivyCrt.Cert | b64enc | quote }}
-  tls.key: {{ $trivyCrt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}

--- a/bitnami/harbor/templates/nginx/tls-secret.yaml
+++ b/bitnami/harbor/templates/nginx/tls-secret.yaml
@@ -1,10 +1,11 @@
 {{- if (include "harbor.autoGenCertForNginx" .) }}
+{{- $secretName := printf "%s" (include "harbor.nginx" .) }}
 {{- $ca := genCA "harbor-ca" 365 }}
 {{- $cn := (required "The \"nginx.tls.commonName\" is required!" .Values.nginx.tls.commonName) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "harbor.nginx" . }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -17,14 +18,11 @@ metadata:
 type: Opaque
 data:
   {{- if regexMatch `^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$` $cn }}
-  {{- $cert := genSignedCert $cn (list $cn) nil 365 $ca }}
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  {{- $cert = genSignedCert $cn (list $cn) nil 365 $ca }}
   {{- else }}
-  {{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  {{- $cert = genSignedCert $cn nil (list $cn) 365 $ca }}
   {{- end }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}

--- a/bitnami/harbor/templates/nginx/tls-secret.yaml
+++ b/bitnami/harbor/templates/nginx/tls-secret.yaml
@@ -17,10 +17,9 @@ metadata:
   {{- end }}
 type: Opaque
 data:
+  {{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}
   {{- if regexMatch `^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$` $cn }}
   {{- $cert = genSignedCert $cn (list $cn) nil 365 $ca }}
-  {{- else }}
-  {{- $cert = genSignedCert $cn nil (list $cn) 365 $ca }}
   {{- end }}
   tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
   tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}

--- a/bitnami/harbor/templates/notary/notary-secret.yaml
+++ b/bitnami/harbor/templates/notary/notary-secret.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.notary.enabled }}
+{{- $secretName := printf "%s" (include "harbor.notary-server" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "harbor.notary-server" . }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -18,9 +19,9 @@ data:
   {{- $ca := genCA "harbor-notary-ca" 365 }}
   {{- $altNames := list (printf "%s.%s.svc" (include "harbor.notary-signer" .) .Release.Namespace | quote) (printf "%s.%s" (include "harbor.notary-signer" .) .Release.Namespace | quote) (include "harbor.notary-signer" .) -}}
   {{- $cert := genSignedCert (include "harbor.notary-signer" .) nil $altNames 365 $ca }}
-  notary-signer-ca.crt: {{ $ca.Cert | b64enc | quote }}
-  notary-signer.crt: {{ $cert.Cert | b64enc | quote }}
-  notary-signer.key: {{ $cert.Key | b64enc | quote }}
+  notary-signer.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "notary-signer.crt" "defaultValue" $cert.Cert "context" $) }}
+  notary-signer.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "notary-signer.key" "defaultValue" $cert.Key "context" $) }}
+  notary-signer-ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "notary-signer-ca.crt" "defaultValue" $ca.Cert "context" $) }}
   {{- end }}
   server-config.postgres.json: {{ tpl (.Files.Get "conf/notary-server.json") . | b64enc }}
   signer-config.postgres.json: {{ tpl (.Files.Get "conf/notary-signer.json") . | b64enc }}


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
