### PR TITLE
[bitnami/mastodon] Add required LOCAL_DOMAIN env variable

### DIFF
--- a/bitnami/mastodon/Chart.yaml
+++ b/bitnami/mastodon/Chart.yaml
@@ -42,4 +42,4 @@ name: mastodon
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/mastodon
   - https://github.com/mastodon/mastodon/
-version: 1.0.1
+version: 1.0.2

--- a/bitnami/mastodon/values.yaml
+++ b/bitnami/mastodon/values.yaml
@@ -118,6 +118,7 @@ defaultConfig: |
   ES_HOST: {{ include "mastodon.elasticsearch.host" . | quote }}
   ES_PORT: {{ include "mastodon.elasticsearch.port" . | quote }}
   WEB_DOMAIN: {{ include "mastodon.web.domain" . | quote }}
+  LOCAL_DOMAIN: {{ include "mastodon.web.domain" . | quote }}
   STREAMING_API_BASE_URL: {{ include "mastodon.streaming.url" . | quote }}
   REDIS_HOST: {{ include "mastodon.redis.host" . | quote }}
   REDIS_PORT: {{ include "mastodon.redis.port" . | quote }}


### PR DESCRIPTION
Signed-off-by: Josh Lee <joshleecreates@users.noreply.github.com>

### Description of the change

The mastodon application requires that this environment variable be set at startup. With this variable set, `WEB_DOMAIN` is optional but I left both for thoroughness. Ideally this should probably be two separate values options to support Mastodon's built-in option to have the WEB UI hosted at a different URL than the backend API.

### Benefits

This fixes the mastodon chart so that the application actually works after log in.

### Possible drawbacks


### Applicable issues


### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
