### PR TITLE
[bitnami/thanos] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 12.0.0
+version: 12.0.1

--- a/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
+++ b/bitnami/thanos/templates/bucketweb/tls-secrets.yaml
@@ -22,12 +22,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.bucketweb.ingress.tls .Values.bucketweb.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.bucketweb.ingress.hostname }}
 {{- $ca := genCA "thanos-bucketweb-ca" 365 }}
 {{- $cert := genSignedCert .Values.bucketweb.ingress.hostname nil (list .Values.bucketweb.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.bucketweb.ingress.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: bucketweb
@@ -39,8 +40,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/compactor/tls-secrets.yaml
+++ b/bitnami/thanos/templates/compactor/tls-secrets.yaml
@@ -22,12 +22,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.compactor.ingress.tls .Values.compactor.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.compactor.ingress.hostname }}
 {{- $ca := genCA "thanos-compactor-ca" 365 }}
 {{- $cert := genSignedCert .Values.compactor.ingress.hostname nil (list .Values.compactor.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.compactor.ingress.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: compactor
@@ -39,8 +40,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/http-certs-secret.yaml
+++ b/bitnami/thanos/templates/http-certs-secret.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.https.enabled (not .Values.https.existingSecret) }}
+{{- $secretName := printf "%s-http-certs-secret" (include "common.names.fullname" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-http-certs-secret" (include "common.names.fullname" .) }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -17,10 +18,10 @@ data:
   {{- $ca := genCA "thanos-ca" 365 }}
   {{- $hostname := printf "%s" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  {{ .Values.https.certFilename }}: {{ $cert.Cert | b64enc | quote }}
-  {{ .Values.https.keyFilename }}: {{ $cert.Key | b64enc | quote }}
+  {{ .Values.https.certFilename }}: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" .Values.https.certFilename "defaultValue" $cert.Cert "context" $) }}
+  {{ .Values.https.keyFilename }}: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" .Values.https.keyFilename "defaultValue" $cert.Key "context" $) }}
   {{- if .Values.https.clientAuthType }}
-  {{ .Values.https.caFilename }}: {{ $ca.Cert | b64enc | quote }}
+  {{ .Values.https.caFilename }}: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" .Values.https.caFilename "defaultValue" $ca.Cert "context" $) }}
   {{- end }}
   {{- else }}
   {{ .Values.https.certFilename }}: {{ required "'https.cert' is required when 'https.enabled=true'" .Values.https.cert | b64enc | quote }}
@@ -29,4 +30,4 @@ data:
   {{ .Values.https.caFilename }}: {{ required "'https.ca' is required when 'https.clientAuthType' is provided" .Values.https.ca | b64enc | quote }}
   {{- end }}
   {{- end }}
-{{ end }}
+{{- end }}

--- a/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
+++ b/bitnami/thanos/templates/query-frontend/tls-secrets.yaml
@@ -22,12 +22,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.queryFrontend.ingress.tls .Values.queryFrontend.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.queryFrontend.ingress.hostname }}
 {{- $ca := genCA "thanos-queryFrontend-ca" 365 }}
 {{- $cert := genSignedCert .Values.queryFrontend.ingress.hostname nil (list .Values.queryFrontend.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.queryFrontend.ingress.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query-frontend
@@ -39,8 +40,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/query/grpc-client-tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/grpc-client-tls-secrets.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.query.enabled .Values.query.grpc.client.tls.enabled (not .Values.query.grpc.client.tls.existingSecret) }}
+{{- $secretName := printf "%s-query-grpc-client" (include "common.names.fullname" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-query-grpc-client" (include "common.names.fullname" .) }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
@@ -18,12 +19,12 @@ data:
   {{- $ca := genCA "thanos-query-grpc-client-ca" 365 }}
   {{- $hostname := printf "%s-query-grpc-client" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  tls-cert: {{ $cert.Cert | b64enc | quote }}
-  tls-key: {{ $cert.Key | b64enc | quote }}
-  ca-cert: {{ $ca.Cert | b64enc | quote }}
+  tls-cert: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls-cert" "defaultValue" $cert.Cert "context" $) }}
+  tls-key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls-key" "defaultValue" $cert.Key "context" $) }}
+  ca-cert: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca-cert" "defaultValue" $ca.Cert "context" $) }}
   {{- else }}
-  tls-cert: {{ .Values.query.grpc.client.tls.cert | b64enc | quote }}
-  tls-key: {{ .Values.query.grpc.client.tls.key | b64enc | quote }}
-  ca-cert : {{ .Values.query.grpc.client.tls.ca | b64enc | quote }}
+  tls-cert: {{ required "'query.grpc.client.tls.cert' is required when 'query.grpc.client.tls=true'" .Values.query.grpc.client.tls.cert | b64enc | quote }}
+  tls-key: {{ required "'query.grpc.client.tls.key' is required when 'query.grpc.client.tls=true'" .Values.query.grpc.client.tls.key | b64enc | quote }}
+  ca-cert: {{ required "'query.grpc.client.tls.ca' is required when 'query.grpc.client.tls=true'" .Values.query.grpc.client.tls.ca | b64enc | quote }}
   {{- end }}
 {{ end }}

--- a/bitnami/thanos/templates/query/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/grpc-server-tls-secrets.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.query.enabled .Values.query.grpc.server.tls.enabled (not .Values.query.grpc.server.tls.existingSecret) }}
+{{- $secretName := printf "%s-query-grpc-server" (include "common.names.fullname" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-query-grpc-server" (include "common.names.fullname" .) }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
@@ -18,12 +19,12 @@ data:
   {{- $ca := genCA "thanos-query-grpc-server-ca" 365 }}
   {{- $hostname := printf "%s-query-grpc-server" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  tls-cert: {{ $cert.Cert | b64enc | quote }}
-  tls-key: {{ $cert.Key | b64enc | quote }}
-  ca-cert: {{ $ca.Cert | b64enc | quote }}
+  tls-cert: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls-cert" "defaultValue" $cert.Cert "context" $) }}
+  tls-key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls-key" "defaultValue" $cert.Key "context" $) }}
+  ca-cert: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca-cert" "defaultValue" $ca.Cert "context" $) }}
   {{- else }}
-  tls-cert: {{ .Values.query.grpc.server.tls.cert | b64enc | quote }}
-  tls-key: {{ .Values.query.grpc.server.tls.key | b64enc | quote }}
-  ca-cert : {{ .Values.query.grpc.server.tls.ca | b64enc | quote }}
+  tls-cert: {{ required "'query.grpc.server.tls.cert' is required when 'query.grpc.server.tls=true'" .Values.query.grpc.server.tls.cert | b64enc | quote }}
+  tls-key: {{ required "'query.grpc.server.tls.key' is required when 'query.grpc.server.tls=true'" .Values.query.grpc.server.tls.key | b64enc | quote }}
+  ca-cert: {{ required "'query.grpc.server.tls.ca' is required when 'query.grpc.server.tls=true'" .Values.query.grpc.server.tls.ca | b64enc | quote }}
   {{- end }}
 {{ end }}

--- a/bitnami/thanos/templates/query/tls-secrets-grpc.yaml
+++ b/bitnami/thanos/templates/query/tls-secrets-grpc.yaml
@@ -22,12 +22,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.query.ingress.grpc.tls .Values.query.ingress.grpc.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.query.ingress.grpc.hostname }}
 {{- $ca := genCA "thanos-query-ca" 365 }}
 {{- $cert := genSignedCert .Values.query.ingress.grpc.hostname nil (list .Values.query.ingress.grpc.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.query.ingress.grpc.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
@@ -39,8 +40,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/query/tls-secrets.yaml
+++ b/bitnami/thanos/templates/query/tls-secrets.yaml
@@ -22,12 +22,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.query.ingress.tls .Values.query.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.query.ingress.hostname }}
 {{- $ca := genCA "thanos-query-ca" 365 }}
 {{- $cert := genSignedCert .Values.query.ingress.hostname nil (list .Values.query.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.query.ingress.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: query
@@ -39,8 +40,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/receive/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/receive/grpc-server-tls-secrets.yaml
@@ -1,9 +1,10 @@
 
 {{- if and .Values.receive.enabled .Values.receive.grpc.server.tls.enabled (not .Values.receive.grpc.server.tls.existingSecret) }}
+{{- $secretName := printf "%s-receive-grpc-server" (include "common.names.fullname" .) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-receive-grpc-server" (include "common.names.fullname" .) }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
@@ -19,12 +20,12 @@ data:
   {{- $ca := genCA "thanos-receive-grpc-server-ca" 365 }}
   {{- $hostname := printf "%s-receive-grpc-server" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  tls-cert: {{ $cert.Cert | b64enc | quote }}
-  tls-key: {{ $cert.Key | b64enc | quote }}
-  ca-cert: {{ $ca.Cert | b64enc | quote }}
+  tls-cert: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls-cert" "defaultValue" $cert.Cert "context" $) }}
+  tls-key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls-key" "defaultValue" $cert.Key "context" $) }}
+  ca-cert: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca-cert" "defaultValue" $ca.Cert "context" $) }}
   {{- else }}
-  tls-cert: {{ .Values.receive.grpc.server.tls.cert | b64enc | quote }}
-  tls-key: {{ .Values.receive.grpc.server.tls.key | b64enc | quote }}
-  ca-cert : {{ .Values.receive.grpc.server.tls.ca | b64enc | quote }}
+  tls-cert: {{ required "'receive.grpc.server.tls.cert' is required when 'receive.grpc.server.tls.enabled=true'" .Values.receive.grpc.server.tls.cert | b64enc | quote }}
+  tls-key: {{ required "'receive.grpc.server.tls.key' is required when 'receive.grpc.server.tls.enabled=true'" .Values.receive.grpc.server.tls.key | b64enc | quote }}
+  ca-cert: {{ required "'receive.grpc.server.tls.ca' is required when 'receive.grpc.server.tls.enabled=true'" .Values.receive.grpc.server.tls.ca | b64enc | quote }}
   {{- end }}
 {{ end }}

--- a/bitnami/thanos/templates/receive/tls-secrets.yaml
+++ b/bitnami/thanos/templates/receive/tls-secrets.yaml
@@ -22,12 +22,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.receive.ingress.tls .Values.receive.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.receive.ingress.hostname }}
 {{- $ca := genCA "thanos-receive-ca" 365 }}
 {{- $cert := genSignedCert .Values.receive.ingress.hostname nil (list .Values.receive.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.receive.ingress.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: receive
@@ -39,8 +40,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/ruler/tls-secrets.yaml
+++ b/bitnami/thanos/templates/ruler/tls-secrets.yaml
@@ -22,12 +22,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.ruler.ingress.tls .Values.ruler.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.ruler.ingress.hostname }}
 {{- $ca := genCA "thanos-ruler-ca" 365 }}
 {{- $cert := genSignedCert .Values.ruler.ingress.hostname nil (list .Values.ruler.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.ruler.ingress.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: ruler
@@ -39,8 +40,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- end }}

--- a/bitnami/thanos/templates/storegateway/grpc-server-tls-secrets.yaml
+++ b/bitnami/thanos/templates/storegateway/grpc-server-tls-secrets.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.storegateway.enabled .Values.storegateway.grpc.server.tls.enabled (not .Values.storegateway.grpc.server.tls.existingSecret) }}
+{{- $secretName := printf "%s-store-grpc-server" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-store-grpc-server" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
@@ -18,12 +19,12 @@ data:
   {{- $ca := genCA "thanos-store-grpc-server-ca" 365 }}
   {{- $hostname := printf "%s-store-grpc-server" (include "common.names.fullname" .) }}
   {{- $cert := genSignedCert $hostname nil (list $hostname) 365 $ca }}
-  tls-cert: {{ $cert.Cert | b64enc | quote }}
-  tls-key: {{ $cert.Key | b64enc | quote }}
-  ca-cert: {{ $ca.Cert | b64enc | quote }}
+  tls-cert: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls-cert" "defaultValue" $cert.Cert "context" $) }}
+  tls-key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls-key" "defaultValue" $cert.Key "context" $) }}
+  ca-cert: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca-cert" "defaultValue" $ca.Cert "context" $) }}
   {{- else }}
-  tls-cert: {{ .Values.storegateway.grpc.server.tls.cert | b64enc | quote }}
-  tls-key: {{ .Values.storegateway.grpc.server.tls.key | b64enc | quote }}
-  ca-cert : {{ .Values.storegateway.grpc.server.tls.ca | b64enc | quote }}
+  tls-cert: {{ required "'storegateway.grpc.server.tls.cert' is required when 'storegateway.grpc.server.tls.enabled=true'" .Values.storegateway.grpc.server.tls.cert | b64enc | quote }}
+  tls-key: {{ required "'storegateway.grpc.server.tls.key' is required when 'storegateway.grpc.server.tls.enabled=true'" .Values.storegateway.grpc.server.tls.key | b64enc | quote }}
+  ca-cert: {{ required "'storegateway.grpc.server.tls.ca' is required when 'storegateway.grpc.server.tls.enabled=true'" .Values.storegateway.grpc.server.tls.ca | b64enc | quote }}
   {{- end }}
 {{ end }}

--- a/bitnami/thanos/templates/storegateway/tls-secrets.yaml
+++ b/bitnami/thanos/templates/storegateway/tls-secrets.yaml
@@ -22,12 +22,13 @@ data:
 {{- end }}
 {{- end }}
 {{- if and .Values.storegateway.ingress.tls .Values.storegateway.ingress.selfSigned }}
+{{- $secretName := printf "%s-tls" .Values.storegateway.ingress.hostname }}
 {{- $ca := genCA "thanos-storegateway-ca" 365 }}
 {{- $cert := genSignedCert .Values.storegateway.ingress.hostname nil (list .Values.storegateway.ingress.hostname) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tls" .Values.storegateway.ingress.hostname }}
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: storegateway
@@ -39,8 +40,8 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ $cert.Cert | b64enc | quote }}
-  tls.key: {{ $cert.Key | b64enc | quote }}
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
