### PR TITLE
[bitnami/kiam] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/kiam/Chart.yaml
+++ b/bitnami/kiam/Chart.yaml
@@ -23,4 +23,4 @@ name: kiam
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kiam
   - https://github.com/uswitch/kiam
-version: 1.1.7
+version: 1.1.8

--- a/bitnami/kiam/templates/_helpers.tpl
+++ b/bitnami/kiam/templates/_helpers.tpl
@@ -41,9 +41,9 @@ Generate certificates for kiam agent and server
 {{- $ca := .ca | default (genCA "kiam-ca" 365) -}}
 {{- $_ := set . "ca" $ca -}}
 {{- $cert := genSignedCert "Kiam Agent" nil nil 365 $ca -}}
-{{ .Values.agent.tlsCerts.caFileName }}: {{ $ca.Cert | b64enc }}
-{{ .Values.agent.tlsCerts.certFileName }}: {{ $cert.Cert | b64enc }}
-{{ .Values.agent.tlsCerts.keyFileName }}: {{ $cert.Key | b64enc }}
+{{ .Values.agent.tlsCerts.certFileName }}: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" .Values.agent.tlsCerts.certFileName "defaultValue" $cert.Cert "context" $) }}
+{{ .Values.agent.tlsCerts.keyFileName }}: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" .Values.agent.tlsCerts.keyFileName "defaultValue" $cert.Key "context" $) }}
+{{ .Values.agent.tlsCerts.caFileName }}: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" .Values.agent.tlsCerts.caFileName "defaultValue" $ca.Cert "context" $) }}
 {{- end -}}
 
 {{- define "kiam.server.gen-certs" -}}
@@ -51,9 +51,9 @@ Generate certificates for kiam agent and server
 {{- $ca := .ca | default (genCA "kiam-ca" 365) -}}
 {{- $_ := set . "ca" $ca -}}
 {{- $cert := genSignedCert "Kiam Server" (list "127.0.0.1") $altNames 365 $ca -}}
-{{ .Values.server.tlsCerts.caFileName }}: {{ $ca.Cert | b64enc }}
-{{ .Values.server.tlsCerts.certFileName }}: {{ $cert.Cert | b64enc }}
-{{ .Values.server.tlsCerts.keyFileName }}: {{ $cert.Key | b64enc }}
+{{ .Values.server.tlsCerts.certFileName }}: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" .Values.server.tlsCerts.certFileName "defaultValue" $cert.Cert "context" $) }}
+{{ .Values.server.tlsCerts.keyFileName }}: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" .Values.server.tlsCerts.keyFileName "defaultValue" $cert.Key "context" $) }}
+{{ .Values.server.tlsCerts.caFileName }}: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" .Values.server.tlsCerts.caFileName "defaultValue" $ca.Cert "context" $) }}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
