### PR TITLE
[bitnami/redis] Update health-configmap.yaml

### DIFF
--- a/bitnami/redis/Chart.yaml
+++ b/bitnami/redis/Chart.yaml
@@ -22,4 +22,4 @@ maintainers:
 name: redis
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/redis
-version: 17.7.4
+version: 17.7.5

--- a/bitnami/redis/templates/health-configmap.yaml
+++ b/bitnami/redis/templates/health-configmap.yaml
@@ -12,35 +12,49 @@ metadata:
   {{- end }}
 data:
   ping_readiness_local.sh: |-
-    #!/bin/bash
+    #!/usr/bin/env bash
+    REDIS_HOST="localhost"
+    REDIS_PORT="6379"
+    redis_cli=(timeout -s 3 1 redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT")
 
     [[ -f $REDIS_PASSWORD_FILE ]] && export REDIS_PASSWORD="$(< "${REDIS_PASSWORD_FILE}")"
     [[ -n "$REDIS_PASSWORD" ]] && export REDISCLI_AUTH="$REDIS_PASSWORD"
-    response=$(
-      timeout -s 3 $1 \
-      redis-cli \
-        -h localhost \
-{{- if .Values.tls.enabled }}
-        -p $REDIS_TLS_PORT \
-        --tls \
-        --cacert {{ template "redis.tlsCACert" . }} \
-        {{- if .Values.tls.authClients }}
-          --cert {{ template "redis.tlsCert" . }} \
-          --key {{ template "redis.tlsCertKey" . }} \
-        {{- end }}
-{{- else }}
-        -p $REDIS_PORT \
-{{- end }}
-        ping
-    )
-    if [ "$?" -eq "124" ]; then
-      echo "Timed out"
-      exit 1
-    fi
-    if [ "$response" != "PONG" ]; then
-      echo "$response"
-      exit 1
-    fi
+
+    function getRedisRole() {
+        "${redis_cli[@]}" info replication 2>/dev/null | grep "role" | tr -d "\r" | tr -d "\n"
+    }
+
+    function checkSlave() {
+        IN_SYNC="$("${redis_cli[@]}" info replication 2>/dev/null | grep "master_sync_in_progress:1" | tr -d "\r" | tr -d "\n")"
+        NO_MASTER="$("${redis_cli[@]}" info replication 2>/dev/null | grep "master_host:127.0.0.1" | tr -d "\r" | tr -d "\n")"
+        if [ -z "$IN_SYNC" ] && [ -z "$NO_MASTER" ]; then
+            exit 0
+        fi
+        exit 1
+    }
+
+    function checkMaster() {
+        exit 0
+    }
+
+    function main() {
+        ROLE=$(getRedisRole)
+        case $ROLE in
+            "role:slave")
+                checkSlave
+                ;;
+            "role:master")
+                checkMaster
+                ;;
+            *)
+                echo "Unknown role"
+                exit 1
+                ;;
+        esac
+    }
+    main "$@"
+    exit 0
+
   ping_liveness_local.sh: |-
     #!/bin/bash
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change is needed because when k8s-cluster doesn't allow saving on disk, we need to disable persistance. When we start deploy changes in config of redis, first pod is going down, and replication to the new pod starts. In period of replication master can go down and new pod, which was replicated to this master can be promoted to be a master. But this pod doesn't has all data, actually when we have a lot of data, on new pod can small piece of this data, so we can lose big part of our data. My change is about watching status of replication and whet it ends we can mark new pod as ready and after that terminate another old pod

### Benefits

Data in redis without persistance isn't lost

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #14738

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [ ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
