### PR TITLE
[bitnami/common] Allow empty registry name

### DIFF
--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.2.3
+appVersion: 2.3.4
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/main/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png
@@ -21,4 +21,4 @@ sources:
   - https://github.com/bitnami/charts
   - https://www.bitnami.com/
 type: library
-version: 2.2.3
+version: 2.2.4

--- a/bitnami/common/Chart.yaml
+++ b/bitnami/common/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # Please make sure that version and appVersion are always the same.
-appVersion: 2.3.4
+appVersion: 2.2.4
 description: A Library Helm Chart for grouping common logic between bitnami charts. This chart is not deployable by itself.
 home: https://github.com/bitnami/charts/tree/main/bitnami/common
 icon: https://bitnami.com/downloads/logos/bitnami-mark.png

--- a/bitnami/common/templates/_images.tpl
+++ b/bitnami/common/templates/_images.tpl
@@ -17,7 +17,11 @@ Return the proper image name
     {{- $separator = "@" -}}
     {{- $termination = .imageRoot.digest | toString -}}
 {{- end -}}
-{{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- if $registryName }}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+{{- else -}}
+    {{- printf "%s%s%s"  $repositoryName $separator $termination -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
This function is modified in order to allow empty registry name.
This allows companies which have a a default proxy to the registries, not to set the registry in every field.

This changes have been tested in rabbitmq operator bitnami chart.



### Description of the change

This function is modified in order to allow empty registry name.
Currently, this is not possible because it generates an image name like this: /reponame:tag

### Benefits

This allows companies which have a default proxy to the registries, not to set the registry in every field.


### Checklist


- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)