### PR TITLE
[bitnami/redis-cluster] Add  size limits to empty dir

### DIFF
--- a/bitnami/redis-cluster/Chart.yaml
+++ b/bitnami/redis-cluster/Chart.yaml
@@ -23,4 +23,4 @@ name: redis-cluster
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
   - http://redis.io/
-version: 8.3.5
+version: 8.3.6

--- a/bitnami/redis-cluster/README.md
+++ b/bitnami/redis-cluster/README.md
@@ -72,12 +72,13 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Global parameters
 
-| Name                      | Description                                     | Value |
-| ------------------------- | ----------------------------------------------- | ----- |
-| `global.imageRegistry`    | Global Docker image registry                    | `""`  |
-| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
-| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
-| `global.redis.password`   | Redis&reg; password (overrides `password`)      | `""`  |
+| Name                      | Description                                     | Value   |
+| ------------------------- | ----------------------------------------------- | ------- |
+| `global.imageRegistry`    | Global Docker image registry                    | `""`    |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`    |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`    |
+| `global.redis.password`   | Redis&reg; password (overrides `password`)      | `""`    |
+| `emptyDir.sizeLimit`      | Size limits on emptyDir                         | `512Mi` |
 
 
 ### Redis&reg; Cluster Common parameters

--- a/bitnami/redis-cluster/templates/redis-statefulset.yaml
+++ b/bitnami/redis-cluster/templates/redis-statefulset.yaml
@@ -412,7 +412,8 @@ spec:
             path: /sys
         {{- end }}
         - name: redis-tmp-conf
-          emptyDir: {}
+          emptyDir: 
+            sizeLimit: {{ .Values.emptyDir.sizeLimit }}
         {{- if .Values.redis.extraVolumes }}
         {{- include "common.tplvalues.render" ( dict "value" .Values.redis.extraVolumes "context" $ ) | nindent 8 }}
         {{- end }}
@@ -424,7 +425,8 @@ spec:
         {{- end }}
         {{- if not .Values.persistence.enabled }}
         - name: redis-data
-          emptyDir: {}
+          emptyDir: 
+            sizeLimit: {{ .Values.emptyDir.sizeLimit }}
         {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -21,7 +21,7 @@ global:
     password: ""
 
 ## @param emptyDir.sizeLimit Size limits on emptyDir
-
+##
 emptyDir:
   sizeLimit: 512Mi
 

--- a/bitnami/redis-cluster/values.yaml
+++ b/bitnami/redis-cluster/values.yaml
@@ -20,6 +20,11 @@ global:
   redis:
     password: ""
 
+## @param emptyDir.sizeLimit Size limits on emptyDir
+
+emptyDir:
+  sizeLimit: 512Mi
+
 ## @section Redis&reg; Cluster Common parameters
 ##
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

Add size limits to empty dir. Best practice to avoid any unnecessary consumption of ephemeral local storage resources. Also, this helm chart cannot be used if there are any gatekeeper validations on kubernetes cluster for empty size limits. 

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Add size limits to empty dir. This will make sure some size limit is enabled on empty dirs mounting to the container. 

### Benefits

Avoid unnecessary consumption of ephemeral local storage resources. 
Make this helm chart used for anyone who has empty dir size limits gatekeeper validations enabled on their k8s cluster.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
