### PR TITLE
[bitnami/redis] fix wrong propagation of loadBalancerSourceRanges

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 17.7.1
+version: 17.7.2

--- a/bitnami/redis/templates/master/service.yaml
+++ b/bitnami/redis/templates/master/service.yaml
@@ -30,7 +30,7 @@ spec:
   loadBalancerIP: {{ .Values.master.service.loadBalancerIP }}
   {{- end }}
   {{- if and (eq .Values.master.service.type "LoadBalancer") (not (empty .Values.master.service.loadBalancerSourceRanges)) }}
-  loadBalancerSourceRanges: {{ .Values.master.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.master.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   {{- if and .Values.master.service.clusterIP (eq .Values.master.service.type "ClusterIP") }}
   clusterIP: {{ .Values.master.service.clusterIP }}

--- a/bitnami/redis/templates/replicas/service.yaml
+++ b/bitnami/redis/templates/replicas/service.yaml
@@ -30,7 +30,7 @@ spec:
   loadBalancerIP: {{ .Values.replica.service.loadBalancerIP }}
   {{- end }}
   {{- if and (eq .Values.replica.service.type "LoadBalancer") (not (empty .Values.replica.service.loadBalancerSourceRanges)) }}
-  loadBalancerSourceRanges: {{ .Values.replica.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.replica.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   {{- if and .Values.replica.service.clusterIP (eq .Values.replica.service.type "ClusterIP") }}
   clusterIP: {{ .Values.replica.service.clusterIP }}

--- a/bitnami/redis/templates/sentinel/service.yaml
+++ b/bitnami/redis/templates/sentinel/service.yaml
@@ -38,7 +38,7 @@ spec:
   loadBalancerIP: {{ .Values.sentinel.service.loadBalancerIP }}
   {{- end }}
   {{- if and (eq .Values.sentinel.service.type "LoadBalancer") (not (empty .Values.sentinel.service.loadBalancerSourceRanges)) }}
-  loadBalancerSourceRanges: {{ .Values.sentinel.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.sentinel.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
   {{- if and .Values.sentinel.service.clusterIP (eq .Values.sentinel.service.type "ClusterIP") }}
   clusterIP: {{ .Values.sentinel.service.clusterIP }}


### PR DESCRIPTION
Signed-off-by: Samuel Linclau <samuel@linclau.fr>

### Description of the change

Updates the templates for the 3 main Services to properly propagate the `loadBalancerSourceRanges` values

### Benefits

This PR fixes the invalid propagation of the loadBalancerSourceRange values, which are interpreted as strings instead of arrays, and causing this error

```shell
$ helm upgrade --set-json 'redis.master.service.loadBalancerSourceRanges=["10.1.2.0/24","10.3.4.0/24"]' (...)

Error: UPGRADE FAILED: cannot patch "redis-master" with kind Service: Service "redis-master" is invalid: spec.LoadBalancerSourceRanges: Invalid value: "[10.1.2.0/24 10.3.4.0/24]": must be a list of IP ranges. For example, 10.240.0.0/24,10.250.0.0/24
```

### Additional information

Here are some manual tests that I made:

- BEFORE the change (invalid yaml array):

```shell
$ helm template --set master.service.type=LoadBalancer \
                --set-json 'master.service.loadBalancerSourceRanges=["2.3.4.5","6.7.8.9"]'
                redis . | grep -C4 loadBalancerSourceRanges
spec:
  type: LoadBalancer
  externalTrafficPolicy: "Local"
  internalTrafficPolicy: Cluster
  loadBalancerSourceRanges: [2.3.4.5 6.7.8.9]
  sessionAffinity: None
  ports:
    - name: tcp-redis
      port: 6379
```

- AFTER the change (the array is valid and works with helm upgrade / install):

```shell
$ helm template --set master.service.type=LoadBalancer \
                --set-json 'master.service.loadBalancerSourceRanges=["2.3.4.5","6.7.8.9"]' \
                redis . | grep -C4 loadBalancerSourceRanges
spec:
  type: LoadBalancer
  externalTrafficPolicy: "Local"
  internalTrafficPolicy: Cluster
  loadBalancerSourceRanges: 
    - 2.3.4.5
    - 6.7.8.9
  sessionAffinity: None
  ports:
)
```

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)


