### PR TITLE
[bitnami/thanos] Add Support for timePartitioning resource management

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 12.0.3
+version: 12.0.4

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -1303,7 +1303,7 @@ timePartitioning:
     max: ""
 ```
 
-You can also specify different resources and limits configurations for each storegateway statefulset. This is done by adding a `resources.requests` and `resources.limits` to each item you wish to change , as shown below:
+You can also specify different resources and limits configurations for each storegateway statefulset. This is done by adding a `resources.requests` and `resources.limits` to each item you wish to change, as shown below:
 
 ```yaml
 timePartitioning:

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -1286,6 +1286,8 @@ Thanos store supports partion based on time.
 
 Setting time partitions will create N number of store statefulsets based on the number of items in the `timePartitioning` list. Each item must contain the min and max time for querying in the supported format (find more details at [Thanos documentation](https://thanos.io/tip/components/store.md/#time-based-partitioning)).
 
+You can speficiy different resources and limits configurations to each storegateway statefulset. This is done by adding a `resources.requests` and `resources.limits` to each item. 
+
 > Note: leaving the `timePartitioning` list empty (`[]`) will create a single store for all data.
 
 For instance, to use 3 stores you can use a **values.yaml** like the one below:

--- a/bitnami/thanos/README.md
+++ b/bitnami/thanos/README.md
@@ -1286,8 +1286,6 @@ Thanos store supports partion based on time.
 
 Setting time partitions will create N number of store statefulsets based on the number of items in the `timePartitioning` list. Each item must contain the min and max time for querying in the supported format (find more details at [Thanos documentation](https://thanos.io/tip/components/store.md/#time-based-partitioning)).
 
-You can speficiy different resources and limits configurations to each storegateway statefulset. This is done by adding a `resources.requests` and `resources.limits` to each item. 
-
 > Note: leaving the `timePartitioning` list empty (`[]`) will create a single store for all data.
 
 For instance, to use 3 stores you can use a **values.yaml** like the one below:
@@ -1300,6 +1298,28 @@ timePartitioning:
   # One store for data newer than 6 weeks and older than 2 weeks
   - min: -6w
     max: -2w
+  # One store for data newer than 2 weeks
+  - min: -2w
+    max: ""
+```
+
+You can also specify different resources and limits configurations for each storegateway statefulset. This is done by adding a `resources.requests` and `resources.limits` to each item you wish to change , as shown below:
+
+```yaml
+timePartitioning:
+  # One store for data older than 6 weeks
+  - min: ""
+    max: -6w
+  # One store for data newer than 6 weeks and older than 2 weeks
+  - min: -6w
+    max: -2w
+    resources: #optional resources declaration for partition
+      requests:
+        cpu: 10m
+        memory: 100Mi
+      limits:
+        cpu: 20m
+        memory: 100Mi
   # One store for data newer than 2 weeks
   - min: -2w
     max: ""

--- a/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/statefulset-sharded.yaml
@@ -243,7 +243,14 @@ spec:
           {{- if $.Values.storegateway.lifecycleHooks }}
           lifecycle: {{- include "common.tplvalues.render" (dict "value" $.Values.storegateway.lifecycleHooks "context" $) | nindent 12 }}
           {{- end }}
-          {{- if $.Values.storegateway.resources }}
+          {{- if $timePartitioning }}
+          {{- $partion := (slice $.Values.storegateway.sharded.timePartitioning  $index) | first }}
+          {{- if $partion.resources }}
+          resources: {{- toYaml $partion.resources | nindent 12 }}
+          {{- else }}
+          resources: {{- toYaml $.Values.storegateway.resources | nindent 12 }}
+          {{- end }}
+          {{- else }}
           resources: {{- toYaml $.Values.storegateway.resources | nindent 12 }}
           {{- end }}
           volumeMounts:


### PR DESCRIPTION

Signed-off-by: Yuval Almog <yuval.almog@riskified.com>

### Description of the change

It is now possible to specify different requests and resources for each StatefulSet storegateway container, with the default values being storegateway.resources.requests and storegateway.resources.limits.

Example for specifying resources per partition: 
```
timePartitioning:
   # One store for data older than 6 weeks
  - min: ""
    max: -6w
    resources: #this will change the StatefulSet storegateway container resources just for this partition 
      requests:
        cpu: 10m
        memory: 100Mi
      limits:
        cpu: 20m
        memory: 100Mi
  # One store for data newer than 6 weeks and older than 2 weeks
  - min: -6w
    max: -2w
  # One store for data newer than 2 weeks
  - min: -2w
    max: ""
```

### Benefits

The current implementation of timeaPrtitioning creates all Statefulsets with the same requests and limits, thus forcing the user to set the resources to be as high as the most resource intensive partition. 

As a result of this change, the user will have the ability to specify exactly the amount of memory and CPU each partition needs, thereby minimizing resource waste  

### Possible drawbacks

None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [NA] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
