### PR TITLE
[bitnami/postgresql-ha] Service annotations (#14523)

### DIFF
--- a/bitnami/postgresql-ha/Chart.yaml
+++ b/bitnami/postgresql-ha/Chart.yaml
@@ -29,4 +29,4 @@ name: postgresql-ha
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/postgresql
   - https://www.postgresql.org/
-version: 11.0.1
+version: 11.1.0

--- a/bitnami/postgresql-ha/README.md
+++ b/bitnami/postgresql-ha/README.md
@@ -7,7 +7,7 @@ This PostgreSQL cluster solution includes the PostgreSQL replication manager, an
 [Overview of PostgreSQL HA](https://www.postgresql.org/)
 
 Trademarks: This software listing is packaged by Bitnami. The respective trademarks mentioned in the offering are owned by the respective companies, and use of them does not imply any affiliation or endorsement.
-                           
+
 ## TL;DR
 
 ```console
@@ -103,6 +103,7 @@ Additionally, if `persistence.resourcePolicy` is set to `keep`, you should manua
 | `postgresql.image.debug`                                     | Specify if debug logs should be enabled                                                                                                                                                                       | `false`                     |
 | `postgresql.labels`                                          | Labels to add to the StatefulSet. Evaluated as template                                                                                                                                                       | `{}`                        |
 | `postgresql.podLabels`                                       | Labels to add to the StatefulSet pods. Evaluated as template                                                                                                                                                  | `{}`                        |
+| `postgresql.serviceAnnotations`                              | Provide any additional annotations for PostgreSQL service                                                                                                                                                     | `{}`                        |
 | `postgresql.replicaCount`                                    | Number of replicas to deploy. Use an odd number. Having 3 replicas is the minimum to get quorum when promoting a new primary.                                                                                 | `3`                         |
 | `postgresql.updateStrategy.type`                             | Postgresql statefulset strategy type                                                                                                                                                                          | `RollingUpdate`             |
 | `postgresql.containerPorts.postgresql`                       | PostgreSQL port                                                                                                                                                                                               | `5432`                      |
@@ -338,6 +339,7 @@ Additionally, if `persistence.resourcePolicy` is set to `keep`, you should manua
 | `pgpool.labels`                                          | Labels to add to the Deployment. Evaluated as template                                                                                   | `{}`                 |
 | `pgpool.podLabels`                                       | Labels to add to the pods. Evaluated as template                                                                                         | `{}`                 |
 | `pgpool.serviceLabels`                                   | Labels to add to the service. Evaluated as template                                                                                      | `{}`                 |
+| `pgpool.serviceAnnotations`                              | Provide any additional annotations for Pgpool service                                                                                    | `{}`                 |
 | `pgpool.customLivenessProbe`                             | Override default liveness probe                                                                                                          | `{}`                 |
 | `pgpool.customReadinessProbe`                            | Override default readiness probe                                                                                                         | `{}`                 |
 | `pgpool.customStartupProbe`                              | Override default startup probe                                                                                                           | `{}`                 |
@@ -567,7 +569,7 @@ Additionally, if `persistence.resourcePolicy` is set to `keep`, you should manua
 | `service.extraPorts`                                  | Extra ports to expose (normally used with the `sidecar` value)                                | `[]`         |
 | `service.sessionAffinity`                             | Control where client requests go, to the same pod or round-robin                              | `None`       |
 | `service.sessionAffinityConfig`                       | Additional settings for the sessionAffinity                                                   | `{}`         |
-| `service.annotations`                                 | Provide any additional annotations for PostgreSQL service                                     | `{}`         |
+| `service.annotations`                                 | Provide any additional annotations both for PostgreSQL and Pgpool services                    | `{}`         |
 | `service.serviceLabels`                               | Labels for PostgreSQL service                                                                 | `{}`         |
 | `networkPolicy.enabled`                               | Enable NetworkPolicy                                                                          | `false`      |
 | `networkPolicy.allowExternal`                         | Don't require client label for connections                                                    | `true`       |

--- a/bitnami/postgresql-ha/templates/pgpool/service.yaml
+++ b/bitnami/postgresql-ha/templates/pgpool/service.yaml
@@ -11,8 +11,11 @@ metadata:
     {{- if .Values.pgpool.serviceLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.pgpool.serviceLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  {{- if or .Values.pgpool.serviceAnnotations .Values.service.annotations .Values.commonAnnotations }}
   annotations:
+    {{- if .Values.pgpool.serviceAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.pgpool.serviceAnnotations "context" $) | nindent 4 }}
+    {{- end }}
     {{- if .Values.service.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
     {{- end }}

--- a/bitnami/postgresql-ha/templates/postgresql/service.yaml
+++ b/bitnami/postgresql-ha/templates/postgresql/service.yaml
@@ -11,8 +11,11 @@ metadata:
     {{- if .Values.service.serviceLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.service.serviceLabels "context" $ ) | nindent 4 }}
     {{- end }}
-  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  {{- if or .Values.postgresql.serviceAnnotations .Values.service.annotations .Values.commonAnnotations }}
   annotations:
+    {{- if .Values.postgresql.serviceAnnotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.postgresql.serviceAnnotations "context" $) | nindent 4 }}
+    {{- end }}
     {{- if .Values.service.annotations }}
     {{- include "common.tplvalues.render" (dict "value" .Values.service.annotations "context" $) | nindent 4 }}
     {{- end }}

--- a/bitnami/postgresql-ha/values.yaml
+++ b/bitnami/postgresql-ha/values.yaml
@@ -124,6 +124,9 @@ postgresql:
   ## @param postgresql.podLabels Labels to add to the StatefulSet pods. Evaluated as template
   ##
   podLabels: {}
+  ## @param postgresql.serviceAnnotations Provide any additional annotations for PostgreSQL service
+  ##
+  serviceAnnotations: {}
   ## @param postgresql.replicaCount Number of replicas to deploy. Use an odd number. Having 3 replicas is the minimum to get quorum when promoting a new primary.
   ##
   replicaCount: 3
@@ -1049,6 +1052,9 @@ pgpool:
   ## @param pgpool.serviceLabels Labels to add to the service. Evaluated as template
   ##
   serviceLabels: {}
+  ## @param pgpool.serviceAnnotations Provide any additional annotations for Pgpool service
+  ##
+  serviceAnnotations: {}
   ## @param pgpool.customLivenessProbe Override default liveness probe
   ##
   customLivenessProbe: {}
@@ -1891,7 +1897,7 @@ service:
   ##   clientIP:
   ##     timeoutSeconds: 300
   sessionAffinityConfig: {}
-  ## @param service.annotations Provide any additional annotations for PostgreSQL service
+  ## @param service.annotations Provide any additional annotations both for PostgreSQL and Pgpool services
   ##
   annotations: {}
   ## @param service.serviceLabels Labels for PostgreSQL service


### PR DESCRIPTION

### Description of the change
Add `pgpool.annotations` and `postgresql.annotations` to the chart values.

### Benefits
It allows Pgpool and PostgreSQL service annotations to be separately configurable. As the pgpool service can be set to `LoadBalancer`, it may need a different set of annotations than postgresql service that is always `ClusterIP`.

### Possible drawbacks
None, the change is backward compatible. The original `service.annotations` still behaves as before and affects both postgresql and pgpool services, although it should be discouraged to use, especially on AWS with ALB ingress controller, because it may lead to unintentional public exposure of the 5432 port.

### Applicable issues
  - fixes #14523

### Checklist
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
