### PR TITLE
replaced specified values by empty ones on resources

### DIFF
--- a/bitnami/ejbca/Chart.yaml
+++ b/bitnami/ejbca/Chart.yaml
@@ -30,4 +30,4 @@ name: ejbca
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/ejbca
   - https://www.ejbca.org/
-version: 6.3.12
+version: 6.3.13

--- a/bitnami/ejbca/README.md
+++ b/bitnami/ejbca/README.md
@@ -131,8 +131,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | `command`                               | Custom command to override image cmd                                                                        | `[]`                  |
 | `args`                                  | Custom args for the custom command                                                                          | `[]`                  |
 | `lifecycleHooks`                        | for the EJBCA container(s) to automate configuration before or after startup                                | `{}`                  |
-| `resources.limits`                      | The resources limits for the container                                                                      | `{}`                  |
-| `resources.requests`                    | The requested resources for the container                                                                   | `{}`                  |
+| `resources.requests`                    | The requested resources for the init container                                                              | `{}`                  |
+| `resources.limits`                      | The resources limits for the init container                                                                 | `{}`                  |
+| `resources.limits`                      | The resources limits for Ejbca containers                                                                   | `{}`                  |
+| `resources.requests`                    | The requested resources for Ejbca containers                                                                | `{}`                  |
 | `containerSecurityContext.enabled`      | Enabled EJBCA containers' Security Context                                                                  | `true`                |
 | `containerSecurityContext.runAsUser`    | Set EJBCA containers' Security Context runAsUser                                                            | `1001`                |
 | `containerSecurityContext.runAsNonRoot` | Set EJBCA container's Security Context runAsNonRoot                                                         | `true`                |

--- a/bitnami/ejbca/values.yaml
+++ b/bitnami/ejbca/values.yaml
@@ -300,15 +300,28 @@ args: []
 ##
 lifecycleHooks: {}
 ## EJBCA containers' resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## @param resources.requests [object] The requested resources for the init container
+## @param resources.limits The resources limits for the init container
 ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
-## @param resources.limits The resources limits for the container
-## @param resources.requests [object] The requested resources for the container
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+## @param resources.limits The resources limits for Ejbca containers
+## @param resources.requests The requested resources for Ejbca containers
 ##
 resources:
+  ## Example:
+  ## limits:
+  ##    cpu: 500m
+  ##    memory: 1Gi
   limits: {}
-  requests:
-    memory: 512Mi
-    cpu: 300m
+  ## Examples:
+  ## requests:
+  ##    cpu: 250m
+  ##    memory: 256Mi
+  requests: {}
 ## K8s Security Context for EJBCA container
 ## @param containerSecurityContext.enabled Enabled EJBCA containers' Security Context
 ## @param containerSecurityContext.runAsUser Set EJBCA containers' Security Context runAsUser


### PR DESCRIPTION
Signed-off-by: Mathges <geslinmariecurie@gmail.com>

### Description of the change

`resources: values` on `values.yaml` don't have default `resources.requests` values anymore

### Benefits

Users will now be able to fully specify `resources.requests`

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #14739

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
