### PR TITLE
[bitnami/kong] feat: :sparkles: Add support for db-less and declarative configuration

### DIFF
--- a/.vib/kong/cypress/cypress.json
+++ b/.vib/kong/cypress/cypress.json
@@ -1,10 +1,9 @@
 {
-  "baseUrl": "http://localhost",
+  "baseUrl": "http://{{ TARGET_IP }}",
   "env": {
     "apikey": "ComplicatedPassword123!4",
     "ingressHost": "www.example.com",
     "ingressPath": "/nginx",
-    "externalIp": "{{ TARGET_IP }}",
     "adminHttpPort": "443"
   }
 }

--- a/.vib/kong/cypress/cypress/integration/kong_spec.js
+++ b/.vib/kong/cypress/cypress/integration/kong_spec.js
@@ -29,8 +29,8 @@ it('allows accessing a restricted service (CRD) when API key is presented', () =
 });
 
 it('allows adding a new service and route through admin API', () => {
-  // As adminAPI is exposed in another port, we need to use the external IP to access it
-  const BASE_URL = `http://${Cypress.env('externalIp')}:${Cypress.env(
+  // As adminAPI is exposed in another port, we need to use a different base url.
+  const BASE_URL = `${Cypress.config('baseUrl')}:${Cypress.env(
     'adminHttpPort'
   )}`;
 

--- a/.vib/kong/vib-publish.json
+++ b/.vib/kong/vib-publish.json
@@ -61,7 +61,6 @@
               "apikey": "ComplicatedPassword123!4",
               "ingressHost": "www.example.com",
               "ingressPath": "/nginx",
-              "externalIp": "{{ TARGET_IP }}",
               "adminHttpPort": "443"
             }
           }

--- a/.vib/kong/vib-verify.json
+++ b/.vib/kong/vib-verify.json
@@ -61,7 +61,6 @@
               "apikey": "ComplicatedPassword123!4",
               "ingressHost": "www.example.com",
               "ingressPath": "/nginx",
-              "externalIp": "{{ TARGET_IP }}",
               "adminHttpPort": "443"
             }
           }

--- a/bitnami/kong/Chart.yaml
+++ b/bitnami/kong/Chart.yaml
@@ -36,4 +36,4 @@ name: kong
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kong
   - https://konghq.com/
-version: 9.0.4
+version: 9.1.0

--- a/bitnami/kong/README.md
+++ b/bitnami/kong/README.md
@@ -88,7 +88,7 @@ $ helm delete my-release
 | `image.pullPolicy`  | kong image pull policy                                                                               | `IfNotPresent`        |
 | `image.pullSecrets` | Specify docker-registry secret names as an array                                                     | `[]`                  |
 | `image.debug`       | Enable image debug mode                                                                              | `false`               |
-| `database`          | Select which database backend Kong will use. Can be 'postgresql' or 'cassandra'                      | `postgresql`          |
+| `database`          | Select which database backend Kong will use. Can be 'postgresql', 'cassandra' or 'off'               | `postgresql`          |
 
 
 ### Kong deployment / daemonset parameters
@@ -139,6 +139,8 @@ $ helm delete my-release
 | `kong.args`                               | Override default container args (useful when using custom images)                                                          | `[]`    |
 | `kong.initScriptsCM`                      | Configmap with init scripts to execute                                                                                     | `""`    |
 | `kong.initScriptsSecret`                  | Configmap with init scripts to execute                                                                                     | `""`    |
+| `kong.declarativeConfig`                  | Declarative configuration to be loaded by Kong (evaluated as a template)                                                   | `""`    |
+| `kong.declarativeConfigCM`                | Configmap with declarative configuration to be loaded by Kong (evaluated as a template)                                    | `""`    |
 | `kong.extraEnvVars`                       | Array containing extra env vars to configure Kong                                                                          | `[]`    |
 | `kong.extraEnvVarsCM`                     | ConfigMap containing extra env vars to configure Kong                                                                      | `""`    |
 | `kong.extraEnvVarsSecret`                 | Secret containing extra env vars to configure Kong (in case of sensitive data)                                             | `""`    |

--- a/bitnami/kong/templates/_helpers.tpl
+++ b/bitnami/kong/templates/_helpers.tpl
@@ -211,7 +211,7 @@ Return true if a secret for a external database should be created
 Return database type
 */}}
 {{- define "kong.database" -}}
-{{- if eq .Values.database "postgres" -}}
+{{- if eq .Values.database "postgresql" -}}
   {{- print "postgres" -}}
 {{- else -}}
   {{- print .Values.database -}}

--- a/bitnami/kong/templates/_helpers.tpl
+++ b/bitnami/kong/templates/_helpers.tpl
@@ -219,7 +219,7 @@ Return database type
 {{- end -}}
 
 {{/*
-Return true if a secret for a external database should be created
+Return the name of the configmap to be used for declarative configuration
 */}}
 {{- define "kong.declarativeConfigMap" -}}
 {{- if .Values.kong.declarativeConfigCM -}}

--- a/bitnami/kong/templates/_helpers.tpl
+++ b/bitnami/kong/templates/_helpers.tpl
@@ -223,7 +223,7 @@ Return the name of the configmap to be used for declarative configuration
 */}}
 {{- define "kong.declarativeConfigMap" -}}
 {{- if .Values.kong.declarativeConfigCM -}}
-  {{- tpl .Values.kong.declarativeConfigCM $ -}}
+  {{- include "common.tplvalues.render" (dict "value" .Values.kong.declarativeConfigCM "context" $) -}}
 {{- else if .Values.kong.declarativeConfig -}}
   {{- printf "%s-declarative-config" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-"  -}}
 {{- end -}}

--- a/bitnami/kong/templates/declarative-config-configmap.yaml
+++ b/bitnami/kong/templates/declarative-config-configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.kong.declarativeConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kong.declarativeConfigMap" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: server
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  kong.yml: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.kong.declarativeConfig "context" $) | nindent 4 }}
+{{- end }}

--- a/bitnami/kong/templates/declarative-config-configmap.yaml
+++ b/bitnami/kong/templates/declarative-config-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.kong.declarativeConfig }}
+{{- if and .Values.kong.declarativeConfig (not .Values.kong.declarativeConfigCM) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/bitnami/kong/templates/dep-ds.yaml
+++ b/bitnami/kong/templates/dep-ds.yaml
@@ -373,13 +373,13 @@ spec:
         {{- if .Values.kong.initScriptsCM }}
         - name: custom-init-scripts-cm
           configMap:
-            name: {{ tpl .Values.kong.initScriptsCM $ }}
+            name: {{ include "common.tplvalues.render" (dict "value" .Values.kong.initScriptsCM "context" $) }}
             defaultMode: 0755
         {{- end }}
         {{- if .Values.kong.initScriptsSecret }}
         - name: custom-init-scripts-secret
           secret:
-            secretName: {{ tpl .Values.kong.initScriptsSecret $ }}
+            name: {{ include "common.tplvalues.render" (dict "value" .Values.kong.initScriptsSecret "context" $) }}
             defaultMode: 0755
         {{- end }}
         {{- if (include "kong.declarativeConfigMap" .) }}

--- a/bitnami/kong/templates/dep-ds.yaml
+++ b/bitnami/kong/templates/dep-ds.yaml
@@ -373,13 +373,13 @@ spec:
         {{- if .Values.kong.initScriptsCM }}
         - name: custom-init-scripts-cm
           configMap:
-            name: {{ .Values.kong.initScriptsCM }}
+            name: {{ tpl .Values.kong.initScriptsCM $ }}
             defaultMode: 0755
         {{- end }}
         {{- if .Values.kong.initScriptsSecret }}
         - name: custom-init-scripts-secret
           secret:
-            secretName: {{ .Values.kong.initScriptsSecret }}
+            secretName: {{ tpl .Values.kong.initScriptsSecret $ }}
             defaultMode: 0755
         {{- end }}
         {{- if (include "kong.declarativeConfigMap" .) }}

--- a/bitnami/kong/templates/dep-ds.yaml
+++ b/bitnami/kong/templates/dep-ds.yaml
@@ -112,7 +112,7 @@ spec:
               value: "0.0.0.0"
             {{- end }}
             - name: KONG_DATABASE
-              value: {{ ternary "postgres" "cassandra" (eq .Values.database "postgresql") | quote }}
+              value: {{ include "kong.database" . | quote }}
             {{- if (eq .Values.database "postgresql") }}
             {{- if .Values.postgresql.auth.usePasswordFiles }}
             - name: KONG_POSTGRESQL_PASSWORD_FILE
@@ -152,6 +152,10 @@ spec:
             {{- if .Values.metrics.enabled }}
             - name: KONG_NGINX_HTTP_INCLUDE
               value: "/bitnami/kong/metrics-exporter/exporter.conf"
+            {{- end }}
+            {{- if (include "kong.declarativeConfigMap" .) }}
+            - name: KONG_DECLARATIVE_CONFIG
+              value: "/bitnami/kong/declarative-conf/kong.yml"
             {{- end }}
             {{- if .Values.kong.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.kong.extraEnvVars "context" $) | nindent 12 }}
@@ -244,6 +248,10 @@ spec:
             {{- if .Values.kong.initScriptsSecret }}
             - name: custom-init-scripts-secret
               mountPath: /docker-entrypoint-initdb.d/secret
+            {{- end }}
+            {{- if (include "kong.declarativeConfigMap" .) }}
+            - name: kong-declarative-conf
+              mountPath: /bitnami/kong/declarative-conf/
             {{- end }}
             {{- if .Values.kong.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.kong.extraVolumeMounts "context" $) | nindent 12 }}
@@ -373,6 +381,11 @@ spec:
           secret:
             secretName: {{ .Values.kong.initScriptsSecret }}
             defaultMode: 0755
+        {{- end }}
+        {{- if (include "kong.declarativeConfigMap" .) }}
+        - name: kong-declarative-conf
+          configMap:
+            name: {{ include "kong.declarativeConfigMap" . | quote }}
         {{- end }}
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}

--- a/bitnami/kong/templates/migrate-job.yaml
+++ b/bitnami/kong/templates/migrate-job.yaml
@@ -1,3 +1,4 @@
+{{- if or (eq .Values.database "postgresql") (eq .Values.database "cassandra") }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -53,7 +54,7 @@ spec:
             - name: KONG_EXIT_AFTER_MIGRATE
               value: "yes"
             - name: KONG_DATABASE
-              value: {{ ternary "postgres" "cassandra" (eq .Values.database "postgresql") | quote }}
+              value: {{ include "kong.database" . | quote }}
             {{- if (eq .Values.database "postgresql") }}
             {{- if .Values.postgresql.auth.usePasswordFiles }}
             - name: KONG_POSTGRESQL_PASSWORD_FILE
@@ -115,3 +116,4 @@ spec:
       volumes:
       {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 6 }}
       {{- end }}
+{{- end }}

--- a/bitnami/kong/values.yaml
+++ b/bitnami/kong/values.yaml
@@ -57,6 +57,7 @@ diagnosticMode:
     - infinity
 
 ## @section Kong common parameters
+##
 
 ## Bitnami kong image version
 ## ref: https://hub.docker.com/r/bitnami/kong/tags/
@@ -89,11 +90,12 @@ image:
   ## Enable debug mode
   ##
   debug: false
-## @param database Select which database backend Kong will use. Can be 'postgresql' or 'cassandra'
+## @param database Select which database backend Kong will use. Can be 'postgresql', 'cassandra' or 'off'
 ##
 database: postgresql
 
 ## @section Kong deployment / daemonset parameters
+##
 
 ## @param useDaemonset Use a daemonset instead of a deployment. `replicaCount` will not take effect.
 ##
@@ -252,6 +254,7 @@ pdb:
   maxUnavailable: "50%"
 
 ## @section Kong Container Parameters
+##
 
 kong:
   ## @param kong.command Override default container command (useful when using custom images)
@@ -268,6 +271,17 @@ kong:
   ## Secret containing `/docker-entrypoint-initdb.d` scripts to be executed at initialization time (that contain sensitive data). Evaluated as a template.
   ##
   initScriptsSecret: ""
+
+  ## @param kong.declarativeConfig Declarative configuration to be loaded by Kong (evaluated as a template)
+  ## https://docs.konghq.com/gateway/latest/production/deployment-topologies/db-less-and-declarative-config/
+  ##
+  declarativeConfig: ""
+
+  ## @param kong.declarativeConfigCM Configmap with declarative configuration to be loaded by Kong (evaluated as a template)
+  ## https://docs.konghq.com/gateway/latest/production/deployment-topologies/db-less-and-declarative-config/
+  ##
+  declarativeConfigCM: ""
+
   ## @param kong.extraEnvVars Array containing extra env vars to configure Kong
   ## For example:
   ## extraEnvVars:
@@ -541,6 +555,7 @@ ingress:
   extraRules: []
 
 ## @section Kong Ingress Controller Container Parameters
+##
 
 ingressController:
   ## @param ingressController.enabled Enable/disable the Kong Ingress Controller
@@ -696,6 +711,7 @@ ingressController:
     rules: []
 
 ## @section Kong Migration job Parameters
+##
 
 migration:
   ## In case you want to use a custom image for Kong migration, set this value


### PR DESCRIPTION

Signed-off-by: Javier Salmeron Garcia <jsalmeron@vmware.com>

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR adds support for not using any database in the Kong chart. This is useful for cases where you want to add a declarative configuration.

This PR also changes the init scripts so they can be evaluated as templates (this is important for cases where you use kong as a subchart

<!-- Describe the scope of your change - i.e. what the change does. -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
