### PR TITLE
[bitnami/solr] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/solr/Chart.yaml
+++ b/bitnami/solr/Chart.yaml
@@ -27,4 +27,4 @@ name: solr
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/solr
   - https://lucene.apache.org/solr/
-version: 7.1.2
+version: 7.1.3

--- a/bitnami/solr/templates/ingress-tls-secrets.yaml
+++ b/bitnami/solr/templates/ingress-tls-secrets.yaml
@@ -21,12 +21,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.ingress.hostname | trunc 63 | trimSuffix "-" }}
 {{- $ca := genCA "solr-ca" 365 }}
 {{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.ingress.hostname | trunc 63 | trimSuffix "-" }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -37,9 +38,9 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}
 

--- a/bitnami/solr/templates/tls-secrets.yaml
+++ b/bitnami/solr/templates/tls-secrets.yaml
@@ -1,15 +1,16 @@
 {{- if (include "solr.createTlsSecret" .) }}
+{{- $secretName := printf "%s-crt" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- $ca := genCA "solr-ca" 365 }}
 {{- $releaseNamespace := .Release.Namespace }}
 {{- $clusterDomain := .Values.clusterDomain }}
 {{- $serviceName := include "common.names.fullname" . }}
 {{- $headlessServiceName := printf "%s-headless" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) $serviceName }}
-{{- $crt := genSignedCert $serviceName nil $altNames 365 $ca }}
+{{- $cert := genSignedCert $serviceName nil $altNames 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-crt" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ $secretName }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: solr
     {{- if .Values.commonLabels }}
@@ -21,7 +22,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $crt.Cert | b64enc | quote }}
-  tls.key: {{ $crt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
