### PR TITLE
[bitnami/harbor] fix nginx custom pod annotations

### DIFF
--- a/bitnami/harbor/Chart.yaml
+++ b/bitnami/harbor/Chart.yaml
@@ -36,4 +36,4 @@ sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registry
   - https://github.com/bitnami/containers/tree/main/bitnami/harbor-registryctl
   - https://goharbor.io/
-version: 16.3.2
+version: 16.3.3

--- a/bitnami/harbor/templates/nginx/deployment.yaml
+++ b/bitnami/harbor/templates/nginx/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         checksum/tls-secret: {{ include (print $.Template.BasePath "/nginx/tls-secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.nginx.podAnnotations }}
-        annotations: {{- include "common.tplvalues.render" (dict "value" .Values.nginx.podAnnotations "context" $) | nindent 8 }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.nginx.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- include "harbor.imagePullSecrets" . | nindent 6 }}


### PR DESCRIPTION

### Description of the change

Remove extra annotations key when nginx.podAnnotations is defined

### Benefits

Allow using nginx.podAnnotations 

### Possible drawbacks

N/A

### Applicable issues

N/A

### Checklist

- [ X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
