### PR TITLE
[bitnami/kafka] Kafka Kraft implementation

### DIFF
--- a/bitnami/kafka/Chart.yaml
+++ b/bitnami/kafka/Chart.yaml
@@ -29,4 +29,4 @@ name: kafka
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/kafka
   - https://kafka.apache.org/
-version: 21.2.0
+version: 21.3.0

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -121,6 +121,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `auth.clientProtocol`                             | Authentication protocol for communications with clients. Allowed protocols: `plaintext`, `tls`, `mtls`, `sasl` and `sasl_tls`                                                       | `plaintext`                         |
 | `auth.externalClientProtocol`                     | Authentication protocol for communications with external clients. Defaults to value of `auth.clientProtocol`. Allowed protocols: `plaintext`, `tls`, `mtls`, `sasl` and `sasl_tls`  | `""`                                |
 | `auth.interBrokerProtocol`                        | Authentication protocol for inter-broker communications. Allowed protocols: `plaintext`, `tls`, `mtls`, `sasl` and `sasl_tls`                                                       | `plaintext`                         |
+| `auth.controllerProtocol`                         | Controller protocol. It is used with Kraft mode only.                                                                                                                               | `plaintext`                         |
 | `auth.sasl.mechanisms`                            | SASL mechanisms when either `auth.interBrokerProtocol`, `auth.clientProtocol` or `auth.externalClientProtocol` are `sasl`. Allowed types: `plain`, `scram-sha-256`, `scram-sha-512` | `plain,scram-sha-256,scram-sha-512` |
 | `auth.sasl.interBrokerMechanism`                  | SASL mechanism for inter broker communication.                                                                                                                                      | `plain`                             |
 | `auth.sasl.jaas.clientUsers`                      | Kafka client user list                                                                                                                                                              | `["user"]`                          |
@@ -465,6 +466,18 @@ The command removes all the Kubernetes components associated with the chart and 
 | `provisioning.sidecars`                                    | Add additional sidecar containers to the Kafka provisioning pod(s)                                                            | `[]`                  |
 | `provisioning.initContainers`                              | Add additional Add init containers to the Kafka provisioning pod(s)                                                           | `[]`                  |
 | `provisioning.waitForKafka`                                | If true use an init container to wait until kafka is ready before starting provisioning                                       | `true`                |
+
+
+### Kraft chart parameters
+
+| Name                            | Description                                                                             | Value               |
+| ------------------------------- | --------------------------------------------------------------------------------------- | ------------------- |
+| `kraft.enabled`                 | Switch to enable or disable the Kraft mode for Kafka                                    | `false`             |
+| `kraft.controllerPort`          | Kafka Controller listener port                                                          | `9095`              |
+| `kraft.processRoles`            | Roles of your Kafka nodes. Nodes can have 'broker', 'controller' roles or both of them. | `broker,controller` |
+| `kraft.controllerListenerNames` | Controller listener names                                                               | `CONTROLLER`        |
+| `kraft.clusterId`               | Kafka ClusterID. You must set it if your cluster contains more than one node.           | `""`                |
+
 
 ### ZooKeeper chart parameters
 

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -60,7 +60,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
-
 ### Common parameters
 
 | Name                      | Description                                                                             | Value           |
@@ -76,7 +75,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `diagnosticMode.enabled`  | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
 | `diagnosticMode.command`  | Command to override all containers in the statefulset                                   | `["sleep"]`     |
 | `diagnosticMode.args`     | Args to override all containers in the statefulset                                      | `["infinity"]`  |
-
 
 ### Kafka parameters
 
@@ -163,7 +161,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraEnvVarsCM`                                  | ConfigMap with extra environment variables                                                                                                                                          | `""`                                |
 | `extraEnvVarsSecret`                              | Secret with extra environment variables                                                                                                                                             | `""`                                |
 
-
 ### Statefulset parameters
 
 | Name                                                | Description                                                                                                                                                                                   | Value           |
@@ -233,7 +230,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `pdb.minAvailable`                                  | Maximum number/percentage of unavailable Kafka replicas                                                                                                                                       | `""`            |
 | `pdb.maxUnavailable`                                | Maximum number/percentage of unavailable Kafka replicas                                                                                                                                       | `1`             |
 
-
 ### Traffic Exposure parameters
 
 | Name                                              | Description                                                                                                              | Value                  |
@@ -285,7 +281,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.externalAccess.from`               | customize the from section for External Access on tcp-external port                                                      | `[]`                   |
 | `networkPolicy.egressRules.customRules`           | Custom network policy rule                                                                                               | `{}`                   |
 
-
 ### Persistence parameters
 
 | Name                           | Description                                                                                                                            | Value                     |
@@ -308,7 +303,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `logPersistence.selector`      | Selector to match an existing Persistent Volume for Kafka log data PVC. If set, the PVC can't have a PV dynamically provisioned for it | `{}`                      |
 | `logPersistence.mountPath`     | Mount path of the Kafka logs volume                                                                                                    | `/opt/bitnami/kafka/logs` |
 
-
 ### Volume Permissions parameters
 
 | Name                                                   | Description                                                                                                                       | Value                   |
@@ -324,7 +318,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                                                                               | `{}`                    |
 | `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                                                                    | `0`                     |
 
-
 ### Other Parameters
 
 | Name                                          | Description                                                                                    | Value   |
@@ -334,7 +327,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created                         | `true`  |
 | `serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                           | `{}`    |
 | `rbac.create`                                 | Whether to create & use RBAC resources or not                                                  | `false` |
-
 
 ### Metrics parameters
 
@@ -424,7 +416,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.prometheusRule.labels`                             | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                            | `{}`                                                                                    |
 | `metrics.prometheusRule.groups`                             | Prometheus Rule Groups for Kafka                                                                                                 | `[]`                                                                                    |
 
-
 ### Kafka provisioning parameters
 
 | Name                                                       | Description                                                                                                                   | Value                 |
@@ -477,7 +468,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `provisioning.initContainers`                              | Add additional Add init containers to the Kafka provisioning pod(s)                                                           | `[]`                  |
 | `provisioning.waitForKafka`                                | If true use an init container to wait until kafka is ready before starting provisioning                                       | `true`                |
 
-
 ### Kraft chart parameters
 
 | Name                            | Description                                                                             | Value                    |
@@ -487,7 +477,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kraft.controllerListenerNames` | Controller listener names                                                               | `CONTROLLER`             |
 | `kraft.clusterId`               | Kafka ClusterID. You must set it if your cluster contains more than one node.           | `kafka_cluster_id_test1` |
 | `kraft.controllerQuorumVoters`  | Quorum voters of Kafka Kraft cluster. Use it for nodes with 'broker' role only.         | `""`                     |
-
 
 ### ZooKeeper chart parameters
 

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -477,6 +477,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `kraft.processRoles`            | Roles of your Kafka nodes. Nodes can have 'broker', 'controller' roles or both of them. | `broker,controller` |
 | `kraft.controllerListenerNames` | Controller listener names                                                               | `CONTROLLER`        |
 | `kraft.clusterId`               | Kafka ClusterID. You must set it if your cluster contains more than one node.           | `""`                |
+| `kraft.controllerQuorumVoters`  | Quorum voters of Kafka Kraft cluster. Use it for nodes with 'broker' role only.         | `""`                |
 
 
 ### ZooKeeper chart parameters

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -484,7 +484,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                                    | Description                                                                                                                                                             | Value               |
 | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
-| `zookeeper.enabled`                     | Switch to enable or disable the ZooKeeper helm chart                                                                                                                    | `true`              |
+| `zookeeper.enabled`                     | Switch to enable or disable the ZooKeeper helm chart. Must be false if you use Kraft mode.                                                                              | `true`              |
 | `zookeeper.replicaCount`                | Number of ZooKeeper nodes                                                                                                                                               | `1`                 |
 | `zookeeper.auth.client.enabled`         | Enable ZooKeeper auth                                                                                                                                                   | `false`             |
 | `zookeeper.auth.client.clientUser`      | User that will use ZooKeeper clients to auth                                                                                                                            | `""`                |
@@ -495,7 +495,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `zookeeper.persistence.storageClass`    | Persistent Volume storage class                                                                                                                                         | `""`                |
 | `zookeeper.persistence.accessModes`     | Persistent Volume access modes                                                                                                                                          | `["ReadWriteOnce"]` |
 | `zookeeper.persistence.size`            | Persistent Volume size                                                                                                                                                  | `8Gi`               |
-| `externalZookeeper.servers`             | List of external zookeeper servers to use. Typically used in combination with 'zookeeperChrootPath'.                                                                    | `[]`                |
+| `externalZookeeper.servers`             | List of external zookeeper servers to use. Typically used in combination with 'zookeeperChrootPath'. Must be false if you use Kraft mode.                               | `[]`                |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -174,6 +174,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `containerPorts.client`                             | Kafka client container port                                                                                                                                                                   | `9092`          |
 | `containerPorts.internal`                           | Kafka inter-broker container port                                                                                                                                                             | `9093`          |
 | `containerPorts.external`                           | Kafka external container port                                                                                                                                                                 | `9094`          |
+| `containerPorts.controller`                         | Kafka Controller listener port. It is used if "kraft.enabled: true"                                                                                                                           | `9095`          |
 | `livenessProbe.enabled`                             | Enable livenessProbe on Kafka containers                                                                                                                                                      | `true`          |
 | `livenessProbe.initialDelaySeconds`                 | Initial delay seconds for livenessProbe                                                                                                                                                       | `10`            |
 | `livenessProbe.periodSeconds`                       | Period seconds for livenessProbe                                                                                                                                                              | `10`            |
@@ -479,14 +480,13 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Kraft chart parameters
 
-| Name                            | Description                                                                             | Value               |
-| ------------------------------- | --------------------------------------------------------------------------------------- | ------------------- |
-| `kraft.enabled`                 | Switch to enable or disable the Kraft mode for Kafka                                    | `false`             |
-| `kraft.controllerPort`          | Kafka Controller listener port                                                          | `9095`              |
-| `kraft.processRoles`            | Roles of your Kafka nodes. Nodes can have 'broker', 'controller' roles or both of them. | `broker,controller` |
-| `kraft.controllerListenerNames` | Controller listener names                                                               | `CONTROLLER`        |
-| `kraft.clusterId`               | Kafka ClusterID. You must set it if your cluster contains more than one node.           | `""`                |
-| `kraft.controllerQuorumVoters`  | Quorum voters of Kafka Kraft cluster. Use it for nodes with 'broker' role only.         | `""`                |
+| Name                            | Description                                                                             | Value                    |
+| ------------------------------- | --------------------------------------------------------------------------------------- | ------------------------ |
+| `kraft.enabled`                 | Switch to enable or disable the Kraft mode for Kafka                                    | `false`                  |
+| `kraft.processRoles`            | Roles of your Kafka nodes. Nodes can have 'broker', 'controller' roles or both of them. | `broker,controller`      |
+| `kraft.controllerListenerNames` | Controller listener names                                                               | `CONTROLLER`             |
+| `kraft.clusterId`               | Kafka ClusterID. You must set it if your cluster contains more than one node.           | `kafka_cluster_id_test1` |
+| `kraft.controllerQuorumVoters`  | Quorum voters of Kafka Kraft cluster. Use it for nodes with 'broker' role only.         | `""`                     |
 
 
 ### ZooKeeper chart parameters
@@ -504,7 +504,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `zookeeper.persistence.storageClass`    | Persistent Volume storage class                                                                                                                                         | `""`                |
 | `zookeeper.persistence.accessModes`     | Persistent Volume access modes                                                                                                                                          | `["ReadWriteOnce"]` |
 | `zookeeper.persistence.size`            | Persistent Volume size                                                                                                                                                  | `8Gi`               |
-| `externalZookeeper.servers`             | List of external zookeeper servers to use. Typically used in combination with 'zookeeperChrootPath'. Must be false if you use Kraft mode.                               | `[]`                |
+| `externalZookeeper.servers`             | List of external zookeeper servers to use. Typically used in combination with 'zookeeperChrootPath'. Must be empty if you use Kraft mode.                               | `[]`                |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,

--- a/bitnami/kafka/README.md
+++ b/bitnami/kafka/README.md
@@ -60,6 +60,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
+
 ### Common parameters
 
 | Name                      | Description                                                                             | Value           |
@@ -75,6 +76,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `diagnosticMode.enabled`  | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
 | `diagnosticMode.command`  | Command to override all containers in the statefulset                                   | `["sleep"]`     |
 | `diagnosticMode.args`     | Args to override all containers in the statefulset                                      | `["infinity"]`  |
+
 
 ### Kafka parameters
 
@@ -161,6 +163,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `extraEnvVarsCM`                                  | ConfigMap with extra environment variables                                                                                                                                          | `""`                                |
 | `extraEnvVarsSecret`                              | Secret with extra environment variables                                                                                                                                             | `""`                                |
 
+
 ### Statefulset parameters
 
 | Name                                                | Description                                                                                                                                                                                   | Value           |
@@ -229,6 +232,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `pdb.minAvailable`                                  | Maximum number/percentage of unavailable Kafka replicas                                                                                                                                       | `""`            |
 | `pdb.maxUnavailable`                                | Maximum number/percentage of unavailable Kafka replicas                                                                                                                                       | `1`             |
 
+
 ### Traffic Exposure parameters
 
 | Name                                              | Description                                                                                                              | Value                  |
@@ -280,6 +284,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `networkPolicy.externalAccess.from`               | customize the from section for External Access on tcp-external port                                                      | `[]`                   |
 | `networkPolicy.egressRules.customRules`           | Custom network policy rule                                                                                               | `{}`                   |
 
+
 ### Persistence parameters
 
 | Name                           | Description                                                                                                                            | Value                     |
@@ -302,6 +307,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `logPersistence.selector`      | Selector to match an existing Persistent Volume for Kafka log data PVC. If set, the PVC can't have a PV dynamically provisioned for it | `{}`                      |
 | `logPersistence.mountPath`     | Mount path of the Kafka logs volume                                                                                                    | `/opt/bitnami/kafka/logs` |
 
+
 ### Volume Permissions parameters
 
 | Name                                                   | Description                                                                                                                       | Value                   |
@@ -317,6 +323,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `volumePermissions.resources.requests`                 | Init container volume-permissions resource requests                                                                               | `{}`                    |
 | `volumePermissions.containerSecurityContext.runAsUser` | User ID for the init container                                                                                                    | `0`                     |
 
+
 ### Other Parameters
 
 | Name                                          | Description                                                                                    | Value   |
@@ -326,6 +333,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `serviceAccount.automountServiceAccountToken` | Allows auto mount of ServiceAccountToken on the serviceAccount created                         | `true`  |
 | `serviceAccount.annotations`                  | Additional custom annotations for the ServiceAccount                                           | `{}`    |
 | `rbac.create`                                 | Whether to create & use RBAC resources or not                                                  | `false` |
+
 
 ### Metrics parameters
 
@@ -414,6 +422,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `metrics.prometheusRule.namespace`                          | Namespace in which Prometheus is running                                                                                         | `""`                                                                                    |
 | `metrics.prometheusRule.labels`                             | Additional labels that can be used so PrometheusRule will be discovered by Prometheus                                            | `{}`                                                                                    |
 | `metrics.prometheusRule.groups`                             | Prometheus Rule Groups for Kafka                                                                                                 | `[]`                                                                                    |
+
 
 ### Kafka provisioning parameters
 

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -383,6 +383,7 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := append $messages (include "kafka.validateValues.tlsSecrets" .) -}}
 {{- $messages := append $messages (include "kafka.validateValues.tlsSecrets.length" .) -}}
 {{- $messages := append $messages (include "kafka.validateValues.tlsPasswords" .) -}}
+{{- $messages := append $messages (include "kafka.validateValues.kraftMode" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -505,5 +506,14 @@ kafka: auth.tls.keyPasswordSecretKey,auth.tls.keystorePasswordSecretKey,auth.tls
     auth.tls.keyPasswordSecretKey,auth.tls.keystorePasswordSecretKey,auth.tls.truststorePasswordSecretKey
     must not be used without passwordsSecret setted.
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate values of Kafka Kraft mode. It cannot be used with zookeeper  */}}
+{{- define "kafka.validateValues.kraftMode" -}}
+{{- $externalZKlen := len .Values.externalZookeeper.servers}}
+{{- if and .Values.kraft.enabled (or .Values.zookeeper.enabled (gt $externalZKlen 0))  }}
+kafka: Kraft mode
+    You cannot use Kraft mode and Zookeeper at the same time. They are mutually exclusive. Disable zookeeper in '.Values.zookeeper.enabled'  and delete values from '.Values.externalZookeeper.servers' if you want to use Kraft mode
 {{- end -}}
 {{- end -}}

--- a/bitnami/kafka/templates/_helpers.tpl
+++ b/bitnami/kafka/templates/_helpers.tpl
@@ -384,6 +384,8 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := append $messages (include "kafka.validateValues.tlsSecrets.length" .) -}}
 {{- $messages := append $messages (include "kafka.validateValues.tlsPasswords" .) -}}
 {{- $messages := append $messages (include "kafka.validateValues.kraftMode" .) -}}
+{{- $messages := append $messages (include "kafka.validateValues.ClusterIdDefinedIfKraft" .) -}}
+{{- $messages := append $messages (include "kafka.validateValues.controllerQuorumVotersDefinedIfKraft" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -515,5 +517,22 @@ kafka: auth.tls.keyPasswordSecretKey,auth.tls.keystorePasswordSecretKey,auth.tls
 {{- if and .Values.kraft.enabled (or .Values.zookeeper.enabled (gt $externalZKlen 0))  }}
 kafka: Kraft mode
     You cannot use Kraft mode and Zookeeper at the same time. They are mutually exclusive. Disable zookeeper in '.Values.zookeeper.enabled'  and delete values from '.Values.externalZookeeper.servers' if you want to use Kraft mode
+{{- end -}}
+{{- end -}}
+
+{{/* Validate ClusterId value. It must be defined if Kraft mode is used.  */}}
+{{- define "kafka.validateValues.ClusterIdDefinedIfKraft" -}}
+{{- if and .Values.kraft.enabled (not .Values.kraft.clusterId) (gt (int .Values.replicaCount) 1) }}
+kafka: Kraft mode
+    .Values.kraft.clusterId must not be empty if .Values.kraft.enabled set to true and .Values.replicaCount > 1.
+{{- end -}}
+{{- end -}}
+
+{{/* Validate controllerQuorumVoters value. It must be defined if it is broker-only deployment.  */}}
+{{- define "kafka.validateValues.controllerQuorumVotersDefinedIfKraft" -}}
+{{- if and .Values.kraft.enabled (not .Values.kraft.controllerQuorumVoters) (not (contains "controller" .Values.kraft.processRoles)) }}
+kafka: Kraft mode
+    .Values.kraft.controllerQuorumVoters must not be empty if .Values.kraft.enabled set to true and .Values.kraft.processRoles does not contain "controller". 
+    If you deploy brokers without controllers you have to define external controllers with .Values.kraft.controllerQuorumVoters
 {{- end -}}
 {{- end -}}

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -76,12 +76,35 @@ data:
     #!/bin/bash
 
     ID="${MY_POD_NAME#"{{ $fullname }}-"}"
+    # If process.roles is not set at all, it is assumed to be in ZooKeeper mode.
+    # https://kafka.apache.org/documentation/#kraft_role
+    
     if [[ -f "{{ .Values.logsDirs | splitList "," | first }}/meta.properties" ]]; then
-        export KAFKA_CFG_BROKER_ID="$(grep "broker.id" "{{ .Values.logsDirs | splitList "," | first }}/meta.properties" | awk -F '=' '{print $2}')"
+        if [[ $KAFKA_CFG_PROCESS_ROLES == "" ]]; then
+            export KAFKA_CFG_BROKER_ID="$(grep "broker.id" "{{ .Values.logsDirs | splitList "," | first }}/meta.properties" | awk -F '=' '{print $2}')"
+        else
+            export KAFKA_CFG_BROKER_ID="$(grep "node.id" "{{ .Values.logsDirs | splitList "," | first }}/meta.properties" | awk -F '=' '{print $2}')"
+        fi
     else
         export KAFKA_CFG_BROKER_ID="$((ID + {{ .Values.minBrokerId }}))"
     fi
 
+    if [[ $KAFKA_CFG_PROCESS_ROLES == *"controller"* ]]; then
+        node_id={{ .Values.minBrokerId }}
+        pod_id=0
+        while :
+        do 
+            VOTERS="${VOTERS}$node_id@{{  include "common.names.fullname" . }}-$pod_id.{{ include "common.names.fullname" . }}-headless.{{ $releaseNamespace }}.svc.cluster.local:{{ .Values.kraft.controllerPort }}"
+            node_id=$(( $node_id + 1 ))
+            pod_id=$(( $pod_id + 1 ))
+            if [[ $pod_id -ge {{ .Values.replicaCount }} ]]; then
+                break
+            else
+                VOTERS="$VOTERS,"
+            fi
+        done
+        export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=$VOTERS
+    fi
     {{- if eq .Values.brokerRackAssignment "aws-az" }}
     export KAFKA_CFG_BROKER_RACK=$(curl "http://169.254.169.254/latest/meta-data/placement/availability-zone-id")
     {{- end }}

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -94,7 +94,7 @@ data:
         pod_id=0
         while :
         do 
-            VOTERS="${VOTERS}$node_id@{{  include "common.names.fullname" . }}-$pod_id.{{ include "common.names.fullname" . }}-headless.{{ $releaseNamespace }}.svc.cluster.local:{{ .Values.kraft.controllerPort }}"
+            VOTERS="${VOTERS}$node_id@{{  include "common.names.fullname" . }}-$pod_id.{{ include "common.names.fullname" . }}-headless.{{ $releaseNamespace }}.svc.cluster.local:{{ .Values.containerPorts.controller }}"
             node_id=$(( $node_id + 1 ))
             pod_id=$(( $pod_id + 1 ))
             if [[ $pod_id -ge {{ .Values.replicaCount }} ]]; then

--- a/bitnami/kafka/templates/scripts-configmap.yaml
+++ b/bitnami/kafka/templates/scripts-configmap.yaml
@@ -94,7 +94,7 @@ data:
         pod_id=0
         while :
         do 
-            VOTERS="${VOTERS}$node_id@{{  include "common.names.fullname" . }}-$pod_id.{{ include "common.names.fullname" . }}-headless.{{ $releaseNamespace }}.svc.cluster.local:{{ .Values.containerPorts.controller }}"
+            VOTERS="${VOTERS}$node_id@{{  include "common.names.fullname" . }}-$pod_id.{{ include "common.names.fullname" . }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }}:{{ .Values.containerPorts.controller }}"
             node_id=$(( $node_id + 1 ))
             pod_id=$(( $pod_id + 1 ))
             if [[ $pod_id -ge {{ .Values.replicaCount }} ]]; then

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -189,14 +189,14 @@ spec:
               value: {{ .Values.listenerSecurityProtocolMap | quote }}
               {{- else if .Values.externalAccess.enabled }}
               value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},EXTERNAL:{{ $externalClientProtocol }}"
-              {{- else if .Values.kraft.enabled }}
-                {{- if .Values.externalAccess.enabled }}
+                {{- if .Values.kraft.enabled }}
               value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},CONTROLLER:{{ $controllerProtocol }},EXTERNAL:{{ $externalClientProtocol }}"
-                {{- else }}
-              value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},CONTROLLER:{{ $controllerProtocol }}"
-                {{- end }}
+                {{- end}}
               {{- else }}
               value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }}"
+                {{- if .Values.kraft.enabled }}
+              value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},CONTROLLER:{{ $controllerProtocol }}"
+                {{- end }}             
               {{- end }}
             {{- if or ($clientProtocol | regexFind "SASL") ($externalClientProtocol | regexFind "SASL") ($interBrokerProtocol | regexFind "SASL") .Values.auth.sasl.jaas.zookeeperUser }}
             - name: KAFKA_CFG_SASL_ENABLED_MECHANISMS
@@ -209,15 +209,15 @@ spec:
               value: {{ join "," .Values.listeners }}
               {{- else if .Values.externalAccess.enabled }}
               value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},EXTERNAL://:{{ .Values.containerPorts.external }}"
-              {{- else if .Values.kraft.enabled }}
-                {{- if .Values.externalAccess.enabled }}
-              value: "INTERNAL:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},CONTROLLER://:{{ .Values.kraft.controllerPort }},EXTERNAL://:{{ .Values.containerPorts.external }}"
-                {{- else }}
-              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},CONTROLLER://:{{ .Values.kraft.controllerPort }}"
+                {{- if .Values.kraft.enabled }}
+              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},CONTROLLER://:{{ .Values.kraft.controllerPort }},EXTERNAL://:{{ .Values.containerPorts.external }}"
                 {{- end }}
               {{- else }}
-              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }}"
-              {{- end }}            
+              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }}"  
+                {{- if .Values.kraft.enabled }}
+              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},CONTROLLER://:{{ .Values.kraft.controllerPort }}"
+                {{- end }}
+              {{- end }}
             {{- if .Values.externalAccess.enabled }}
             {{- if .Values.externalAccess.autoDiscovery.enabled }}
             - name: SHARED_FILE

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -376,6 +376,8 @@ spec:
               value: {{ .Values.kraft.controllerListenerNames | quote }}  
             - name: KAFKA_ENABLE_KRAFT
               value: "true"
+            - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
+              value: {{ .Values.kraft.controllerQuorumVoters}}
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" ( dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -196,7 +196,7 @@ spec:
               value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }}"
                 {{- if .Values.kraft.enabled }}
               value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},CONTROLLER:{{ $controllerProtocol }}"
-                {{- end }}             
+                {{- end }}
               {{- end }}
             {{- if or ($clientProtocol | regexFind "SASL") ($externalClientProtocol | regexFind "SASL") ($interBrokerProtocol | regexFind "SASL") .Values.auth.sasl.jaas.zookeeperUser }}
             - name: KAFKA_CFG_SASL_ENABLED_MECHANISMS

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -4,6 +4,7 @@
 {{- $clusterDomain := .Values.clusterDomain }}
 {{- $interBrokerProtocol := include "kafka.listenerType" (dict "protocol" .Values.auth.interBrokerProtocol) -}}
 {{- $clientProtocol := include "kafka.listenerType" (dict "protocol" .Values.auth.clientProtocol) -}}
+{{- $controllerProtocol := include "kafka.listenerType" (dict "protocol" .Values.auth.controllerProtocol) -}}
 {{- $externalClientProtocol := include "kafka.listenerType" (dict "protocol" (include "kafka.externalClientProtocol" . )) -}}
 apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
@@ -188,6 +189,12 @@ spec:
               value: {{ .Values.listenerSecurityProtocolMap | quote }}
               {{- else if .Values.externalAccess.enabled }}
               value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},EXTERNAL:{{ $externalClientProtocol }}"
+              {{- else if .Values.kraft.enabled }}
+                {{- if .Values.externalAccess.enabled }}
+              value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},CONTROLLER:{{ $controllerProtocol }},EXTERNAL:{{ $externalClientProtocol }}"
+                {{- else }}
+              value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},CONTROLLER:{{ $controllerProtocol }}"
+                {{- end }}
               {{- else }}
               value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }}"
               {{- end }}
@@ -202,9 +209,15 @@ spec:
               value: {{ join "," .Values.listeners }}
               {{- else if .Values.externalAccess.enabled }}
               value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},EXTERNAL://:{{ .Values.containerPorts.external }}"
+              {{- else if .Values.kraft.enabled }}
+                {{- if .Values.externalAccess.enabled }}
+              value: "INTERNAL:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},CONTROLLER://:{{ .Values.kraft.controllerPort }},EXTERNAL://:{{ .Values.containerPorts.external }}"
+                {{- else }}
+              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},CONTROLLER://:{{ .Values.kraft.controllerPort }}"
+                {{- end }}
               {{- else }}
               value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }}"
-              {{- end }}
+              {{- end }}            
             {{- if .Values.externalAccess.enabled }}
             {{- if .Values.externalAccess.autoDiscovery.enabled }}
             - name: SHARED_FILE
@@ -354,6 +367,16 @@ spec:
               value: {{ .Values.allowEveryoneIfNoAclFound | quote }}
             - name: KAFKA_CFG_SUPER_USERS
               value: {{ .Values.superUsers | quote }}
+            {{- if .Values.kraft.enabled }}
+            - name: KAFKA_KRAFT_CLUSTER_ID
+              value: {{ .Values.kraft.clusterId | quote }}  
+            - name: KAFKA_CFG_PROCESS_ROLES
+              value: {{ .Values.kraft.processRoles | quote }}  
+            - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES
+              value: {{ .Values.kraft.controllerListenerNames | quote }}  
+            - name: KAFKA_ENABLE_KRAFT
+              value: "true"
+            {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" ( dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/bitnami/kafka/templates/statefulset.yaml
+++ b/bitnami/kafka/templates/statefulset.yaml
@@ -188,14 +188,16 @@ spec:
               {{- if .Values.listenerSecurityProtocolMap }}
               value: {{ .Values.listenerSecurityProtocolMap | quote }}
               {{- else if .Values.externalAccess.enabled }}
-              value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},EXTERNAL:{{ $externalClientProtocol }}"
                 {{- if .Values.kraft.enabled }}
+              value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},EXTERNAL:{{ $externalClientProtocol }}"
+                {{- else }}
               value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},CONTROLLER:{{ $controllerProtocol }},EXTERNAL:{{ $externalClientProtocol }}"
                 {{- end}}
               {{- else }}
-              value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }}"
                 {{- if .Values.kraft.enabled }}
               value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }},CONTROLLER:{{ $controllerProtocol }}"
+                {{- else }}
+              value: "INTERNAL:{{ $interBrokerProtocol }},CLIENT:{{ $clientProtocol }}"
                 {{- end }}
               {{- end }}
             {{- if or ($clientProtocol | regexFind "SASL") ($externalClientProtocol | regexFind "SASL") ($interBrokerProtocol | regexFind "SASL") .Values.auth.sasl.jaas.zookeeperUser }}
@@ -208,14 +210,16 @@ spec:
               {{- if .Values.listeners }}
               value: {{ join "," .Values.listeners }}
               {{- else if .Values.externalAccess.enabled }}
-              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},EXTERNAL://:{{ .Values.containerPorts.external }}"
                 {{- if .Values.kraft.enabled }}
-              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},CONTROLLER://:{{ .Values.kraft.controllerPort }},EXTERNAL://:{{ .Values.containerPorts.external }}"
+              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},CONTROLLER://:{{ .Values.containerPorts.controller }},EXTERNAL://:{{ .Values.containerPorts.external }}"
+                {{- else }}
+              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},EXTERNAL://:{{ .Values.containerPorts.external }}"
                 {{- end }}
               {{- else }}
-              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }}"  
                 {{- if .Values.kraft.enabled }}
-              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},CONTROLLER://:{{ .Values.kraft.controllerPort }}"
+              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }},CONTROLLER://:{{ .Values.containerPorts.controller }}"
+                {{- else }}
+              value: "INTERNAL://:{{ .Values.containerPorts.internal }},CLIENT://:{{ .Values.containerPorts.client }}"
                 {{- end }}
               {{- end }}
             {{- if .Values.externalAccess.enabled }}
@@ -376,8 +380,10 @@ spec:
               value: {{ .Values.kraft.controllerListenerNames | quote }}  
             - name: KAFKA_ENABLE_KRAFT
               value: "true"
+              {{- if .Values.kraft.controllerQuorumVoters }}
             - name: KAFKA_CFG_CONTROLLER_QUORUM_VOTERS
               value: {{ .Values.kraft.controllerQuorumVoters}}
+              {{- end }}
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" ( dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
@@ -401,6 +407,10 @@ spec:
             {{- if .Values.externalAccess.enabled }}
             - name: kafka-external
               containerPort: {{ .Values.containerPorts.external }}
+            {{- end }}
+            {{- if and .Values.kraft.enabled (contains "controller" .Values.kraft.processRoles) }}
+            - name: kafka-ctlr
+              containerPort: {{ .Values.containerPorts.controller }}
             {{- end }}
           {{- if not .Values.diagnosticMode.enabled }}
           {{- if .Values.customLivenessProbe }}

--- a/bitnami/kafka/templates/svc-headless.yaml
+++ b/bitnami/kafka/templates/svc-headless.yaml
@@ -33,5 +33,11 @@ spec:
       port: {{ .Values.service.ports.internal }}
       protocol: TCP
       targetPort: kafka-internal
+    {{- if and .Values.kraft.enabled (contains "controller" .Values.kraft.processRoles) }}
+    - name: tcp-controller
+      protocol: TCP
+      port: {{ .Values.containerPorts.controller }}
+      targetPort: kafka-ctlr
+    {{- end }}
   selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: kafka

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1743,6 +1743,10 @@ kraft:
   ## Example: k2yipv1sRue7z2_Y3o976A
   ##
   clusterId: ""
+  ## @param kraft.controllerQuorumVoters Quorum voters of Kafka Kraft cluster. Use it for nodes with 'broker' role only.
+  ## Example: 1@controller1.example.com:9095,2@controller2.example.com:9095
+  ##
+  controllerQuorumVoters: ""
 
 
 

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -1757,8 +1757,7 @@ kraft:
 ## https://github.com/bitnami/charts/blob/main/bitnami/zookeeper/values.yaml
 ##
 zookeeper:
-  ## @param zookeeper.enabled Switch to enable or disable the ZooKeeper helm chart
-  ## Must be false if you use Kraft mode.
+  ## @param zookeeper.enabled Switch to enable or disable the ZooKeeper helm chart. Must be false if you use Kraft mode.
   ##
   enabled: true
   ## @param zookeeper.replicaCount Number of ZooKeeper nodes
@@ -1801,6 +1800,6 @@ zookeeper:
 ## All of these values are only used if `zookeeper.enabled=false`
 ##
 externalZookeeper:
-  ## @param externalZookeeper.servers List of external zookeeper servers to use. Typically used in combination with 'zookeeperChrootPath'.
-  ## Must be empty if you use Kraft mode.
+  ## @param externalZookeeper.servers List of external zookeeper servers to use. Typically used in combination with 'zookeeperChrootPath'. Must be false if you use Kraft mode.
+  ##
   servers: []

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -449,11 +449,13 @@ brokerRackAssignment: ""
 ## @param containerPorts.client Kafka client container port
 ## @param containerPorts.internal Kafka inter-broker container port
 ## @param containerPorts.external Kafka external container port
+## @param containerPorts.controller Kafka Controller listener port. It is used if "kraft.enabled: true"
 ##
 containerPorts:
   client: 9092
   internal: 9093
   external: 9094
+  controller: 9095
 ## Configure extra options for Kafka containers' liveness, readiness and startup probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
 ## @param livenessProbe.enabled Enable livenessProbe on Kafka containers
@@ -1729,9 +1731,6 @@ kraft:
   ## @param kraft.enabled Switch to enable or disable the Kraft mode for Kafka
   ##
   enabled: false
-  ## @param kraft.controllerPort Kafka Controller listener port
-  ##
-  controllerPort: 9095
   ## @param kraft.processRoles Roles of your Kafka nodes. Nodes can have 'broker', 'controller' roles or both of them.
   ##
   processRoles: broker,controller
@@ -1742,13 +1741,11 @@ kraft:
   ## Generate with `cat /proc/sys/kernel/random/uuid | tr -d '-' | base64 | cut -b 1-22`. Run `export LC_ALL=C` before if you generate it on MacOS.
   ## Example: k2yipv1sRue7z2_Y3o976A
   ##
-  clusterId: ""
+  clusterId: "kafka_cluster_id_test1"
   ## @param kraft.controllerQuorumVoters Quorum voters of Kafka Kraft cluster. Use it for nodes with 'broker' role only.
   ## Example: 1@controller1.example.com:9095,2@controller2.example.com:9095
   ##
   controllerQuorumVoters: ""
-
-
 
 ## @section ZooKeeper chart parameters
 ##
@@ -1800,6 +1797,6 @@ zookeeper:
 ## All of these values are only used if `zookeeper.enabled=false`
 ##
 externalZookeeper:
-  ## @param externalZookeeper.servers List of external zookeeper servers to use. Typically used in combination with 'zookeeperChrootPath'. Must be false if you use Kraft mode.
+  ## @param externalZookeeper.servers List of external zookeeper servers to use. Typically used in combination with 'zookeeperChrootPath'. Must be empty if you use Kraft mode.
   ##
   servers: []

--- a/bitnami/kafka/values.yaml
+++ b/bitnami/kafka/values.yaml
@@ -244,6 +244,9 @@ auth:
   # https://github.com/bitnami/charts/pull/8902/
   externalClientProtocol: ""
   interBrokerProtocol: plaintext
+  ## @param auth.controllerProtocol Controller protocol. It is used with Kraft mode only.
+  ##
+  controllerProtocol: plaintext
   ## SASL configuration
   ##
   sasl:
@@ -1717,6 +1720,32 @@ provisioning:
   ##
   waitForKafka: true
 
+## @section Kraft chart parameters
+
+## Kraft configuration
+## Kafka mode without Zookeeper. Kafka nodes can work as controllers in this mode.
+##
+kraft:
+  ## @param kraft.enabled Switch to enable or disable the Kraft mode for Kafka
+  ##
+  enabled: false
+  ## @param kraft.controllerPort Kafka Controller listener port
+  ##
+  controllerPort: 9095
+  ## @param kraft.processRoles Roles of your Kafka nodes. Nodes can have 'broker', 'controller' roles or both of them.
+  ##
+  processRoles: broker,controller
+  ## @param kraft.controllerListenerNames Controller listener names
+  ##
+  controllerListenerNames: CONTROLLER
+  ## @param kraft.clusterId Kafka ClusterID. You must set it if your cluster contains more than one node.
+  ## Generate with `cat /proc/sys/kernel/random/uuid | tr -d '-' | base64 | cut -b 1-22`. Run `export LC_ALL=C` before if you generate it on MacOS.
+  ## Example: k2yipv1sRue7z2_Y3o976A
+  ##
+  clusterId: ""
+
+
+
 ## @section ZooKeeper chart parameters
 ##
 
@@ -1725,6 +1754,7 @@ provisioning:
 ##
 zookeeper:
   ## @param zookeeper.enabled Switch to enable or disable the ZooKeeper helm chart
+  ## Must be false if you use Kraft mode.
   ##
   enabled: true
   ## @param zookeeper.replicaCount Number of ZooKeeper nodes
@@ -1768,5 +1798,5 @@ zookeeper:
 ##
 externalZookeeper:
   ## @param externalZookeeper.servers List of external zookeeper servers to use. Typically used in combination with 'zookeeperChrootPath'.
-  ##
+  ## Must be empty if you use Kraft mode.
   servers: []


### PR DESCRIPTION
Signed-off-by: Danil Kuchukov <danil.kuchukov@outlook.com>

### Kraft mode implementation

This PR implements Kraft mode of Kafka (without Zookeeper). 

### Benefits

It is a pretty important feature of Kafka and the current chart does not support it.

### Possible drawbacks

I tested it with Zookeeper and without it, but it would be great if other people help with testing for backward compatibility.

### Applicable issues

- Currently, bitnami docker image of Kafka does not support sasl_tls and sasl modes with Kraft mode. It hangs on "Creating zookeeper users" even when Kraft mode is enabled. I know what must be fixed and plan to create a PR next week.
- Scaling is not supported. It is known issue when using Kraft. To fix that we need to delete __cluster_metadata/quorum-state file before scaling. I'm not sure how to do that better. We can do it either with helm hooks or init-container.

### Checklist

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
