### PR TITLE
[bitnami/zookeeper] Don't regenerate self-signed certs on upgrade

### DIFF
--- a/bitnami/zookeeper/Chart.yaml
+++ b/bitnami/zookeeper/Chart.yaml
@@ -21,4 +21,4 @@ name: zookeeper
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/zookeeper
   - https://zookeeper.apache.org/
-version: 11.1.1
+version: 11.1.2

--- a/bitnami/zookeeper/templates/tls-secrets.yaml
+++ b/bitnami/zookeeper/templates/tls-secrets.yaml
@@ -1,4 +1,5 @@
 {{- if (include "zookeeper.client.createTlsSecret" .) }}
+{{- $secretName := printf "%s-client-crt" (include "common.names.fullname" .) }}
 {{- $ca := genCA "zookeeper-client-ca" 365 }}
 {{- $releaseNamespace := .Release.Namespace }}
 {{- $clusterDomain := .Values.clusterDomain }}
@@ -6,11 +7,11 @@
 {{- $serviceName := include "common.names.fullname" . }}
 {{- $headlessServiceName := printf "%s-headless" (include "common.names.fullname" .) }}
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) "127.0.0.1" "localhost" $fullname }}
-{{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
+{{- $cert := genSignedCert $fullname nil $altNames 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.names.fullname" . }}-client-crt
+  name: {{ $secretName }}
   namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -21,11 +22,12 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $crt.Cert | b64enc | quote }}
-  tls.key: {{ $crt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
 {{- if (include "zookeeper.quorum.createTlsSecret" .) }}
+{{- $secretName := printf "%s-quorum-crt" (include "common.names.fullname" .) }}
 {{- $ca := genCA "zookeeper-quorum-ca" 365 }}
 {{- $releaseNamespace := .Release.Namespace }}
 {{- $clusterDomain := .Values.clusterDomain }}
@@ -33,12 +35,12 @@ data:
 {{- $serviceName := include "common.names.fullname" . }}
 {{- $headlessServiceName := printf "%s-headless" (include "common.names.fullname" .) }}
 {{- $altNames := list (printf "*.%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $headlessServiceName $releaseNamespace $clusterDomain) (printf "*.%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) (printf "%s.%s.svc.%s" $serviceName $releaseNamespace $clusterDomain) $fullname }}
-{{- $crt := genSignedCert $fullname nil $altNames 365 $ca }}
+{{- $cert := genSignedCert $fullname nil $altNames 365 $ca }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "common.names.fullname" . }}-quorum-crt
+  name: {{ $secretName }}
   namespace: {{ template "zookeeper.namespace" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -49,7 +51,7 @@ metadata:
   {{- end }}
 type: kubernetes.io/tls
 data:
-  ca.crt: {{ $ca.Cert | b64enc | quote }}
-  tls.crt: {{ $crt.Cert | b64enc | quote }}
-  tls.key: {{ $crt.Key | b64enc | quote }}
+  tls.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.crt" "defaultValue" $cert.Cert "context" $) }}
+  tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
+  ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}


### PR DESCRIPTION
### Description of the change

Don't recreate self-signed certificates on when upgrading the chart.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
