### PR TITLE
[bitnami/grafana-operator] - Adding support for existing volume provisioned outside the chart

### DIFF
--- a/bitnami/grafana-operator/Chart.yaml
+++ b/bitnami/grafana-operator/Chart.yaml
@@ -23,4 +23,4 @@ name: grafana-operator
 sources:
   - https://github.com/grafana-operator/grafana-operator
   - https://github.com/bitnami/containers/tree/main/bitnami/grafana-operator
-version: 2.7.20
+version: 2.7.21

--- a/bitnami/grafana-operator/README.md
+++ b/bitnami/grafana-operator/README.md
@@ -243,6 +243,7 @@ For more information, refer to the [documentation on the differences between the
 | `grafana.ingress.tlsSecret`                                 | The name for the secret to use for the tls termination                                                     | `grafana.local-tls`      |
 | `grafana.persistence.enabled`                               | Enable persistent storage for the grafana deployment                                                       | `false`                  |
 | `grafana.persistence.storageClass`                          | Define the storageClass for the persistent storage if not defined default is used                          | `""`                     |
+| `grafana.persistence.existingVolume`                        | Define the existingVolume for the persistent storage provisioned outside this chart                        | `""`                     |
 | `grafana.persistence.accessModes`                           | Define the accessModes for the persistent storage                                                          | `["ReadWriteOnce"]`      |
 | `grafana.persistence.annotations`                           | Add annotations to the persistent volume                                                                   | `{}`                     |
 | `grafana.persistence.size`                                  | Define the size of the PersistentVolumeClaim to request for                                                | `10Gi`                   |

--- a/bitnami/grafana-operator/templates/grafana.yaml
+++ b/bitnami/grafana-operator/templates/grafana.yaml
@@ -36,6 +36,9 @@ spec:
         - {{ . | quote }}
       {{- end }}
     size: {{ .Values.grafana.persistence.size }}
+    {{- if .Values.grafana.persistence.existingVolume }}
+    volumeName: {{ .Values.grafana.persistence.existingVolume }}
+    {{- end }}
     {{- if .Values.grafana.persistence.storageClass }}
     class: {{ .Values.grafana.persistence.storageClass }}
     {{- end }}

--- a/bitnami/grafana-operator/values.yaml
+++ b/bitnami/grafana-operator/values.yaml
@@ -666,6 +666,9 @@ grafana:
     ##   GKE, AWS & OpenStack)
     ##
     storageClass: ""
+    ## @param grafana.persistence.existingVolume Define the existingVolume for the persistent storage provisioned outside this chart
+    ## https://github.com/grafana-operator/grafana-operator/blob/master/deploy/examppersistentvolume/Grafana-existingVolume.yaml
+    existingVolume: ""
     ## @param grafana.persistence.accessModes Define the accessModes for the persistent storage
     ##
     accessModes:


### PR DESCRIPTION
### Description of the change
Adding support for existingVolume to be with Grafana. Details are already in issue #14796

### Benefits
data persistence outside grafana-operator helm release 

### Applicable issues
- fixes #14796 

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)