### PR TITLE
Fonction name was wrong

### DIFF
--- a/bitnami/argo-cd/templates/applicationset/servicemonitor.yaml
+++ b/bitnami/argo-cd/templates/applicationset/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "argo-cd.applicationSet" . }}
+  name: {{ include "argocd.applicationSet" . }}
   {{- if .Values.applicationSet.metrics.serviceMonitor.namespace }}
   namespace: {{ .Values.applicationSet.metrics.serviceMonitor.namespace | quote }}
   {{- else }}


### PR DESCRIPTION
correct
```
executing "argo-cd/templates/applicationset/servicemonitor.yaml" at <include "argo-cd.applicationSet" .>: error calling include: template: no template "argo-cd.applicationSet" associated with template "gotpl"
```
Signed-off-by: SoulKyu <30684712+SoulKyu@users.noreply.github.com>