### PR TITLE
[bitnami/ejbca] Increase tests stability

### DIFF
--- a/.vib/ejbca/cypress/cypress/integration/ejbca_spec.js
+++ b/.vib/ejbca/cypress/cypress/integration/ejbca_spec.js
@@ -16,14 +16,15 @@ it('allows to enrol and verify certificate', () => {
       // Clicking on the button will download the certificate, but Cypress
       // expects the page to be reloaded and fails with a timeout. We manually
       // force the reload to avoid it and then verify that the file was indeed
-      // downloaded.
+      // downloaded. The timeout is high to ensure the file is completely downloaded
+      // before the reload (and avoid flakiness in slow clusters)
       cy.window()
         .document()
         .then(function (doc) {
           doc.addEventListener('click', () => {
             setTimeout(function () {
               doc.location.reload();
-            }, 2000);
+            }, 12000);
           });
 
           cy.contains('input', 'Enroll').click();

--- a/.vib/ejbca/goss/goss-wait.yaml
+++ b/.vib/ejbca/goss/goss-wait.yaml
@@ -1,0 +1,9 @@
+command:
+  # During the initilization process, EJBCA is restarted to apply some settings. It
+  # might happen that GOSS tests are launched precisely when this restart is triggered,
+  # leading to false positives. This ensures some time has passed before proceeding with
+  # the tests, increasing the resiliency.
+  wait-to-be-available:
+    exec: "sleep 120"
+    exit-status: 0
+    timeout: 130000

--- a/.vib/ejbca/vib-publish.json
+++ b/.vib/ejbca/vib-publish.json
@@ -26,7 +26,7 @@
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
-            "name": "M4"
+            "name": "L4"
           }
         }
       },
@@ -47,7 +47,10 @@
             "remote": {
               "workload": "deploy-ejbca"
             },
-            "vars_file": "vars.yaml"
+            "vars_file": "vars.yaml",
+            "wait": {
+              "file": "goss-wait.yaml"
+            }
           }
         },
         {

--- a/.vib/ejbca/vib-verify.json
+++ b/.vib/ejbca/vib-verify.json
@@ -26,7 +26,7 @@
         "target_platform": {
           "target_platform_id": "{VIB_ENV_TARGET_PLATFORM}",
           "size": {
-            "name": "M4"
+            "name": "L4"
           }
         }
       },
@@ -47,7 +47,10 @@
             "remote": {
               "workload": "deploy-ejbca"
             },
-            "vars_file": "vars.yaml"
+            "vars_file": "vars.yaml",
+            "wait": {
+              "file": "goss-wait.yaml"
+            }
           }
         },
         {


### PR DESCRIPTION
### Description of the change

This PR should increase the stability of VIB tests for EJBCA, introducing new timeouts when necessary.

### Benefits

This will avoid having to trigger the tests multiple times due to false positives.

### Possible drawbacks

Tests may take a little bit longer to run.

### Applicable issues

None

### Additional information

Tested in https://github.com/joancafom/charts/pull/105 with 4 successful ✅ in a row.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
