### PR TITLE
[bitnami/keycloak] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/keycloak/Chart.yaml
+++ b/bitnami/keycloak/Chart.yaml
@@ -26,4 +26,4 @@ name: keycloak
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/keycloak
   - https://github.com/keycloak/keycloak
-version: 13.0.2
+version: 13.0.3

--- a/bitnami/keycloak/templates/tls-secret.yaml
+++ b/bitnami/keycloak/templates/tls-secret.yaml
@@ -21,11 +21,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.ingress.hostname }}
 {{- $ca := genCA "keycloak-ca" 365 }}
 {{- $cert := genSignedCert (tpl .Values.ingress.hostname .) nil (list (tpl .Values.ingress.hostname .)) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
+  name: {{ $secretName }}
   name: {{ printf "%s-tls" (tpl .Values.ingress.hostname .) }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
@@ -37,12 +39,13 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}
 {{- if (include "keycloak.createTlsSecret" $) }}
+{{- $secretName := printf "%s-crt" (include "common.names.fullname" .) }}
 {{- $ca := genCA "keycloak-ca" 365 }}
 {{- $releaseNamespace := include "common.names.namespace" . }}
 {{- $clusterDomain := .Values.clusterDomain }}
@@ -50,7 +53,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-crt" (include "common.names.fullname" .) }}
+  name: {{ $secretName }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: keycloak
@@ -65,9 +68,9 @@ data:
   {{- $replicaCount := int .Values.replicaCount }}
   {{- $svcName := include "common.names.fullname" . }}
   {{- $altNames := list (printf "%s.%s.svc.%s" $svcName $releaseNamespace $clusterDomain) (printf "%s.%s" $svcName $releaseNamespace) $svcName }}
-  {{- $crt := genSignedCert $svcName nil $altNames 365 $ca }}
-  tls.crt: {{ $crt.Cert | b64enc | quote }}
-  tls.key: {{ $crt.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  {{- $cert := genSignedCert $svcName nil $altNames 365 $ca }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
