### PR TITLE
[bitnami/common] chore: Correct common.images.image global in example

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.2.2
+appVersion: 2.2.3
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/main/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -21,4 +21,4 @@ sources:
   - https://github.com/bitnami/charts
   - https://www.bitnami.com/
 type: library
-version: 2.2.2
+version: 2.2.3

--- a/bitnami/common/templates/_images.tpl
+++ b/bitnami/common/templates/_images.tpl
@@ -1,7 +1,7 @@
 {{/* vim: set filetype=mustache: */}}
 {{/*
 Return the proper image name
-{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" $) }}
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" .Values.global ) }}
 */}}
 {{- define "common.images.image" -}}
 {{- $registryName := .imageRoot.registry -}}


### PR DESCRIPTION
Corrected example use of "common.images.image" template.

### Description of the change

Change from `... "global" $` to `..."global" .Values.global"`.

### Benefits

Less confusion when using the template and leaning against the docs.

### Possible drawbacks

That it will start to actually work for some people who might have used the current example.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
