### PR TITLE
[bitnami/contour] add contour.logFormat configuration

### DIFF
--- a/bitnami/contour/Chart.yaml
+++ b/bitnami/contour/Chart.yaml
@@ -25,4 +25,4 @@ sources:
   - https://github.com/envoyproxy/envoy
   - https://github.com/bitnami/containers/tree/main/bitnami/contour
   - https://projectcontour.io
-version: 11.0.0
+version: 11.0.1

--- a/bitnami/contour/README.md
+++ b/bitnami/contour/README.md
@@ -66,7 +66,6 @@ helm uninstall my-release
 | `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
 | `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
 
-
 ### Common parameters
 
 | Name                     | Description                                                                             | Value   |
@@ -81,7 +80,6 @@ helm uninstall my-release
 | `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false` |
 | `diagnosticMode.command` | Command to override all containers in the deployment                                    | `[]`    |
 | `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `[]`    |
-
 
 ### Contour parameters
 
@@ -186,9 +184,9 @@ helm uninstall my-release
 | `contour.ingressClass.create`                                 | Whether to create or not the IngressClass resource                                                                                 | `true`                |
 | `contour.ingressClass.default`                                | Mark IngressClass resource as default for cluster                                                                                  | `true`                |
 | `contour.debug`                                               | Enable Contour debug log level                                                                                                     | `false`               |
+| `contour.logFormat`                                           | Set contour log-format. Default text, either text or json.                                                                         | `text`                |
 | `contour.kubernetesDebug`                                     | Contour kubernetes debug log level, Default 0, minimum 0, maximum 9.                                                               | `0`                   |
 | `contour.rootNamespaces`                                      | Restrict Contour to searching these namespaces for root ingress routes.                                                            | `""`                  |
-
 
 ### Envoy parameters
 
@@ -305,7 +303,6 @@ helm uninstall my-release
 | `envoy.extraEnvVarsCM`                              | ConfigMap containing extra env vars to be added to all Envoy containers                                               | `""`                  |
 | `envoy.extraEnvVarsSecret`                          | Secret containing extra env vars to be added to all Envoy containers                                                  | `""`                  |
 
-
 ### Default backend parameters
 
 | Name                                                   | Description                                                                                                     | Value                    |
@@ -399,7 +396,6 @@ helm uninstall my-release
 | `ingress.secrets`                                      | If you're providing your own certificates, please use this to add the certificates as secrets                   | `[]`                     |
 | `ingress.extraRules`                                   | Additional rules to be covered with this ingress record                                                         | `[]`                     |
 
-
 ### Metrics parameters
 
 | Name                                       | Description                                                                                                                          | Value                    |
@@ -414,7 +410,6 @@ helm uninstall my-release
 | `metrics.serviceMonitor.scrapeTimeout`     | The timeout after which the scrape is ended                                                                                          | `""`                     |
 | `metrics.serviceMonitor.selector`          | Specify honorLabels parameter to add the scrape endpoint                                                                             | `{}`                     |
 | `metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                                                                  | `{}`                     |
-
 
 ### Other parameters
 

--- a/bitnami/contour/templates/contour/deployment.yaml
+++ b/bitnami/contour/templates/contour/deployment.yaml
@@ -113,6 +113,7 @@ spec:
             {{- if .Values.contour.debug }}
             - --debug
             {{- end }}
+            - --log-format={{ .Values.contour.logFormat }}
             - --kubernetes-debug={{ .Values.contour.kubernetesDebug }}
             {{- if (include "contour.isIngressClassNameDefined" .) }}
             - --ingress-class-name={{ include "contour.ingressClassName" . }}

--- a/bitnami/contour/values.yaml
+++ b/bitnami/contour/values.yaml
@@ -454,6 +454,10 @@ contour:
   ##
   debug: false
 
+  ## @param contour.logFormat Set contour log-format. Default text, either text or json.
+  ##
+  logFormat: text
+
   ## @param contour.kubernetesDebug Contour kubernetes debug log level, Default 0, minimum 0, maximum 9.
   ##
   kubernetesDebug: 0


### PR DESCRIPTION
### Description of the change

This PR adds a new contour.logFormat parameter in the values.yaml file. 

### Benefits

Changing the logFormat to json is a frequent operation to make contour work well with log aggregation tools like Cloud Logging or Datadog. Those expect structured json logs. 
With the current chart one must provide `--log-format=json` in the `contour.extraArgs` section which is cumbersome and unintuitive for such a frequent operation. Additionally, one must match the contour documentation with the chart documentation to find the parameter in the first place.
Given that the accesslog-format for envoy is prominently highlighted in the documentation, I believe that the log-format should also be a first-class configuration parameter.

### Possible drawbacks

This change opens a second way to configure the same thing, because the logFormat could be configured using the new flag or the `contour.extraArgs`. Given that the same applies to `contour.debug` or `contour.kubernetesDebug`, I believe that this drawback is acceptable.

### Applicable issues

n/a

### Additional information

n/a

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
