### PR TITLE
[rabbitmq-cluster-operator] Fix issue with caBundle not using existing CA certificate

### DIFF
--- a/bitnami/rabbitmq-cluster-operator/Chart.yaml
+++ b/bitnami/rabbitmq-cluster-operator/Chart.yaml
@@ -26,4 +26,4 @@ name: rabbitmq-cluster-operator
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq-cluster-operator
   - https://github.com/rabbitmq/cluster-operator
-version: 3.2.2
+version: 3.2.3

--- a/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/validating-webhook-configuration.yaml
+++ b/bitnami/rabbitmq-cluster-operator/templates/messaging-topology-operator/validating-webhook-configuration.yaml
@@ -46,7 +46,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
@@ -70,7 +70,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
@@ -94,7 +94,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
@@ -118,7 +118,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
@@ -142,7 +142,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
@@ -166,7 +166,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
@@ -190,7 +190,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
@@ -214,7 +214,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
@@ -238,7 +238,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
@@ -262,7 +262,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}
@@ -286,7 +286,7 @@ webhooks:
       - v1
     clientConfig:
       {{- if not .Values.useCertManager }}
-      caBundle: {{ default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle | b64enc | quote }}
+      caBundle: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" (default $ca.Cert .Values.msgTopologyOperator.existingWebhookCertCABundle) "context" $) }}
       {{- end }}
       service:
         name: {{ template "rmqco.msgTopologyOperator.webhook.fullname" . }}


### PR DESCRIPTION
### Description of the change

Fixes a bug introduced in #14654, where the `ca.crt` will stop being regenerated in every release.

I missed the references to `$ca.cert` in caBundle, causing it to change to the new CA although the deployment reused the previous CA cert.

### Applicable issues

- fixes #14908

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
