### PR TITLE
[bitnami/tensorflow-resnet] Move port tests to addr ones

### DIFF
--- a/.vib/tensorflow-resnet/goss/goss.yaml
+++ b/.vib/tensorflow-resnet/goss/goss.yaml
@@ -1,11 +1,10 @@
 addr:
-  tcp://tensorflow-resnet:{{ .Vars.service.ports.server }}:
+  127.0.0.1:{{ .Vars.containerPorts.server }}:
     reachable: true
-port:
-  tcp:{{ .Vars.containerPorts.server }}:
-    listening: true
-  tcp:{{ .Vars.containerPorts.restApi }}:
-    listening: true
+  127.0.0.1:{{ .Vars.containerPorts.restApi }}:
+    reachable: true
+  tensorflow-resnet:{{ .Vars.service.ports.server }}:
+    reachable: true
 file:
   /bitnami/model-data:
     exists: true


### PR DESCRIPTION
Signed-off-by: jotamartos <jotamartos@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

<!-- Describe the scope of your change - i.e. what the change does. -->

In https://github.com/bitnami/charts/pull/14773, I erroneously tested the solution in EKS and the changes didn't fixed the tests in that platform. With the current PR, I moved the port tests to addr ones to solve the issues when testing that cluster. This way we can confirm in a different way that the service is listening in the expected ports

```
bitnami ~/projects/charts/.vib/tensorflow-resnet/goss (update-tf-goss-tests) $ goss -g goss.yaml --vars vars.yaml render >  bla.yaml
bitnami ~/projects/charts/.vib/tensorflow-resnet/goss (update-tf-goss-tests) $ k cp bla.yaml jota-tr-tensorflow-resnet-89cb67b87-4fjvx:/tmp/
Defaulted container "tensorflow-serving" out of: tensorflow-serving, seed (init)
bitnami ~/projects/charts/.vib/tensorflow-resnet/goss (update-tf-goss-tests) $ k exec -it jota-tr-tensorflow-resnet-89cb67b87-4fjvx -- cat /tmp/bla.yaml
Defaulted container "tensorflow-serving" out of: tensorflow-serving, seed (init)
file:
  /bitnami/model-data:
    exists: true
    mode: "2777"
    owner: root
    filetype: directory
    contains: []
addr:
  127.0.0.1:8500:
    reachable: true
    timeout: 0
  127.0.0.1:8501:
    reachable: true
    timeout: 0
  jota-tr-tensorflow-resnet:8501:
    reachable: true
    timeout: 0
command:
  check-user-info:
    exec: if [ $(id -u) -lt 1002 ] || [ $(id -G | awk '{print $2}') -lt 1002 ]; then
      exit 1; fi
    exit-status: 0
    stdout: []
    stderr: []
    timeout: 0
bitnami ~/projects/charts/.vib/tensorflow-resnet/goss (update-tf-goss-tests) $ k exec -it jota-tr-tensorflow-resnet-89cb67b87-4fjvx -- /tmp/goss -g /tmp/bla.yaml validate
Defaulted container "tensorflow-serving" out of: tensorflow-serving, seed (init)
........

Total Duration: 0.005s
Count: 8, Failed: 0, Skipped: 0
```

### Benefits

<!-- What benefits will be realized by the code change? -->
Fix tests in EKS

### Possible drawbacks

<!-- Describe any known limitations with your change -->
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

There were some platforms in which these tests were failing.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [NA] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [NA] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
