### PR TITLE
[bitnami/postgresql] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/postgresql/Chart.yaml
+++ b/bitnami/postgresql/Chart.yaml
@@ -26,4 +26,4 @@ name: postgresql
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
-version: 12.1.12
+version: 12.1.13

--- a/bitnami/postgresql/templates/tls-secrets.yaml
+++ b/bitnami/postgresql/templates/tls-secrets.yaml
@@ -1,4 +1,5 @@
 {{- if (include "postgresql.createTlsSecret" . ) }}
+{{- $secretName := printf "%s-crt" (include "common.names.fullname" .) }}
 {{- $ca := genCA "postgresql-ca" 365 }}
 {{- $fullname := include "common.names.fullname" . }}
 {{- $releaseNamespace := .Release.Namespace }}
@@ -6,11 +7,11 @@
 {{- $primaryHeadlessServiceName := include "postgresql.primary.svc.headless" . }}
 {{- $readHeadlessServiceName := include "postgresql.readReplica.svc.headless" . }}
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $fullname $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $fullname $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $primaryHeadlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $primaryHeadlessServiceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $readHeadlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $readHeadlessServiceName $releaseNamespace $clusterDomain) $fullname }}
-{{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
+{{- $cert := genSignedCert $fullname nil $altNames 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-crt" (include "common.names.fullname" .) }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -21,7 +22,7 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $crt.Cert | b64enc | quote }}
-  tls.key: {{ $crt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
