### PR TITLE
[bitnami/sonarqube] Fix VIB test for sonarqube verion 9.9

### DIFF
--- a/.vib/sonarqube/cypress/cypress/integration/sonarqube_spec.js
+++ b/.vib/sonarqube/cypress/cypress/integration/sonarqube_spec.js
@@ -18,9 +18,11 @@ it('allows adding a project and a quality gate', () => {
       cy.contains('Create').click();
       cy.get('#quality-gate-form-name').type(`${qualityGates.newQualityGate.name}${random}`);
       cy.get('[type="submit"]').contains('Save').click();
+
+      cy.contains('Unlock editing').click();
       cy.contains('Add Condition').click();
       cy.get('#condition-metric').click();
-      cy.contains('Lines').click({force: true});
+      cy.contains('Lines to Cover').click({force: true});
       cy.get('#condition-threshold').type(qualityGates.newQualityGate.threshold);
       cy.get('[type="submit"]').click();
 


### PR DESCRIPTION
Signed-off-by: Rafael Rios Saavedra <rrios@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Updates the test for the changes in the interface in sonarqube version 9.9.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
