### PR TITLE
[bitnami/wordpress] Remove updateStrategy.rollingUpdate: {} from wordpress chart to allow using Recreate update strategy

### DIFF
--- a/bitnami/wordpress/Chart.yaml
+++ b/bitnami/wordpress/Chart.yaml
@@ -35,4 +35,4 @@ name: wordpress
 sources:
   - https://github.com/bitnami/containers/tree/main/bitnami/wordpress
   - https://wordpress.org/
-version: 15.2.44
+version: 15.2.45

--- a/bitnami/wordpress/README.md
+++ b/bitnami/wordpress/README.md
@@ -144,7 +144,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
 | `replicaCount`                                      | Number of WordPress replicas to deploy                                                                                   | `1`              |
 | `updateStrategy.type`                               | WordPress deployment strategy type                                                                                       | `RollingUpdate`  |
-| `updateStrategy.rollingUpdate`                      | WordPress deployment rolling update configuration parameters                                                             | `{}`             |
 | `schedulerName`                                     | Alternate scheduler                                                                                                      | `""`             |
 | `topologySpreadConstraints`                         | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template | `[]`             |
 | `priorityClassName`                                 | Name of the existing priority class to be used by WordPress pods, priority class needs to be created beforehand          | `""`             |

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -273,7 +273,6 @@ replicaCount: 1
 ##
 updateStrategy:
   type: RollingUpdate
-  rollingUpdate: {}
 ## @param schedulerName Alternate scheduler
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -261,7 +261,6 @@ multisite:
 ##
 replicaCount: 1
 ## @param updateStrategy.type WordPress deployment strategy type
-## @param updateStrategy.rollingUpdate WordPress deployment rolling update configuration parameters
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 ## NOTE: Set it to `Recreate` if you use a PV that cannot be mounted on multiple pods
 ## e.g:


### PR DESCRIPTION
### Description of the change

Currently, the wordpress helm chart specifies the following in the values.yaml

```
updateStrategy:
  type: RollingUpdate
  rollingUpdate: {}
```

When you use the wordpress helm chart as a subchart of another helm chart, there is no way to overwrite the `updateStrategy.rollingUpdate` property to remove it. This causes problems as soon as you want to use the `Recreate` update strategy. Then helm throws the following error:

```
Deployment.apps "my-app-wordpress" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

To fix, this, I align the values.yaml with that of other bitnami helm charts like Kibana: https://github.com/andreas-eberle/charts/blob/main/bitnami/kibana/values.yaml#L104


### Benefits

With this change, it becomes possible to use the wordpress helm chart as a subchart with the Recreate update strategy. This is needed if you don't have WriteMany volumes. 

### Possible drawbacks

none



### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [x] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
