### PR TITLE
[bitnami/thanos] fix context for statefulset

### DIFF
--- a/bitnami/thanos/Chart.yaml
+++ b/bitnami/thanos/Chart.yaml
@@ -28,4 +28,4 @@ name: thanos
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/thanos
   - https://thanos.io
-version: 12.0.3
+version: 12.0.4

--- a/bitnami/thanos/templates/storegateway/hpa-sharded.yaml
+++ b/bitnami/thanos/templates/storegateway/hpa-sharded.yaml
@@ -24,7 +24,7 @@ metadata:
   {{- end }}
 spec:
   scaleTargetRef:
-    apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+    apiVersion: {{ include "common.capabilities.statefulset.apiVersion" $ }}
     kind: StatefulSet
     name: {{ printf "%s-storegateway-%s" (include "common.names.fullname" $) (toString $index) | trunc 63 | trimSuffix "-" }}
   minReplicas: {{ $.Values.storegateway.autoscaling.minReplicas }}


### PR DESCRIPTION

### Description of the change

The original fix for hardcoded apiversion https://github.com/bitnami/charts/pull/13542 used the wrong context in the range statement which results in a template error.

### Benefits

No more template error and people can use sharded HPAs for the storagegateway

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
