### PR TITLE
[bitnami/drupal] Remove specified resources on values.yaml

### DIFF
--- a/bitnami/drupal/Chart.yaml
+++ b/bitnami/drupal/Chart.yaml
@@ -31,4 +31,4 @@ name: drupal
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/drupal
   - https://www.drupal.org/
-version: 13.0.2
+version: 13.0.3

--- a/bitnami/drupal/README.md
+++ b/bitnami/drupal/README.md
@@ -136,8 +136,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | `nodeAffinityPreset.values`                   | Node label values to match. Ignored if `affinity` is set.                                                              | `[]`                  |
 | `affinity`                                    | Affinity for pod assignment                                                                                            | `{}`                  |
 | `nodeSelector`                                | Node labels for pod assignment. Evaluated as a template.                                                               | `{}`                  |
-| `resources.requests`                          | The requested resources for the init container                                                                         | `{}`                  |
-| `resources.limits`                            | The resources limits for the init container                                                                            | `{}`                  |
+| `resources.limits`                            | The resources limits for Matomo containers                                                                             | `{}`                  |
+| `resources.requests`                          | The requested resources for Matomo containers                                                                          | `{}`                  |
 | `podSecurityContext.enabled`                  | Enable Drupal pods' Security Context                                                                                   | `true`                |
 | `podSecurityContext.fsGroup`                  | Drupal pods' group ID                                                                                                  | `1001`                |
 | `containerSecurityContext.enabled`            | Enable Drupal containers' Security Context                                                                             | `true`                |

--- a/bitnami/drupal/values.yaml
+++ b/bitnami/drupal/values.yaml
@@ -277,15 +277,25 @@ affinity: {}
 ##
 nodeSelector: {}
 ## Drupal container's resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-## @param resources.requests [object] The requested resources for the init container
-## @param resources.limits The resources limits for the init container
+## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param resources.limits The resources limits for Matomo containers
+## @param resources.requests The requested resources for Matomo containers
 ##
 resources:
-  requests:
-    memory: 512Mi
-    cpu: 300m
+  ## Example:
+  ## limits:
+  ##    cpu: 500m
+  ##    memory: 1Gi
   limits: {}
+  ## Examples:
+  ## requests:
+  ##    cpu: 250m
+  ##    memory: 256Mi
+  requests: {}
 ## Configure Pods Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## @param podSecurityContext.enabled Enable Drupal pods' Security Context


### PR DESCRIPTION
Signed-off-by: Mathges <geslinmariecurie@gmail.com>

### Description of the change
`resources:` values on `values.yaml` don't have default `resources.requests` values anymore

### Benefits

Users will now be able to fully specify `resources.requests`

### Applicable issues

  - fixes #14739 

### Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
