### PR TITLE
[bitnami/tensorflow-resnet] Remove protocol from Tensorflow's goss tests

### DIFF
--- a/.vib/tensorflow-resnet/goss/goss.yaml
+++ b/.vib/tensorflow-resnet/goss/goss.yaml
@@ -1,10 +1,10 @@
 addr:
-  tcp://tensorflow-resnet:{{ .Vars.service.ports.server }}:
+  tensorflow-resnet:{{ .Vars.service.ports.server }}:
     reachable: true
 port:
-  tcp:{{ .Vars.containerPorts.server }}:
+  {{ .Vars.containerPorts.server }}:
     listening: true
-  tcp:{{ .Vars.containerPorts.restApi }}:
+  {{ .Vars.containerPorts.restApi }}:
     listening: true
 file:
   /bitnami/model-data:


### PR DESCRIPTION
Signed-off-by: jotamartos <jotamartos@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

Goss looks for the information in the /proc/net/tcp and /proc/net/tcp6 files. The Tensorflow's service works properly in all platforms (for both IPv4 and IPv6). However, the /proc/net/tcp doesn't reflect that information. Removing the protocol (optional) makes goss confirm that there is something working on that port

### Benefits

<!-- What benefits will be realized by the code change? -->

Tests pass in all platforms

### Possible drawbacks

<!-- Describe any known limitations with your change -->

None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

There were some platforms in which these tests were failing.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [NA] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [NA] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
